### PR TITLE
feat(rdf-api): Add a general-purpose SHACL validation utility (DSP-930)

### DIFF
--- a/docs/05-internals/design/principles/rdf-api.md
+++ b/docs/05-internals/design/principles/rdf-api.md
@@ -49,10 +49,12 @@ The API is in the package `org.knora.webapi.messages.util.rdf`. It includes:
 - `JsonLDUtil`, which provides specialised functionality for working
   with RDF in JSON-LD format, and for converting between RDF models
   and JSON-LD documents. `RdfFormatUtil` uses `JsonLDUtil` when appropriate.
+  
+- `ShaclValidator`, which validates RDF models using SHACL shapes.
 
 To work with RDF models, start with `RdfFeatureFactory`, which returns instances
-of `RdfNodeFactory`, `RdfModelFactory`, and `RdfFormatUtil`, using feature toggle
-configuration. `JsonLDUtil` does not need a feature factory.
+of `RdfNodeFactory`, `RdfModelFactory`, `RdfFormatUtil`, and `ShaclValidator`,
+using feature toggle configuration. `JsonLDUtil` does not need a feature factory.
 
 To iterate efficiently over the statements in an `RdfModel`, use its `iterator` method.
 An `RdfModel` cannot be modified while you are iterating over it.
@@ -83,6 +85,15 @@ construct one of these.
 In tests, it can be useful to run SPARQL queries to check the content of
 an `RdfModel`. To do this, use the `RdfModel.asRepository` method, which
 returns an `RdfRepository` that can run `SELECT` queries.
+
+
+## SHACL validation
+
+On startup, graphs of SHACL shapes are loaded from Turtle files in a directory specified
+by `app.shacl.shapes-dir` in `application.conf`, and in subdirectories of
+that directory. To validate the default graph of an `RdfModel` using a graph of
+SHACL shapes, call `ShaclValidator.validate`, specifying the relative path of the
+Turtle file containing the graph of shapes.
 
 
 ## Implementations

--- a/test_data/shacl/test/person.ttl
+++ b/test_data/shacl/test/person.ttl
@@ -1,0 +1,13 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+ex:PersonShape a sh:NodeShape ;
+  sh:targetClass foaf:Person ;
+  sh:property ex:PersonShapeProperty .
+
+ex:PersonShapeProperty sh:path foaf:age ;
+  sh:datatype xsd:int ;
+  sh:maxCount 1 ;
+  sh:minCount 1 .

--- a/third_party/dependencies.bzl
+++ b/third_party/dependencies.bzl
@@ -84,8 +84,9 @@ def dependencies():
             "org.xmlunit:xmlunit-core:2.1.1",
 
             # other
-            "org.eclipse.rdf4j:rdf4j-runtime:3.0.0",
-            "org.eclipse.rdf4j:rdf4j-shacl:3.0.0",
+            "org.eclipse.rdf4j:rdf4j-runtime:3.4.4",
+            "org.eclipse.rdf4j:rdf4j-client:3.4.4",
+            "org.eclipse.rdf4j:rdf4j-shacl:3.4.4",
             "org.rogach:scallop_2.12:3.2.0",
             "com.google.gwt:gwt-servlet:2.8.0",
             "net.sf.saxon:Saxon-HE:9.9.0-2",

--- a/third_party/dependencies.bzl
+++ b/third_party/dependencies.bzl
@@ -85,6 +85,7 @@ def dependencies():
 
             # other
             "org.eclipse.rdf4j:rdf4j-runtime:3.0.0",
+            "org.eclipse.rdf4j:rdf4j-shacl:3.0.0",
             "org.rogach:scallop_2.12:3.2.0",
             "com.google.gwt:gwt-servlet:2.8.0",
             "net.sf.saxon:Saxon-HE:9.9.0-2",

--- a/webapi/BUILD.bazel
+++ b/webapi/BUILD.bazel
@@ -212,6 +212,7 @@ scala_library(
         "//webapi/src/main/scala/org/knora/webapi/app",
         "//webapi/src/main/scala/org/knora/webapi/core",
         "//webapi/src/main/scala/org/knora/webapi/exceptions",
+        "//webapi/src/main/scala/org/knora/webapi/feature",
         "//webapi/src/main/scala/org/knora/webapi/instrumentation",
         "//webapi/src/main/scala/org/knora/webapi/messages",
         "//webapi/src/main/scala/org/knora/webapi/routing",

--- a/webapi/src/it/scala/org/knora/webapi/ITKnoraFakeSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/ITKnoraFakeSpec.scala
@@ -20,6 +20,7 @@
 package org.knora.webapi
 
 import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
@@ -33,6 +34,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import spray.json.{JsObject, _}
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.util.rdf.RdfFeatureFactory
 
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext}
@@ -63,8 +65,9 @@ class ITKnoraFakeSpec(_system: ActorSystem) extends Core with KnoraFakeCore with
 
     /* Needs to be initialized before any responders */
     StringFormatter.initForTest()
+    RdfFeatureFactory.init(settings)
 
-    val log = akka.event.Logging(system, this.getClass)
+    val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
 
     protected val baseApiUrl: String = settings.internalKnoraApiBaseUrl
     protected val baseInternalSipiUrl: String = settings.internalSipiBaseUrl

--- a/webapi/src/it/scala/org/knora/webapi/ITKnoraLiveSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/ITKnoraLiveSpec.scala
@@ -36,7 +36,7 @@ import org.knora.webapi.exceptions.AssertionException
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.app.appmessages.{AppStart, AppStop, SetAllowReloadOverHTTPState}
 import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, TriplestoreJsonProtocol}
-import org.knora.webapi.messages.util.rdf.{JsonLDDocument, JsonLDUtil}
+import org.knora.webapi.messages.util.rdf.{JsonLDDocument, JsonLDUtil, RdfFeatureFactory}
 import org.knora.webapi.settings._
 import org.knora.webapi.util.StartupUtils
 import org.scalatest.matchers.should.Matchers
@@ -75,6 +75,7 @@ class ITKnoraLiveSpec(_system: ActorSystem) extends Core with StartupUtils with 
 
     /* Needs to be initialized before any responders */
     StringFormatter.initForTest()
+    RdfFeatureFactory.init(settings)
 
     val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
 

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -264,35 +264,41 @@ akka-http-cors {
 }
 
 app {
-     feature-toggles {
-         new-list-admin-routes {
-             description = "Replace the old list admin routes with new ones."
+    feature-toggles {
+        new-list-admin-routes {
+            description = "Replace the old list admin routes with new ones."
 
-             available-versions = [ 1 ]
-             default-version = 1
-             enabled-by-default = no
-             override-allowed = yes
-             expiration-date = "2021-12-01T00:00:00Z"
+            available-versions = [ 1 ]
+            default-version = 1
+            enabled-by-default = no
+            override-allowed = yes
+            expiration-date = "2021-12-01T00:00:00Z"
 
-             developer-emails = [
-                 "Sepideh Alassi <sepideh.alassi@dasch.swiss>"
-                 "Benjamin Geer <benjamin.geer@dasch.swiss>"
-             ]
-         }
+            developer-emails = [
+                "Sepideh Alassi <sepideh.alassi@dasch.swiss>"
+                "Benjamin Geer <benjamin.geer@dasch.swiss>"
+            ]
+        }
 
-         jena-rdf-library {
-             description = "Use the Jena API for RDF processing. If turned off, use the RDF4J API."
+        jena-rdf-library {
+            description = "Use the Jena API for RDF processing. If turned off, use the RDF4J API."
 
-             available-versions = [ 1 ]
-             default-version = 1
-             enabled-by-default = no
-             override-allowed = yes
+            available-versions = [ 1 ]
+            default-version = 1
+            enabled-by-default = no
+            override-allowed = yes
 
-             developer-emails = [
-                 "Benjamin Geer <benjamin.geer@dasch.swiss>"
-             ]
-         }
-     }
+            developer-emails = [
+                "Benjamin Geer <benjamin.geer@dasch.swiss>"
+            ]
+        }
+    }
+
+    shacl {
+        # The directory that SHACL shapes are loaded from.
+        shapes-dir = "shacl"
+        shapes-dir = ${?KNORA_WEBAPI_SHACLE_SHAPES_DIR}
+    }
 
     print-extended-config = false // If true, an extended list of configuration parameters will be printed out at startup.
     print-extended-config = ${?KNORA_WEBAPI_PRINT_EXTENDED_CONFIG}

--- a/webapi/src/main/scala/org/knora/webapi/app/LiveCore.scala
+++ b/webapi/src/main/scala/org/knora/webapi/app/LiveCore.scala
@@ -27,8 +27,8 @@ import org.knora.webapi.settings.{KnoraDispatchers, KnoraSettings, KnoraSettings
 import scala.concurrent.ExecutionContext
 import scala.language.postfixOps
 import scala.languageFeature.postfixOps
-
 import org.knora.webapi.core.Core
+import org.knora.webapi.messages.util.rdf.RdfFeatureFactory
 
 
 /**
@@ -57,8 +57,10 @@ trait LiveCore extends Core {
     implicit val executionContext: ExecutionContext = system.dispatchers.lookup(KnoraDispatchers.KnoraActorDispatcher)
 
 
-    // Initialise StringFormatter with the system settings. This must happen before any responders are constructed.
+    // Initialise StringFormatter and RdfFeatureFactory with the system settings.
+    // This must happen before any responders are constructed.
     StringFormatter.init(settings)
+    RdfFeatureFactory.init(settings)
 
     /**
      * The main application supervisor actor which is at the top of the actor

--- a/webapi/src/main/scala/org/knora/webapi/messages/BUILD.bazel
+++ b/webapi/src/main/scala/org/knora/webapi/messages/BUILD.bazel
@@ -37,6 +37,7 @@ scala_library(
         "@maven//:org_eclipse_rdf4j_rdf4j_repository_sail",
         "@maven//:org_eclipse_rdf4j_rdf4j_sail_api",
         "@maven//:org_eclipse_rdf4j_rdf4j_sail_memory",
+        "@maven//:org_eclipse_rdf4j_rdf4j_shacl",
         "@maven//:org_jodd_jodd",
         "@maven//:org_scala_lang_modules_scala_xml_2_12",
         "@maven//:org_scala_lang_scala_library",

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -125,6 +125,16 @@ object OntologyConstants {
         val DateTimeStamp: IRI = XsdPrefixExpansion + "dateTimeStamp"
     }
 
+    object Shacl {
+        val ShaclPrefixExpansion: IRI = "http://www.w3.org/ns/shacl#"
+
+        val Conforms: IRI = ShaclPrefixExpansion + "conforms"
+        val Result: IRI = ShaclPrefixExpansion + "result"
+        val SourceConstraintComponent: IRI = ShaclPrefixExpansion + "sourceConstraintComponent"
+        val DatatypeConstraintComponent: IRI = ShaclPrefixExpansion + "DatatypeConstraintComponent"
+        val MaxCountConstraintComponent: IRI = ShaclPrefixExpansion + "MaxCountConstraintComponent"
+    }
+
     /**
      * http://schema.org
      */

--- a/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
@@ -319,18 +319,6 @@ object StringFormatter {
     }
 
     /**
-     * Initialises the singleton instance of [[StringFormatter]] for use in a client program that will connect to Knora.
-     */
-    def initForClient(knoraHostAndPort: String): Unit = {
-        this.synchronized {
-            generalInstance match {
-                case Some(_) => ()
-                case None => generalInstance = Some(new StringFormatter(maybeKnoraHostAndPort = Some(knoraHostAndPort)))
-            }
-        }
-    }
-
-    /**
      * Initialises the singleton instance of [[StringFormatter]] for a test.
      */
     def initForTest(): Unit = {

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/AbstractShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/AbstractShaclValidator.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.messages.util.rdf
+
+import java.io.File
+import java.nio.file.Path
+
+import org.knora.webapi.exceptions.AssertionException
+
+/**
+ * An abstract base class for classes that validate RDF models using SHACL shapes.
+ *
+ * @param baseDir       the base directory that SHACL graphs are loaded from.
+ * @param rdfFormatUtil an [[RdfFormatUtil]].
+ * @tparam ShaclGraphT an implementation-specific representation of a graph of SHACL shapes.
+ */
+abstract class AbstractShaclValidator[ShaclGraphT](baseDir: File, private val rdfFormatUtil: RdfFormatUtil) extends ShaclValidator {
+
+    /**
+     * A map of relative paths to objects representing graphs of SHACL shapes.
+     */
+    private val shaclGraphs: Map[Path, ShaclGraphT] = if (baseDir.exists) {
+        loadShaclGraphs(baseDir, baseDir)
+    } else {
+        Map.empty
+    }
+
+    def validate(rdfModel: RdfModel, shaclPath: Path): ShaclValidationResult = {
+        validateWithShaclGraph(
+            rdfModel = rdfModel,
+            shaclGraph = shaclGraphs.getOrElse(shaclPath, throw AssertionException(s"SHACL graph $shaclPath not found"))
+        )
+    }
+
+    /**
+     * Recursively loads graphs of SHACL shapes from a directory and its subdirectories.
+     *
+     * @param baseDir the base directory that SHACL graphs are loaded from.
+     * @param dir     the base directory or a subdirectory.
+     * @return a map of file paths (relative to the base directory) to graphs of SHACL shapes.
+     */
+    private def loadShaclGraphs(baseDir: File, dir: File): Map[Path, ShaclGraphT] = {
+        // Parse the files representing SHACL graphs in this directory.
+        val modelsInDir: Map[Path, ShaclGraphT] = dir.listFiles.collect {
+            case file: File if file.isFile && file.getName.endsWith(".ttl") =>
+                // Map each SHACL file's relative path to a ShapesT containing the SHACL graph.
+                val relativePath: Path = baseDir.toPath.relativize(file.toPath)
+                val shaclModel: RdfModel = rdfFormatUtil.fileToRdfModel(file = file, rdfFormat = Turtle)
+                relativePath -> rdfModelToShaclGraph(shaclModel)
+        }.toMap
+
+        // Recurse in subdirectories.
+        modelsInDir ++ dir.listFiles.filter(_.isDirectory).flatMap {
+            subDir => loadShaclGraphs(baseDir = baseDir, dir = subDir)
+        }
+    }
+
+    /**
+     * Validates the default graph of an [[RdfModel]] using a graph of SHACL shapes.
+     *
+     * @param rdfModel the [[RdfModel]] to be validated.
+     * @param shaclGraph a graph of SHACL shapes.
+     * @return the validation result.
+     */
+    protected def validateWithShaclGraph(rdfModel: RdfModel, shaclGraph: ShaclGraphT): ShaclValidationResult
+
+    /**
+     * Converts the default graph of an [[RdfModel]] to a [[ShaclGraphT]].
+     *
+     * @param rdfModel an [[RdfModel]] whose default graph contains SHACL shapes.
+     * @return a [[ShaclGraphT]] representing the SHACL shapes.
+     */
+    protected def rdfModelToShaclGraph(rdfModel: RdfModel): ShaclGraphT
+}

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfModel.scala
@@ -20,6 +20,7 @@
 package org.knora.webapi.messages.util.rdf
 
 import org.knora.webapi.IRI
+import org.knora.webapi.exceptions.InvalidRdfException
 import org.knora.webapi.messages.OntologyConstants
 
 import scala.util.control.Exception.allCatch
@@ -135,6 +136,72 @@ trait Statement {
     def obj: RdfNode
 
     def context: Option[IRI]
+
+    /**
+     * Returns the object of this statement as an [[RdfResource]].
+     */
+    def getResourceObject: RdfResource = {
+        obj match {
+            case rdfResource: RdfResource => rdfResource
+            case _ => throw InvalidRdfException(s"The object of $pred is not a resource")
+        }
+    }
+
+    /**
+     * Returns the object of this statement as an [[IriNode]].
+     */
+    def getIriObject: IriNode = {
+        obj match {
+            case iriNode: IriNode => iriNode
+            case _ => throw InvalidRdfException(s"The object of $pred is not an IRI")
+        }
+    }
+
+    /**
+     * Returns the object of this statement as a [[BlankNode]].
+     */
+    def getBlankNodeObject: BlankNode = {
+        obj match {
+            case blankNode: BlankNode => blankNode
+            case _ => throw InvalidRdfException(s"The object of $pred is not a blank node")
+        }
+    }
+
+    /**
+     * Returns the boolean value of the object of this statement.
+     */
+    def getBooleanObject: Boolean = {
+        def invalid: Nothing = throw InvalidRdfException(s"The object of $pred is not a boolean value")
+
+        obj match {
+            case datatypeLiteral: DatatypeLiteral => datatypeLiteral.booleanValue(invalid)
+            case _ => invalid
+        }
+    }
+
+    /**
+     * Returns the integer value of the object of this statement.
+     */
+    def getIntegerObject: BigInt = {
+        def invalid: Nothing = throw InvalidRdfException(s"The object of $pred is not an integer")
+
+        obj match {
+            case datatypeLiteral: DatatypeLiteral => datatypeLiteral.integerValue(invalid)
+            case _ => invalid
+        }
+    }
+
+    /**
+     * Returns the decimal value of the object of this statement.
+     */
+    def getDecimalObject: BigDecimal = {
+        def invalid: Nothing = throw InvalidRdfException(s"The object of $pred is not a decimal")
+
+        obj match {
+            case datatypeLiteral: DatatypeLiteral => datatypeLiteral.decimalValue(invalid)
+            case _ => invalid
+        }
+    }
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/ShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/ShaclValidator.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.messages.util.rdf
+
+import java.io.File
+import java.nio.file.Path
+
+import org.knora.webapi.exceptions.AssertionException
+
+/**
+ * A trait for the results of SHACL validation operations.
+ */
+sealed trait ShaclValidationResult
+
+/**
+ * Indicates that data passed SHACL validation.
+ */
+case object ShaclValidationSuccess extends ShaclValidationResult
+
+/**
+ * Indicates that data did not pass SHACL validation.
+ *
+ * @param reportModel an [[RdfModel]] describing the failure.
+ */
+case class ShaclValidationFailure(reportModel: RdfModel) extends ShaclValidationResult
+
+/**
+ * A trait for classes that validate RDF models using SHACL shapes.
+ */
+trait ShaclValidator {
+    /**
+     * Validates the default graph of an [[RdfModel]] using SHACL shapes.
+     *
+     * @param rdfModel  the model to be validated.
+     * @param shaclPath a path identifying the graph of SHACL shapes to be used.
+     * @return a [[ShaclValidationResult]].
+     */
+    def validate(rdfModel: RdfModel, shaclPath: Path): ShaclValidationResult
+}
+
+/**
+ * An abstract base class for classes that validate RDF models using SHACL shapes.
+ *
+ * @param baseDir       the base directory that SHACL graphs are loaded from.
+ * @param rdfFormatUtil an [[RdfFormatUtil]].
+ * @tparam ShaclGraphT an implementation-specific representation of a graph of SHACL shapes.
+ */
+abstract class AbstractShaclValidator[ShaclGraphT](baseDir: File, rdfFormatUtil: RdfFormatUtil) extends ShaclValidator {
+
+    /**
+     * A map of relative paths to objects representing graphs of SHACL shapes.
+     */
+    private val shaclGraphs: Map[Path, ShaclGraphT] = if (baseDir.exists) {
+        loadShaclGraphs(baseDir, baseDir)
+    } else {
+        Map.empty
+    }
+
+    def validate(rdfModel: RdfModel, shaclPath: Path): ShaclValidationResult = {
+        validateWithShaclGraph(
+            rdfModel = rdfModel,
+            shaclGraph = shaclGraphs.getOrElse(shaclPath, throw AssertionException(s"SHACL graph $shaclPath not found"))
+        )
+    }
+
+    /**
+     * Recursively loads graphs of SHACL shapes from a directory and its subdirectories.
+     *
+     * @param baseDir the base directory that SHACL graphs are loaded from.
+     * @param dir     the base directory or a subdirectory.
+     * @return a map of file paths (relative to the base directory) to graphs of SHACL shapes.
+     */
+    private def loadShaclGraphs(baseDir: File, dir: File): Map[Path, ShaclGraphT] = {
+        // Parse the files representing SHACL graphs in this directory.
+        val modelsInDir: Map[Path, ShaclGraphT] = dir.listFiles.collect {
+            case file: File if file.isFile && file.getName.endsWith(".ttl") =>
+                // Map each SHACL file's relative path to a ShapesT containing the SHACL graph.
+                val relativePath: Path = baseDir.toPath.relativize(file.toPath)
+                val shaclModel: RdfModel = rdfFormatUtil.fileToRdfModel(file = file, rdfFormat = Turtle)
+                relativePath -> rdfModelToShaclGraph(shaclModel)
+        }.toMap
+
+        // Recurse in subdirectories.
+        modelsInDir ++ dir.listFiles.filter(_.isDirectory).flatMap {
+            subDir => loadShaclGraphs(baseDir = baseDir, dir = subDir)
+        }
+    }
+
+    /**
+     * Validates the default graph of an [[RdfModel]] using a graph of SHACL shapes.
+     *
+     * @param rdfModel the [[RdfModel]] to be validated.
+     * @param shaclGraph a graph of SHACL shapes.
+     * @return the validation result.
+     */
+    protected def validateWithShaclGraph(rdfModel: RdfModel, shaclGraph: ShaclGraphT): ShaclValidationResult
+
+    /**
+     * Converts the default graph of an [[RdfModel]] to a [[ShaclGraphT]].
+     *
+     * @param rdfModel an [[RdfModel]] whose default graph contains SHACL shapes.
+     * @return a [[ShaclGraphT]] representing the SHACL shapes.
+     */
+    protected def rdfModelToShaclGraph(rdfModel: RdfModel): ShaclGraphT
+}

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidator.scala
@@ -34,7 +34,8 @@ import org.knora.webapi.messages.util.rdf._
  */
 class JenaShaclValidator(baseDir: File,
                          rdfFormatUtil: JenaFormatUtil,
-                         private val nodeFactory: JenaNodeFactory) extends AbstractShaclValidator[jena.shacl.Shapes](baseDir, rdfFormatUtil) {
+                         private val nodeFactory: JenaNodeFactory)
+    extends AbstractShaclValidator[jena.shacl.Shapes](baseDir, rdfFormatUtil) {
 
     import JenaConversions._
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidator.scala
@@ -19,7 +19,7 @@
 
 package org.knora.webapi.messages.util.rdf.jenaimpl
 
-import java.io.File
+import java.nio.file.Path
 
 import org.apache.jena
 import org.apache.jena.query.DatasetFactory
@@ -32,7 +32,7 @@ import org.knora.webapi.messages.util.rdf._
  * @param rdfFormatUtil an [[JenaFormatUtil]].
  * @param nodeFactory   a [[JenaNodeFactory]].
  */
-class JenaShaclValidator(baseDir: File,
+class JenaShaclValidator(baseDir: Path,
                          rdfFormatUtil: JenaFormatUtil,
                          private val nodeFactory: JenaNodeFactory)
     extends AbstractShaclValidator[jena.shacl.Shapes](baseDir, rdfFormatUtil) {

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidator.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.messages.util.rdf.jenaimpl
+
+import java.io.File
+
+import org.apache.jena
+import org.apache.jena.query.DatasetFactory
+import org.knora.webapi.messages.util.rdf._
+
+/**
+ * Performs SHACL validation using Jena.
+ *
+ * @param baseDir       the base directory that SHACL graphs are loaded from.
+ * @param rdfFormatUtil an [[JenaFormatUtil]].
+ * @param nodeFactory   a [[JenaNodeFactory]].
+ */
+class JenaShaclValidator(baseDir: File,
+                         rdfFormatUtil: JenaFormatUtil,
+                         private val nodeFactory: JenaNodeFactory) extends AbstractShaclValidator[jena.shacl.Shapes](baseDir, rdfFormatUtil) {
+
+    import JenaConversions._
+
+    private val shaclValidator: jena.shacl.ShaclValidator = jena.shacl.ShaclValidator.get
+
+    override def validateWithShaclGraph(rdfModel: RdfModel, shaclGraph: jena.shacl.Shapes): ShaclValidationResult = {
+        // Get the jena.graph.Graph representing the model's default graph.
+        val graphToValidate: jena.graph.Graph = rdfModel.asJenaDataset.asDatasetGraph.getDefaultGraph
+
+        // Validate the data and get Jena's validation report.
+        val validationReport: jena.shacl.ValidationReport = shaclValidator.validate(shaclGraph, graphToValidate)
+
+        // Did the data pass validation?
+        if (validationReport.conforms) {
+            // Yes.
+            ShaclValidationSuccess
+        } else {
+            // No. Convert the validation report to an RdfModel, and return it.
+            ShaclValidationFailure(
+                new JenaModel(
+                    dataset = DatasetFactory.wrap(validationReport.getModel),
+                    nodeFactory = nodeFactory
+                )
+            )
+        }
+    }
+
+    override def rdfModelToShaclGraph(rdfModel: RdfModel): jena.shacl.Shapes = {
+        jena.shacl.Shapes.parse(rdfModel.asJenaDataset.asDatasetGraph.getDefaultGraph)
+    }
+}

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidator.scala
@@ -19,7 +19,7 @@
 
 package org.knora.webapi.messages.util.rdf.rdf4jimpl
 
-import java.io.File
+import java.nio.file.Path
 
 import org.eclipse.rdf4j
 import org.knora.webapi.messages.util.rdf._
@@ -33,7 +33,7 @@ import scala.util.{Failure, Success, Try}
  * @param rdfFormatUtil an [[RdfFormatUtil]].
  * @param nodeFactory   an [[RDF4JNodeFactory]].
  */
-class RDF4JShaclValidator(baseDir: File,
+class RDF4JShaclValidator(baseDir: Path,
                           rdfFormatUtil: RDF4JFormatUtil,
                           private val nodeFactory: RDF4JNodeFactory)
     extends AbstractShaclValidator[rdf4j.model.Model](baseDir, rdfFormatUtil) {

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidator.scala
@@ -35,7 +35,8 @@ import scala.util.{Failure, Success, Try}
  */
 class RDF4JShaclValidator(baseDir: File,
                           rdfFormatUtil: RDF4JFormatUtil,
-                          private val nodeFactory: RDF4JNodeFactory) extends AbstractShaclValidator[rdf4j.model.Model](baseDir, rdfFormatUtil) {
+                          private val nodeFactory: RDF4JNodeFactory)
+    extends AbstractShaclValidator[rdf4j.model.Model](baseDir, rdfFormatUtil) {
 
     import RDF4JConversions._
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidator.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.messages.util.rdf.rdf4jimpl
+
+import java.io.File
+
+import org.eclipse.rdf4j
+import org.knora.webapi.messages.util.rdf._
+
+import scala.util.{Failure, Success, Try}
+
+/**
+ * Performs SHACL validation using RDF4J.
+ *
+ * @param baseDir       the base directory that SHACL graphs are loaded from.
+ * @param rdfFormatUtil an [[RdfFormatUtil]].
+ * @param nodeFactory   an [[RDF4JNodeFactory]].
+ */
+class RDF4JShaclValidator(baseDir: File,
+                          rdfFormatUtil: RDF4JFormatUtil,
+                          private val nodeFactory: RDF4JNodeFactory) extends AbstractShaclValidator[rdf4j.model.Model](baseDir, rdfFormatUtil) {
+
+    import RDF4JConversions._
+
+    override def validateWithShaclGraph(rdfModel: RdfModel, shaclGraph: rdf4j.model.Model): ShaclValidationResult = {
+        // Make a SailRepository repository that supports SHACL validation.
+        val shaclSail = new rdf4j.sail.shacl.ShaclSail(new rdf4j.sail.memory.MemoryStore())
+        val repository = new rdf4j.repository.sail.SailRepository(shaclSail)
+
+        // Open a connection to the repository and begin a transaction.
+        val connection: rdf4j.repository.sail.SailRepositoryConnection = repository.getConnection
+        connection.begin()
+
+        // Add the graph of SHACL shapes.
+        connection.add(shaclGraph, rdf4j.model.vocabulary.RDF4J.SHACL_SHAPE_GRAPH)
+
+        // Add the default graph of the input model to be validated.
+        connection.add(rdfModel.asRDF4JModel.filter(null, null, null, null))
+
+        // Commit the transaction to validate the data.
+        val validationTry: Try[ShaclValidationResult] = Try {
+            connection.commit()
+            ShaclValidationSuccess
+        }
+
+        // Was an exception thrown?
+        val validationResultTry: Try[ShaclValidationResult] = validationTry.recoverWith {
+            // Yes. Was it because the data didn't pass validation?
+            case repositoryException: rdf4j.repository.RepositoryException =>
+                Option(repositoryException.getCause) match {
+                    case Some(cause: Throwable) =>
+                        cause match {
+                            case shaclValidationException: rdf4j.sail.shacl.ShaclSailValidationException =>
+                                // Yes. Convert the validation report to an RdfModel and return it.
+                                Success(
+                                    ShaclValidationFailure(
+                                        new RDF4JModel(
+                                            model = shaclValidationException.validationReportAsModel,
+                                            nodeFactory = nodeFactory
+                                        )
+                                    )
+                                )
+
+                            case _ =>
+                                // No, it was for some other reason.
+                                Failure(repositoryException)
+                        }
+
+                    case None =>
+                        // No, it was for some other reason.
+                        Failure(repositoryException)
+                }
+
+            case other: Throwable =>
+                // No, it was for some other reason.
+                Failure(other)
+
+        }
+
+        connection.close()
+        repository.shutDown()
+        validationResultTry.get
+    }
+
+    override protected def rdfModelToShaclGraph(rdfModel: RdfModel): rdf4j.model.Model = {
+        rdfModel.asRDF4JModel
+    }
+}

--- a/webapi/src/main/scala/org/knora/webapi/settings/KnoraSettings.scala
+++ b/webapi/src/main/scala/org/knora/webapi/settings/KnoraSettings.scala
@@ -250,6 +250,8 @@ class KnoraSettingsImpl(config: Config, log: LoggingAdapter) extends Extension {
         None
     }
 
+    val shaclShapesDir: File = new File(config.getString("app.shacl.shapes-dir"))
+
     val featureToggles: Set[FeatureToggleBaseConfig] = if (config.hasPath(featureTogglesPath)) {
         Try {
             config.getObject(featureTogglesPath).asScala.toMap.map {

--- a/webapi/src/main/scala/org/knora/webapi/settings/KnoraSettings.scala
+++ b/webapi/src/main/scala/org/knora/webapi/settings/KnoraSettings.scala
@@ -20,7 +20,7 @@
 package org.knora.webapi.settings
 
 import java.io.File
-import java.nio.file.{Files, Paths}
+import java.nio.file.{Files, Path, Paths}
 import java.time.Instant
 
 import akka.ConfigurationException
@@ -250,7 +250,7 @@ class KnoraSettingsImpl(config: Config, log: LoggingAdapter) extends Extension {
         None
     }
 
-    val shaclShapesDir: File = new File(config.getString("app.shacl.shapes-dir"))
+    val shaclShapesDir: Path = Paths.get(config.getString("app.shacl.shapes-dir"))
 
     val featureToggles: Set[FeatureToggleBaseConfig] = if (config.hasPath(featureTogglesPath)) {
         Try {

--- a/webapi/src/test/scala/org/knora/webapi/CoreSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/CoreSpec.scala
@@ -33,6 +33,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.app.appmessages.{AppStart, AppStop, SetAllowReloadOverHTTPState}
 import org.knora.webapi.messages.store.cacheservicemessages.CacheServiceFlushDB
 import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, ResetRepositoryContent}
+import org.knora.webapi.messages.util.rdf.RdfFeatureFactory
 import org.knora.webapi.messages.util.{KnoraSystemInstances, ResponderData}
 import org.knora.webapi.messages.v2.responder.ontologymessages.LoadOntologiesRequestV2
 import org.knora.webapi.settings.{KnoraDispatchers, KnoraSettings, KnoraSettingsImpl, _}
@@ -88,6 +89,7 @@ abstract class CoreSpec(_system: ActorSystem) extends TestKit(_system) with Core
 
     // needs to be initialized early on
     StringFormatter.initForTest()
+    RdfFeatureFactory.init(settings)
 
     val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
 

--- a/webapi/src/test/scala/org/knora/webapi/E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/E2ESpec.scala
@@ -78,6 +78,7 @@ class E2ESpec(_system: ActorSystem) extends Core with StartupUtils with Triplest
 
     /* Needs to be initialized before any responders */
     StringFormatter.initForTest()
+    RdfFeatureFactory.init(settings)
 
     val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
 

--- a/webapi/src/test/scala/org/knora/webapi/R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/R2RSpec.scala
@@ -62,6 +62,9 @@ class R2RSpec extends Core with StartupUtils with Suite with ScalatestRouteTest 
 
     implicit lazy val settings: KnoraSettingsImpl = KnoraSettings(_system)
 
+    StringFormatter.initForTest()
+    RdfFeatureFactory.init(settings)
+
     protected val defaultFeatureFactoryConfig: FeatureFactoryConfig = new TestFeatureFactoryConfig(
         testToggles = Set.empty,
         parent = new KnoraSettingsFeatureFactoryConfig(settings)
@@ -73,8 +76,6 @@ class R2RSpec extends Core with StartupUtils with Suite with ScalatestRouteTest 
     override def createActorSystem(): ActorSystem = _system
 
     def actorRefFactory: ActorSystem = _system
-
-    StringFormatter.initForTest()
 
     implicit val knoraExceptionHandler: ExceptionHandler = handler.KnoraExceptionHandler(settings)
 

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/BUILD.bazel
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/BUILD.bazel
@@ -10,5 +10,6 @@ filegroup(
         "RdfFormatUtilSpec.scala",
         "JsonLDUtilSpec.scala",
         "KnoraResponseV2Spec.scala",
+        "ShaclValidatorSpec.scala",
     ],
 )

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/JsonLDUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/JsonLDUtilSpec.scala
@@ -23,7 +23,6 @@ import java.io.File
 
 import org.knora.webapi.CoreSpec
 import org.knora.webapi.feature._
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.rdf._
 import org.knora.webapi.util.FileUtil
 import spray.json.{JsValue, JsonParser}
@@ -39,8 +38,6 @@ abstract class JsonLDUtilSpec(featureToggle: FeatureToggle) extends CoreSpec {
 
     private val rdfFormatUtil: RdfFormatUtil = RdfFeatureFactory.getRdfFormatUtil(featureFactoryConfig)
     private val rdfModelFactory: RdfModelFactory = RdfFeatureFactory.getRdfModelFactory(featureFactoryConfig)
-
-    StringFormatter.initForTest()
 
     "The JSON-LD tool" should {
         "parse JSON-LD text, compact it with an empty context, convert the result to a JsonLDDocument, and convert that back to text" in {

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfFormatUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfFormatUtilSpec.scala
@@ -19,20 +19,18 @@
 
 package org.knora.webapi.util.rdf
 
-import java.io.{BufferedInputStream, ByteArrayInputStream, ByteArrayOutputStream, File, FileInputStream}
+import java.io._
 
-import org.knora.webapi.{CoreSpec, IRI}
 import org.knora.webapi.feature.{FeatureFactoryConfig, FeatureToggle, KnoraSettingsFeatureFactoryConfig, TestFeatureFactoryConfig}
+import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.util.rdf._
-import org.knora.webapi.messages.{OntologyConstants, StringFormatter}
 import org.knora.webapi.util.FileUtil
+import org.knora.webapi.{CoreSpec, IRI}
 
 /**
  * Tests implementations of [[RdfFormatUtil]].
  */
 abstract class RdfFormatUtilSpec(featureToggle: FeatureToggle) extends CoreSpec {
-    StringFormatter.initForTest()
-
     private val featureFactoryConfig: FeatureFactoryConfig = new TestFeatureFactoryConfig(
         testToggles = Set(featureToggle),
         parent = new KnoraSettingsFeatureFactoryConfig(settings)

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/BUILD.bazel
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/BUILD.bazel
@@ -82,3 +82,22 @@ scala_test(
     ] + BASE_TEST_DEPENDENCIES_WITH_JSON_LD,
 )
 
+scala_test(
+    name = "JenaShaclValidatorSpec",
+    size = "small",
+    srcs = [
+        "JenaShaclValidatorSpec.scala",
+        "//webapi/src/test/scala/org/knora/webapi/messages/util/rdf:ShaclValidatorSpec.scala",
+    ],
+    data = [
+        "//knora-ontologies",
+        "//test_data",
+    ],
+    jvm_flags = ["-Dconfig.resource=fuseki.conf"],
+    # unused_dependency_checker_mode = "warn",
+    deps = ALL_WEBAPI_MAIN_DEPENDENCIES + [
+        "//webapi:main_library",
+        "//webapi:test_library",
+        "@maven//:org_apache_jena_apache_jena_libs"
+    ] + BASE_TEST_DEPENDENCIES_WITH_JSON_LD,
+)

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidatorSpec.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.util.rdf.jenaimpl
+
+import org.knora.webapi.feature.{FeatureToggle, ToggleStateOn}
+import org.knora.webapi.util.rdf.ShaclValidatorSpec
+
+/**
+ * Tests [[org.knora.webapi.messages.util.rdf.ShaclValidator]] using the Jena API.
+ */
+class JenaShaclValidatorSpec extends ShaclValidatorSpec(FeatureToggle("jena-rdf-library", ToggleStateOn(1)))

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/BUILD.bazel
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/BUILD.bazel
@@ -81,3 +81,23 @@ scala_test(
         "@maven//:org_apache_jena_apache_jena_libs"
     ] + BASE_TEST_DEPENDENCIES_WITH_JSON_LD,
 )
+
+scala_test(
+    name = "RDF4JShaclValidatorSpec",
+    size = "small",
+    srcs = [
+        "RDF4JShaclValidatorSpec.scala",
+        "//webapi/src/test/scala/org/knora/webapi/messages/util/rdf:ShaclValidatorSpec.scala",
+    ],
+    data = [
+        "//knora-ontologies",
+        "//test_data",
+    ],
+    jvm_flags = ["-Dconfig.resource=fuseki.conf"],
+    # unused_dependency_checker_mode = "warn",
+    deps = ALL_WEBAPI_MAIN_DEPENDENCIES + [
+        "//webapi:main_library",
+        "//webapi:test_library",
+        "@maven//:org_apache_jena_apache_jena_libs"
+    ] + BASE_TEST_DEPENDENCIES_WITH_JSON_LD,
+)

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidatorSpec.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.util.rdf.rdf4jimpl
+
+import org.knora.webapi.feature.{FeatureToggle, ToggleStateOff}
+import org.knora.webapi.util.rdf.ShaclValidatorSpec
+
+/**
+ * Tests [[org.knora.webapi.messages.util.rdf.ShaclValidator]] using the RDF4J API.
+ */
+class RDF4JShaclValidatorSpec extends ShaclValidatorSpec(FeatureToggle("jena-rdf-library", ToggleStateOff))


### PR DESCRIPTION
resolves DSP-930.

- [x] Add SHACL validation API in `ShaclValidator.scala`.
- [x] Add implementations:
  - [x] `JenaShaclValidator`
  - [x] `RDF4JShaclValidator`
- [x] Return these from `RdfFeatureFactory`.
- [x] Add tests.
- [x] Update docs.

  