### PR TITLE
refactor: Replace Cardinality isStricterThan with isIncludedIn

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ontology/OntologyHelpers.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ontology/OntologyHelpers.scala
@@ -1936,7 +1936,7 @@ object OntologyHelpers {
             if (thisClassProp == baseClassProp || basePropsOfThisClassProp.contains(baseClassProp)) {
               // Yes. Is the directly defined one at least as restrictive as the inheritable one?
 
-              if (baseClassCardinality.cardinality.isStricterThan(thisClassCardinality.cardinality)) {
+              if (thisClassCardinality.cardinality.isNotIncludedIn(baseClassCardinality.cardinality)) {
                 // No. Throw an exception.
                 errorFun(
                   s"In class <${classIri.toOntologySchema(errorSchema)}>, the directly defined cardinality '${thisClassCardinality.cardinality.toString}' on ${thisClassProp

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/model/Cardinality.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/model/Cardinality.scala
@@ -24,7 +24,7 @@ sealed trait Cardinality {
    * is included in its entire range of possible values.
    *
    * @param other The cardinality to be compared against.
-   * @return `true` if this cardinality is include in the `other`, `false` otherwise.
+   * @return `true` if this cardinality is included in the `other`, `false` otherwise.
    */
   def isIncludedIn(other: Cardinality): Boolean = {
     val lowerBoundIsIncluded = this.min >= other.min && other.max.forall(this.min <= _)

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/CardinalityService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/CardinalityService.scala
@@ -152,7 +152,7 @@ final case class CardinalityServiceLive(
       propSmartIri          <- iriConverter.asInternalSmartIri(propertyIri)
       classInfoMaybe        <- ontologyRepo.findClassBy(classIri)
       inheritedCardinalities = classInfoMaybe.flatMap(_.inheritedCardinalities.get(propSmartIri)).map(_.cardinality)
-    } yield inheritedCardinalities.forall(_.isStricterThan(newCardinality))
+    } yield inheritedCardinalities.forall(newCardinality.isNotIncludedIn)
 
   /**
    * Checks if a specific cardinality may be replaced.

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/CardinalityServiceLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/CardinalityServiceLiveSpec.scala
@@ -28,7 +28,7 @@ import org.knora.webapi.slice.ontology.domain.model.Cardinality.AtLeastOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.Unbounded
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
-import org.knora.webapi.slice.ontology.domain.model.Cardinality.allCardinalities
+import org.knora.webapi.slice.ontology.domain.model.CardinalitySpec.Generator.cardinalitiesGen
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanSetCardinalityCheckResult.BaseClassCheckFailure
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanSetCardinalityCheckResult.CanSetCheckSuccess
@@ -42,17 +42,6 @@ import org.knora.webapi.store.triplestore.TestDatasetBuilder._
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceFake
 
 object CardinalityServiceLiveSpec extends ZIOSpecDefault {
-
-  def cardinalitiesGen(cardinalities: Cardinality*): Gen[Any, Cardinality] = Gen.fromZIO {
-    val candidates: Array[Cardinality] = if (cardinalities != Nil) { cardinalities.toArray }
-    else { allCardinalities }
-    val length = candidates.length
-    if (length == 0) {
-      throw new IllegalArgumentException()
-    } else {
-      Random.nextIntBetween(0, length).map(i => candidates(i))
-    }
-  }
 
   private object IsPropertyUsedInResourcesTestData {
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/model/CardinalitySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/model/CardinalitySpec.scala
@@ -25,7 +25,7 @@ object CardinalitySpec extends ZIOSpecDefault {
       if (length == 0) {
         throw new IllegalArgumentException("The parameter cardinalities may not be an empty Array.")
       } else {
-        Random.nextIntBetween(0, length).map(i => candidates(i))
+        Random.nextIntBetween(0, length).map(candidates(_))
       }
     }
   }

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/model/CardinalitySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/model/CardinalitySpec.scala
@@ -11,13 +11,23 @@ import zio.test._
 
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality
 import org.knora.webapi.slice.ontology.domain.model.Cardinality._
+import org.knora.webapi.slice.ontology.domain.model.CardinalitySpec.Generator.cardinalitiesGen
 
 object CardinalitySpec extends ZIOSpecDefault {
-  val cardinalityGen: Gen[Any, Cardinality] = {
-    val list = Array(AtLeastOne, ExactlyOne, ZeroOrOne, Unbounded)
-    Gen.fromZIO(for {
-      random <- Random.nextIntBetween(0, list.length)
-    } yield list(random))
+  object Generator {
+    def cardinalitiesGen(cardinalities: Cardinality*): Gen[Any, Cardinality] = Gen.fromZIO {
+      val candidates: Array[Cardinality] = if (cardinalities != Nil) {
+        cardinalities.toArray
+      } else {
+        allCardinalities
+      }
+      val length = candidates.length
+      if (length == 0) {
+        throw new IllegalArgumentException("The parameter cardinalities may not be an empty Array")
+      } else {
+        Random.nextIntBetween(0, length).map(i => candidates(i))
+      }
+    }
   }
 
   val spec: Spec[TestEnvironment with Scope, Nothing] = suite("CardinalitySpec")(
@@ -32,50 +42,30 @@ object CardinalitySpec extends ZIOSpecDefault {
         assertTrue(ExactlyOne.toString == "1")
       }
     ),
-    suite("Cardinality isStricterThan")(
-      test("Same cardinality is never stricter") {
-        check(cardinalityGen)(c => assertTrue(!c.isStricterThan(c)))
+    suite("Cardinality isIncludedIn")(
+      test("Same cardinality is always included in itself") {
+        check(cardinalitiesGen())(c => assertTrue(c.isIncludedIn(c)))
       },
-      suite(s"Unbounded $Unbounded")(
-        test(s"'$AtLeastOne' is stricter than $Unbounded") {
-          assertTrue(AtLeastOne.isStricterThan(Unbounded))
-        },
-        test(s"'$ExactlyOne is stricter than $Unbounded") {
-          assertTrue(ExactlyOne.isStricterThan(Unbounded))
-        },
-        test(s"'$ZeroOrOne' is stricter than $Unbounded") {
-          assertTrue(ZeroOrOne.isStricterThan(Unbounded))
-        },
-        test(s"'$Unbounded' is NOT stricter than any other") {
-          check(cardinalityGen) { other =>
-            assertTrue(!Unbounded.isStricterThan(other))
-          }
+      test(s"All cardinalities are included in Unbounded '$Unbounded'") {
+        check(cardinalitiesGen()) { other =>
+          assertTrue(other.isIncludedIn(Unbounded))
         }
-      ),
-      suite(s"AtLeastOne $AtLeastOne")(
-        test(s"'$AtLeastOne' is NOT stricter than $ExactlyOne") {
-          assertTrue(!AtLeastOne.isStricterThan(ExactlyOne))
-        },
-        test(s"'$AtLeastOne' is stricter than $ZeroOrOne") {
-          assertTrue(AtLeastOne.isStricterThan(ZeroOrOne))
+      },
+      test(s"AtLeastOne '$AtLeastOne' is not included in: ZeroOrOne '$ZeroOrOne', ExactlyOne '$ExactlyOne'") {
+        check(cardinalitiesGen(ZeroOrOne, ExactlyOne)) { other =>
+          assertTrue(AtLeastOne.isNotIncludedIn(other))
         }
-      ),
-      suite(s"ExactlyOne $ExactlyOne")(
-        test(s"'$ExactlyOne' is stricter than $AtLeastOne") {
-          assertTrue(ExactlyOne.isStricterThan(AtLeastOne))
-        },
-        test(s"'$ExactlyOne' is stricter than $ZeroOrOne") {
-          assertTrue(ExactlyOne.isStricterThan(ZeroOrOne))
+      },
+      test(s"ZeroOrOne '$ZeroOrOne' is NOT included in: AtLeastOne '$AtLeastOne', ExactlyOne '$ExactlyOne''") {
+        check(cardinalitiesGen(AtLeastOne, ExactlyOne)) { other =>
+          assertTrue(ZeroOrOne.isNotIncludedIn(other))
         }
-      ),
-      suite(s"ZeroOrOne $ZeroOrOne")(
-        test(s"'$ZeroOrOne' is stricter than $AtLeastOne") {
-          assertTrue(ZeroOrOne.isStricterThan(AtLeastOne))
-        },
-        test(s"'$ZeroOrOne' is NOT stricter than $ExactlyOne") {
-          assertTrue(!ZeroOrOne.isStricterThan(ExactlyOne))
+      },
+      test(s"ExactlyOne '$ExactlyOne' is included in all other Cardinalities") {
+        check(cardinalitiesGen()) { other =>
+          assertTrue(ExactlyOne.isIncludedIn(other))
         }
-      )
+      }
     ),
     suite("toOwl")(
       test(s"AtLeastOne $AtLeastOne") {

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/model/CardinalitySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/model/CardinalitySpec.scala
@@ -23,7 +23,7 @@ object CardinalitySpec extends ZIOSpecDefault {
       }
       val length = candidates.length
       if (length == 0) {
-        throw new IllegalArgumentException("The parameter cardinalities may not be an empty Array")
+        throw new IllegalArgumentException("The parameter cardinalities may not be an empty Array.")
       } else {
         Random.nextIntBetween(0, length).map(i => candidates(i))
       }

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/model/CardinalitySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/model/CardinalitySpec.scala
@@ -51,7 +51,7 @@ object CardinalitySpec extends ZIOSpecDefault {
           assertTrue(other.isIncludedIn(Unbounded))
         }
       },
-      test(s"AtLeastOne '$AtLeastOne' is not included in: ZeroOrOne '$ZeroOrOne', ExactlyOne '$ExactlyOne'") {
+      test(s"AtLeastOne '$AtLeastOne' is NOT included in: ZeroOrOne '$ZeroOrOne', ExactlyOne '$ExactlyOne'") {
         check(cardinalitiesGen(ZeroOrOne, ExactlyOne)) { other =>
           assertTrue(AtLeastOne.isNotIncludedIn(other))
         }


### PR DESCRIPTION
### Task Description/Number

A cardinality includes another cardinality if and only if the other cardinality is included in its entire range of possible values.

The previous method `isStricterThan` assumes/suggests a commutative property in the sense that when comparing different cardinalities `a` and `b` then if the comparison `a isStricterThan b == false` then `b isStricterThan a == true` must also hold. However, this is not the always the case as for example it is with `ZeroOrOne` and `AtLeastOne`. Both cardinalities are "stricter" than the other as their range of values only has a very small intersection and none contains the other in full. In the future with the introduction of other cardinalities e.g. ExactlyTwo an intersection might not even occur.

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the Jira ticket number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-1563

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] Bugfix: represents bug fixes
- [x] Refactor: represents production code refactoring
- [ ] Feature: represents a new feature
- [ ] Documentation: documentation changes (no production code change)
- [ ] Chore: maintenance tasks (no production code change)
- [ ] Style: styles updates (no production code change)
- [ ] Test: all about tests: adding, refactoring tests (no production code change)
- [ ] Other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
