### PR TITLE
feat(api-v2): Improve error message when an XSLT transformation file is not found (DSP-1404)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -1770,10 +1770,17 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
             requestingUser = requestingUser
           )
 
-          for {
+          val xslTransformationFuture = for {
             xslTransformation: GetXSLTransformationResponseV2 <- (responderManager ? teiHeaderXsltRequest)
               .mapTo[GetXSLTransformationResponseV2]
           } yield Some(xslTransformation.xslt)
+
+          xslTransformationFuture.recover {
+            case notFound: NotFoundException =>
+              throw SipiException(s"TEI header XSL transformation <$headerIri> not found: ${notFound.message}")
+
+            case other => throw other
+          }
 
         case None => Future(None)
       }
@@ -1819,11 +1826,18 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                 requestingUser = requestingUser
               )
 
-              for {
+              val xslTransformationFuture = for {
                 xslTransformation: GetXSLTransformationResponseV2 <- (responderManager ? teiBodyXsltRequest)
                   .mapTo[GetXSLTransformationResponseV2]
               } yield xslTransformation.xslt
 
+              xslTransformationFuture.recover {
+                case notFound: NotFoundException =>
+                  throw SipiException(
+                    s"Default XSL transformation <${teiMapping.mapping.defaultXSLTransformation.get}> not found for mapping <${teiMapping.mappingIri}>: ${notFound.message}")
+
+                case other => throw other
+              }
             case None => throw BadRequestException(s"Default XSL Transformation expected for mapping $otherMapping")
           }
       }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResponderWithStandoffV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResponderWithStandoffV2.scala
@@ -55,7 +55,8 @@ abstract class ResponderWithStandoffV2(responderData: ResponderData) extends Res
 
     // collect the Iris of the mappings referred to in the resources' text values
     val mappingIris: Set[IRI] = queryResultsSeparated.flatMap {
-      case (_, assertions: ResourceWithValueRdfData) =>
+      case (resourceIri: IRI, assertions: ResourceWithValueRdfData) =>
+        println(s"********* Getting standoff mappings for resource $resourceIri")
         ConstructResponseUtilV2.getMappingIrisFromValuePropertyAssertions(assertions.valuePropertyAssertions)
     }.toSet
 
@@ -79,6 +80,9 @@ abstract class ResponderWithStandoffV2(responderData: ResponderData) extends Res
           for {
             // if given, get the default XSL transformation
             xsltOption: Option[String] <- if (mapping.mapping.defaultXSLTransformation.nonEmpty) {
+              println(
+                s"******* Getting default XSL transformation ${mapping.mapping.defaultXSLTransformation.get} for mapping ${mapping.mappingIri}")
+
               for {
                 xslTransformation: GetXSLTransformationResponseV2 <- (responderManager ? GetXSLTransformationRequestV2(
                   mapping.mapping.defaultXSLTransformation.get,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResponderWithStandoffV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResponderWithStandoffV2.scala
@@ -90,9 +90,9 @@ abstract class ResponderWithStandoffV2(responderData: ResponderData) extends Res
               } yield Some(xslTransformation.xslt)
 
               xslTransformationFuture.recover {
-                case _: NotFoundException =>
+                case notFound: NotFoundException =>
                   throw NotFoundException(
-                    s"Default XSL transformation <${mapping.mapping.defaultXSLTransformation.get}> not found for mapping <${mapping.mappingIri}>")
+                    s"Default XSL transformation <${mapping.mapping.defaultXSLTransformation.get}> not found for mapping <${mapping.mappingIri}>: ${notFound.message}")
                 case other => throw other
               }
             } else {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResponderWithStandoffV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResponderWithStandoffV2.scala
@@ -22,7 +22,7 @@ package org.knora.webapi.responders.v2
 import akka.http.scaladsl.util.FastFuture
 import akka.pattern._
 import org.knora.webapi.IRI
-import org.knora.webapi.exceptions.NotFoundException
+import org.knora.webapi.exceptions.{NotFoundException, SipiException}
 import org.knora.webapi.feature.FeatureFactoryConfig
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.util.ConstructResponseUtilV2.{MappingAndXSLTransformation, ResourceWithValueRdfData}
@@ -91,8 +91,9 @@ abstract class ResponderWithStandoffV2(responderData: ResponderData) extends Res
 
               xslTransformationFuture.recover {
                 case notFound: NotFoundException =>
-                  throw NotFoundException(
+                  throw SipiException(
                     s"Default XSL transformation <${mapping.mapping.defaultXSLTransformation.get}> not found for mapping <${mapping.mappingIri}>: ${notFound.message}")
+
                 case other => throw other
               }
             } else {

--- a/webapi/src/main/scala/org/knora/webapi/store/iiif/SipiConnector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/iiif/SipiConnector.scala
@@ -221,13 +221,23 @@ class SipiConnector extends Actor with ActorLogging {
     } yield SipiGetTextFileResponse(responseStr)
 
     sipiResponseTry.recover {
+      case notFoundException: NotFoundException =>
+        throw NotFoundException(
+          s"Unable to get file ${textFileRequest.fileUrl} from Sipi as requested by ${textFileRequest.senderName}: ${notFoundException.message}")
+
       case badRequestException: BadRequestException =>
         throw SipiException(
           s"Unable to get file ${textFileRequest.fileUrl} from Sipi as requested by ${textFileRequest.senderName}: ${badRequestException.message}")
+
       case sipiException: SipiException =>
         throw SipiException(
           s"Unable to get file ${textFileRequest.fileUrl} from Sipi as requested by ${textFileRequest.senderName}: ${sipiException.message}",
           sipiException.cause
+        )
+
+      case other =>
+        throw SipiException(
+          s"Unable to get file ${textFileRequest.fileUrl} from Sipi as requested by ${textFileRequest.senderName}: ${other.getMessage}"
         )
     }
   }

--- a/webapi/src/test/scala/org/knora/webapi/it/v1/KnoraSipiIntegrationV1ITSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/it/v1/KnoraSipiIntegrationV1ITSpec.scala
@@ -729,7 +729,7 @@ class KnoraSipiIntegrationV1ITSpec
         Await.result(response.entity.toStrict(2.seconds).map(_.data.decodeString("UTF-8")), 2.seconds)
       assert(responseBodyStr.contains("Unable to get file"))
       assert(responseBodyStr.contains("as requested by org.knora.webapi.responders.v2.StandoffResponderV2"))
-      assert(responseBodyStr.contains("Sipi responded with HTTP status code 404"))
+      assert(responseBodyStr.contains("Not Found"))
     }
 
     "create a resource with a PDF file attached" in {


### PR DESCRIPTION
If a default XSL transformation isn't found for a standoff mapping, returns an error message like:

```
org.knora.webapi.exceptions.SipiException: Default XSL transformation
<http://rdfh.ch/0801/smVjS18pSpyBm_TeTiXuoA> not found for mapping
<http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF/mappings/leooLetterMapping>:
Unable to get file http://sipi:1024/0801/3QlCAYIGInS-G2RGy0nWAkk/file from Sipi as requested by
org.knora.webapi.responders.v2.StandoffResponderV2: Not Found"
```

resolves DSP-1404
