### PR TITLE
chore(documentation): bug fix in documentation deployment (DSP-1605)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -428,7 +428,7 @@ jobs:
       docs-build-test
     ]
     runs-on: ubuntu-latest
-    # if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
     steps:
       - name: Checkout main
         uses: actions/checkout@v2


### PR DESCRIPTION
resolves DSP-1605

I updated the gh actions workflow, but accidentally I pushed the changes into the main branch which shouldn't be possible. You'll see the changes in commit bb852c9d and 88da8bc3. In the second commit I commented the if statement in the step "deploy documentation only on release" to see, if it runs (s. [here](https://github.com/dasch-swiss/dsp-api/runs/2527170125?check_suite_focus=true)). In this PR I uncommented the line again. 