### PR TITLE
fix: Test file issue

### DIFF
--- a/webapi/src/test/scala/org/knora/webapi/routing/admin/ProjectsRouteZSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/routing/admin/ProjectsRouteZSpec.scala
@@ -324,7 +324,7 @@ object ProjectsRouteZSpec extends ZIOSpecDefault {
       val mockService: ULayer[ProjectsService] = ProjectsServiceMock
         .GetAllProjectData(
           assertion = Assertion.equalTo(identifier, user),
-          result = Expectation.value[ProjectDataGetResponseADM](ProjectDataGetResponseADM(path))
+          result = Expectation.value[ProjectDataGetResponseADM](ProjectDataGetResponseADM(testFile))
         )
         .toLayer
       for {

--- a/webapi/src/test/scala/org/knora/webapi/routing/admin/ProjectsRouteZSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/routing/admin/ProjectsRouteZSpec.scala
@@ -318,7 +318,7 @@ object ProjectsRouteZSpec extends ZIOSpecDefault {
       val iri      = identifier.asIriIdentifierOption.getOrElse(throw BadRequestException("Invalid project IRI"))
       val user     = KnoraSystemInstances.Users.SystemUser
       val request  = Request.get(url = URL(basePathProjectsIri / encode(iri) / "AllData"))
-      val path     = file.Paths.get("src/test/resources/getAllDataFile.trig")
+      val path     = file.Paths.get("getAllDataFile.trig")
       val testFile = file.Files.createFile(path)
 
       val mockService: ULayer[ProjectsService] = ProjectsServiceMock

--- a/webapi/src/test/scala/org/knora/webapi/routing/admin/ProjectsRouteZSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/routing/admin/ProjectsRouteZSpec.scala
@@ -315,10 +315,12 @@ object ProjectsRouteZSpec extends ZIOSpecDefault {
       val identifier: ProjectIdentifierADM = ProjectIdentifierADM.IriIdentifier
         .fromString("http://rdfh.ch/projects/0001")
         .getOrElse(throw BadRequestException("Invalid project IRI"))
-      val iri     = identifier.asIriIdentifierOption.getOrElse(throw BadRequestException("Invalid project IRI"))
-      val user    = KnoraSystemInstances.Users.SystemUser
-      val request = Request.get(url = URL(basePathProjectsIri / encode(iri) / "AllData"))
-      val path    = file.Paths.get("src/test/resources/getAllDataFile.trig")
+      val iri      = identifier.asIriIdentifierOption.getOrElse(throw BadRequestException("Invalid project IRI"))
+      val user     = KnoraSystemInstances.Users.SystemUser
+      val request  = Request.get(url = URL(basePathProjectsIri / encode(iri) / "AllData"))
+      val path     = file.Paths.get("src/test/resources/getAllDataFile.trig")
+      val testFile = file.Files.createFile(path)
+
       val mockService: ULayer[ProjectsService] = ProjectsServiceMock
         .GetAllProjectData(
           assertion = Assertion.equalTo(identifier, user),
@@ -334,7 +336,7 @@ object ProjectsRouteZSpec extends ZIOSpecDefault {
       val iri     = "http://rdfh.ch/project/0001"
       val user    = KnoraSystemInstances.Users.SystemUser
       val request = Request.get(url = URL(basePathProjectsIri / encode(iri) / "AllData"))
-      val path    = file.Paths.get("src/test/resources/getAllDataFile.trig")
+      val path    = file.Paths.get("...")
 
       for {
         response     <- applyRoutes(request).provide(ProjectsServiceMock.empty)


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the Jira ticket number or, in case of unscheduled work, a short description of the task at hand -->

In [PR 2413](https://github.com/dasch-swiss/dsp-api/pull/2413), the test file in test/resources was deleted by the route after the test run without re-creating it. As a consequence, the next test run failed. The problem is fixed now by the test creating its own test file (which can then safely be deleted by the route afterwards).

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [x] Bugfix: represents bug fixes
- [ ] Refactor: represents production code refactoring
- [ ] Feature: represents a new feature
- [ ] Documentation: documentation changes (no production code change)
- [ ] Chore: maintenance tasks (no production code change)
- [ ] Style: styles updates (no production code change)
- [x] Test: all about tests: adding, refactoring tests (no production code change)
- [ ] Other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
