### PR TITLE
chore(rdf-api): Use the Jena RDF API implementation by default (DSP-1153)

### DIFF
--- a/docs/05-internals/design/principles/rdf-api.md
+++ b/docs/05-internals/design/principles/rdf-api.md
@@ -86,6 +86,10 @@ In tests, it can be useful to run SPARQL queries to check the content of
 an `RdfModel`. To do this, use the `RdfModel.asRepository` method, which
 returns an `RdfRepository` that can run `SELECT` queries.
 
+The configuration of the default graph depends on which underlying
+RDF library is used. If you are querying data in named graphs, use `FROM`
+or quad patterns rather than the default graph.
+
 
 ## SHACL validation
 

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -285,7 +285,7 @@ app {
 
             available-versions = [ 1 ]
             default-version = 1
-            enabled-by-default = no
+            enabled-by-default = yes
             override-allowed = yes
 
             developer-emails = [

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaModel.scala
@@ -458,7 +458,18 @@ class JenaRepository(private val dataset: jena.query.Dataset) extends RdfReposit
       val varNames: Iterator[String] = querySolution.varNames.asScala
 
       val rowMap: Map[String, String] = varNames.map { varName =>
-        varName -> querySolution.get(varName).asNode.toString
+        val varValue: jena.graph.Node = querySolution.get(varName).asNode
+
+        // Is the value a literal?
+        val varValueStr: String = if (varValue.isLiteral) {
+          // Yes. Get its lexical form, i.e. don't include its datatype in its string representation.
+          varValue.getLiteralLexicalForm
+        } else {
+          // No, it's an IRI or blank node ID, so its string representation is OK.
+          varValue.toString
+        }
+
+        varName -> varValueStr
       }.toMap
 
       rowBuffer.append(VariableResultsRow(new ErrorHandlingMap[String, String](rowMap, { key: String =>

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfModelSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfModelSpec.scala
@@ -315,14 +315,13 @@ abstract class RdfModelSpec(featureToggle: FeatureToggle) extends CoreSpec {
       val rdfRepository: RdfRepository = anythingModel.asRepository
 
       val selectQuery =
-        """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                  |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
-                  |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                  |
-                  |SELECT ?resource ?value ?decimalValue WHERE {
-                  |    ?resource anything:hasDecimal ?value .
-                  |    ?value knora-base:valueHasDecimal ?decimalValue .
-                  |} ORDER BY ?resource""".stripMargin
+        """PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
+          |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+          |
+          |SELECT ?resource ?value ?decimalValue WHERE {
+          |    ?resource anything:hasDecimal ?value .
+          |    ?value knora-base:valueHasDecimal ?decimalValue .
+          |} ORDER BY ?resource""".stripMargin
 
       val queryResult: SparqlSelectResult = rdfRepository.doSelect(selectQuery)
 

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfModelSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfModelSpec.scala
@@ -317,25 +317,29 @@ abstract class RdfModelSpec(featureToggle: FeatureToggle) extends CoreSpec {
       val selectQuery =
         """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                   |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
+                  |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                   |
-                  |SELECT ?resource ?value WHERE {
+                  |SELECT ?resource ?value ?decimalValue WHERE {
                   |    ?resource anything:hasDecimal ?value .
+                  |    ?value knora-base:valueHasDecimal ?decimalValue .
                   |} ORDER BY ?resource""".stripMargin
 
       val queryResult: SparqlSelectResult = rdfRepository.doSelect(selectQuery)
 
-      assert(queryResult.head.vars == Seq("resource", "value"))
+      assert(queryResult.head.vars == Seq("resource", "value", "decimalValue"))
 
       val results: Seq[Map[String, String]] = queryResult.results.bindings.map(_.rowMap)
 
       val expectedResults = Seq(
         Map(
           "resource" -> "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw",
-          "value" -> "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/bXMwnrHvQH2DMjOFrGmNzg"
+          "value" -> "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/bXMwnrHvQH2DMjOFrGmNzg",
+          "decimalValue" -> "1.5"
         ),
         Map(
           "resource" -> "http://rdfh.ch/0001/uqmMo72OQ2K2xe7mkIytlg",
-          "value" -> "http://rdfh.ch/0001/uqmMo72OQ2K2xe7mkIytlg/values/85et-o-STOmn2JcVqrGTCQ"
+          "value" -> "http://rdfh.ch/0001/uqmMo72OQ2K2xe7mkIytlg/values/85et-o-STOmn2JcVqrGTCQ",
+          "decimalValue" -> "2.1"
         )
       )
 

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1307Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1307Spec.scala
@@ -40,7 +40,9 @@ class UpgradePluginPR1307Spec extends UpgradePluginSpec {
         """
                   |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                   |
-                  |SELECT ?s ?maxStartIndex WHERE {
+                  |SELECT ?s ?maxStartIndex
+                  |FROM <http://www.knora.org/data/0001/anything>
+                  |WHERE {
                   |    ?s knora-base:valueHasMaxStandoffStartIndex ?maxStartIndex .
                   |}
                   |""".stripMargin
@@ -64,7 +66,9 @@ class UpgradePluginPR1307Spec extends UpgradePluginSpec {
         """
                   |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                   |
-                  |SELECT ?tag WHERE {
+                  |SELECT ?tag
+                  |FROM <http://www.knora.org/data/0001/anything>
+                  |WHERE {
                   |    <http://rdfh.ch/0001/qN1igiDRSAemBBktbRHn6g/values/xyUIf8QHS5aFrlt7Q4F1FQ> knora-base:valueHasStandoff ?tag .
                   |} ORDER BY ?tag
                   |""".stripMargin
@@ -92,7 +96,9 @@ class UpgradePluginPR1307Spec extends UpgradePluginSpec {
         """
                   |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                   |
-                  |SELECT ?tag ?startIndex ?startParent WHERE {
+                  |SELECT ?tag ?startIndex ?startParent
+                  |FROM <http://www.knora.org/data/0001/anything>
+                  |WHERE {
                   |    ?tag knora-base:standoffTagHasStartIndex ?startIndex .
                   |
                   |    OPTIONAL {

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1307Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1307Spec.scala
@@ -37,15 +37,14 @@ class UpgradePluginPR1307Spec extends UpgradePluginSpec {
       // Check that knora-base:valueHasMaxStandoffStartIndex was added.
 
       val query1: String =
-        """
-                  |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                  |
-                  |SELECT ?s ?maxStartIndex
-                  |FROM <http://www.knora.org/data/0001/anything>
-                  |WHERE {
-                  |    ?s knora-base:valueHasMaxStandoffStartIndex ?maxStartIndex .
-                  |}
-                  |""".stripMargin
+        """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+          |
+          |SELECT ?s ?maxStartIndex
+          |FROM <http://www.knora.org/data/0001/anything>
+          |WHERE {
+          |    ?s knora-base:valueHasMaxStandoffStartIndex ?maxStartIndex .
+          |}
+          |""".stripMargin
 
       val queryResult1: SparqlSelectResult = repository.doSelect(selectQuery = query1)
 
@@ -63,15 +62,14 @@ class UpgradePluginPR1307Spec extends UpgradePluginSpec {
       // Check that the standoff tags' IRIs were changed correctly.
 
       val query2: String =
-        """
-                  |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                  |
-                  |SELECT ?tag
-                  |FROM <http://www.knora.org/data/0001/anything>
-                  |WHERE {
-                  |    <http://rdfh.ch/0001/qN1igiDRSAemBBktbRHn6g/values/xyUIf8QHS5aFrlt7Q4F1FQ> knora-base:valueHasStandoff ?tag .
-                  |} ORDER BY ?tag
-                  |""".stripMargin
+        """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+          |
+          |SELECT ?tag
+          |FROM <http://www.knora.org/data/0001/anything>
+          |WHERE {
+          |    <http://rdfh.ch/0001/qN1igiDRSAemBBktbRHn6g/values/xyUIf8QHS5aFrlt7Q4F1FQ> knora-base:valueHasStandoff ?tag .
+          |} ORDER BY ?tag
+          |""".stripMargin
 
       val queryResult2: SparqlSelectResult = repository.doSelect(selectQuery = query2)
 
@@ -93,19 +91,18 @@ class UpgradePluginPR1307Spec extends UpgradePluginSpec {
       // Check that the objects of knora-base:standoffTagHasStartParent were changed correctly.
 
       val query3: String =
-        """
-                  |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                  |
-                  |SELECT ?tag ?startIndex ?startParent
-                  |FROM <http://www.knora.org/data/0001/anything>
-                  |WHERE {
-                  |    ?tag knora-base:standoffTagHasStartIndex ?startIndex .
-                  |
-                  |    OPTIONAL {
-                  |        ?tag knora-base:standoffTagHasStartParent ?startParent .
-                  |    }
-                  |} ORDER BY ?tag
-                  |""".stripMargin
+        """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+          |
+          |SELECT ?tag ?startIndex ?startParent
+          |FROM <http://www.knora.org/data/0001/anything>
+          |WHERE {
+          |    ?tag knora-base:standoffTagHasStartIndex ?startIndex .
+          |
+          |    OPTIONAL {
+          |        ?tag knora-base:standoffTagHasStartParent ?startParent .
+          |    }
+          |} ORDER BY ?tag
+          |""".stripMargin
 
       val queryResult3: SparqlSelectResult = repository.doSelect(selectQuery = query3)
 

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1372Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1372Spec.scala
@@ -37,14 +37,15 @@ class UpgradePluginPR1372Spec extends UpgradePluginSpec {
       // Check that permissions were removed.
 
       val query: String =
-        """
-                  |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                  |
-                  |SELECT ?value WHERE {
-                  |    ?value knora-base:valueCreationDate ?creationDate ;
-                  |    knora-base:hasPermissions ?permissions .
-                  |} ORDER BY ?value
-                  |""".stripMargin
+        """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+          |
+          |SELECT ?value
+          |FROM <http://www.knora.org/data/0001/anything>
+          |WHERE {
+          |    ?value knora-base:valueCreationDate ?creationDate ;
+          |    knora-base:hasPermissions ?permissions .
+          |} ORDER BY ?value
+          |""".stripMargin
 
       val queryResult1: SparqlSelectResult = repository.doSelect(selectQuery = query)
 

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1615Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1615Spec.scala
@@ -37,10 +37,12 @@ class UpgradePluginPR1615Spec extends UpgradePluginSpec {
       // Check that <http://rdfh.ch/0000/forbiddenResource> was removed.
 
       val query1: String =
-        """SELECT ?p ?o WHERE {
-                  |    <http://rdfh.ch/0000/forbiddenResource> ?p ?o .
-                  |}
-                  |""".stripMargin
+        """SELECT ?p ?o
+          |FROM <http://www.knora.org/data/0000/SystemProject>
+          |WHERE {
+          |    <http://rdfh.ch/0000/forbiddenResource> ?p ?o .
+          |}
+          |""".stripMargin
 
       val queryResult1: SparqlSelectResult = repository.doSelect(selectQuery = query1)
       assert(queryResult1.results.bindings.isEmpty)
@@ -48,10 +50,12 @@ class UpgradePluginPR1615Spec extends UpgradePluginSpec {
       // Check that other data is still there.
 
       val query2: String =
-        """SELECT ?p ?o WHERE {
-                  |    <http://rdfh.ch/lists/FFFF/ynm01> ?p ?o .
-                  |}
-                  |""".stripMargin
+        """SELECT ?p ?o
+          |FROM <http://www.knora.org/data/0000/SystemProject>
+          |WHERE {
+          |    <http://rdfh.ch/lists/FFFF/ynm01> ?p ?o .
+          |}
+          |""".stripMargin
 
       val queryResult2: SparqlSelectResult = repository.doSelect(selectQuery = query2)
       assert(queryResult2.results.bindings.nonEmpty)

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginSpec.scala
@@ -29,7 +29,7 @@ import org.knora.webapi.messages.util.rdf._
   * Provides helper methods for specs that test upgrade plugins.
   */
 abstract class UpgradePluginSpec extends CoreSpec() {
-  private val rdfFormatUtil: RdfFormatUtil = RdfFeatureFactory.getRdfFormatUtil(defaultFeatureFactoryConfig)
+  protected val rdfFormatUtil: RdfFormatUtil = RdfFeatureFactory.getRdfFormatUtil(defaultFeatureFactoryConfig)
 
   /**
     * Parses a TriG file and returns it as an [[RdfModel]].


### PR DESCRIPTION
resolves DSP-1153

- [x] Set feature toggle `jena-rdf-library` to be on by default.
- [x] Fix SPARQL in tests to use named graphs correctly with Jena.
  - [x] Document why.
- [x] Fix the string representation of datatype values in SPARQL query results from an in-memory repository.
  - [x] Check that in a test.