### PR TITLE
refactor: bring back stack-down-delete-volumes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,4 @@
 ===REMOVE===
 Important! Please follow the new guidelines for naming Pull Requests: https://docs.dasch.swiss/developers/dsp/contribution/#pull-request-guidelines
 ===REMOVE===
-
 resolves DSP-

--- a/Makefile
+++ b/Makefile
@@ -275,27 +275,27 @@ test: docker-build ## runs all test targets.
 #################################
 
 .PHONY: init-db-test
-init-db-test: stack-db-remove stack-db-only ## initializes the knora-test repository
+init-db-test: stack-down-delete-volumes stack-db-only ## initializes the knora-test repository
 	@echo $@
 	@$(MAKE) -C webapi/scripts fuseki-init-knora-test
 
 .PHONY: init-db-test-minimal
-init-db-test-minimal: stack-db-remove stack-db-only ## initializes the knora-test repository with minimal data
+init-db-test-minimal: stack-down-delete-volumes stack-db-only ## initializes the knora-test repository with minimal data
 	@echo $@
 	@$(MAKE) -C webapi/scripts fuseki-init-knora-test-minimal
 
 .PHONY: init-db-test-empty
-init-db-test-empty: stack-db-remove stack-db-only ## initializes the knora-test repository with minimal data
+init-db-test-empty: stack-down-delete-volumes stack-db-only ## initializes the knora-test repository with minimal data
 	@echo $@
 	@$(MAKE) -C webapi/scripts fuseki-init-knora-test-empty
 
 .PHONY: init-db-test-unit
-init-db-test-unit: stack-db-remove stack-db-only ## initializes the knora-test-unit repository
+init-db-test-unit: stack-down-delete-volumes stack-db-only ## initializes the knora-test-unit repository
 	@echo $@
 	@$(MAKE) -C webapi/scripts fuseki-init-knora-test-unit
 
 .PHONY: init-db-test-unit-minimal
-init-db-test-unit-minimal: stack-db-remove stack-db-only ## initializes the knora-test-unit repository with minimal data
+init-db-test-unit-minimal: stack-down-delete-volumes stack-db-only ## initializes the knora-test-unit repository with minimal data
 	@echo $@
 	@$(MAKE) -C webapi/scripts fuseki-init-knora-test-unit-minimal
 

--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,8 @@ stack-status:
 stack-down: ## stops the knora-stack.
 	docker-compose -f docker-compose.yml down
 
-.PHONY: stack-db-remove
-stack-db-remove: ## stops the knora-stack and deletes any created volumes (deletes the database!).
+.PHONY: stack-down-delete-volumes
+stack-down-delete-volumes: ## stops the knora-stack and deletes any created volumes (deletes the database!).
 	docker-compose -f docker-compose.yml down --volumes
 
 .PHONY: stack-config

--- a/docs/01-introduction/data-formats.md
+++ b/docs/01-introduction/data-formats.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/01-introduction/example-project.md
+++ b/docs/01-introduction/example-project.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/01-introduction/index.md
+++ b/docs/01-introduction/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/01-introduction/standoff-rdf.md
+++ b/docs/01-introduction/standoff-rdf.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/01-introduction/what-is-knora.md
+++ b/docs/01-introduction/what-is-knora.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/02-knora-ontologies/index.md
+++ b/docs/02-knora-ontologies/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/02-knora-ontologies/introduction.md
+++ b/docs/02-knora-ontologies/introduction.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/02-knora-ontologies/knora-base.md
+++ b/docs/02-knora-ontologies/knora-base.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/02-knora-ontologies/salsah-gui.md
+++ b/docs/02-knora-ontologies/salsah-gui.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/groups.md
+++ b/docs/03-apis/api-admin/groups.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/index.md
+++ b/docs/03-apis/api-admin/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/introduction.md
+++ b/docs/03-apis/api-admin/introduction.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/lists.md
+++ b/docs/03-apis/api-admin/lists.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/lists_new-list-admin-routes_v1.md
+++ b/docs/03-apis/api-admin/lists_new-list-admin-routes_v1.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/overview.md
+++ b/docs/03-apis/api-admin/overview.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/permissions.md
+++ b/docs/03-apis/api-admin/permissions.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/projects.md
+++ b/docs/03-apis/api-admin/projects.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/stores.md
+++ b/docs/03-apis/api-admin/stores.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-admin/users.md
+++ b/docs/03-apis/api-admin/users.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-util/health.md
+++ b/docs/03-apis/api-util/health.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-util/index.md
+++ b/docs/03-apis/api-util/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-util/version.md
+++ b/docs/03-apis/api-util/version.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/adding-resources.md
+++ b/docs/03-apis/api-v1/adding-resources.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/adding-values.md
+++ b/docs/03-apis/api-v1/adding-values.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/authentication.md
+++ b/docs/03-apis/api-v1/authentication.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/changing-values.md
+++ b/docs/03-apis/api-v1/changing-values.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/delete-resources-and-values.md
+++ b/docs/03-apis/api-v1/delete-resources-and-values.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/index.md
+++ b/docs/03-apis/api-v1/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/introduction.md
+++ b/docs/03-apis/api-v1/introduction.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/reading-and-searching-resources.md
+++ b/docs/03-apis/api-v1/reading-and-searching-resources.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/reading-values.md
+++ b/docs/03-apis/api-v1/reading-values.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v1/xml-to-standoff-mapping.md
+++ b/docs/03-apis/api-v1/xml-to-standoff-mapping.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/authentication.md
+++ b/docs/03-apis/api-v2/authentication.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/editing-resources.md
+++ b/docs/03-apis/api-v2/editing-resources.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/editing-values.md
+++ b/docs/03-apis/api-v2/editing-values.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/getting-lists.md
+++ b/docs/03-apis/api-v2/getting-lists.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/index.md
+++ b/docs/03-apis/api-v2/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/introduction.md
+++ b/docs/03-apis/api-v2/introduction.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/knora-iris.md
+++ b/docs/03-apis/api-v2/knora-iris.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/metadata.md
+++ b/docs/03-apis/api-v2/metadata.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/ontology-information.md
+++ b/docs/03-apis/api-v2/ontology-information.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/permalinks.md
+++ b/docs/03-apis/api-v2/permalinks.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/query-language.md
+++ b/docs/03-apis/api-v2/query-language.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/reading-and-searching-resources.md
+++ b/docs/03-apis/api-v2/reading-and-searching-resources.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/reading-user-permissions.md
+++ b/docs/03-apis/api-v2/reading-user-permissions.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/tei-xml.md
+++ b/docs/03-apis/api-v2/tei-xml.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/api-v2/xml-to-standoff-mapping.md
+++ b/docs/03-apis/api-v2/xml-to-standoff-mapping.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/feature-toggles.md
+++ b/docs/03-apis/feature-toggles.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/03-apis/index.md
+++ b/docs/03-apis/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/04-publishing-deployment/configuration.md
+++ b/docs/04-publishing-deployment/configuration.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/04-publishing-deployment/getting-started.md
+++ b/docs/04-publishing-deployment/getting-started.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/04-publishing-deployment/index.md
+++ b/docs/04-publishing-deployment/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/04-publishing-deployment/publishing.md
+++ b/docs/04-publishing-deployment/publishing.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/04-publishing-deployment/updates.md
+++ b/docs/04-publishing-deployment/updates.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-admin/administration.md
+++ b/docs/05-internals/design/api-admin/administration.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-admin/index.md
+++ b/docs/05-internals/design/api-admin/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v1/how-to-add-a-route.md
+++ b/docs/05-internals/design/api-v1/how-to-add-a-route.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v1/index.md
+++ b/docs/05-internals/design/api-v1/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v1/json.md
+++ b/docs/05-internals/design/api-v1/json.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/ark.md
+++ b/docs/05-internals/design/api-v2/ark.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/content-wrappers.md
+++ b/docs/05-internals/design/api-v2/content-wrappers.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/gravsearch.md
+++ b/docs/05-internals/design/api-v2/gravsearch.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/how-to-add-a-route.md
+++ b/docs/05-internals/design/api-v2/how-to-add-a-route.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/index.md
+++ b/docs/05-internals/design/api-v2/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/json-ld.md
+++ b/docs/05-internals/design/api-v2/json-ld.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/ontology-management.md
+++ b/docs/05-internals/design/api-v2/ontology-management.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/ontology-schemas.md
+++ b/docs/05-internals/design/api-v2/ontology-schemas.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/overview.md
+++ b/docs/05-internals/design/api-v2/overview.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/query-design.md
+++ b/docs/05-internals/design/api-v2/query-design.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/sipi.md
+++ b/docs/05-internals/design/api-v2/sipi.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/smart-iris.md
+++ b/docs/05-internals/design/api-v2/smart-iris.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/api-v2/standoff.md
+++ b/docs/05-internals/design/api-v2/standoff.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/authentication.md
+++ b/docs/05-internals/design/principles/authentication.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/consistency-checking.md
+++ b/docs/05-internals/design/principles/consistency-checking.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/design-overview.md
+++ b/docs/05-internals/design/principles/design-overview.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/feature-toggles.md
+++ b/docs/05-internals/design/principles/feature-toggles.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/futures-with-akka.md
+++ b/docs/05-internals/design/principles/futures-with-akka.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/http-module.md
+++ b/docs/05-internals/design/principles/http-module.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/index.md
+++ b/docs/05-internals/design/principles/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/rdf-api.md
+++ b/docs/05-internals/design/principles/rdf-api.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/store-module.md
+++ b/docs/05-internals/design/principles/store-module.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/design/principles/triplestore-updates.md
+++ b/docs/05-internals/design/principles/triplestore-updates.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/building-and-running.md
+++ b/docs/05-internals/development/building-and-running.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/docker-cheat-sheet.md
+++ b/docs/05-internals/development/docker-cheat-sheet.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/docker-compose.md
+++ b/docs/05-internals/development/docker-compose.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/generating-client-test-data.md
+++ b/docs/05-internals/development/generating-client-test-data.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/graphdb.md
+++ b/docs/05-internals/development/graphdb.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/index.md
+++ b/docs/05-internals/development/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/intellij-config.md
+++ b/docs/05-internals/development/intellij-config.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/monitoring.md
+++ b/docs/05-internals/development/monitoring.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/overview.md
+++ b/docs/05-internals/development/overview.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/profiling.md
+++ b/docs/05-internals/development/profiling.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/testing.md
+++ b/docs/05-internals/development/testing.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/05-internals/development/updating-repositories.md
+++ b/docs/05-internals/development/updating-repositories.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/06-salsah/index.md
+++ b/docs/06-salsah/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/07-sipi/index.md
+++ b/docs/07-sipi/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/07-sipi/setup-sipi-for-knora.md
+++ b/docs/07-sipi/setup-sipi-for-knora.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/07-sipi/sipi-and-knora.md
+++ b/docs/07-sipi/sipi-and-knora.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/08-lucene/index.md
+++ b/docs/08-lucene/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2015-2019 the contributors (see Contributors.md).
+Copyright © 2015-2021 the contributors (see Contributors.md).
 
 This file is part of Knora.
 

--- a/docs/src/api-admin/index.html
+++ b/docs/src/api-admin/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright © 2015-2019 the contributors (see Contributors.md).
+  ~ Copyright © 2015-2021 the contributors (see Contributors.md).
   ~
   ~ This file is part of Knora.
   ~

--- a/docs/src/api-v1/addValueFormats.ts
+++ b/docs/src/api-v1/addValueFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/basicMessageComponents.ts
+++ b/docs/src/api-v1/basicMessageComponents.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/changeValueFormats.ts
+++ b/docs/src/api-v1/changeValueFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/createResourceFormats.ts
+++ b/docs/src/api-v1/createResourceFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/deleteResponseFormats.ts
+++ b/docs/src/api-v1/deleteResponseFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/graphDataResponseFormats.ts
+++ b/docs/src/api-v1/graphDataResponseFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/groupFormats.ts
+++ b/docs/src/api-v1/groupFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/hierarchicalListResponseFormats.ts
+++ b/docs/src/api-v1/hierarchicalListResponseFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/mappingFormats.ts
+++ b/docs/src/api-v1/mappingFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/permissionFormats.ts
+++ b/docs/src/api-v1/permissionFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/projectFormats.ts
+++ b/docs/src/api-v1/projectFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/resourceResponseFormats.ts
+++ b/docs/src/api-v1/resourceResponseFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleAddValues.ts
+++ b/docs/src/api-v1/sampleRequests/sampleAddValues.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleChangeValues.ts
+++ b/docs/src/api-v1/sampleRequests/sampleChangeValues.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleCreateResources.ts
+++ b/docs/src/api-v1/sampleRequests/sampleCreateResources.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleDeleteResponses.ts
+++ b/docs/src/api-v1/sampleRequests/sampleDeleteResponses.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleGraphDataResponse.ts
+++ b/docs/src/api-v1/sampleRequests/sampleGraphDataResponse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleHierarchicalList.ts
+++ b/docs/src/api-v1/sampleRequests/sampleHierarchicalList.ts
@@ -1,6 +1,6 @@
 
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleLoginResponse.ts
+++ b/docs/src/api-v1/sampleRequests/sampleLoginResponse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleResourceResponses.ts
+++ b/docs/src/api-v1/sampleRequests/sampleResourceResponses.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sampleRequests/sampleValueResponse.ts
+++ b/docs/src/api-v1/sampleRequests/sampleValueResponse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/searchResponseFormats.ts
+++ b/docs/src/api-v1/searchResponseFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/sessionResponseFormats.ts
+++ b/docs/src/api-v1/sessionResponseFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/userFormats.ts
+++ b/docs/src/api-v1/userFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/docs/src/api-v1/valueResponseFormats.ts
+++ b/docs/src/api-v1/valueResponseFormats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/knora-ontologies/knora-admin.ttl
+++ b/knora-ontologies/knora-admin.ttl
@@ -1,4 +1,4 @@
-# Copyright © 2015-2019 the contributors (see Contributors.md).
+# Copyright © 2015-2021 the contributors (see Contributors.md).
 #
 # This file is part of Knora.
 #

--- a/knora-ontologies/knora-base.ttl
+++ b/knora-ontologies/knora-base.ttl
@@ -1,4 +1,4 @@
-# Copyright © 2015-2019 the contributors (see Contributors.md).
+# Copyright © 2015-2021 the contributors (see Contributors.md).
 #
 # This file is part of Knora.
 #

--- a/knora-ontologies/salsah-gui.ttl
+++ b/knora-ontologies/salsah-gui.ttl
@@ -1,4 +1,4 @@
-# Copyright © 2015-2019 the contributors (see Contributors.md).
+# Copyright © 2015-2021 the contributors (see Contributors.md).
 #
 # This file is part of Knora.
 #

--- a/knora-ontologies/standoff-data.ttl
+++ b/knora-ontologies/standoff-data.ttl
@@ -1,4 +1,4 @@
-# Copyright © 2015-2019 the contributors (see Contributors.md).
+# Copyright © 2015-2021 the contributors (see Contributors.md).
 #
 # This file is part of Knora.
 #

--- a/knora-ontologies/standoff-onto.ttl
+++ b/knora-ontologies/standoff-onto.ttl
@@ -1,4 +1,4 @@
-# Copyright © 2015-2019 the contributors (see Contributors.md).
+# Copyright © 2015-2021 the contributors (see Contributors.md).
 #
 # This file is part of Knora.
 #

--- a/salsah1/public/default.css
+++ b/salsah1/public/default.css
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *
@@ -281,7 +281,7 @@ code {
   font-family: Courrier, monospace;
 }
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *
@@ -416,7 +416,7 @@ body {
   border-bottom: 1px solid #999;
 }
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *
@@ -601,7 +601,7 @@ body {
   border-bottom-width: 1px;
 }
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *
@@ -831,7 +831,7 @@ input.disp_csv {
   background: url('icons/sets/view/csv_icon&16.png') no-repeat top left;
 }
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *
@@ -889,7 +889,7 @@ input.disp_csv {
   opacity: 0.5;
 }
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *
@@ -948,7 +948,7 @@ input.disp_csv {
   border-bottom: 1px solid #000;
 }
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *
@@ -1307,7 +1307,7 @@ table.chartable td {
   border: 1px solid #000000;
 }
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/default.less
+++ b/salsah1/public/default.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/00_init_javascript.js
+++ b/salsah1/public/js/00_init_javascript.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/01_salsah_api.js
+++ b/salsah1/public/js/01_salsah_api.js
@@ -1,7 +1,7 @@
 
 
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/02_searchlist.js
+++ b/salsah1/public/js/02_searchlist.js
@@ -1,6 +1,6 @@
 
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/03_showval.js
+++ b/salsah1/public/js/03_showval.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/datehelpers.js
+++ b/salsah1/public/js/datehelpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/imagebase.js
+++ b/salsah1/public/js/imagebase.js
@@ -1,6 +1,6 @@
 
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/infowin.js
+++ b/salsah1/public/js/infowin.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/innerdim.js
+++ b/salsah1/public/js/innerdim.js
@@ -1,7 +1,7 @@
 
 
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.avplayer.js
+++ b/salsah1/public/js/jquery.avplayer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.avtranscript.js
+++ b/salsah1/public/js/jquery.avtranscript.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.center.js
+++ b/salsah1/public/js/jquery.center.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.chartable.js
+++ b/salsah1/public/js/jquery.chartable.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.colorpicker.js
+++ b/salsah1/public/js/jquery.colorpicker.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.dateobj.js
+++ b/salsah1/public/js/jquery.dateobj.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.dialog.js
+++ b/salsah1/public/js/jquery.dialog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.dialogbox.js
+++ b/salsah1/public/js/jquery.dialogbox.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.dragndrop.js
+++ b/salsah1/public/js/jquery.dragndrop.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.editvalue.js
+++ b/salsah1/public/js/jquery.editvalue.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.elestack.js
+++ b/salsah1/public/js/jquery.elestack.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.extsearch.js
+++ b/salsah1/public/js/jquery.extsearch.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.flipbook.js
+++ b/salsah1/public/js/jquery.flipbook.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.geonameobj.js
+++ b/salsah1/public/js/jquery.geonameobj.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.geonames.js
+++ b/salsah1/public/js/jquery.geonames.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.graph.js
+++ b/salsah1/public/js/jquery.graph.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.hlist.js
+++ b/salsah1/public/js/jquery.hlist.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.htmleditor.js
+++ b/salsah1/public/js/jquery.htmleditor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.iconclass.js
+++ b/salsah1/public/js/jquery.iconclass.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.imageslider.js
+++ b/salsah1/public/js/jquery.imageslider.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.imagezoom.js
+++ b/salsah1/public/js/jquery.imagezoom.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.location.js
+++ b/salsah1/public/js/jquery.location.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.modaliframe.js
+++ b/salsah1/public/js/jquery.modaliframe.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.numberrange.js
+++ b/salsah1/public/js/jquery.numberrange.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.pgbar.js
+++ b/salsah1/public/js/jquery.pgbar.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.propedit.js
+++ b/salsah1/public/js/jquery.propedit.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.regions.js
+++ b/salsah1/public/js/jquery.regions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.resadd.js
+++ b/salsah1/public/js/jquery.resadd.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.searchbox.js
+++ b/salsah1/public/js/jquery.searchbox.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.searchext.js
+++ b/salsah1/public/js/jquery.searchext.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.selection.js
+++ b/salsah1/public/js/jquery.selection.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.selradio.js
+++ b/salsah1/public/js/jquery.selradio.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.simpledialog.js
+++ b/salsah1/public/js/jquery.simpledialog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.simpsearch.js
+++ b/salsah1/public/js/jquery.simpsearch.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.slider.js
+++ b/salsah1/public/js/jquery.slider.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.spinbox.js
+++ b/salsah1/public/js/jquery.spinbox.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.table2csv.js
+++ b/salsah1/public/js/jquery.table2csv.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.tableedit.js
+++ b/salsah1/public/js/jquery.tableedit.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.tabs.js
+++ b/salsah1/public/js/jquery.tabs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.timeobj.js
+++ b/salsah1/public/js/jquery.timeobj.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.transcr.js
+++ b/salsah1/public/js/jquery.transcr.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.valcomment.js
+++ b/salsah1/public/js/jquery.valcomment.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/jquery.win.js
+++ b/salsah1/public/js/jquery.win.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/load_infowin.js
+++ b/salsah1/public/js/load_infowin.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/login.js
+++ b/salsah1/public/js/login.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/metadata_event.js
+++ b/salsah1/public/js/metadata_event.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/tablelist.js
+++ b/salsah1/public/js/tablelist.js
@@ -1,6 +1,6 @@
 
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/js/workwin.js
+++ b/salsah1/public/js/workwin.js
@@ -1,6 +1,6 @@
 
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/less/dock.less
+++ b/salsah1/public/less/dock.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/less/imagebase.less
+++ b/salsah1/public/less/imagebase.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/less/main.less
+++ b/salsah1/public/less/main.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/less/propedit.less
+++ b/salsah1/public/less/propedit.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/less/search.less
+++ b/salsah1/public/less/search.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/less/tabs.less
+++ b/salsah1/public/less/tabs.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/less/win.less
+++ b/salsah1/public/less/win.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/public/less/workwin.less
+++ b/salsah1/public/less/workwin.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/src/main/scala/org/knora/salsah/Main.scala
+++ b/salsah1/src/main/scala/org/knora/salsah/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/src/main/scala/org/knora/salsah/Settings.scala
+++ b/salsah1/src/main/scala/org/knora/salsah/Settings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/salsah1/src/test/scala/org/knora/salsah/SalsahSpec.scala
+++ b/salsah1/src/test/scala/org/knora/salsah/SalsahSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/sipi/config/sipi.knora-docker-config.lua
+++ b/sipi/config/sipi.knora-docker-config.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/config/sipi.knora-docker-no-auth-config.lua
+++ b/sipi/config/sipi.knora-docker-no-auth-config.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/config/sipi.knora-docker-test-config.lua
+++ b/sipi/config/sipi.knora-docker-test-config.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/config/sipi.knora-local-config.lua
+++ b/sipi/config/sipi.knora-local-config.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/images/0801/HOX3ZO0bmkn-DtOIUZBpvrP.xsl
+++ b/sipi/images/0801/HOX3ZO0bmkn-DtOIUZBpvrP.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/sipi/images/0801/IhH6F5GD9K7-D1hIZjjmcUq.xsl
+++ b/sipi/images/0801/IhH6F5GD9K7-D1hIZjjmcUq.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/sipi/scripts/admin_upload.lua
+++ b/sipi/scripts/admin_upload.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/cache.lua
+++ b/sipi/scripts/cache.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/clean_temp_dir.lua
+++ b/sipi/scripts/clean_temp_dir.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/debug.lua
+++ b/sipi/scripts/debug.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/delete_temp_file.lua
+++ b/sipi/scripts/delete_temp_file.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/exit.lua
+++ b/sipi/scripts/exit.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/file_info.lua
+++ b/sipi/scripts/file_info.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/get_knora_session.lua
+++ b/sipi/scripts/get_knora_session.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/jwt.lua
+++ b/sipi/scripts/jwt.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/send_response.lua
+++ b/sipi/scripts/send_response.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/sipi.init-knora-no-auth.lua
+++ b/sipi/scripts/sipi.init-knora-no-auth.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/sipi.init-knora-test.lua
+++ b/sipi/scripts/sipi.init-knora-test.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/sipi.init-knora.lua
+++ b/sipi/scripts/sipi.init-knora.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/store.lua
+++ b/sipi/scripts/store.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/test1.lua
+++ b/sipi/scripts/test1.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/test2.lua
+++ b/sipi/scripts/test2.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/test_file_info.lua
+++ b/sipi/scripts/test_file_info.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/test_functions.lua
+++ b/sipi/scripts/test_functions.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/test_knora_session_cookie.lua
+++ b/sipi/scripts/test_knora_session_cookie.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/upload.lua
+++ b/sipi/scripts/upload.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/sipi/scripts/util.lua
+++ b/sipi/scripts/util.lua
@@ -1,4 +1,4 @@
--- Copyright © 2015-2019 the contributors (see Contributors.md).
+-- Copyright © 2015-2021 the contributors (see Contributors.md).
 --
 -- This file is part of Knora.
 --

--- a/test_data/test_route/texts/beol/standoffToTEI.xsl
+++ b/test_data/test_route/texts/beol/standoffToTEI.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/resources/knoraXmlImport.xsd
+++ b/webapi/src/main/resources/knoraXmlImport.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/resources/mappingXMLToStandoff.xsd
+++ b/webapi/src/main/resources/mappingXMLToStandoff.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/resources/standoffToTEI.xsl
+++ b/webapi/src/main/resources/standoffToTEI.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/LanguageCodes.scala
+++ b/webapi/src/main/scala/org/knora/webapi/LanguageCodes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/OntologySchema.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologySchema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/RdfMediaTypes.scala
+++ b/webapi/src/main/scala/org/knora/webapi/RdfMediaTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/annotation/ApiMayChange.scala
+++ b/webapi/src/main/scala/org/knora/webapi/annotation/ApiMayChange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/annotation/ProjectUnique.scala
+++ b/webapi/src/main/scala/org/knora/webapi/annotation/ProjectUnique.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/annotation/ServerUnique.scala
+++ b/webapi/src/main/scala/org/knora/webapi/annotation/ServerUnique.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/AbstractShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/AbstractShaclValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfFeatureFactory.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfFeatureFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfFormatUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfFormatUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/ShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/ShaclValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaFormatUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaFormatUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JFormatUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JFormatUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/resourcemessages/ResourceMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/resourcemessages/ResourceMessagesV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/valuemessages/ValueMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/valuemessages/ValueMessagesV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/IriLocker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/IriLocker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/Responder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/Responder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/ResponderManager.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/ResponderManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/SipiResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/SipiResponderADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/StoresResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/StoresResponderADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/CkanResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/CkanResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ListsResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ListsResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/OntologyResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/OntologyResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ProjectsResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ProjectsResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/SearchResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/SearchResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/StandoffResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/StandoffResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/UsersResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/UsersResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ListsResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ListsResponderV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/MetadataResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/MetadataResponderV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResponderWithStandoffV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResponderWithStandoffV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/HealthRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/HealthRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/KnoraRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/KnoraRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/RejectingRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RejectingRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  * This file is part of Knora.
  * Knora is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/SwaggerApiDocsRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/SwaggerApiDocsRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/SipiRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/SipiRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/StoreRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/StoreRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/DeleteListItemsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/DeleteListItemsRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/ListsRouteADMFeatureFactory.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/ListsRouteADMFeatureFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/NewListsRouteADMFeature.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/NewListsRouteADMFeature.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/OldListsRouteADMFeature.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/OldListsRouteADMFeature.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/UpdateListItemsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/lists/UpdateListItemsRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/permissions/CreatePermissionRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/permissions/CreatePermissionRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/permissions/GetPermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/permissions/GetPermissionsRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/permissions/UpdatePermissionRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/permissions/UpdatePermissionRouteADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/AssetsRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/AssetsRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/AuthenticationRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/AuthenticationRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/CkanRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/CkanRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ListsRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ListsRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ProjectsRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ProjectsRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourceTypesRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourceTypesRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourcesRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourcesRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/SearchRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/SearchRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/StandoffRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/StandoffRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/UsersRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/UsersRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ValuesRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ValuesRouteV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/AuthenticationRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/AuthenticationRouteV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ListsRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ListsRouteV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/StandoffRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/StandoffRouteV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/StoreManager.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/StoreManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/iiif/IIIFManager.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/iiif/IIIFManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/iiif/SipiConnector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/iiif/SipiConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/RdfDataObjectFactory.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/RdfDataObjectFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/TriplestoreManager.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/TriplestoreManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/embedded/JenaTDBActor.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/embedded/JenaTDBActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/http/HttpTriplestoreConnector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/http/HttpTriplestoreConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/NoopPlugin.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/NoopPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1307.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1307.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1322.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1322.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1367.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1367.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1372.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1372.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1615.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1615.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1746.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1746.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/util/ActorUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/ActorUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/util/ApacheLuceneSupport.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/ApacheLuceneSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/util/Base64UrlCheckDigit.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/Base64UrlCheckDigit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/util/FileUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/FileUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/util/JavaUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/JavaUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/scala/org/knora/webapi/util/SipiUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/SipiUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/gravsearch/getResourceWithSpecifiedProperties.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/gravsearch/getResourceWithSpecifiedProperties.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/changeParentNode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/changeParentNode.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkGroupExistsByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkGroupExistsByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkGroupExistsByName.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkGroupExistsByName.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkIriExists.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkIriExists.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListNodeExistsByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListNodeExistsByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListNodeExistsByName.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListNodeExistsByName.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListNodeNameIsProjectUnique.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListNodeNameIsProjectUnique.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListRootNodeExistsByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListRootNodeExistsByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkProjectExistsByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkProjectExistsByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkProjectExistsByShortcode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkProjectExistsByShortcode.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkProjectExistsByShortname.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkProjectExistsByShortname.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkUserExists.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkUserExists.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkUserExistsByEmail.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkUserExistsByEmail.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkUserExistsByUsername.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkUserExistsByUsername.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewAdministrativePermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewAdministrativePermission.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewDefaultObjectAccessPermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewDefaultObjectAccessPermission.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewGroup.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewGroup.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewListNode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewListNode.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewProject.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewProject.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewUser.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewUser.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/deleteNode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/deleteNode.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getFileValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getFileValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getFileValueGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getFileValueGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getFileValueStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getFileValueStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getGroups.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getGroups.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getListNode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getListNode.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getListNodeWithChildren.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getListNodeWithChildren.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getLists.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getLists.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getNodePath.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getNodePath.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getParentNode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getParentNode.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getPermissionByIRI.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getPermissionByIRI.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectAdminData.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectAdminData.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectAdminMembers.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectAdminMembers.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectMembers.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectMembers.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectPermissions.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectPermissions.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjects.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjects.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getUsers.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getUsers.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/isNodeUsed.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/isNodeUsed.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateGroup.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateGroup.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateListInfo.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateListInfo.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateNodePosition.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateNodePosition.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updatePermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updatePermission.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateProject.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateProject.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateUser.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateUser.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/addValueVersion.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/addValueVersion.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/changeComment.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/changeComment.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/changeLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/changeLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/changeResourceLabel.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/changeResourceLabel.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/checkResourceDeletion.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/checkResourceDeletion.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/checkResourceLabelChange.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/checkResourceLabelChange.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/checkUserExists.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/checkUserExists.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/checkValueDeletion.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/checkValueDeletion.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/ckanDokubib.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/ckanDokubib.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/ckanIncunabula.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/ckanIncunabula.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/createLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/createLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/createNewResources.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/createNewResources.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/createValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/createValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/deleteLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/deleteLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/deleteResource.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/deleteResource.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/deleteValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/deleteValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/findLinkValueByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/findLinkValueByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/findLinkValueByObject.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/findLinkValueByObject.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/findResourceWithValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/findResourceWithValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/findValueInVersions.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/findValueInVersions.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateInsertStatementsForCreateLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateInsertStatementsForCreateLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateInsertStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateInsertStatementsForCreateValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateInsertStatementsForStandoffLinks.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateInsertStatementsForStandoffLinks.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateWhereStatementsForCreateLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateWhereStatementsForCreateLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateWhereStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateWhereStatementsForCreateValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateWhereStatementsForGetMapping.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/generateWhereStatementsForGetMapping.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getAdministrativePermissionByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getAdministrativePermissionByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getAdministrativePermissionForProjectAndGroup.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getAdministrativePermissionForProjectAndGroup.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getAdministrativePermissionsForProject.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getAdministrativePermissionsForProject.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getContext.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getContext.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getContextGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getContextGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getContextStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getContextStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getCreatedResource.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getCreatedResource.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getDefaultObjectAccessPermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getDefaultObjectAccessPermission.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getDefaultObjectAccessPermissionByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getDefaultObjectAccessPermissionByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getDefaultObjectAccessPermissionsForProject.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getDefaultObjectAccessPermissionsForProject.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getFileValuesForResource.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getFileValuesForResource.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGraphData.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGraphData.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGraphDataGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGraphDataGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGraphDataStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGraphDataStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroupByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroupByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroupByName.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroupByName.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroupMembersByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroupMembersByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroupMembersByName.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroupMembersByName.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroups.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getGroups.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getIncomingReferences.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getIncomingReferences.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getIncomingReferencesGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getIncomingReferencesGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getIncomingReferencesStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getIncomingReferencesStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getLastModificationDate.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getLastModificationDate.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getLinkSourceAndTargetPermissions.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getLinkSourceAndTargetPermissions.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getList.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getList.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getNodePath.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getNodePath.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getObjectAccessPermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getObjectAccessPermission.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectAdminMembersByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectAdminMembersByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectAdminMembersByShortname.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectAdminMembersByShortname.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectByShortcode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectByShortcode.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectByShortname.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectByShortname.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectMembersByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectMembersByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectMembersByShortname.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjectMembersByShortname.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjects.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getProjects.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getRegions.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getRegions.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getRegionsGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getRegionsGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getRegionsStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getRegionsStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceClass.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceClass.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceInfo.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceInfo.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceInfoGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceInfoGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceInfoStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceInfoStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourcePropertiesAndValues.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourcePropertiesAndValues.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourcePropertiesAndValuesGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourcePropertiesAndValuesGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourcePropertiesAndValuesStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourcePropertiesAndValuesStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceSearchResult.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceSearchResult.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceSearchResultGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceSearchResultGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceSearchResultStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceSearchResultStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceTypesForNamedGraph.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourceTypesForNamedGraph.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourcesByProjectAndType.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getResourcesByProjectAndType.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getUserByEmail.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getUserByEmail.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getUserByIri.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getUserByIri.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getUsers.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getUsers.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getValueGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getValueGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getValueStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getValueStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getVersionHistory.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getVersionHistory.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getVersionHistoryGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getVersionHistoryGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getVersionHistoryStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getVersionHistoryStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/isPartOf.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/isPartOf.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/isPartOfGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/isPartOfGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/isPartOfStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/isPartOfStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchExtended.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchExtended.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchExtendedGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchExtendedGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchExtendedStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchExtendedStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchFulltext.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchFulltext.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchFulltextGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchFulltextGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchFulltextStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/searchFulltextStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/addCardinalitiesToClass.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/addCardinalitiesToClass.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/addValueVersion.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/addValueVersion.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeClassLabelsOrComments.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeClassLabelsOrComments.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeLinkMetadata.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeLinkMetadata.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeLinkTarget.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeLinkTarget.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeOntologyMetadata.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeOntologyMetadata.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeResourceMetadata.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeResourceMetadata.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeValuePermissions.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changeValuePermissions.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/checkResourceDeletion.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/checkResourceDeletion.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/checkValueDeletion.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/checkValueDeletion.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createClass.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createClass.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createNewMapping.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createNewMapping.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createNewResources.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createNewResources.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createOntology.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createOntology.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createProperty.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createProperty.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteClass.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteClass.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteOntology.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteOntology.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteProperty.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteProperty.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteResource.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteResource.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResource.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResource.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResourceGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResourceGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResourceStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResourceStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForCreateLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForCreateLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForCreateProperty.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForCreateProperty.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForCreateValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForPredicates.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForPredicates.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForStandoffLinks.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForStandoffLinks.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForValueContent.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateInsertStatementsForValueContent.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateWhereStatementsForCreateLink.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateWhereStatementsForCreateLink.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateWhereStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/generateWhereStatementsForCreateValue.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getAllOntologyMetadata.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getAllOntologyMetadata.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getClassDefinition.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getClassDefinition.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getDeleteDate.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getDeleteDate.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getGraphData.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getGraphData.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getGraphDataGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getGraphDataGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getGraphDataStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getGraphDataStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getMapping.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getMapping.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getOntologyGraph.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getOntologyGraph.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getOntologyInfo.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getOntologyInfo.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getPropertyDefinition.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getPropertyDefinition.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcePropertiesAndValues.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcePropertiesAndValues.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcePropertiesAndValuesGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcePropertiesAndValuesGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcePropertiesAndValuesStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcePropertiesAndValuesStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourceValueVersionHistory.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourceValueVersionHistory.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourceValueVersionHistoryGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourceValueVersionHistoryGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourceValueVersionHistoryStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourceValueVersionHistoryStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcesInProjectPrequery.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcesInProjectPrequery.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcesInProjectPrequeryGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcesInProjectPrequeryGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcesInProjectPrequeryStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcesInProjectPrequeryStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getStandoffTagByUUID.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getStandoffTagByUUID.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/isEntityUsed.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/isEntityUsed.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/isOntologyUsed.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/isOntologyUsed.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/replaceClassCardinalities.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/replaceClassCardinalities.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchFulltext.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchFulltext.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchFulltextGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchFulltextGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchFulltextStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchFulltextStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabel.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabel.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabelGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabelGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabelStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabelStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabelSubQuerySelectGraphDB.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabelSubQuerySelectGraphDB.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabelSubQuerySelectStandard.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/searchResourceByLabelSubQuerySelectStandard.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/util/generateContributorsMarkdown.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/util/generateContributorsMarkdown.scala.txt
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/views/resource/properties.scala.html
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/views/resource/properties.scala.html
@@ -1,5 +1,5 @@
 @*
-* Copyright © 2015-2019 the contributors (see Contributors.md).
+* Copyright © 2015-2021 the contributors (see Contributors.md).
 *
 * This file is part of Knora.
 *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/xsd/v1/xmlImport.scala.xml
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/xsd/v1/xmlImport.scala.xml
@@ -1,5 +1,5 @@
 @*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *
@@ -64,7 +64,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/resources/logback-test.xml
+++ b/webapi/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright © 2015-2019 the contributors (see Contributors.md).
+  ~ Copyright © 2015-2021 the contributors (see Contributors.md).
   ~
   ~ This file is part of Knora.
   ~

--- a/webapi/src/test/scala/org/knora/webapi/CoreSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/CoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/E2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/E2ESimSpec.scala
@@ -1,6 +1,6 @@
 /*
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/ITKnoraFakeSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/ITKnoraFakeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/ITKnoraLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/ITKnoraLiveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/KnoraFakeCore.scala
+++ b/webapi/src/test/scala/org/knora/webapi/KnoraFakeCore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/TestContainers.scala
+++ b/webapi/src/test/scala/org/knora/webapi/TestContainers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/TestProbeMaker.scala
+++ b/webapi/src/test/scala/org/knora/webapi/TestProbeMaker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/contributors/GenerateContributorsFileSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/contributors/GenerateContributorsFileSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/CORSSupportE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/CORSSupportE2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ClientTestDataCollector.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ClientTestDataCollector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ExampleE2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ExampleE2ESimSpec.scala
@@ -1,6 +1,6 @@
 /*
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ExceptionHandlerR2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ExceptionHandlerR2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  * This file is part of Knora.
  * Knora is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/webapi/src/test/scala/org/knora/webapi/e2e/FeatureToggleR2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/FeatureToggleR2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/HealthRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/HealthRouteE2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  * This file is part of Knora.
  * Knora is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/RejectingRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/RejectingRouteE2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  * This file is part of Knora.
  * Knora is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/AdminMixE2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/AdminMixE2ESimSpec.scala
@@ -1,6 +1,6 @@
 /*
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESimSpec.scala
@@ -1,6 +1,6 @@
 /*
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESimSpec.scala
@@ -1,6 +1,6 @@
 /*
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/SipiADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/SipiADME2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/StoreADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/StoreADME2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/DeleteListItemsRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/DeleteListItemsRouteADME2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/NewListsRoutesADMFeatureE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/NewListsRoutesADMFeatureE2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/OldListsRouteADMFeatureE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/OldListsRouteADMFeatureE2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/UpdateListItemsRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/UpdateListItemsRouteADME2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/AuthenticationV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/AuthenticationV1E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ListsV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ListsV1E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/PermissionsHandlingV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/PermissionsHandlingV1E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ProjectsV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ProjectsV1E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ResourcesV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ResourcesV1R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/SearchV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/SearchV1R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/SipiV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/SipiV1R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/StandoffV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/StandoffV1R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/UsersV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/UsersV1E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ValuesV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ValuesV1R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/AuthenticationV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/AuthenticationV2E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/JSONLDHandlingV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/JSONLDHandlingV2R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ListsRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ListsRouteV2R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/MarkupHeader.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/MarkupHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ProjectHeader.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ProjectHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResponseCheckerV2.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResponseCheckerV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResponseCheckerV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResponseCheckerV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SchemaHeader.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SchemaHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/StandoffRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/StandoffRouteV2R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ValuesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ValuesRouteV2E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ValuesV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ValuesV2R2RSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/StringFormatterSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/StringFormatterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/groupsmessages/GroupsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/groupsmessages/GroupsMessagesADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessagesSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessagesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/CalendarDateUtilV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/CalendarDateUtilV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/ConstructResponseUtilV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/ConstructResponseUtilV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/DateUtilV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/DateUtilV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/PermissionUtilADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/PermissionUtilADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/JsonLDUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/JsonLDUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/KnoraResponseV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/KnoraResponseV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfFormatUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfFormatUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfModelSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/RdfModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/ShaclValidatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/ShaclValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaFormatUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaFormatUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaJsonLDUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaJsonLDUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaKnoraResponseV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaKnoraResponseV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaModelSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/jenaimpl/JenaShaclValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JFormatUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JFormatUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JJsonLDUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JJsonLDUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JKnoraResponseV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JKnoraResponseV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JModelSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/rdf4jimpl/RDF4JShaclValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/search/SparqlTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/search/SparqlTransformerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/GravsearchParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/GravsearchParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/standoff/StandoffTagUtilV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/standoff/StandoffTagUtilV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/standoff/XMLToStandoffUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/standoff/XMLToStandoffUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/standoff/XMLUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/standoff/XMLUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/v1/responder/sessionmessages/SessionMessagesV1.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v1/responder/sessionmessages/SessionMessagesV1.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/v1/responder/usermessages/UserMessagesV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v1/responder/usermessages/UserMessagesV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/metadatamessages/MetadataMessagesV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/metadatamessages/MetadataMessagesV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/ontologymessages/InputOntologyV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/ontologymessages/InputOntologyV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/other/v1/DrawingsGodsV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/other/v1/DrawingsGodsV1E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/other/v1/DrawingsGodsV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/other/v1/DrawingsGodsV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  * This file is part of Knora.
  * Knora is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/webapi/src/test/scala/org/knora/webapi/other/v2/LumieresLausanneV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/other/v2/LumieresLausanneV2E2ESpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/MockableResponderManager.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/MockableResponderManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/ListsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/ListsResponderADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/ProjectsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/ProjectsResponderADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/SipiResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/SipiResponderADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/UsersResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/UsersResponderADMSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ListsResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ListsResponderV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/OntologyResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/OntologyResponderV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ProjectsResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ProjectsResponderV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1SpecContextData.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1SpecContextData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1SpecFullData.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1SpecFullData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/UsersResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/UsersResponderV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ValuesResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ValuesResponderV1Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/ListsResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/ListsResponderV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/MetadataResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/MetadataResponderV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponseCheckerV2.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponseCheckerV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponseCheckerV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponseCheckerV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/routing/AuthenticatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/routing/AuthenticatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/routing/JWTHelperSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/routing/JWTHelperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedOntologyTestDataADM.scala
+++ b/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedOntologyTestDataADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedPermissionsTestData.scala
+++ b/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedPermissionsTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/MockableStoreManager.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/MockableStoreManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/iiif/MockSipiConnector.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/iiif/MockSipiConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/iiif/MockableIIIFManager.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/iiif/MockableIIIFManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/AllTriplestoreSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/AllTriplestoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1307Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1307Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1322Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1322Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1367Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1367Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1372Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1372Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1615Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1615Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1746Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR1746Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/util/AkkaHttpUtils.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/AkkaHttpUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/util/ApacheLuceneSupportSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/ApacheLuceneSupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/util/Base64UrlCheckDigitSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/Base64UrlCheckDigitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/util/MutableTestIri.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/MutableTestIri.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/util/StartupUtils.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/StartupUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  *  This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/util/StringLiteralSequenceV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/StringLiteralSequenceV2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/util/TestExtractorMethods.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/TestExtractorMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/test/scala/org/knora/webapi/util/cache/CacheUtilSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/cache/CacheUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * Copyright © 2015-2021 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *


### PR DESCRIPTION
This PR is due [that change](https://github.com/dasch-swiss/dsp-api/pull/1773/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L189) and brings back `stack-down-delete-volumes` stack target. It also updates copyright years and pr template.
