### PR TITLE
fix (ListsEndPoint) Allow empty comments (DSP-1251 )

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
@@ -162,13 +162,9 @@ case class ChangeNodeInfoApiRequestADM(listIri: IRI,
   if (hasRootNode.isDefined && !stringFormatter.isKnoraListIriStr(hasRootNode.get)) {
     throw BadRequestException(s"Invalid root node IRI is given.")
   }
-  // If payload contains label or comments they should not be empty
+  // If payload contains labels, they should not be empty
   if (labels.exists(_.isEmpty)) {
-    throw BadRequestException(UPDATE_REQUEST_EMPTY_LABEL_OR_COMMENT_ERROR)
-  }
-
-  if (comments.exists(_.isEmpty)) {
-    throw BadRequestException(UPDATE_REQUEST_EMPTY_LABEL_OR_COMMENT_ERROR)
+    throw BadRequestException(UPDATE_REQUEST_EMPTY_LABEL_ERROR)
   }
 
   def toJsValue: JsValue = changeListInfoApiRequestADMFormat.write(this)

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesUtilADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesUtilADM.scala
@@ -30,5 +30,5 @@ object ListsMessagesUtilADM {
   val LIST_CREATE_PERMISSION_ERROR = "A list can only be created by the project or system administrator."
   val LIST_NODE_CREATE_PERMISSION_ERROR = "A list node can only be created by the project or system administrator."
   val LIST_CHANGE_PERMISSION_ERROR = "A list can only be changed by the project or system administrator."
-  val UPDATE_REQUEST_EMPTY_LABEL_OR_COMMENT_ERROR = "List labels and comments cannot be empty."
+  val UPDATE_REQUEST_EMPTY_LABEL_ERROR = "List labels cannot be empty."
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/UpdateListItemsRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/lists/UpdateListItemsRouteADME2ESpec.scala
@@ -218,6 +218,27 @@ class UpdateListItemsRouteADME2ESpec
           )
         )
       }
+      "delete node comments" in {
+        val deleteCommentsLabels =
+          s"""{
+             |    "comments": []
+             |}""".stripMargin
+        val encodedListUrl = java.net.URLEncoder.encode(treeListInfo.id, "utf-8")
+
+        val request = Put(baseApiUrl + s"/admin/lists/" + encodedListUrl + "/comments",
+                          HttpEntity(ContentTypes.`application/json`, deleteCommentsLabels)) ~> addCredentials(
+          anythingAdminUserCreds.basicHttpCredentials)
+        val response: HttpResponse = singleAwaitingRequest(request)
+        // log.debug(s"response: ${response.toString}")
+        response.status should be(StatusCodes.OK)
+        val receivedListInfo: ListRootNodeInfoADM =
+          AkkaHttpUtils.httpResponseToJson(response).fields("listinfo").convertTo[ListRootNodeInfoADM]
+
+        receivedListInfo.projectIri should be(SharedTestDataADM.ANYTHING_PROJECT_IRI)
+
+        val comments: Seq[StringLiteralV2] = receivedListInfo.comments.stringLiterals
+        comments.size should be(0)
+      }
     }
 
     "updating child nodes" should {

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
@@ -321,7 +321,7 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
       thrown.getMessage should equal(PROJECT_IRI_INVALID_ERROR)
     }
 
-    "throw 'BadRequestException' for `ChangeNodeInfoApiRequestADM` when labels and comments are empty" in {
+    "throw 'BadRequestException' for `ChangeNodeInfoApiRequestADM` when labels are empty" in {
 
       val payload =
         s"""
@@ -335,7 +335,7 @@ class ListsMessagesADMSpec extends CoreSpec(ListsMessagesADMSpec.config) with Li
 
       val thrown = the[BadRequestException] thrownBy payload.parseJson.convertTo[ChangeNodeInfoApiRequestADM]
 
-      thrown.getMessage should equal(UPDATE_REQUEST_EMPTY_LABEL_OR_COMMENT_ERROR)
+      thrown.getMessage should equal(UPDATE_REQUEST_EMPTY_LABEL_ERROR)
     }
 
     "throw 'ForbiddenException' if user requesting `createChildNodeRequest` is not system or project admin" in {


### PR DESCRIPTION
resolves DSP-1251

Allow `comments:[]` in payload of routes 
- `PUT: /admin/lists/<listItemIri>/comments`
- `PUT: /admin/lists/<listItemIri>`