### PR TITLE
fix(gravsearch): Keep rdf:type knora-api:Resource when needed (DSP-1407)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/AnnotationReadingGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/AnnotationReadingGravsearchTypeInspector.scala
@@ -119,7 +119,7 @@ class AnnotationReadingGravsearchTypeInspector(nextInspector: Option[GravsearchT
       extends WhereVisitor[Vector[GravsearchTypeAnnotation]] {
     override def visitStatementInWhere(statementPattern: StatementPattern,
                                        acc: Vector[GravsearchTypeAnnotation]): Vector[GravsearchTypeAnnotation] = {
-      if (GravsearchTypeInspectionUtil.isAnnotationStatement(statementPattern)) {
+      if (GravsearchTypeInspectionUtil.canBeAnnotationStatement(statementPattern)) {
         acc :+ annotationStatementToAnnotation(statementPattern, querySchema)
       } else {
         acc

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
@@ -173,10 +173,10 @@ object GravsearchTypeInspectionUtil {
   private class AnnotationRemovingWhereTransformer extends WhereTransformer {
     override def transformStatementInWhere(statementPattern: StatementPattern,
                                            inputOrderBy: Seq[OrderCriterion]): Seq[QueryPattern] = {
-      if (!isAnnotationStatement(statementPattern)) {
-        Seq(statementPattern)
-      } else {
+      if (mustBeAnnotationStatement(statementPattern)) {
         Seq.empty[QueryPattern]
+      } else {
+        Seq(statementPattern)
       }
     }
 
@@ -209,12 +209,43 @@ object GravsearchTypeInspectionUtil {
   }
 
   /**
-    * Determines whether a statement pattern represents a Gravsearch type annotation.
+    * Determines whether a statement pattern must represent a Gravsearch type annotation.
     *
     * @param statementPattern the statement pattern.
-    * @return `true` if the statement pattern represents a type annotation.
+    * @return `true` if the statement pattern must represent a type annotation.
     */
-  def isAnnotationStatement(statementPattern: StatementPattern): Boolean = {
+  def mustBeAnnotationStatement(statementPattern: StatementPattern): Boolean = {
+    // Does the statement have rdf:type knora-api:Resource (which is not necessarily a Gravsearch type annotation)?
+    def hasRdfTypeKnoraApiResource: Boolean = {
+      statementPattern.pred match {
+        case predIriRef: IriRef =>
+          if (predIriRef.iri.toString == OntologyConstants.Rdf.Type) {
+            statementPattern.obj match {
+              case objIriRef: IriRef =>
+                OntologyConstants.KnoraApi.KnoraApiV2ResourceIris.contains(objIriRef.iri.toString)
+
+              case _ => false
+            }
+          } else {
+            false
+          }
+
+        case _ => false
+      }
+    }
+
+    // If the statement can be a type annotation and doesn't have rdf:type knora-api:Resource, return true.
+    // Otherwise, return false.
+    canBeAnnotationStatement(statementPattern) && !hasRdfTypeKnoraApiResource
+  }
+
+  /**
+    * Determines whether a statement pattern can represent a Gravsearch type annotation.
+    *
+    * @param statementPattern the statement pattern.
+    * @return `true` if the statement pattern can represent a type annotation.
+    */
+  def canBeAnnotationStatement(statementPattern: StatementPattern): Boolean = {
 
     /**
       * Returns `true` if an entity is an IRI representing a type that is valid for use in a type annotation.


### PR DESCRIPTION
resolves DSP-1407

- [x] Don't assume that `rdf:type knora-api:Resource` is always a Gravsearch type annotation and remove it.
- [x] Add an optimisation that removes `rdf:type knora-api:Resource` if there's another statement at the same level of the `WHERE` clause with the same subject and predicate and a different type IRI.
