### PR TITLE
chore(gh-ci): Bring back the client-test-data command to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,52 @@ jobs:
           df -h
           docker system df
 
+# ------------------------------------------
+# ------------------------------------------
+# Test client-test-data 
+  client-test-data:
+    name: Test client-test-data 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 50
+      - uses: joschi/setup-jdk@v2
+        with:
+          java-version: '11' # The OpenJDK version to make available on the path
+          architecture: 'x64' # defaults to 'x64'
+      - name: Install requirements
+        run: sudo apt-get install ca-certificates-java expect redis-tools unzip
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+          npm install --global typedoc
+          npm install --global @bazel/bazelisk
+          sudo apt-get install graphviz
+      - name: Generate api-client-test-data
+        run: make client-test-data
+      - name: Disk Free
+        run: |
+          df -h
+          docker system df
+          docker system prune --all --force --volumes
+          df -h
+# ------------------------------------------
+# ------------------------------------------
+
+
+
+
+
   api-unit-tests:
     name: API Unit Tests
     needs: compile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
 # Test client-test-data 
   client-test-data:
     name: Test client-test-data 
+    needs: compile
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -68,35 +69,14 @@ jobs:
           architecture: 'x64' # defaults to 'x64'
       - name: Install requirements
         run: sudo apt-get install ca-certificates-java expect redis-tools unzip
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Set up Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r docs/requirements.txt
-          npm install --global typedoc
-          npm install --global @bazel/bazelisk
-          sudo apt-get install graphviz
       - name: Generate api-client-test-data
         run: make client-test-data
-      - name: Disk Free
+      - name: Disk Free After
         run: |
           df -h
           docker system df
-          docker system prune --all --force --volumes
-          df -h
 # ------------------------------------------
 # ------------------------------------------
-
-
-
-
 
   api-unit-tests:
     name: API Unit Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -346,6 +346,7 @@ jobs:
       api-unit-tests,
       api-e2e-tests,
       api-integration-tests,
+      client-test-data,
       upgrade-integration-tests,
       docs-build-test
     ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
 # ------------------------------------------
 # ------------------------------------------
 # Test client-test-data 
-  client-test-data:
+  client-test-data-tests:
     name: Test client-test-data 
     needs: compile
     runs-on: ubuntu-latest
@@ -346,7 +346,7 @@ jobs:
       api-unit-tests,
       api-e2e-tests,
       api-integration-tests,
-      client-test-data,
+      client-test-data-tests,
       upgrade-integration-tests,
       docs-build-test
     ]


### PR DESCRIPTION
We have to be sure, that everything runs well before publishing new version of DSP-API. The last release was not successful because of failing `make client-test-data` command. This PR brings back this step to github actions. The release publish process depends on a successful generation of client-test-data.
