### PR TITLE
fix(ontology): link value property is still not editable after updating the property metadata (DEV-1116)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -2753,6 +2753,7 @@ class OntologyResponderV2(responderData: ResponderData) extends Responder(respon
           maybeUnescapedNewLinkValuePropertyDef.map { unescapedNewLinkPropertyDef =>
             unescapedNewLinkPropertyDef.propertyIri -> ReadPropertyInfoV2(
               entityInfoContent = unescapedNewLinkPropertyDef,
+              isEditable = true,
               isResourceProp = true,
               isLinkValueProp = true
             )
@@ -3277,6 +3278,7 @@ class OntologyResponderV2(responderData: ResponderData) extends Responder(respon
           maybeNewLinkValuePropertyDef.map { newLinkPropertyDef: PropertyInfoContentV2 =>
             newLinkPropertyDef.propertyIri -> ReadPropertyInfoV2(
               entityInfoContent = newLinkPropertyDef,
+              isEditable = true,
               isResourceProp = true,
               isLinkValueProp = true
             )

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -216,6 +216,10 @@ class OntologyV2R2RSpec extends R2RSpec {
   private val incunabulaPartOf =
     URLEncoder.encode(SharedOntologyTestDataADM.INCUNABULA_PartOf_Property_LocalHost, "UTF-8")
 
+  private val anythingOntoLocalhostIri = SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost
+  private val hasOtherNothingIri       = anythingOntoLocalhostIri + "#hasOtherNothing"
+  private val hasOtherNothingValueIri  = anythingOntoLocalhostIri + "#hasOtherNothingValue"
+
   // The URLs and expected response files for each HTTP GET test.
   private val httpGetTests = Seq(
     HttpGetTest(
@@ -1749,15 +1753,11 @@ class OntologyV2R2RSpec extends R2RSpec {
 
     "update the property label and check if the property is still correctly marked as `isEditable: true`" in {
       // update label and comment of a property
-      val ontoIri          = SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost
-      val propertyIri      = ontoIri + "#hasOtherNothing"
-      val propertyValueIri = ontoIri + "#hasOtherNothingValue"
-      val newLabel         = "updated label"
-
+      val newLabel = "updated label"
       val params =
         s"""
            |{
-           |  "@id" : "$ontoIri",
+           |  "@id" : "$anythingOntoLocalhostIri",
            |  "@type": "owl:Ontology",
            |  "knora-api:lastModificationDate" : {
            |    "@type" : "xsd:dateTimeStamp",
@@ -1765,7 +1765,7 @@ class OntologyV2R2RSpec extends R2RSpec {
            |  },
            |  "@graph": [
            |    {
-           |      "@id": "$propertyIri",
+           |      "@id": "$hasOtherNothingIri",
            |      "@type" : "owl:ObjectProperty",
            |      "rdfs:label": {
            |        "@language": "en",
@@ -1790,11 +1790,11 @@ class OntologyV2R2RSpec extends R2RSpec {
         assert(status == StatusCodes.OK, response.toString)
         val responseJsonDoc    = JsonLDUtil.parseJsonLD(responseStr)
         val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
-        assert(updatedOntologyIri == ontoIri)
+        assert(updatedOntologyIri == anythingOntoLocalhostIri)
         val graph               = responseJsonDoc.body.requireArray("@graph").value
         val property            = graph.head.asInstanceOf[JsonLDObject]
         val returnedPropertyIri = property.requireString("@id")
-        returnedPropertyIri should equal(propertyIri)
+        returnedPropertyIri should equal(hasOtherNothingIri)
         val returnedLabel = property.requireObject(OntologyConstants.Rdfs.Label).requireString("@value")
         returnedLabel should equal(newLabel)
         val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
@@ -1816,7 +1816,7 @@ class OntologyV2R2RSpec extends R2RSpec {
           val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
 
           val graph           = responseJsonDoc.body.requireArray("@graph").value.map(_.asInstanceOf[JsonLDObject])
-          val nothingValue    = graph.filter(_.requireString("@id") == propertyValueIri).head
+          val nothingValue    = graph.filter(_.requireString("@id") == hasOtherNothingValueIri).head
           val isEditableMaybe = nothingValue.maybeBoolean(OntologyConstants.KnoraApiV2Complex.IsEditable)
           isEditableMaybe should equal(Some(true))
         }
@@ -1825,15 +1825,12 @@ class OntologyV2R2RSpec extends R2RSpec {
 
     "update the property comment and check if the property is still correctly marked as `isEditable: true`" in {
       // update label and comment of a property
-      val ontoIri          = SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost
-      val propertyIri      = ontoIri + "#hasOtherNothing"
-      val propertyValueIri = ontoIri + "#hasOtherNothingValue"
-      val newComment       = "updated comment"
+      val newComment = "updated comment"
 
       val params =
         s"""
            |{
-           |  "@id" : "$ontoIri",
+           |  "@id" : "$anythingOntoLocalhostIri",
            |  "@type": "owl:Ontology",
            |  "knora-api:lastModificationDate" : {
            |    "@type" : "xsd:dateTimeStamp",
@@ -1841,7 +1838,7 @@ class OntologyV2R2RSpec extends R2RSpec {
            |  },
            |  "@graph": [
            |    {
-           |      "@id": "$propertyIri",
+           |      "@id": "$hasOtherNothingIri",
            |      "@type" : "owl:ObjectProperty",
            |      "rdfs:comment": {
            |        "@language": "en",
@@ -1866,11 +1863,11 @@ class OntologyV2R2RSpec extends R2RSpec {
         assert(status == StatusCodes.OK, response.toString)
         val responseJsonDoc    = JsonLDUtil.parseJsonLD(responseStr)
         val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
-        assert(updatedOntologyIri == ontoIri)
+        assert(updatedOntologyIri == anythingOntoLocalhostIri)
         val graph               = responseJsonDoc.body.requireArray("@graph").value
         val property            = graph.head.asInstanceOf[JsonLDObject]
         val returnedPropertyIri = property.requireString("@id")
-        returnedPropertyIri should equal(propertyIri)
+        returnedPropertyIri should equal(hasOtherNothingIri)
         val returnedComment = property.requireObject(OntologyConstants.Rdfs.Comment).requireString("@value")
         returnedComment should equal(newComment)
         val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
@@ -1892,7 +1889,7 @@ class OntologyV2R2RSpec extends R2RSpec {
           val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
 
           val graph           = responseJsonDoc.body.requireArray("@graph").value.map(_.asInstanceOf[JsonLDObject])
-          val nothingValue    = graph.filter(_.requireString("@id") == propertyValueIri).head
+          val nothingValue    = graph.filter(_.requireString("@id") == hasOtherNothingValueIri).head
           val isEditableMaybe = nothingValue.maybeBoolean(OntologyConstants.KnoraApiV2Complex.IsEditable)
           isEditableMaybe should equal(Some(true))
         }
@@ -1901,10 +1898,7 @@ class OntologyV2R2RSpec extends R2RSpec {
 
     "delete the property comment and check if the property is still correctly marked as `isEditable: true`" in {
       // update label and comment of a property
-      val ontoIri            = SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost
-      val propertyIri        = ontoIri + "#hasOtherNothing"
-      val propertyValueIri   = ontoIri + "#hasOtherNothingValue"
-      val propertyIriEncoded = URLEncoder.encode(propertyIri, "UTF-8")
+      val propertyIriEncoded = URLEncoder.encode(hasOtherNothingIri, "UTF-8")
 
       Delete(
         s"/v2/ontologies/properties/comment/$propertyIriEncoded?lastModificationDate=$anythingLastModDate"
@@ -1916,11 +1910,11 @@ class OntologyV2R2RSpec extends R2RSpec {
         assert(status == StatusCodes.OK, response.toString)
         val responseJsonDoc    = JsonLDUtil.parseJsonLD(responseStr)
         val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
-        assert(updatedOntologyIri == ontoIri)
+        assert(updatedOntologyIri == anythingOntoLocalhostIri)
         val graph               = responseJsonDoc.body.requireArray("@graph").value
         val property            = graph.head.asInstanceOf[JsonLDObject]
         val returnedPropertyIri = property.requireString("@id")
-        returnedPropertyIri should equal(propertyIri)
+        returnedPropertyIri should equal(hasOtherNothingIri)
         assert(property.value.get(OntologyConstants.Rdfs.Comment) == None)
         val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
           key = OntologyConstants.KnoraApiV2Complex.LastModificationDate,
@@ -1941,7 +1935,7 @@ class OntologyV2R2RSpec extends R2RSpec {
           val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
 
           val graph           = responseJsonDoc.body.requireArray("@graph").value.map(_.asInstanceOf[JsonLDObject])
-          val nothingValue    = graph.filter(_.requireString("@id") == propertyValueIri).head
+          val nothingValue    = graph.filter(_.requireString("@id") == hasOtherNothingValueIri).head
           val isEditableMaybe = nothingValue.maybeBoolean(OntologyConstants.KnoraApiV2Complex.IsEditable)
           isEditableMaybe should equal(Some(true))
         }
@@ -1950,14 +1944,11 @@ class OntologyV2R2RSpec extends R2RSpec {
 
     "update the property guiElement and check if the property is still correctly marked as `isEditable: true`" in {
       // update label and comment of a property
-      val ontoIri          = SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost
-      val propertyIri      = ontoIri + "#hasOtherNothing"
-      val propertyValueIri = ontoIri + "#hasOtherNothingValue"
 
       val params =
         s"""
            |{
-           |  "@id" : "$ontoIri",
+           |  "@id" : "$anythingOntoLocalhostIri",
            |  "@type": "owl:Ontology",
            |  "knora-api:lastModificationDate" : {
            |    "@type" : "xsd:dateTimeStamp",
@@ -1965,7 +1956,7 @@ class OntologyV2R2RSpec extends R2RSpec {
            |  },
            |  "@graph": [
            |    {
-           |      "@id": "$propertyIri",
+           |      "@id": "$hasOtherNothingIri",
            |      "@type" : "owl:ObjectProperty",
            |      "salsah-gui:guiElement": {
            |        "@id": "salsah-gui:Searchbox"
@@ -1993,11 +1984,11 @@ class OntologyV2R2RSpec extends R2RSpec {
         assert(status == StatusCodes.OK, response.toString)
         val responseJsonDoc    = JsonLDUtil.parseJsonLD(responseStr)
         val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
-        assert(updatedOntologyIri == ontoIri)
+        assert(updatedOntologyIri == anythingOntoLocalhostIri)
         val graph               = responseJsonDoc.body.requireArray("@graph").value
         val property            = graph.head.asInstanceOf[JsonLDObject]
         val returnedPropertyIri = property.requireString("@id")
-        returnedPropertyIri should equal(propertyIri)
+        returnedPropertyIri should equal(hasOtherNothingIri)
         val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
           key = OntologyConstants.KnoraApiV2Complex.LastModificationDate,
           expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
@@ -2017,7 +2008,7 @@ class OntologyV2R2RSpec extends R2RSpec {
           val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
 
           val graph           = responseJsonDoc.body.requireArray("@graph").value.map(_.asInstanceOf[JsonLDObject])
-          val nothingValue    = graph.filter(_.requireString("@id") == propertyValueIri).head
+          val nothingValue    = graph.filter(_.requireString("@id") == hasOtherNothingValueIri).head
           val isEditableMaybe = nothingValue.maybeBoolean(OntologyConstants.KnoraApiV2Complex.IsEditable)
           isEditableMaybe should equal(Some(true))
         }


### PR DESCRIPTION
<!-- Important! Please follow the new guidelines for naming Pull Requests: https://docs.dasch.swiss/developers/dsp/contribution/#pull-request-guidelines-->

Resolves DEV-1116

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: DEV-1116


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
