### PR TITLE
chore(knora-base): fix typo

### DIFF
--- a/knora-ontologies/knora-base.ttl
+++ b/knora-ontologies/knora-base.ttl
@@ -757,7 +757,7 @@
 
             rdfs:comment "Region of interest within a digital object (e.g. an image)"@en ;
 
-            rdfs:label "is Region von"@de ,
+            rdfs:label "ist Region von"@de ,
                        "is region of"@en ,
                        "est région de"@fr ,
                        "è regione di"@it ;
@@ -778,7 +778,7 @@
 
                 rdfs:comment "Region of interest within a digital object (e.g. an image)"@en ;
 
-                rdfs:label "is Region von"@de ,
+                rdfs:label "ist Region von"@de ,
                            "is region of"@en ,
                            "est région de"@fr ,
                            "è regione di"@it ;

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/OntologyResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/OntologyResponderV1Spec.scala
@@ -387,7 +387,7 @@ class OntologyResponderV1Spec extends CoreSpec() with ImplicitSender {
           occurrence = "1",
           vocabulary = "http://www.knora.org/ontology/knora-base",
           description = Some("Region of interest within a digital object (e.g. an image)"),
-          label = Some("is Region von"),
+          label = Some("ist Region von"),
           name = "http://www.knora.org/ontology/knora-base#isRegionOf",
           id = "http://www.knora.org/ontology/knora-base#isRegionOf"
         ),

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1Spec.scala
@@ -144,7 +144,7 @@ object ResourcesResponderV1Spec {
         ),
         PropertyGetV1(
           "http://www.knora.org/ontology/knora-base#isRegionOf",
-          Some("is Region von"),
+          Some("ist Region von"),
           Some("http://www.knora.org/ontology/knora-base#LinkValue"),
           Some("textval"),
           None,


### PR DESCRIPTION
There was a typo in the german label of "region is part of"
