### PR TITLE
DSP-1033 Reposition List Nodes

### DIFF
--- a/docs/03-apis/api-admin/lists.md
+++ b/docs/03-apis/api-admin/lists.md
@@ -348,7 +348,7 @@ and the new position as below:
 
 Then the node `childNode4` will be put in position 1, and its siblings will be shifted accordingly. The new position given 
 in the request body cannot be the same as the child node's original position. If `position: -1` is given, the node will 
-be positioned at the end of children list, and its siblings will be shifted to left. In case of repositioning the node 
+be moved to the end of children list, and its siblings will be shifted to left. In case of repositioning the node 
 within its current parent, the maximum permitted position is the length of its children list, i.e. in this example the 
 highest allowed position is 4.
 

--- a/docs/03-apis/api-admin/lists.md
+++ b/docs/03-apis/api-admin/lists.md
@@ -334,8 +334,10 @@ The position of an existing child node can be updated. The child node can be eit
 current parent node, or can be added to another parent node in a specific position. The IRI of the parent node 
 and the new position of the child node must be given in the request body. 
 
-Suppose a parent node `parentNode1` has five children in positions 0-4. To change the position of its child node 
-`childNode4` from its original position 3 to position 1, the request body should specify the IRI of its parent node 
+If a node is supposed to be repositioned to the end of a parent node's children, give `position: -1`.
+
+Suppose a parent node `parentNode1` has five children in positions 0-4, to change the position of its child node 
+`childNode4` from its original position 3 to position 1 the request body should specify the IRI of its parent node 
 and the new position as below:
 ```json
    {
@@ -345,9 +347,10 @@ and the new position as below:
 ```
 
 Then the node `childNode4` will be put in position 1, and its siblings will be shifted accordingly. The new position given 
-in the request body cannot be the same as the child node's original position. In case of repositioning the node within its 
-current parent, the maximum permitted position is the length of its children list, i.e. in this example the highest allowed 
-position is 4.
+in the request body cannot be the same as the child node's original position. If `position: -1` is given, the node will 
+be positioned at the end of children list, and its siblings will be shifted to left. In case of repositioning the node 
+within its current parent, the maximum permitted position is the length of its children list, i.e. in this example the 
+highest allowed position is 4.
 
 To reposition a child node `childNode4` to another parent node `parentNode2` in a specific position, for 
 example `position: 3`, the IRI of the new parent node and the position the node must be placed within children of 
@@ -362,12 +365,14 @@ example `position: 3`, the IRI of the new parent node and the position the node 
 
 In this case, the `childNode4` is removed from the list of children of its old parent `parentNode1` and its old 
 siblings are shifted accordingly. Then the node `childNode4` is added to the specified new parent, i.e. `parentNode2`, in 
-the given position. The new siblings are shifted accordingly. 
+the given position. The new siblings are shifted accordingly.
 
-Note that, the furthest the node can be placed is at the end of the list of the children of `parentNode2`, 
-the maximum permitted position is length of children of `parentNode2`+1. That means 
+Note that, the furthest the node can be placed is at the end of the list of the children of `parentNode2`. That means 
 if `parentNode2` had 3 children with positions 0-2, then `childNode4` can be placed in position 0-3 within children 
-of its new parent node. 
+of its new parent node. If the `position: -1` is given, the node will be appended to the end of new parent's children, 
+and new siblings will not be shifted. 
+
+Values less than -1 are not permitted for parameter `position`.
  
 - Required permission: SystemAdmin / ProjectAdmin
 - Response: returns the updated parent node with all its children.

--- a/docs/03-apis/api-admin/lists.md
+++ b/docs/03-apis/api-admin/lists.md
@@ -36,6 +36,8 @@ If IRI of the child node is given, return the node with its immediate children.
 - `PUT: /admin/lists/<listItemIri>/name` : update the name of the node (root or child).
 - `PUT: /admin/lists/<listItemIri>/labels` : update labels of the node (root or child).
 - `PUT: /admin/lists/<listItemIri>/comments` : update comments of the node (root or child).
+- `PUT: /admin/lists/<nodeIri>/position` : update position of a child node within its current parent or by changing its 
+parent node.
 
 - `DELETE: /admin/lists/<listItemIri>` : delete a list (i.e. root node) or a child node and 
 all its children, if not used
@@ -325,6 +327,51 @@ If only name of the node must be updated, it can be given as below in the body o
 Alternatively, basic information of the child node can be updated individually as explained above (See 
 [update node name](#update-list-or-nodes-name), [update node labels](#update-list-or-nodes-labels), and 
 [update node comments](#update-list-or-nodes-comments)).
+
+### Repositioning a child node
+
+The position of an existing child node can be updated. The child node can be either repositioned within its 
+current parent node, or can be added to another parent node in a specific position. The IRI of the parent node 
+and the new position of the child node must be given in the request body. 
+
+Suppose a parent node `parentNode1` has five children in positions 0-4. To change the position of its child node 
+`childNode4` from its original position 3 to position 1, the request body should specify the IRI of its parent node 
+and the new position as below:
+```json
+   {
+      "parentNodeIri": "<parentNode1-IRI>",
+      "position": 1
+  }
+```
+
+Then the node `childNode4` will be put in position 1, and its siblings will be shifted accordingly. The new position given 
+in the request body cannot be the same as the child node's original position. In case of repositioning the node within its 
+current parent, the maximum permitted position is the length of its children list, i.e. in this example the highest allowed 
+position is 4.
+
+To reposition a child node `childNode4` to another parent node `parentNode2` in a specific position, for 
+example `position: 3`, the IRI of the new parent node and the position the node must be placed within children of 
+`parentNode2` must be given as:
+
+```json
+   {
+      "parentNodeIri": "<parentNode2-IRI>",
+      "position": 3
+  }
+```
+
+In this case, the `childNode4` is removed from the list of children of its old parent `parentNode1` and its old 
+siblings are shifted accordingly. Then the node `childNode4` is added to the specified new parent, i.e. `parentNode2`, in 
+the given position. The new siblings are shifted accordingly. 
+
+Note that, the furthest the node can be placed is at the end of the list of the children of `parentNode2`, 
+the maximum permitted position is length of children of `parentNode2`+1. That means 
+if `parentNode2` had 3 children with positions 0-2, then `childNode4` can be placed in position 0-3 within children 
+of its new parent node. 
+ 
+- Required permission: SystemAdmin / ProjectAdmin
+- Response: returns the updated parent node with all its children.
+- Put `/admin/lists/<nodeIri>/position`
 
 ### Delete a list or a node
 An entire list or a single node of it can be completely deleted, if not in use. Before deleting an entire list 

--- a/docs/03-apis/api-admin/lists_new-list-admin-routes_v1.md
+++ b/docs/03-apis/api-admin/lists_new-list-admin-routes_v1.md
@@ -254,8 +254,10 @@ The position of an existing child node can be updated. The child node can be eit
 current parent node, or can be added to another parent node in a specific position. The IRI of the parent node 
 and the new position of the child node must be given in the request body. 
 
-Suppose a parent node `parentNode1` has five children in positions 0-4. To change the position of its child node 
-`childNode4` from its original position 3 to position 1, the request body should specify the IRI of its parent node 
+If a node is supposed to be repositioned to the end of a parent node's children, give `position: -1`.
+
+Suppose a parent node `parentNode1` has five children in positions 0-4, to change the position of its child node 
+`childNode4` from its original position 3 to position 1 the request body should specify the IRI of its parent node 
 and the new position as below:
 ```json
    {
@@ -265,9 +267,10 @@ and the new position as below:
 ```
 
 Then the node `childNode4` will be put in position 1, and its siblings will be shifted accordingly. The new position given 
-in the request body cannot be the same as the child node's original position. In case of repositioning the node within its 
-current parent, the maximum permitted position is the length of its children list, i.e. in this example the highest allowed 
-position is 4.
+in the request body cannot be the same as the child node's original position. If `position: -1` is given, the node will 
+be positioned at the end of children list, and its siblings will be shifted to left. In case of repositioning the node 
+within its current parent, the maximum permitted position is the length of its children list, i.e. in this example the 
+highest allowed position is 4.
 
 To reposition a child node `childNode4` to another parent node `parentNode2` in a specific position, for 
 example `position: 3`, the IRI of the new parent node and the position the node must be placed within children of 
@@ -282,12 +285,14 @@ example `position: 3`, the IRI of the new parent node and the position the node 
 
 In this case, the `childNode4` is removed from the list of children of its old parent `parentNode1` and its old 
 siblings are shifted accordingly. Then the node `childNode4` is added to the specified new parent, i.e. `parentNode2`, in 
-the given position. The new siblings are shifted accordingly. 
+the given position. The new siblings are shifted accordingly.
 
-Note that, the furthest the node can be placed is at the end of the list of the children of `parentNode2`, 
-the maximum permitted position is length of children of `parentNode2`+1. That means 
+Note that, the furthest the node can be placed is at the end of the list of the children of `parentNode2`. That means 
 if `parentNode2` had 3 children with positions 0-2, then `childNode4` can be placed in position 0-3 within children 
-of its new parent node. 
+of its new parent node. If the `position: -1` is given, the node will be appended to the end of new parent's children, 
+and new siblings will not be shifted. 
+
+Values less than -1 are not permitted for parameter `position`.
  
 - Required permission: SystemAdmin / ProjectAdmin
 - Response: returns the updated parent node with all its children.

--- a/docs/03-apis/api-admin/lists_new-list-admin-routes_v1.md
+++ b/docs/03-apis/api-admin/lists_new-list-admin-routes_v1.md
@@ -40,6 +40,8 @@ To use activate: `new-list-admin-routes:1`.
 - `PUT: /admin/lists/<listItemIri>/name` : update the name of the node (root or child).
 - `PUT: /admin/lists/<listItemIri>/labels` : update labels of the node (root or child).
 - `PUT: /admin/lists/<listItemIri>/comments` : update comments of the node (root or child).
+- `PUT: /admin/lists/<nodeIri>/position` : update position of a child node within its current parent or by changing its 
+parent node.
 
 - `DELETE: /admin/lists/<listItemIri>` : delete a list (i.e. root node) or a child node and 
 all its children, if not used
@@ -245,6 +247,51 @@ There is no need to specify the project IRI because it is automatically extracte
 }
 ```
 There is no need to specify the project IRI because it is automatically extracted using the given `<listItemIRI>`.
+
+### Repositioning a child node
+
+The position of an existing child node can be updated. The child node can be either repositioned within its 
+current parent node, or can be added to another parent node in a specific position. The IRI of the parent node 
+and the new position of the child node must be given in the request body. 
+
+Suppose a parent node `parentNode1` has five children in positions 0-4. To change the position of its child node 
+`childNode4` from its original position 3 to position 1, the request body should specify the IRI of its parent node 
+and the new position as below:
+```json
+   {
+      "parentNodeIri": "<parentNode1-IRI>",
+      "position": 1
+  }
+```
+
+Then the node `childNode4` will be put in position 1, and its siblings will be shifted accordingly. The new position given 
+in the request body cannot be the same as the child node's original position. In case of repositioning the node within its 
+current parent, the maximum permitted position is the length of its children list, i.e. in this example the highest allowed 
+position is 4.
+
+To reposition a child node `childNode4` to another parent node `parentNode2` in a specific position, for 
+example `position: 3`, the IRI of the new parent node and the position the node must be placed within children of 
+`parentNode2` must be given as:
+
+```json
+   {
+      "parentNodeIri": "<parentNode2-IRI>",
+      "position": 3
+  }
+```
+
+In this case, the `childNode4` is removed from the list of children of its old parent `parentNode1` and its old 
+siblings are shifted accordingly. Then the node `childNode4` is added to the specified new parent, i.e. `parentNode2`, in 
+the given position. The new siblings are shifted accordingly. 
+
+Note that, the furthest the node can be placed is at the end of the list of the children of `parentNode2`, 
+the maximum permitted position is length of children of `parentNode2`+1. That means 
+if `parentNode2` had 3 children with positions 0-2, then `childNode4` can be placed in position 0-3 within children 
+of its new parent node. 
+ 
+- Required permission: SystemAdmin / ProjectAdmin
+- Response: returns the updated parent node with all its children.
+- Put `/admin/lists/<nodeIri>/position`
 
 ### Delete a list or a node
 An entire list or a single node of it can be completely deleted, if not in use. Before deleting an entire list 

--- a/docs/03-apis/api-admin/lists_new-list-admin-routes_v1.md
+++ b/docs/03-apis/api-admin/lists_new-list-admin-routes_v1.md
@@ -268,7 +268,7 @@ and the new position as below:
 
 Then the node `childNode4` will be put in position 1, and its siblings will be shifted accordingly. The new position given 
 in the request body cannot be the same as the child node's original position. If `position: -1` is given, the node will 
-be positioned at the end of children list, and its siblings will be shifted to left. In case of repositioning the node 
+be moved to the end of children list, and its siblings will be shifted to left. In case of repositioning the node 
 within its current parent, the maximum permitted position is the length of its children list, i.e. in this example the 
 highest allowed position is 4.
 

--- a/test_data/all_data/anything-data.ttl
+++ b/test_data/all_data/anything-data.ttl
@@ -1854,7 +1854,8 @@
   knora-base:hasRootNode <http://rdfh.ch/lists/0001/notUsedList>;
   knora-base:listNodePosition 0;
   rdfs:label "node 1"@en ;
-  knora-base:hasSubListNode <http://rdfh.ch/lists/0001/notUsedList011> .
+  knora-base:hasSubListNode <http://rdfh.ch/lists/0001/notUsedList011>, <http://rdfh.ch/lists/0001/notUsedList012>,
+  <http://rdfh.ch/lists/0001/notUsedList013>, <http://rdfh.ch/lists/0001/notUsedList014>, <http://rdfh.ch/lists/0001/notUsedList015> .
 
 <http://rdfh.ch/lists/0001/notUsedList02> a knora-base:ListNode;
   knora-base:listNodeName "node 2";
@@ -1873,3 +1874,27 @@
   knora-base:hasRootNode <http://rdfh.ch/lists/0001/notUsedList>;
   knora-base:listNodePosition 0;
   rdfs:label "child of node 1"@en .
+
+<http://rdfh.ch/lists/0001/notUsedList012> a knora-base:ListNode;
+  knora-base:listNodeName "List012";
+  knora-base:hasRootNode <http://rdfh.ch/lists/0001/notUsedList>;
+  knora-base:listNodePosition 1;
+  rdfs:label "List012"@en .
+
+<http://rdfh.ch/lists/0001/notUsedList013> a knora-base:ListNode;
+  knora-base:listNodeName "List013";
+  knora-base:hasRootNode <http://rdfh.ch/lists/0001/notUsedList>;
+  knora-base:listNodePosition 2;
+  rdfs:label "List013"@en .
+
+<http://rdfh.ch/lists/0001/notUsedList014> a knora-base:ListNode;
+  knora-base:listNodeName "List014";
+  knora-base:hasRootNode <http://rdfh.ch/lists/0001/notUsedList>;
+  knora-base:listNodePosition 3;
+  rdfs:label "List014"@en .
+
+<http://rdfh.ch/lists/0001/notUsedList015> a knora-base:ListNode;
+  knora-base:listNodeName "List015";
+  knora-base:hasRootNode <http://rdfh.ch/lists/0001/notUsedList>;
+  knora-base:listNodePosition 4;
+  rdfs:label "List015"@en .

--- a/test_data/all_data/anything-data.ttl
+++ b/test_data/all_data/anything-data.ttl
@@ -1898,3 +1898,4 @@
   knora-base:hasRootNode <http://rdfh.ch/lists/0001/notUsedList>;
   knora-base:listNodePosition 4;
   rdfs:label "List015"@en .
+  

--- a/webapi/scripts/expected-client-test-data.txt
+++ b/webapi/scripts/expected-client-test-data.txt
@@ -65,6 +65,10 @@ test-data/admin/lists/update-childNode-labels-request.json
 test-data/admin/lists/update-childNode-labels-response.json
 test-data/admin/lists/update-childNode-name-request.json
 test-data/admin/lists/update-childNode-name-response.json
+test-data/admin/lists/update-childNode-position-new-parent-request.json
+test-data/admin/lists/update-childNode-position-new-parent-response.json
+test-data/admin/lists/update-childNode-position-request.json
+test-data/admin/lists/update-childNode-position-response.json
 test-data/admin/lists/update-list-info-comment-label-multiple-languages-request.json
 test-data/admin/lists/update-list-info-comment-label-multiple-languages-response.json
 test-data/admin/lists/update-list-info-request.json

--- a/webapi/scripts/expected-client-test-data.txt
+++ b/webapi/scripts/expected-client-test-data.txt
@@ -67,8 +67,12 @@ test-data/admin/lists/update-childNode-name-request.json
 test-data/admin/lists/update-childNode-name-response.json
 test-data/admin/lists/update-childNode-position-new-parent-request.json
 test-data/admin/lists/update-childNode-position-new-parent-response.json
+test-data/admin/lists/update-childNode-position-new-parent-to-end-request.json
+test-data/admin/lists/update-childNode-position-new-parent-to-end-response.json
 test-data/admin/lists/update-childNode-position-request.json
 test-data/admin/lists/update-childNode-position-response.json
+test-data/admin/lists/update-childNode-position-to-end-request.json
+test-data/admin/lists/update-childNode-position-to-end-response.json
 test-data/admin/lists/update-list-info-comment-label-multiple-languages-request.json
 test-data/admin/lists/update-list-info-comment-label-multiple-languages-response.json
 test-data/admin/lists/update-list-info-request.json

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
@@ -205,6 +205,14 @@ case class ChangeNodeCommentsApiRequestADM(comments: Seq[StringLiteralV2]) exten
  * @param parentIri the parent node Iri.
  */
 case class ChangeNodePositionApiRequestADM(position: Int, parentIri: IRI) extends ListADMJsonProtocol {
+    private val stringFormatter = StringFormatter.getInstanceForConstantOntologies
+
+    if (parentIri.isEmpty) {
+        throw BadRequestException(s"IRI of parent node is missing.")
+    }
+    if (!stringFormatter.isKnoraListIriStr(parentIri)) {
+        throw BadRequestException(s"Invalid IRI is given: $parentIri.")
+    }
 
     def toJsValue: JsValue = changeNodePositionApiRequestADMFormat.write(this)
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
@@ -504,6 +504,15 @@ case class ChildNodeDeleteResponseADM(node: ListNodeADM) extends ListItemDeleteR
     def toJsValue: JsValue = listNodeDeleteResponseADMFormat.write(this)
 }
 
+/**
+ * Responds to change of a child node's position by returning its parent node together with list of its children.
+ *
+ * @param node the updated parent node.
+ */
+case class NodePositionChangeResponseADM(node: ListNodeADM) extends KnoraResponseADM with ListADMJsonProtocol {
+
+    def toJsValue: JsValue = changeNodePositionApiResponseADMFormat.write(this)
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Components of messages
@@ -1237,6 +1246,7 @@ trait ListADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol with
     implicit val changeNodeLabelsApiRequestADMFormat: RootJsonFormat[ChangeNodeLabelsApiRequestADM] = jsonFormat(ChangeNodeLabelsApiRequestADM, "labels")
     implicit val changeNodeCommentsApiRequestADMFormat: RootJsonFormat[ChangeNodeCommentsApiRequestADM] = jsonFormat(ChangeNodeCommentsApiRequestADM, "comments")
     implicit val changeNodePositionApiRequestADMFormat: RootJsonFormat[ChangeNodePositionApiRequestADM] = jsonFormat(ChangeNodePositionApiRequestADM, "position", "parentNodeIri")
+    implicit val changeNodePositionApiResponseADMFormat: RootJsonFormat[NodePositionChangeResponseADM] = jsonFormat(NodePositionChangeResponseADM, "node")
     implicit val listNodeDeleteResponseADMFormat: RootJsonFormat[ChildNodeDeleteResponseADM] = jsonFormat(ChildNodeDeleteResponseADM, "node")
     implicit val listDeleteResponseADMFormat: RootJsonFormat[ListDeleteResponseADM] = jsonFormat(ListDeleteResponseADM, "iri", "deleted")
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
@@ -198,6 +198,17 @@ case class ChangeNodeCommentsApiRequestADM(comments: Seq[StringLiteralV2]) exten
     def toJsValue: JsValue = changeNodeCommentsApiRequestADMFormat.write(this)
 }
 
+/**
+ * Represents an API request payload that asks the Knora API server to update the position of child node.
+ *
+ * @param position  the new position of the node.
+ * @param parentIri the parent node Iri.
+ */
+case class ChangeNodePositionApiRequestADM(position: Int, parentIri: IRI) extends ListADMJsonProtocol {
+
+    def toJsValue: JsValue = changeNodePositionApiRequestADMFormat.write(this)
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Messages
 
@@ -356,6 +367,21 @@ case class NodeLabelsChangeRequestADM(nodeIri: IRI,
  */
 case class NodeCommentsChangeRequestADM(nodeIri: IRI,
                                         changeNodeCommentsRequest: ChangeNodeCommentsApiRequestADM,
+                                        featureFactoryConfig: FeatureFactoryConfig,
+                                        requestingUser: UserADM,
+                                        apiRequestID: UUID) extends ListsResponderRequestADM
+
+/**
+ * Request updating the position of an existing node.
+ *
+ * @param nodeIri                   the IRI of the node whose position should be updated.
+ * @param changeNodePositionRequest the payload containing the new comments.
+ * @param featureFactoryConfig      the feature factory configuration.
+ * @param requestingUser            the user initiating the request.
+ * @param apiRequestID              the ID of the API request.
+ */
+case class NodePositionChangeRequestADM(nodeIri: IRI,
+                                        changeNodePositionRequest: ChangeNodePositionApiRequestADM,
                                         featureFactoryConfig: FeatureFactoryConfig,
                                         requestingUser: UserADM,
                                         apiRequestID: UUID) extends ListsResponderRequestADM
@@ -1202,6 +1228,7 @@ trait ListADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol with
     implicit val changeNodeNameApiRequestADMFormat: RootJsonFormat[ChangeNodeNameApiRequestADM] = jsonFormat(ChangeNodeNameApiRequestADM, "name")
     implicit val changeNodeLabelsApiRequestADMFormat: RootJsonFormat[ChangeNodeLabelsApiRequestADM] = jsonFormat(ChangeNodeLabelsApiRequestADM, "labels")
     implicit val changeNodeCommentsApiRequestADMFormat: RootJsonFormat[ChangeNodeCommentsApiRequestADM] = jsonFormat(ChangeNodeCommentsApiRequestADM, "comments")
+    implicit val changeNodePositionApiRequestADMFormat: RootJsonFormat[ChangeNodePositionApiRequestADM] = jsonFormat(ChangeNodePositionApiRequestADM, "position", "parentNodeIri")
     implicit val listNodeDeleteResponseADMFormat: RootJsonFormat[ChildNodeDeleteResponseADM] = jsonFormat(ChildNodeDeleteResponseADM, "node")
     implicit val listDeleteResponseADMFormat: RootJsonFormat[ListDeleteResponseADM] = jsonFormat(ListDeleteResponseADM, "iri", "deleted")
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
@@ -1204,16 +1204,15 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
          * The highest position a node can be placed is to the end of the parents children; that means length of existing
          * children + 1
          *
-         * @param parentNode the parent to which the node should belong.
+         * @param parentNode  the parent to which the node should belong.
          * @param isNewParent identifier that node is added to another parent or not.
-         *
          * @throws BadRequestException if given position is out of range.
          */
         def isNewPositionValid(parentNode: ListNodeADM, isNewParent: Boolean): Unit = {
             val numberOfChildren = parentNode.getChildren.size
             // If the node must be added to a new parent, highest valid position is numberOfChildren+1
             // That means the furthests a node can be positioned is being appended to the end of children of the new parent.
-            if(isNewParent && changeNodePositionRequest.position >  numberOfChildren + 1) {
+            if (isNewParent && changeNodePositionRequest.position > numberOfChildren + 1) {
                 throw BadRequestException(s"Invalid position given, maximum allowed is=${numberOfChildren + 1}.")
             }
 
@@ -1223,6 +1222,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 throw BadRequestException(s"Invalid position given, maximum allowed is=${numberOfChildren}.")
             }
         }
+
         /**
          * Checks that the position of the node is updated and node is sublist of specified parent.
          * It also checks the sibling nodes are shifted accordingly.
@@ -1232,10 +1232,10 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
          */
         def verifyParentChildrenUpdate(): Future[ListNodeADM] = for {
             maybeParentNode <- listNodeGetADM(nodeIri = changeNodePositionRequest.parentIri,
-                                                shallow = false,
-                                                featureFactoryConfig = featureFactoryConfig,
-                                                requestingUser = KnoraSystemInstances.Users.SystemUser
-                                            )
+                shallow = false,
+                featureFactoryConfig = featureFactoryConfig,
+                requestingUser = KnoraSystemInstances.Users.SystemUser
+            )
             updatedParent = maybeParentNode.get
             updatedChildren: Seq[ListChildNodeADM] = updatedParent.getChildren
             (siblingsPositionedBefore: Seq[ListChildNodeADM],
@@ -1243,16 +1243,16 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
 
             // verify that node is among children of specified parent in correct position
             updatedNode = rest.head
-            _ = if (updatedNode.id != nodeIri || updatedNode.position!= changeNodePositionRequest.position) {
+            _ = if (updatedNode.id != nodeIri || updatedNode.position != changeNodePositionRequest.position) {
                 throw UpdateNotPerformedException(s"Node is not repositioned correctly in specified parent node. Please report this as a bug.")
             }
             leftPositions: Seq[Int] = siblingsPositionedBefore.map(child => child.position)
-            _ = if(leftPositions != leftPositions.sorted) {
+            _ = if (leftPositions != leftPositions.sorted) {
                 throw UpdateNotPerformedException(s"Something has gone wrong with shifting nodes. Please report this as a bug.")
             }
             siblingsPositionedAfter = rest.slice(1, rest.length)
             rightSiblings: Seq[Int] = siblingsPositionedAfter.map(child => child.position)
-            _ = if(rightSiblings != rightSiblings.sorted) {
+            _ = if (rightSiblings != rightSiblings.sorted) {
                 throw UpdateNotPerformedException(s"Something has gone wrong with shifting nodes. Please report this as a bug.")
             }
 
@@ -1261,9 +1261,9 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
         /**
          * Changes position of the node within its original parent.
          *
-         * @param node the node whose position should be updated.
-         * @param parentIri the IRI of the parent node.
-         * @param newPosition the new node position.
+         * @param node           the node whose position should be updated.
+         * @param parentIri      the IRI of the parent node.
+         * @param newPosition    the new node position.
          * @param dataNamedGraph the new node position.
          * @throws UpdateNotPerformedException in the case the given new position is the same as current position.
          */
@@ -1290,10 +1290,10 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 featureFactoryConfig = featureFactoryConfig)
 
             // update position of siblings
-            _ <- if(currPosition < newPosition) {
+            _ <- if (currPosition < newPosition) {
                 for {
                     // shift siblings to left
-                    updatedSiblings <- shiftNodes(startPos = currPosition+1,
+                    updatedSiblings <- shiftNodes(startPos = currPosition + 1,
                         endPos = newPosition,
                         nodes = parentNode.getChildren,
                         shiftToLeft = true,
@@ -1305,7 +1305,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 for {
                     // shift siblings to right
                     updatedSiblings <- shiftNodes(startPos = newPosition,
-                        endPos = currPosition-1,
+                        endPos = currPosition - 1,
                         nodes = parentNode.getChildren,
                         shiftToLeft = false,
                         dataNamedGraph = dataNamedGraph,
@@ -1321,18 +1321,18 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
          * Changes position of the node, remove from current parent and add to the sepcified parent.
          * It shifts the new siblings and old siblings.
          *
-         * @param node the node whose position should be updated.
-         * @param newParentIri the IRI of the new parent node.
-         * @param currParentIri the IRI of the current parent node.
-         * @param newPosition the new node position.
+         * @param node           the node whose position should be updated.
+         * @param newParentIri   the IRI of the new parent node.
+         * @param currParentIri  the IRI of the current parent node.
+         * @param newPosition    the new node position.
          * @param dataNamedGraph the new node position.
          * @throws UpdateNotPerformedException in the case the given new position is the same as current position.
          */
         def updateParentAndPosition(node: ListChildNodeADM,
-                                   newParentIri: IRI,
-                                   currParentIri: IRI,
-                                   newPosition: Int,
-                                   dataNamedGraph: IRI): Future[Unit] = for {
+                                    newParentIri: IRI,
+                                    currParentIri: IRI,
+                                    newPosition: Int,
+                                    dataNamedGraph: IRI): Future[Unit] = for {
             // get current parent node with its immediate children
             maybeCurrentParentNode <- listNodeGetADM(nodeIri = currParentIri,
                 shallow = true,
@@ -1360,7 +1360,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 featureFactoryConfig = featureFactoryConfig)
 
             // shift current siblings with a higher position to left as if the node is deleted
-            _ <- shiftNodes(startPos = currentNodePosition+1,
+            _ <- shiftNodes(startPos = currentNodePosition + 1,
                 endPos = currentSiblings.last.position,
                 nodes = currentSiblings,
                 shiftToLeft = true,
@@ -1424,12 +1424,12 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             currentParentNodeIri: IRI <- getParentNodeIRI(nodeIri, featureFactoryConfig)
             _ <- if (currentParentNodeIri == changeNodePositionRequest.parentIri) {
                 updatePositionWithinSameParent(node = node,
-                        parentIri = currentParentNodeIri,
-                        newPosition = changeNodePositionRequest.position,
-                        dataNamedGraph = dataNamedGraph
-                    )
+                    parentIri = currentParentNodeIri,
+                    newPosition = changeNodePositionRequest.position,
+                    dataNamedGraph = dataNamedGraph
+                )
             } else {
-                updateParentAndPosition(node=node,
+                updateParentAndPosition(node = node,
                     newParentIri = changeNodePositionRequest.parentIri,
                     currParentIri = currentParentNodeIri,
                     newPosition = changeNodePositionRequest.position,
@@ -1469,7 +1469,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
         /**
          * Checks if node itself or any of its children is in use.
          *
-         * @param nodeIri    the node's IRI.
+         * @param nodeIri      the node's IRI.
          * @param nodeChildren the children of the node.
          * @throws BadRequestException in case a node or one of its children is in use.
          */
@@ -1550,7 +1550,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             }
 
             // shift the siblings that were positioned after the deleted node, one place to left.
-            updatedChildren <- shiftNodes(startPos = positionOfDeletedNode+1,
+            updatedChildren <- shiftNodes(startPos = positionOfDeletedNode + 1,
                 endPos = remainingChildren.last.position,
                 nodes = remainingChildren,
                 shiftToLeft = true,
@@ -1921,9 +1921,9 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
     /**
      * Helper method to update position of a node without changing its parent.
      *
-     * @param nodeIri     the IRI of the node that must be shifted.
-     * @param newPosition the new position of the child node.
-     * @param dataNamedGraph the data named graph of the project.
+     * @param nodeIri              the IRI of the node that must be shifted.
+     * @param newPosition          the new position of the child node.
+     * @param dataNamedGraph       the data named graph of the project.
      * @param featureFactoryConfig the feature factory configuration.
      * @throws UpdateNotPerformedException if the position of the node could not be updated.
      * @return a [[ListChildNodeADM]].
@@ -1960,11 +1960,11 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
      * Helper method to shift nodes between positions startPos and endPos to the left if 'shiftToLeft' is true,
      * otherwise shift them one position to the right.
      *
-     * @param startPos the position of first node in range that must be shifted.
-     * @param endPos the position of last node in range that must be shifted.
-     * @param nodes the list of all nodes.
-     * @param shiftToLeft shift nodes to left if true, otherwise to right.
-     * @param dataNamedGraph the data named graph of the project.
+     * @param startPos             the position of first node in range that must be shifted.
+     * @param endPos               the position of last node in range that must be shifted.
+     * @param nodes                the list of all nodes.
+     * @param shiftToLeft          shift nodes to left if true, otherwise to right.
+     * @param dataNamedGraph       the data named graph of the project.
      * @param featureFactoryConfig the feature factory configuration.
      * @throws UpdateNotPerformedException if the position of a node could not be updated.
      * @return a sequence of [[ListChildNodeADM]].
@@ -1982,7 +1982,9 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
         updatePositionFutures = nodesTobeUpdated.map {
             child =>
                 val currPos = child.position
-                val newPos = if(shiftToLeft){ currPos-1 } else currPos+1
+                val newPos = if (shiftToLeft) {
+                    currPos - 1
+                } else currPos + 1
 
                 updatePositionOfNode(
                     nodeIri = child.id,
@@ -1997,10 +1999,10 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
     /**
      * Helper method to change parent node of a node.
      *
-     * @param nodeIri the IRI of the node.
-     * @param oldParentIri the IRI of the current parent node.
-     * @param newParentIri the IRI of the new parent node.
-     * @param dataNamedGraph the data named graph of the project.
+     * @param nodeIri              the IRI of the node.
+     * @param oldParentIri         the IRI of the current parent node.
+     * @param newParentIri         the IRI of the new parent node.
+     * @param dataNamedGraph       the data named graph of the project.
      * @param featureFactoryConfig the feature factory configuration.
      * @throws UpdateNotPerformedException if the parent of a node could not be updated.
      */
@@ -2029,7 +2031,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             requestingUser = KnoraSystemInstances.Users.SystemUser
         )
         childrenOfOldParent = maybeOldParent.get.getChildren
-        _ = if(childrenOfOldParent.exists(node => node.id == nodeIri)) {
+        _ = if (childrenOfOldParent.exists(node => node.id == nodeIri)) {
             throw UpdateNotPerformedException(s"Node ${nodeIri} is still a child of ${oldParentIri}. Report this as a bug.")
         }
         // get new parent node with its immediate children
@@ -2039,7 +2041,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             requestingUser = KnoraSystemInstances.Users.SystemUser
         )
         childrenOfNewParent = maybeNewParentNode.get.getChildren
-        _ = if(!childrenOfNewParent.exists(node => node.id == nodeIri)) {
+        _ = if (!childrenOfNewParent.exists(node => node.id == nodeIri)) {
             throw UpdateNotPerformedException(s"Node ${nodeIri} is not added to parent node ${newParentIri}. ")
         }
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
@@ -87,10 +87,11 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
         // log.debug("listsGetRequestV2")
 
         for {
-            sparqlQuery <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getLists(
-                triplestore = settings.triplestoreType,
-                maybeProjectIri = projectIri
-            ).toString()
+            sparqlQuery <- Future(
+                org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getLists(
+                    triplestore = settings.triplestoreType,
+                    maybeProjectIri = projectIri
+                ).toString()
             )
 
             listsResponse <- (storeManager ? SparqlExtendedConstructRequest(
@@ -265,10 +266,11 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                                    featureFactoryConfig: FeatureFactoryConfig,
                                    requestingUser: UserADM): Future[Option[ListNodeInfoADM]] = {
         for {
-            sparqlQuery <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getListNode(
-                triplestore = settings.triplestoreType,
-                nodeIri = nodeIri
-            ).toString()
+            sparqlQuery <- Future(
+                org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getListNode(
+                    triplestore = settings.triplestoreType,
+                    nodeIri = nodeIri
+                ).toString()
             )
 
             // _ = log.debug("listNodeInfoGetADM - sparqlQuery: {}", sparqlQuery)
@@ -396,10 +398,11 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                                requestingUser: UserADM): Future[Option[ListNodeADM]] = {
         for {
             // this query will give us only the information about the root node.
-            sparqlQuery <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getListNode(
-                triplestore = settings.triplestoreType,
-                nodeIri = nodeIri
-            ).toString()
+            sparqlQuery <- Future(
+                org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getListNode(
+                    triplestore = settings.triplestoreType,
+                    nodeIri = nodeIri
+                ).toString()
             )
 
             listInfoResponse <- (storeManager ? SparqlExtendedConstructRequest(
@@ -565,6 +568,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                     startNodeIri = ofNodeIri
                 ).toString()
             }
+
             nodeWithChildrenResponse <- (storeManager ? SparqlExtendedConstructRequest(
                 sparql = nodeChildrenQuery,
                 featureFactoryConfig = featureFactoryConfig,
@@ -1728,7 +1732,9 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
      */
     private def projectByIriExists(projectIri: IRI): Future[Boolean] = {
         for {
-            askString <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkProjectExistsByIri(projectIri).toString)
+            askString <- Future(
+                org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkProjectExistsByIri(projectIri).toString
+            )
             //_ = log.debug("projectByIriExists - query: {}", askString)
 
             askResponse <- (storeManager ? SparqlAskRequest(askString)).mapTo[SparqlAskResponse]
@@ -1745,7 +1751,9 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
      */
     private def rootNodeByIriExists(rootNodeIri: IRI): Future[Boolean] = {
         for {
-            askString <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkListRootNodeExistsByIri(rootNodeIri).toString)
+            askString <- Future(
+                org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkListRootNodeExistsByIri(rootNodeIri).toString
+            )
             // _ = log.debug("rootNodeByIriExists - query: {}", askString)
 
             askResponse <- (storeManager ? SparqlAskRequest(askString)).mapTo[SparqlAskResponse]
@@ -1762,7 +1770,9 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
      */
     private def nodeByIriExists(nodeIri: IRI): Future[Boolean] = {
         for {
-            askString <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkListNodeExistsByIri(nodeIri).toString)
+            askString <- Future(
+                org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkListNodeExistsByIri(nodeIri).toString
+            )
             // _ = log.debug("rootNodeByIriExists - query: {}", askString)
 
             askResponse <- (storeManager ? SparqlAskRequest(askString)).mapTo[SparqlAskResponse]
@@ -1783,7 +1793,12 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
         listNodeName match {
             case Some(name) =>
                 for {
-                    askString <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkListNodeNameIsProjectUnique(projectIri = projectIri, listNodeName = name).toString)
+                    askString <- Future(
+                        org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkListNodeNameIsProjectUnique(
+                            projectIri = projectIri,
+                            listNodeName = name
+                        ).toString
+                    )
                     //_ = log.debug("listNodeNameIsProjectUnique - query: {}", askString)
 
                     askResponse <- (storeManager ? SparqlAskRequest(askString)).mapTo[SparqlAskResponse]
@@ -1891,10 +1906,11 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
      */
     protected def isNodeUsed(nodeIri: IRI,
                              errorFun: => Nothing): Future[Unit] = for {
-        isNodeUsedSparql <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.isNodeUsed(
-            triplestore = settings.triplestoreType,
-            nodeIri = nodeIri
-        ).toString()
+        isNodeUsedSparql <- Future(
+            org.knora.webapi.messages.twirl.queries.sparql.admin.txt.isNodeUsed(
+                triplestore = settings.triplestoreType,
+                nodeIri = nodeIri
+            ).toString()
         )
 
         isNodeUsedResponse: SparqlSelectResult <- (storeManager ? SparqlSelectRequest(isNodeUsedSparql)).mapTo[SparqlSelectResult]
@@ -1939,10 +1955,11 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
      */
     protected def getParentNodeIRI(nodeIri: IRI, featureFactoryConfig: FeatureFactoryConfig): Future[IRI] = for {
         // query statement
-        getParentNodeSparqlString: String <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getParentNode(
-            triplestore = settings.triplestoreType,
-            nodeIri = nodeIri
-        ).toString
+        getParentNodeSparqlString: String <- Future(
+            org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getParentNode(
+                triplestore = settings.triplestoreType,
+                nodeIri = nodeIri
+            ).toString
         )
 
         parentNodeResponse <- (storeManager ? SparqlExtendedConstructRequest(
@@ -1969,12 +1986,13 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
     protected def deleteNode(dataNamedGraph: IRI, nodeIri: IRI, isRootNode: Boolean): Future[Unit] = for {
 
         // Generate SPARQL for erasing a node.
-        sparqlDeleteNode: String <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.deleteNode(
-            triplestore = settings.triplestoreType,
-            dataNamedGraph = dataNamedGraph,
-            nodeIri = nodeIri,
-            isRootNode = isRootNode
-        ).toString()
+        sparqlDeleteNode: String <- Future(
+            org.knora.webapi.messages.twirl.queries.sparql.admin.txt.deleteNode(
+                triplestore = settings.triplestoreType,
+                dataNamedGraph = dataNamedGraph,
+                nodeIri = nodeIri,
+                isRootNode = isRootNode
+            ).toString()
         )
 
         // Do the update.
@@ -2003,12 +2021,13 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                                        dataNamedGraph: IRI,
                                        featureFactoryConfig: FeatureFactoryConfig): Future[ListChildNodeADM] = for {
         // Generate SPARQL for erasing a node.
-        sparqlUpdateNodePosition: String <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.updateNodePosition(
-            triplestore = settings.triplestoreType,
-            dataNamedGraph = dataNamedGraph,
-            nodeIri = nodeIri,
-            newPosition = newPosition
-        ).toString()
+        sparqlUpdateNodePosition: String <- Future(
+            org.knora.webapi.messages.twirl.queries.sparql.admin.txt.updateNodePosition(
+                triplestore = settings.triplestoreType,
+                dataNamedGraph = dataNamedGraph,
+                nodeIri = nodeIri,
+                newPosition = newPosition
+            ).toString()
         )
 
         _ <- (storeManager ? SparqlUpdateRequest(sparqlUpdateNodePosition)).mapTo[SparqlUpdateResponse]
@@ -2086,13 +2105,14 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                                    featureFactoryConfig: FeatureFactoryConfig): Future[Unit] = for {
 
         // Generate SPARQL for changing the parent node of the node.
-        sparqlChangeParentNode: String <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.changeParentNode(
-            triplestore = settings.triplestoreType,
-            dataNamedGraph = dataNamedGraph,
-            nodeIri = nodeIri,
-            currentParentIri = oldParentIri,
-            newParentIri = newParentIri
-        ).toString()
+        sparqlChangeParentNode: String <- Future(
+            org.knora.webapi.messages.twirl.queries.sparql.admin.txt.changeParentNode(
+                triplestore = settings.triplestoreType,
+                dataNamedGraph = dataNamedGraph,
+                nodeIri = nodeIri,
+                currentParentIri = oldParentIri,
+                newParentIri = newParentIri
+            ).toString()
         )
 
         _ <- (storeManager ? SparqlUpdateRequest(sparqlChangeParentNode)).mapTo[SparqlUpdateResponse]

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
@@ -90,7 +90,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             sparqlQuery <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getLists(
                 triplestore = settings.triplestoreType,
                 maybeProjectIri = projectIri
-            ).toString())
+            ).toString()
+            )
 
             listsResponse <- (storeManager ? SparqlExtendedConstructRequest(
                 sparql = sparqlQuery,
@@ -151,7 +152,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                         KnoraSystemInstances.Users.SystemUser
                     )
 
-                    maybeRootNodeInfo <- listNodeInfoGetADM(nodeIri = rootNodeIri,
+                    maybeRootNodeInfo <- listNodeInfoGetADM(
+                        nodeIri = rootNodeIri,
                         featureFactoryConfig = featureFactoryConfig,
                         requestingUser = KnoraSystemInstances.Users.SystemUser
                     )
@@ -266,7 +268,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             sparqlQuery <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getListNode(
                 triplestore = settings.triplestoreType,
                 nodeIri = nodeIri
-            ).toString())
+            ).toString()
+            )
 
             // _ = log.debug("listNodeInfoGetADM - sparqlQuery: {}", sparqlQuery)
 
@@ -396,7 +399,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             sparqlQuery <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getListNode(
                 triplestore = settings.triplestoreType,
                 nodeIri = nodeIri
-            ).toString())
+            ).toString()
+            )
 
             listInfoResponse <- (storeManager ? SparqlExtendedConstructRequest(
                 sparql = sparqlQuery,
@@ -408,10 +412,12 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             maybeListNode: Option[ListNodeADM] <- if (listInfoResponse.statements.nonEmpty) {
                 for {
                     // here we know that the list exists and it is fine if children is an empty list
-                    children: Seq[ListChildNodeADM] <- getChildren(ofNodeIri = nodeIri,
+                    children: Seq[ListChildNodeADM] <- getChildren(
+                        ofNodeIri = nodeIri,
                         shallow = shallow,
                         featureFactoryConfig = featureFactoryConfig,
-                        requestingUser = requestingUser)
+                        requestingUser = requestingUser
+                    )
 
                     // _ = log.debug(s"listGetADM - children count: {}", children.size)
 
@@ -986,12 +992,15 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 throw ForbiddenException(LIST_CHANGE_PERMISSION_ERROR)
             }
 
-            changeNodeNameSparqlString <- getUpdateNodeInfoSparqlStatement(changeNodeInfoRequest =
-                ChangeNodeInfoApiRequestADM(
-                    listIri = nodeIri,
-                    projectIri = projectIri,
-                    name = Some(changeNodeNameRequest.name)),
-                featureFactoryConfig = featureFactoryConfig)
+            changeNodeNameSparqlString <- getUpdateNodeInfoSparqlStatement(
+                changeNodeInfoRequest =
+                    ChangeNodeInfoApiRequestADM(
+                        listIri = nodeIri,
+                        projectIri = projectIri,
+                        name = Some(changeNodeNameRequest.name)
+                    ),
+                featureFactoryConfig = featureFactoryConfig
+            )
 
             changeResourceResponse <- (storeManager ? SparqlUpdateRequest(changeNodeNameSparqlString)).mapTo[SparqlUpdateResponse]
 
@@ -1064,11 +1073,13 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 // not project or a system admin
                 throw ForbiddenException(LIST_CHANGE_PERMISSION_ERROR)
             }
-            changeNodeLabelsSparqlString <- getUpdateNodeInfoSparqlStatement(changeNodeInfoRequest =
-                ChangeNodeInfoApiRequestADM(
-                    listIri = nodeIri,
-                    projectIri = projectIri,
-                    labels = Some(changeNodeLabelsRequest.labels)),
+            changeNodeLabelsSparqlString <- getUpdateNodeInfoSparqlStatement(
+                changeNodeInfoRequest =
+                    ChangeNodeInfoApiRequestADM(
+                        listIri = nodeIri,
+                        projectIri = projectIri,
+                        labels = Some(changeNodeLabelsRequest.labels)
+                    ),
                 featureFactoryConfig = featureFactoryConfig
             )
             changeResourceResponse <- (storeManager ? SparqlUpdateRequest(changeNodeLabelsSparqlString)).mapTo[SparqlUpdateResponse]
@@ -1143,11 +1154,13 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 throw ForbiddenException(LIST_CHANGE_PERMISSION_ERROR)
             }
 
-            changeNodeCommentsSparqlString <- getUpdateNodeInfoSparqlStatement(changeNodeInfoRequest =
-                ChangeNodeInfoApiRequestADM(
-                    listIri = nodeIri,
-                    projectIri = projectIri,
-                    comments = Some(changeNodeCommentsRequest.comments)),
+            changeNodeCommentsSparqlString <- getUpdateNodeInfoSparqlStatement(
+                changeNodeInfoRequest =
+                    ChangeNodeInfoApiRequestADM(
+                        listIri = nodeIri,
+                        projectIri = projectIri,
+                        comments = Some(changeNodeCommentsRequest.comments)
+                    ),
                 featureFactoryConfig = featureFactoryConfig
             )
             _ <- (storeManager ? SparqlUpdateRequest(changeNodeCommentsSparqlString)).mapTo[SparqlUpdateResponse]
@@ -1241,7 +1254,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
          * @throws UpdateNotPerformedException if some thing has gone wrong during the update.
          */
         def verifyParentChildrenUpdate(newPosition: Int): Future[ListNodeADM] = for {
-            maybeParentNode <- listNodeGetADM(nodeIri = changeNodePositionRequest.parentIri,
+            maybeParentNode <- listNodeGetADM(
+                nodeIri = changeNodePositionRequest.parentIri,
                 shallow = false,
                 featureFactoryConfig = featureFactoryConfig,
                 requestingUser = KnoraSystemInstances.Users.SystemUser
@@ -1284,7 +1298,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                                            dataNamedGraph: IRI): Future[Int] = for {
 
             // get parent node with its immediate children
-            maybeParentNode <- listNodeGetADM(nodeIri = parentIri,
+            maybeParentNode <- listNodeGetADM(
+                nodeIri = parentIri,
                 shallow = true,
                 featureFactoryConfig = featureFactoryConfig,
                 requestingUser = KnoraSystemInstances.Users.SystemUser
@@ -1304,13 +1319,15 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 nodeIri = node.id,
                 newPosition = newPosition,
                 dataNamedGraph = dataNamedGraph,
-                featureFactoryConfig = featureFactoryConfig)
+                featureFactoryConfig = featureFactoryConfig
+            )
 
             // update position of siblings
             _ <- if (currPosition < newPosition) {
                 for {
                     // shift siblings to left
-                    updatedSiblings <- shiftNodes(startPos = currPosition + 1,
+                    updatedSiblings <- shiftNodes(
+                        startPos = currPosition + 1,
                         endPos = newPosition,
                         nodes = parentChildren,
                         shiftToLeft = true,
@@ -1321,7 +1338,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             } else if (currPosition > newPosition) {
                 for {
                     // shift siblings to right
-                    updatedSiblings <- shiftNodes(startPos = newPosition,
+                    updatedSiblings <- shiftNodes(
+                        startPos = newPosition,
                         endPos = currPosition - 1,
                         nodes = parentChildren,
                         shiftToLeft = false,
@@ -1352,14 +1370,16 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                                     givenPosition: Int,
                                     dataNamedGraph: IRI): Future[Int] = for {
             // get current parent node with its immediate children
-            maybeCurrentParentNode <- listNodeGetADM(nodeIri = currParentIri,
+            maybeCurrentParentNode <- listNodeGetADM(
+                nodeIri = currParentIri,
                 shallow = true,
                 featureFactoryConfig = featureFactoryConfig,
                 requestingUser = KnoraSystemInstances.Users.SystemUser
             )
             currentSiblings = maybeCurrentParentNode.get.getChildren
             // get new parent node with its immediate children
-            maybeNewParentNode <- listNodeGetADM(nodeIri = newParentIri,
+            maybeNewParentNode <- listNodeGetADM(
+                nodeIri = newParentIri,
                 shallow = true,
                 featureFactoryConfig = featureFactoryConfig,
                 requestingUser = KnoraSystemInstances.Users.SystemUser
@@ -1380,10 +1400,12 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 nodeIri = node.id,
                 newPosition = newPosition,
                 dataNamedGraph = dataNamedGraph,
-                featureFactoryConfig = featureFactoryConfig)
+                featureFactoryConfig = featureFactoryConfig
+            )
 
             // shift current siblings with a higher position to left as if the node is deleted
-            _ <- shiftNodes(startPos = currentNodePosition + 1,
+            _ <- shiftNodes(
+                startPos = currentNodePosition + 1,
                 endPos = currentSiblings.last.position,
                 nodes = currentSiblings,
                 shiftToLeft = true,
@@ -1399,7 +1421,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                 // No. Shift new siblings with the same and higher position
                 // to right, as if the node is inserted in the given position
                 for {
-                    updatedSiblings <- shiftNodes(startPos = newPosition,
+                    updatedSiblings <- shiftNodes(
+                        startPos = newPosition,
                         endPos = newSiblings.last.position,
                         nodes = newSiblings,
                         shiftToLeft = false,
@@ -1410,7 +1433,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             }
 
             /* update the sublists of parent nodes */
-            _ <- changeParentNode(nodeIri = node.id,
+            _ <- changeParentNode(
+                nodeIri = node.id,
                 oldParentIri = currParentIri,
                 newParentIri = newParentIri,
                 dataNamedGraph = dataNamedGraph,
@@ -1440,7 +1464,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             }
 
             // get node in its current position
-            maybeNode <- listNodeGetADM(nodeIri = nodeIri,
+            maybeNode <- listNodeGetADM(
+                nodeIri = nodeIri,
                 shallow = true,
                 featureFactoryConfig = featureFactoryConfig,
                 requestingUser = KnoraSystemInstances.Users.SystemUser
@@ -1454,13 +1479,15 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             // get node's current parent
             currentParentNodeIri: IRI <- getParentNodeIRI(nodeIri, featureFactoryConfig)
             newPosition <- if (currentParentNodeIri == changeNodePositionRequest.parentIri) {
-                updatePositionWithinSameParent(node = node,
+                updatePositionWithinSameParent(
+                    node = node,
                     parentIri = currentParentNodeIri,
                     givenPosition = changeNodePositionRequest.position,
                     dataNamedGraph = dataNamedGraph
                 )
             } else {
-                updateParentAndPosition(node = node,
+                updateParentAndPosition(
+                    node = node,
                     newParentIri = changeNodePositionRequest.parentIri,
                     currParentIri = currentParentNodeIri,
                     givenPosition = changeNodePositionRequest.position,
@@ -1581,7 +1608,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             }
 
             // shift the siblings that were positioned after the deleted node, one place to left.
-            updatedChildren <- shiftNodes(startPos = positionOfDeletedNode + 1,
+            updatedChildren <- shiftNodes(
+                startPos = positionOfDeletedNode + 1,
                 endPos = remainingChildren.last.position,
                 nodes = remainingChildren,
                 shiftToLeft = true,
@@ -1664,11 +1692,13 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
                         )
 
                         // update the parent node
-                        updatedParentNode <- updateParentNode(deletedNodeIri = nodeIri,
+                        updatedParentNode <- updateParentNode(
+                            deletedNodeIri = nodeIri,
                             positionOfDeletedNode = childNode.position,
                             parentNodeIri = parentNodeIri,
                             dataNamedGraph = dataNamedGraph,
-                            featureFactoryConfig = featureFactoryConfig)
+                            featureFactoryConfig = featureFactoryConfig
+                        )
 
                     } yield ChildNodeDeleteResponseADM(node = updatedParentNode)
 
@@ -1836,10 +1866,12 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
 
             case Some(childNode: ListChildNodeADM) =>
                 for {
-                    maybeRoot <- listNodeGetADM(nodeIri = childNode.hasRootNode,
+                    maybeRoot <- listNodeGetADM(
+                        nodeIri = childNode.hasRootNode,
                         shallow = true,
                         featureFactoryConfig = featureFactoryConfig,
-                        requestingUser = KnoraSystemInstances.Users.SystemUser)
+                        requestingUser = KnoraSystemInstances.Users.SystemUser
+                    )
                     rootProjectIri = maybeRoot match {
                         case Some(rootNode: ListRootNodeADM) => rootNode.projectIri
                         case _ => throw BadRequestException(s"Root node of $nodeIri was not found. Please verify the given IRI.")
@@ -1862,7 +1894,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
         isNodeUsedSparql <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.isNodeUsed(
             triplestore = settings.triplestoreType,
             nodeIri = nodeIri
-        ).toString())
+        ).toString()
+        )
 
         isNodeUsedResponse: SparqlSelectResult <- (storeManager ? SparqlSelectRequest(isNodeUsedSparql)).mapTo[SparqlSelectResult]
 
@@ -1880,10 +1913,13 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
      */
     protected def getDataNamedGraph(projectIri: IRI, featureFactoryConfig: FeatureFactoryConfig): Future[IRI] = for {
         /* Get the project information */
-        maybeProject <- (responderManager ? ProjectGetADM(ProjectIdentifierADM(
-            maybeIri = Some(projectIri)),
+        maybeProject <- (responderManager ? ProjectGetADM(
+            ProjectIdentifierADM(
+                maybeIri = Some(projectIri)
+            ),
             featureFactoryConfig = featureFactoryConfig,
-            KnoraSystemInstances.Users.SystemUser)).mapTo[Option[ProjectADM]]
+            KnoraSystemInstances.Users.SystemUser
+        )).mapTo[Option[ProjectADM]]
 
         project: ProjectADM = maybeProject match {
             case Some(project: ProjectADM) => project
@@ -1906,7 +1942,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
         getParentNodeSparqlString: String <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getParentNode(
             triplestore = settings.triplestoreType,
             nodeIri = nodeIri
-        ).toString)
+        ).toString
+        )
 
         parentNodeResponse <- (storeManager ? SparqlExtendedConstructRequest(
             sparql = getParentNodeSparqlString,
@@ -1914,7 +1951,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
         )).mapTo[SparqlExtendedConstructResponse]
 
         parentStatements = parentNodeResponse.statements.headOption.getOrElse(
-            throw BadRequestException(s"The parent node for $nodeIri not found, report this as a bug."))
+            throw BadRequestException(s"The parent node for $nodeIri not found, report this as a bug.")
+        )
 
         parentNodeIri = parentStatements._1.toString
     } yield parentNodeIri
@@ -1936,7 +1974,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             dataNamedGraph = dataNamedGraph,
             nodeIri = nodeIri,
             isRootNode = isRootNode
-        ).toString())
+        ).toString()
+        )
 
         // Do the update.
         _ <- (storeManager ? SparqlUpdateRequest(sparqlDeleteNode)).mapTo[SparqlUpdateResponse]
@@ -1969,15 +2008,18 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             dataNamedGraph = dataNamedGraph,
             nodeIri = nodeIri,
             newPosition = newPosition
-        ).toString())
+        ).toString()
+        )
 
         _ <- (storeManager ? SparqlUpdateRequest(sparqlUpdateNodePosition)).mapTo[SparqlUpdateResponse]
 
         /* Verify that the node info was updated */
-        maybeNode <- listNodeGetADM(nodeIri = nodeIri,
+        maybeNode <- listNodeGetADM(
+            nodeIri = nodeIri,
             shallow = false,
             featureFactoryConfig = featureFactoryConfig,
-            requestingUser = KnoraSystemInstances.Users.SystemUser)
+            requestingUser = KnoraSystemInstances.Users.SystemUser
+        )
 
         childNode: ListChildNodeADM = maybeNode.getOrElse(throw BadRequestException(s"Node with $nodeIri could not be found to update its position.")).asInstanceOf[ListChildNodeADM]
 
@@ -2050,13 +2092,15 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             nodeIri = nodeIri,
             currentParentIri = oldParentIri,
             newParentIri = newParentIri
-        ).toString())
+        ).toString()
+        )
 
         _ <- (storeManager ? SparqlUpdateRequest(sparqlChangeParentNode)).mapTo[SparqlUpdateResponse]
 
         /* verify that parents were updated */
         // get old parent node with its immediate children
-        maybeOldParent <- listNodeGetADM(nodeIri = oldParentIri,
+        maybeOldParent <- listNodeGetADM(
+            nodeIri = oldParentIri,
             shallow = true,
             featureFactoryConfig = featureFactoryConfig,
             requestingUser = KnoraSystemInstances.Users.SystemUser
@@ -2066,7 +2110,8 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             throw UpdateNotPerformedException(s"Node ${nodeIri} is still a child of ${oldParentIri}. Report this as a bug.")
         }
         // get new parent node with its immediate children
-        maybeNewParentNode <- listNodeGetADM(nodeIri = newParentIri,
+        maybeNewParentNode <- listNodeGetADM(
+            nodeIri = newParentIri,
             shallow = true,
             featureFactoryConfig = featureFactoryConfig,
             requestingUser = KnoraSystemInstances.Users.SystemUser

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/NewListsRouteADMFeature.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/NewListsRouteADMFeature.scala
@@ -182,7 +182,7 @@ class NewListsRouteADMFeature(routeData: KnoraRouteData) extends KnoraRoute(rout
      * update list
      */
     @Path("/{IRI}")
-    @ApiOperation(value = "Update basic node information", nickname = "newPutListItem", httpMethod = "PUT", response = classOf[RootNodeInfoGetResponseADM])
+    @ApiOperation(value = "Update basic node information", nickname = "newPutListItem", httpMethod = "PUT", response = classOf[NodeInfoGetResponseADM])
     @ApiImplicitParams(Array(
         new ApiImplicitParam(name = "body", value = "\"list\" item to update", required = true,
             dataTypeClass = classOf[ChangeNodeInfoApiRequestADM], paramType = "body"),

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/changeParentNode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/changeParentNode.scala.txt
@@ -1,0 +1,69 @@
+@*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
+
+@**
+ * Changes the parent node of an existing node.
+ *
+ * @param triplestore        the name of the triplestore being used. The template uses this value to exclude inferred
+                             results from the WHERE clause of the update.
+ * @param dataNamedGraph     the named graph to update.
+ * @param nodeIri            the IRI of the list we want to update.
+ * @param currentParentIri   the IRI of the current parent node.
+ * @param newParentIri       the IRI of the new parent node.
+ *@
+@(triplestore: String,
+  dataNamedGraph: IRI,
+  nodeIri: IRI,
+  currentParentIri: IRI,
+  newParentIri: IRI
+  )
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+WITH <@dataNamedGraph>
+DELETE {
+
+    ?currentParentNode knora-base:hasSubListNode ?node .
+
+} INSERT {
+    ?newParentNode knora-base:hasSubListNode ?node .
+}
+
+@* Ensure that inference is not used in the WHERE clause of this update. *@
+@if(triplestore.startsWith("graphdb")) {
+    USING <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@dataNamedGraph") AS ?dataNamedGraph)
+    BIND(IRI("@nodeIri") AS ?node)
+    BIND(IRI("@currentParentIri") AS ?currentParentNode)
+    BIND(IRI("@newParentIri") AS ?newParentNode)
+
+    ?node rdf:type knora-base:ListNode .
+
+    ?currentParentNode rdf:type knora-base:ListNode .
+    ?currentParentNode knora-base:hasSubListNode ?node .
+    ?newParentNode rdf:type knora-base:ListNode .
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/DeleteListItemsRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/DeleteListItemsRouteADME2ESpec.scala
@@ -109,7 +109,7 @@ class DeleteListItemsRouteADME2ESpec extends E2ESpec(DeleteListItemsRouteADME2ES
                 lastChild.position should be (1)
                 // first child must have its child
                 val firstChild = children.head
-                firstChild.children.size should be (1)
+                firstChild.children.size should be (5)
 
                 clientTestDataCollector.addFile(
                     TestDataFileContent(

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/DeleteListItemsRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/DeleteListItemsRouteADME2ESpec.scala
@@ -45,8 +45,8 @@ object DeleteListItemsRouteADME2ESpec {
 }
 
 /**
-  * End-to-End (E2E) test specification for testing  endpoint.
-  */
+ * End-to-End (E2E) test specification for testing  endpoint.
+ */
 class DeleteListItemsRouteADME2ESpec extends E2ESpec(DeleteListItemsRouteADME2ESpec.config) with SessionJsonProtocol with TriplestoreJsonProtocol with ListADMJsonProtocol {
 
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(5.seconds)
@@ -102,14 +102,14 @@ class DeleteListItemsRouteADME2ESpec extends E2ESpec(DeleteListItemsRouteADME2ES
                 response.status should be(StatusCodes.OK)
                 val node = AkkaHttpUtils.httpResponseToJson(response).fields("node").convertTo[ListNodeADM]
                 val children = node.getChildren
-                children.size should be (2)
+                children.size should be(2)
                 // last child must be shifted one place to left
                 val lastChild = children.last
-                lastChild.id should be ("http://rdfh.ch/lists/0001/notUsedList03")
-                lastChild.position should be (1)
+                lastChild.id should be("http://rdfh.ch/lists/0001/notUsedList03")
+                lastChild.position should be(1)
                 // first child must have its child
                 val firstChild = children.head
-                firstChild.children.size should be (5)
+                firstChild.children.size should be(5)
 
                 clientTestDataCollector.addFile(
                     TestDataFileContent(
@@ -129,7 +129,7 @@ class DeleteListItemsRouteADME2ESpec extends E2ESpec(DeleteListItemsRouteADME2ES
                 val response: HttpResponse = singleAwaitingRequest(request)
                 response.status should be(StatusCodes.OK)
                 val deletedStatus = AkkaHttpUtils.httpResponseToJson(response).fields("deleted")
-                deletedStatus.convertTo[Boolean] should be (true)
+                deletedStatus.convertTo[Boolean] should be(true)
 
                 clientTestDataCollector.addFile(
                     TestDataFileContent(

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/UpdateListItemsRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/UpdateListItemsRouteADME2ESpec.scala
@@ -395,6 +395,49 @@ class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ES
                 )
             }
 
+            "reposition child node to the end of its parent's children" in {
+                val parentIri = "http://rdfh.ch/lists/0001/notUsedList01"
+                val newPosition = -1
+                val nodeIri = "http://rdfh.ch/lists/0001/notUsedList012"
+                val updateNodeName =
+                    s"""{
+                       |    "parentNodeIri": "$parentIri",
+                       |    "position": $newPosition
+                       |}""".stripMargin
+
+                clientTestDataCollector.addFile(
+                    TestDataFileContent(
+                        filePath = TestDataFilePath(
+                            directoryPath = clientTestDataPath,
+                            filename = "update-childNode-position-to-end-request",
+                            fileExtension = "json"
+                        ),
+                        text = updateNodeName
+                    )
+                )
+
+                val encodedListUrl = java.net.URLEncoder.encode(nodeIri, "utf-8")
+
+                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/position", HttpEntity(ContentTypes.`application/json`, updateNodeName)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
+                val response: HttpResponse = singleAwaitingRequest(request)
+
+                response.status should be(StatusCodes.OK)
+
+                val receivedNode: ListNodeADM = AkkaHttpUtils.httpResponseToJson(response).fields("node").convertTo[ListNodeADM]
+                receivedNode.getNodeId should be(parentIri)
+
+                clientTestDataCollector.addFile(
+                    TestDataFileContent(
+                        filePath = TestDataFilePath(
+                            directoryPath = clientTestDataPath,
+                            filename = "update-childNode-position-to-end-response",
+                            fileExtension = "json"
+                        ),
+                        text = responseToString(response)
+                    )
+                )
+            }
+
             "update parent and position of the child node" in {
                 val parentIri = "http://rdfh.ch/lists/0001/notUsedList"
                 val newPosition = 2
@@ -431,6 +474,49 @@ class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ES
                         filePath = TestDataFilePath(
                             directoryPath = clientTestDataPath,
                             filename = "update-childNode-position-new-parent-response",
+                            fileExtension = "json"
+                        ),
+                        text = responseToString(response)
+                    )
+                )
+            }
+
+            "reposition child node to end of another parent's children" in {
+                val parentIri = "http://rdfh.ch/lists/0001/notUsedList"
+                val newPosition = -1
+                val nodeIri = "http://rdfh.ch/lists/0001/notUsedList015"
+                val updateNodeName =
+                    s"""{
+                       |    "parentNodeIri": "$parentIri",
+                       |    "position": $newPosition
+                       |}""".stripMargin
+
+                clientTestDataCollector.addFile(
+                    TestDataFileContent(
+                        filePath = TestDataFilePath(
+                            directoryPath = clientTestDataPath,
+                            filename = "update-childNode-position-new-parent-to-end-request",
+                            fileExtension = "json"
+                        ),
+                        text = updateNodeName
+                    )
+                )
+
+                val encodedListUrl = java.net.URLEncoder.encode(nodeIri, "utf-8")
+
+                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/position", HttpEntity(ContentTypes.`application/json`, updateNodeName)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
+                val response: HttpResponse = singleAwaitingRequest(request)
+
+                response.status should be(StatusCodes.OK)
+
+                val receivedNode: ListNodeADM = AkkaHttpUtils.httpResponseToJson(response).fields("node").convertTo[ListNodeADM]
+                receivedNode.getNodeId should be(parentIri)
+
+                clientTestDataCollector.addFile(
+                    TestDataFileContent(
+                        filePath = TestDataFilePath(
+                            directoryPath = clientTestDataPath,
+                            filename = "update-childNode-position-new-parent-to-end-response",
                             fileExtension = "json"
                         ),
                         text = responseToString(response)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/UpdateListItemsRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/UpdateListItemsRouteADME2ESpec.scala
@@ -44,8 +44,8 @@ object UpdateListItemsRouteADME2ESpec {
 }
 
 /**
-  * End-to-End (E2E) test specification for testing update node props routes.
-  */
+ * End-to-End (E2E) test specification for testing update node props routes.
+ */
 class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ESpec.config) with SessionJsonProtocol with TriplestoreJsonProtocol with ListADMJsonProtocol {
 
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(5.seconds)
@@ -230,13 +230,13 @@ class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ES
 
                 val encodedListUrl = java.net.URLEncoder.encode(treeChildNode.id, "utf-8")
 
-                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/name", HttpEntity(ContentTypes.`application/json`, updateNodeName))~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
+                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/name", HttpEntity(ContentTypes.`application/json`, updateNodeName)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
                 val response: HttpResponse = singleAwaitingRequest(request)
 
                 response.status should be(StatusCodes.OK)
 
                 val receivedNodeInfo: ListChildNodeInfoADM = AkkaHttpUtils.httpResponseToJson(response).fields("nodeinfo").convertTo[ListChildNodeInfoADM]
-                receivedNodeInfo.name.get should be (newName)
+                receivedNodeInfo.name.get should be(newName)
 
                 clientTestDataCollector.addFile(
                     TestDataFileContent(
@@ -269,15 +269,15 @@ class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ES
 
                 val encodedListUrl = java.net.URLEncoder.encode(treeChildNode.id, "utf-8")
 
-                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/labels", HttpEntity(ContentTypes.`application/json`, updateNodeLabels))~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
+                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/labels", HttpEntity(ContentTypes.`application/json`, updateNodeLabels)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
                 val response: HttpResponse = singleAwaitingRequest(request)
 
                 response.status should be(StatusCodes.OK)
 
                 val receivedNodeInfo: ListChildNodeInfoADM = AkkaHttpUtils.httpResponseToJson(response).fields("nodeinfo").convertTo[ListChildNodeInfoADM]
                 val labels: Seq[StringLiteralV2] = receivedNodeInfo.labels.stringLiterals
-                labels.size should be (1)
-                labels should contain (StringLiteralV2(value = "nya märkningen för nod", language = Some("se")))
+                labels.size should be(1)
+                labels should contain(StringLiteralV2(value = "nya märkningen för nod", language = Some("se")))
 
 
                 clientTestDataCollector.addFile(
@@ -311,15 +311,15 @@ class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ES
 
                 val encodedListUrl = java.net.URLEncoder.encode(treeChildNode.id, "utf-8")
 
-                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/comments", HttpEntity(ContentTypes.`application/json`, updateNodeComments))~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
+                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/comments", HttpEntity(ContentTypes.`application/json`, updateNodeComments)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
                 val response: HttpResponse = singleAwaitingRequest(request)
 
                 response.status should be(StatusCodes.OK)
 
                 val receivedNodeInfo: ListChildNodeInfoADM = AkkaHttpUtils.httpResponseToJson(response).fields("nodeinfo").convertTo[ListChildNodeInfoADM]
                 val comments: Seq[StringLiteralV2] = receivedNodeInfo.comments.stringLiterals
-                comments.size should be (1)
-                comments should contain (StringLiteralV2(value = "nya kommentarer för nod", language = Some("se")))
+                comments.size should be(1)
+                comments should contain(StringLiteralV2(value = "nya kommentarer för nod", language = Some("se")))
 
 
                 clientTestDataCollector.addFile(
@@ -335,21 +335,21 @@ class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ES
             }
 
             "not update the position of a node if given IRI is invalid" in {
-                    val parentIri = "http://rdfh.ch/lists/0001/notUsedList01"
-                    val newPosition = 1
-                    val nodeIri = "invalid-iri"
-                    val updateNodeName =
-                        s"""{
-                           |    "parentNodeIri": "$parentIri",
-                           |    "position": $newPosition
-                           |}""".stripMargin
+                val parentIri = "http://rdfh.ch/lists/0001/notUsedList01"
+                val newPosition = 1
+                val nodeIri = "invalid-iri"
+                val updateNodeName =
+                    s"""{
+                       |    "parentNodeIri": "$parentIri",
+                       |    "position": $newPosition
+                       |}""".stripMargin
 
-                    val encodedListUrl = java.net.URLEncoder.encode(nodeIri, "utf-8")
+                val encodedListUrl = java.net.URLEncoder.encode(nodeIri, "utf-8")
 
-                    val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/position", HttpEntity(ContentTypes.`application/json`, updateNodeName))~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
-                    val response: HttpResponse = singleAwaitingRequest(request)
+                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/position", HttpEntity(ContentTypes.`application/json`, updateNodeName)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
+                val response: HttpResponse = singleAwaitingRequest(request)
 
-                    response.status should be (StatusCodes.BadRequest)
+                response.status should be(StatusCodes.BadRequest)
             }
 
             "update only the position of the child node within same parent" in {
@@ -375,7 +375,7 @@ class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ES
 
                 val encodedListUrl = java.net.URLEncoder.encode(nodeIri, "utf-8")
 
-                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/position", HttpEntity(ContentTypes.`application/json`, updateNodeName))~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
+                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/position", HttpEntity(ContentTypes.`application/json`, updateNodeName)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
                 val response: HttpResponse = singleAwaitingRequest(request)
 
                 response.status should be(StatusCodes.OK)
@@ -418,7 +418,7 @@ class UpdateListItemsRouteADME2ESpec extends E2ESpec(UpdateListItemsRouteADME2ES
 
                 val encodedListUrl = java.net.URLEncoder.encode(nodeIri, "utf-8")
 
-                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/position", HttpEntity(ContentTypes.`application/json`, updateNodeName))~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
+                val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/position", HttpEntity(ContentTypes.`application/json`, updateNodeName)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
                 val response: HttpResponse = singleAwaitingRequest(request)
 
                 response.status should be(StatusCodes.OK)

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
@@ -483,5 +483,36 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
 
         }
 
+        "throw 'BadRequestException' for `ChangeNodePositionApiRequestADM` when no parent node iri is given" in {
+
+            val payload =
+                s"""
+                   |{
+                   |    "parentNodeIri": "",
+                   |    "position": 1
+                   |}
+                """.stripMargin
+
+            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodePositionApiRequestADM]
+
+            thrown.getMessage should equal ("IRI of parent node is missing.")
+
+        }
+
+        "throw 'BadRequestException' for `ChangeNodePositionApiRequestADM` when parent node IRI is invalid" in {
+            val invalid_parentIri = "invalid-iri"
+            val payload =
+                s"""
+                   |{
+                   |    "parentNodeIri": "${invalid_parentIri}",
+                   |    "position": 1
+                   |}
+                """.stripMargin
+
+            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodePositionApiRequestADM]
+
+            thrown.getMessage should equal (s"Invalid IRI is given: $invalid_parentIri.")
+
+        }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
@@ -37,9 +37,10 @@ object ListsMessagesADMSpec {
           akka.stdout-loglevel = "DEBUG"
         """.stripMargin)
 }
+
 /**
-  * This spec is used to test 'ListAdminMessages'.
-  */
+ * This spec is used to test 'ListAdminMessages'.
+ */
 class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with ListADMJsonProtocol {
 
     val exampleListIri = "http://rdfh.ch/lists/00FF/abcd"
@@ -48,7 +49,7 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
 
         "work for a 'ListRootNodeInfoADM'" in {
 
-            val listInfo = ListRootNodeInfoADM (
+            val listInfo = ListRootNodeInfoADM(
                 id = "http://rdfh.ch/lists/73d0ec0302",
                 projectIri = "http://rdfh.ch/projects/00FF",
                 labels = StringLiteralSequenceV2(Vector(StringLiteralV2("Title", Some("en")), StringLiteralV2("Titel", Some("de")), StringLiteralV2("Titre", Some("fr")))),
@@ -66,7 +67,7 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
 
         "work for a 'ListChildNodeInfoADM'" in {
 
-            val listNodeInfo = ListChildNodeInfoADM (
+            val listNodeInfo = ListChildNodeInfoADM(
                 id = "http://rdfh.ch/lists/00FF/526f26ed04",
                 name = Some("sommer"),
                 labels = StringLiteralSequenceV2(Vector(StringLiteralV2("Sommer"))),
@@ -162,9 +163,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
 
-            thrown.getMessage should equal (PROJECT_IRI_MISSING_ERROR)
+            thrown.getMessage should equal(PROJECT_IRI_MISSING_ERROR)
 
         }
 
@@ -181,7 +182,7 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
 
             val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
 
-            thrown.getMessage should equal (PROJECT_IRI_INVALID_ERROR)
+            thrown.getMessage should equal(PROJECT_IRI_INVALID_ERROR)
         }
 
         "throw 'BadRequestException' for `CreateListApiRequestADM` when labels is empty" in {
@@ -197,7 +198,7 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
 
             val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
 
-            thrown.getMessage should equal (LABEL_MISSING_ERROR)
+            thrown.getMessage should equal(LABEL_MISSING_ERROR)
         }
 
         "throw a 'BadRequestException' for `CreateListApiRequestADM` when an invalid list IRI is given" in {
@@ -215,7 +216,7 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
 
             val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
 
-            thrown.getMessage should equal ("Invalid list IRI")
+            thrown.getMessage should equal("Invalid list IRI")
         }
 
         "throw 'BadRequestException' for `CreateListApiRequestADM` when value of a label is missing" in {
@@ -229,9 +230,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
 
-            thrown.getMessage should equal ("String value is missing.")
+            thrown.getMessage should equal("String value is missing.")
         }
 
         "throw 'BadRequestException' for `CreateListApiRequestADM` when value of a comment is missing" in {
@@ -246,9 +247,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateListApiRequestADM]
 
-            thrown.getMessage should equal ("String value is missing.")
+            thrown.getMessage should equal("String value is missing.")
         }
 
         "throw 'BadRequestException' for `ChangeNodeInfoApiRequestADM` when list IRI is empty" in {
@@ -263,9 +264,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
 
-            thrown.getMessage should equal ("IRI of list item is missing.")
+            thrown.getMessage should equal("IRI of list item is missing.")
         }
 
         "throw 'BadRequestException' for `ChangeNodeInfoApiRequestADM` when list IRI is invalid" in {
@@ -273,16 +274,16 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
             val payload =
                 s"""
                    |{
-                   |    "listIri": "${invalidIri}",
+                   |    "listIri": "$invalidIri",
                    |    "projectIri": "${SharedTestDataADM.IMAGES_PROJECT_IRI}",
                    |    "labels": [{ "value": "Neue geönderte Liste", "language": "de"}, { "value": "Changed list", "language": "en"}],
                    |    "comments": [{ "value": "Neuer Kommentar", "language": "de"}, { "value": "New comment", "language": "en"}]
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
 
-            thrown.getMessage should equal (s"Invalid IRI is given: ${invalidIri}.")
+            thrown.getMessage should equal(s"Invalid IRI is given: $invalidIri.")
         }
 
         "throw 'BadRequestException' for `ChangeNodeInfoApiRequestADM` when project IRI is empty" in {
@@ -296,9 +297,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
 
-            thrown.getMessage should equal (PROJECT_IRI_MISSING_ERROR)
+            thrown.getMessage should equal(PROJECT_IRI_MISSING_ERROR)
         }
 
         "throw 'BadRequestException' for `ChangeNodeInfoApiRequestADM` when project IRI is invalid" in {
@@ -312,9 +313,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
 
-            thrown.getMessage should equal (PROJECT_IRI_INVALID_ERROR)
+            thrown.getMessage should equal(PROJECT_IRI_INVALID_ERROR)
         }
 
         "throw 'BadRequestException' for `ChangeNodeInfoApiRequestADM` when labels and comments are empty" in {
@@ -329,9 +330,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
 
-            thrown.getMessage should equal (UPDATE_REQUEST_EMPTY_LABEL_OR_COMMENT_ERROR)
+            thrown.getMessage should equal(UPDATE_REQUEST_EMPTY_LABEL_OR_COMMENT_ERROR)
         }
 
         "throw 'ForbiddenException' if user requesting `createChildNodeRequest` is not system or project admin" in {
@@ -366,7 +367,7 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                             StringLiteralV2(value = "Neuer Kommentar", language = Some("de")),
                             StringLiteralV2(value = "New comment", language = Some("en"))
                         )
-                    )),
+                        )),
                     featureFactoryConfig = defaultFeatureFactoryConfig,
                     requestingUser = SharedTestDataADM.imagesUser02,
                     apiRequestID = UUID.randomUUID
@@ -387,9 +388,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
 
-            thrown.getMessage should equal (LIST_NODE_IRI_INVALID_ERROR)
+            thrown.getMessage should equal(LIST_NODE_IRI_INVALID_ERROR)
 
         }
 
@@ -405,9 +406,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
 
-            thrown.getMessage should equal (LIST_NODE_IRI_INVALID_ERROR)
+            thrown.getMessage should equal(LIST_NODE_IRI_INVALID_ERROR)
 
         }
 
@@ -423,9 +424,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
 
-            thrown.getMessage should equal (PROJECT_IRI_MISSING_ERROR)
+            thrown.getMessage should equal(PROJECT_IRI_MISSING_ERROR)
 
         }
 
@@ -441,9 +442,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
 
-            thrown.getMessage should equal (PROJECT_IRI_INVALID_ERROR)
+            thrown.getMessage should equal(PROJECT_IRI_INVALID_ERROR)
 
         }
 
@@ -459,9 +460,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
 
-            thrown.getMessage should equal (LABEL_MISSING_ERROR)
+            thrown.getMessage should equal(LABEL_MISSING_ERROR)
 
         }
 
@@ -477,9 +478,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[CreateNodeApiRequestADM]
 
-            thrown.getMessage should equal ("Invalid list node IRI")
+            thrown.getMessage should equal("Invalid list node IRI")
 
         }
 
@@ -493,9 +494,9 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodePositionApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodePositionApiRequestADM]
 
-            thrown.getMessage should equal ("IRI of parent node is missing.")
+            thrown.getMessage should equal("IRI of parent node is missing.")
 
         }
 
@@ -504,14 +505,14 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
             val payload =
                 s"""
                    |{
-                   |    "parentNodeIri": "${invalid_parentIri}",
+                   |    "parentNodeIri": "$invalid_parentIri",
                    |    "position": 1
                    |}
                 """.stripMargin
 
-            val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodePositionApiRequestADM]
+            val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodePositionApiRequestADM]
 
-            thrown.getMessage should equal (s"Invalid IRI is given: $invalid_parentIri.")
+            thrown.getMessage should equal(s"Invalid IRI is given: $invalid_parentIri.")
 
         }
     }

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/ListsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/ListsResponderADMSpec.scala
@@ -308,93 +308,93 @@ class ListsResponderADMSpec extends CoreSpec(ListsResponderADMSpec.config) with 
 
             "add second child to list - to the root node" in {
                 responderManager ! ListChildNodeCreateRequestADM(
-                       createChildNodeRequest = CreateNodeApiRequestADM(
-                           parentNodeIri = Some(newListIri.get),
-                           projectIri = IMAGES_PROJECT_IRI,
-                           name = Some("second"),
-                           labels = Seq(StringLiteralV2(value = "New Second Child List Node Value", language = Some("en"))),
-                           comments = Seq(StringLiteralV2(value = "New Second Child List Node Comment", language = Some("en")))
-                       ),
-                        featureFactoryConfig = defaultFeatureFactoryConfig,
-                        requestingUser = SharedTestDataADM.imagesUser01,
-                        apiRequestID = UUID.randomUUID
-               )
+                    createChildNodeRequest = CreateNodeApiRequestADM(
+                        parentNodeIri = Some(newListIri.get),
+                        projectIri = IMAGES_PROJECT_IRI,
+                        name = Some("second"),
+                        labels = Seq(StringLiteralV2(value = "New Second Child List Node Value", language = Some("en"))),
+                        comments = Seq(StringLiteralV2(value = "New Second Child List Node Comment", language = Some("en")))
+                    ),
+                    featureFactoryConfig = defaultFeatureFactoryConfig,
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID
+                )
 
-               val received: ChildNodeInfoGetResponseADM = expectMsgType[ChildNodeInfoGetResponseADM](timeout)
-               val nodeInfo = received.nodeinfo
+                val received: ChildNodeInfoGetResponseADM = expectMsgType[ChildNodeInfoGetResponseADM](timeout)
+                val nodeInfo = received.nodeinfo
 
-               // check correct node info
-               val childNodeInfo = nodeInfo match {
-                   case info: ListChildNodeInfoADM => info
-                   case something => fail(s"expecting ListChildNodeInfoADM but got ${something.getClass.toString} instead.")
-               }
+                // check correct node info
+                val childNodeInfo = nodeInfo match {
+                    case info: ListChildNodeInfoADM => info
+                    case something => fail(s"expecting ListChildNodeInfoADM but got ${something.getClass.toString} instead.")
+                }
 
-               // check labels
-               val labels: Seq[StringLiteralV2] = childNodeInfo.labels.stringLiterals
-               labels.size should be(1)
-               labels.sorted should be(Seq(StringLiteralV2(value = "New Second Child List Node Value", language = Some("en"))))
-
-
-               // check comments
-               val comments = childNodeInfo.comments.stringLiterals
-               comments.size should be(1)
-               comments.sorted should be(Seq(StringLiteralV2(value = "New Second Child List Node Comment", language = Some("en"))))
-
-               // check position
-               val position = childNodeInfo.position
-               position should be(1)
-
-               // check has root node
-               val rootNode = childNodeInfo.hasRootNode
-               rootNode should be(newListIri.get)
-
-               secondChildIri.set(childNodeInfo.id)
-           }
-
-           "add child to second child node" in {
-               responderManager ! ListChildNodeCreateRequestADM(
-                   createChildNodeRequest = CreateNodeApiRequestADM(
-                       parentNodeIri = Some(secondChildIri.get),
-                       projectIri = IMAGES_PROJECT_IRI,
-                       name = Some("third"),
-                       labels = Seq(StringLiteralV2(value = "New Third Child List Node Value", language = Some("en"))),
-                       comments = Seq(StringLiteralV2(value = "New Third Child List Node Comment", language = Some("en")))
-                   ),
-                   featureFactoryConfig = defaultFeatureFactoryConfig,
-                   requestingUser = SharedTestDataADM.imagesUser01,
-                   apiRequestID = UUID.randomUUID
-               )
-
-               val received: ChildNodeInfoGetResponseADM = expectMsgType[ChildNodeInfoGetResponseADM](timeout)
-               val nodeInfo = received.nodeinfo
-
-               // check correct node info
-               val childNodeInfo = nodeInfo match {
-                   case info: ListChildNodeInfoADM => info
-                   case something => fail(s"expecting ListChildNodeInfoADM but got ${something.getClass.toString} instead.")
-               }
-
-               // check labels
-               val labels: Seq[StringLiteralV2] = childNodeInfo.labels.stringLiterals
-               labels.size should be(1)
-               labels.sorted should be(Seq(StringLiteralV2(value = "New Third Child List Node Value", language = Some("en"))))
+                // check labels
+                val labels: Seq[StringLiteralV2] = childNodeInfo.labels.stringLiterals
+                labels.size should be(1)
+                labels.sorted should be(Seq(StringLiteralV2(value = "New Second Child List Node Value", language = Some("en"))))
 
 
-               // check comments
-               val comments = childNodeInfo.comments.stringLiterals
-               comments.size should be(1)
-               comments.sorted should be(Seq(StringLiteralV2(value = "New Third Child List Node Comment", language = Some("en"))))
+                // check comments
+                val comments = childNodeInfo.comments.stringLiterals
+                comments.size should be(1)
+                comments.sorted should be(Seq(StringLiteralV2(value = "New Second Child List Node Comment", language = Some("en"))))
 
-               // check position
-               val position = childNodeInfo.position
-               position should be(0)
+                // check position
+                val position = childNodeInfo.position
+                position should be(1)
 
-               // check has root node
-               val rootNode = childNodeInfo.hasRootNode
-               rootNode should be(newListIri.get)
+                // check has root node
+                val rootNode = childNodeInfo.hasRootNode
+                rootNode should be(newListIri.get)
 
-               thirdChildIri.set(childNodeInfo.id)
-           }
+                secondChildIri.set(childNodeInfo.id)
+            }
+
+            "add child to second child node" in {
+                responderManager ! ListChildNodeCreateRequestADM(
+                    createChildNodeRequest = CreateNodeApiRequestADM(
+                        parentNodeIri = Some(secondChildIri.get),
+                        projectIri = IMAGES_PROJECT_IRI,
+                        name = Some("third"),
+                        labels = Seq(StringLiteralV2(value = "New Third Child List Node Value", language = Some("en"))),
+                        comments = Seq(StringLiteralV2(value = "New Third Child List Node Comment", language = Some("en")))
+                    ),
+                    featureFactoryConfig = defaultFeatureFactoryConfig,
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID
+                )
+
+                val received: ChildNodeInfoGetResponseADM = expectMsgType[ChildNodeInfoGetResponseADM](timeout)
+                val nodeInfo = received.nodeinfo
+
+                // check correct node info
+                val childNodeInfo = nodeInfo match {
+                    case info: ListChildNodeInfoADM => info
+                    case something => fail(s"expecting ListChildNodeInfoADM but got ${something.getClass.toString} instead.")
+                }
+
+                // check labels
+                val labels: Seq[StringLiteralV2] = childNodeInfo.labels.stringLiterals
+                labels.size should be(1)
+                labels.sorted should be(Seq(StringLiteralV2(value = "New Third Child List Node Value", language = Some("en"))))
+
+
+                // check comments
+                val comments = childNodeInfo.comments.stringLiterals
+                comments.size should be(1)
+                comments.sorted should be(Seq(StringLiteralV2(value = "New Third Child List Node Comment", language = Some("en"))))
+
+                // check position
+                val position = childNodeInfo.position
+                position should be(0)
+
+                // check has root node
+                val rootNode = childNodeInfo.hasRootNode
+                rootNode should be(newListIri.get)
+
+                thirdChildIri.set(childNodeInfo.id)
+            }
         }
 
         "used to reposition nodes" should {
@@ -529,7 +529,7 @@ class ListsResponderADMSpec extends CoreSpec(ListsResponderADMSpec.config) with 
                 val childrenOfNewParent = parentNode.getChildren
 
                 // node must be in children of new parent
-                childrenOfNewParent.size should be (4)
+                childrenOfNewParent.size should be(4)
                 val isNodeAdd = childrenOfNewParent.exists(child => child.id == nodeIri && child.position == 2)
                 isNodeAdd should be(true)
 
@@ -546,7 +546,7 @@ class ListsResponderADMSpec extends CoreSpec(ListsResponderADMSpec.config) with 
                 val receivedNode: ListNodeGetResponseADM = expectMsgType[ListNodeGetResponseADM](timeout)
                 // node must not be in children of old parent
                 val oldParentChildren = receivedNode.node.children
-                oldParentChildren.size should be (4)
+                oldParentChildren.size should be(4)
                 val isNodeUpdated = oldParentChildren.exists(child => child.id == nodeIri)
                 isNodeUpdated should be(false)
 
@@ -575,7 +575,7 @@ class ListsResponderADMSpec extends CoreSpec(ListsResponderADMSpec.config) with 
 
                 /* check children of new parent node */
                 val childrenOfNewParent = parentNode.getChildren
-                childrenOfNewParent.size should be (5)
+                childrenOfNewParent.size should be(5)
                 val isNodeUpdated = childrenOfNewParent.exists(child => child.id == nodeIri && child.position == 2)
                 isNodeUpdated should be(true)
 
@@ -671,15 +671,15 @@ class ListsResponderADMSpec extends CoreSpec(ListsResponderADMSpec.config) with 
                 val received: ChildNodeDeleteResponseADM = expectMsgType[ChildNodeDeleteResponseADM](timeout)
                 val parentNode = received.node
                 val remainingChildren = parentNode.getChildren
-                remainingChildren.size should be (2)
+                remainingChildren.size should be(2)
                 //last child should be shifted to left
-                remainingChildren.last.position should be (1)
+                remainingChildren.last.position should be(1)
 
                 // first node should still have its child
                 val firstChild = remainingChildren.head
-                firstChild.id should be ("http://rdfh.ch/lists/0001/notUsedList01")
-                firstChild.position should be (0)
-                firstChild.children.size should be (5)
+                firstChild.id should be("http://rdfh.ch/lists/0001/notUsedList01")
+                firstChild.position should be(0)
+                firstChild.children.size should be(5)
             }
 
             "delete a child node that is not in use" in {
@@ -693,10 +693,10 @@ class ListsResponderADMSpec extends CoreSpec(ListsResponderADMSpec.config) with 
                 val received: ChildNodeDeleteResponseADM = expectMsgType[ChildNodeDeleteResponseADM](timeout)
                 val parentNode = received.node
                 val remainingChildren = parentNode.getChildren
-                remainingChildren.size should be (1)
+                remainingChildren.size should be(1)
                 val firstChild = remainingChildren.head
-                firstChild.id should be ("http://rdfh.ch/lists/0001/notUsedList03")
-                firstChild.position should be (0)
+                firstChild.id should be("http://rdfh.ch/lists/0001/notUsedList03")
+                firstChild.position should be(0)
             }
 
             "delete a list (i.e. root node) that is not in use in ontology" in {
@@ -708,8 +708,8 @@ class ListsResponderADMSpec extends CoreSpec(ListsResponderADMSpec.config) with 
                     apiRequestID = UUID.randomUUID
                 )
                 val received: ListDeleteResponseADM = expectMsgType[ListDeleteResponseADM](timeout)
-                received.iri should be (listIri)
-                received.deleted should be (true)
+                received.iri should be(listIri)
+                received.deleted should be(true)
             }
         }
 

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/ListsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/ListsResponderADMSpec.scala
@@ -413,6 +413,36 @@ class ListsResponderADMSpec extends CoreSpec(ListsResponderADMSpec.config) with 
                 expectMsg(Failure(UpdateNotPerformedException(s"The given position is the same as node's current position.")))
             }
 
+            "not reposition a node if new position is out of range" in {
+                val nodeIri = "http://rdfh.ch/lists/0001/notUsedList014"
+                responderManager ! NodePositionChangeRequestADM(
+                    nodeIri = nodeIri,
+                    changeNodePositionRequest = ChangeNodePositionApiRequestADM(
+                        position = 30,
+                        parentIri = "http://rdfh.ch/lists/0001/notUsedList01"
+                    ),
+                    featureFactoryConfig = defaultFeatureFactoryConfig,
+                    requestingUser = SharedTestDataADM.anythingAdminUser,
+                    apiRequestID = UUID.randomUUID
+                )
+                expectMsg(Failure(BadRequestException(s"Invalid position given, maximum allowed is=5!")))
+            }
+
+            "not reposition a node to another parent node if new position is out of range" in {
+                val nodeIri = "http://rdfh.ch/lists/0001/notUsedList014"
+                responderManager ! NodePositionChangeRequestADM(
+                    nodeIri = nodeIri,
+                    changeNodePositionRequest = ChangeNodePositionApiRequestADM(
+                        position = 30,
+                        parentIri = "http://rdfh.ch/lists/0001/notUsedList"
+                    ),
+                    featureFactoryConfig = defaultFeatureFactoryConfig,
+                    requestingUser = SharedTestDataADM.anythingAdminUser,
+                    apiRequestID = UUID.randomUUID
+                )
+                expectMsg(Failure(BadRequestException(s"Invalid position given, maximum allowed is=4!")))
+            }
+
             "reposition node List014 from position 3 to 1 (shift to right)" in {
                 val nodeIri = "http://rdfh.ch/lists/0001/notUsedList014"
                 val parentIri = "http://rdfh.ch/lists/0001/notUsedList01"


### PR DESCRIPTION
resolves DSP-1033
new route for this: PUT `admin/lists/<nodeIri>/position`. Requires `parentIri` and the new `position` in the request body.
- [x] reposition a child node within the same parent, shift siblings accordingly.
- [x] change parent of a child node, and position it in a specific position among new siblings. Shift the new siblings accordingly.
- [x] if position=-1, move the node to the end of children of  the given parent node.
- [x] add tests 
- [x] add test data
- [x] add documentation