### PR TITLE
fix!: return empty list instead of an error on GET /admin/groups route (DEV-1599)

### DIFF
--- a/webapi/src/it/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
@@ -62,7 +62,7 @@ class GroupsResponderADMSpec extends CoreSpec with ImplicitSender {
           groupIri = "http://rdfh.ch/groups/notexisting"
         )
 
-        expectMsgPF(timeout) { case msg: akka.actor.Status.Failure =>
+        expectMsgPF(timeout) { case msg: Failure =>
           msg.cause.isInstanceOf[NotFoundException] should ===(true)
         }
       }
@@ -127,7 +127,7 @@ class GroupsResponderADMSpec extends CoreSpec with ImplicitSender {
           apiRequestID = UUID.randomUUID
         )
 
-        expectMsgPF(timeout) { case msg: akka.actor.Status.Failure =>
+        expectMsgPF(timeout) { case msg: Failure =>
           msg.cause.isInstanceOf[DuplicateValueException] should ===(true)
         }
       }
@@ -176,7 +176,7 @@ class GroupsResponderADMSpec extends CoreSpec with ImplicitSender {
           apiRequestID = UUID.randomUUID
         )
 
-        expectMsgPF(timeout) { case msg: akka.actor.Status.Failure =>
+        expectMsgPF(timeout) { case msg: Failure =>
           msg.cause.isInstanceOf[NotFoundException] should ===(true)
         }
       }
@@ -196,7 +196,7 @@ class GroupsResponderADMSpec extends CoreSpec with ImplicitSender {
           apiRequestID = UUID.randomUUID
         )
 
-        expectMsgPF(timeout) { case msg: akka.actor.Status.Failure =>
+        expectMsgPF(timeout) { case msg: Failure =>
           msg.cause.isInstanceOf[BadRequestException] should ===(true)
         }
       }
@@ -255,7 +255,7 @@ class GroupsResponderADMSpec extends CoreSpec with ImplicitSender {
           requestingUser = SharedTestDataADM.rootUser
         )
 
-        expectMsgPF(timeout) { case msg: akka.actor.Status.Failure =>
+        expectMsgPF(timeout) { case msg: Failure =>
           msg.cause.isInstanceOf[NotFoundException] should ===(true)
         }
       }

--- a/webapi/src/it/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
@@ -238,7 +238,6 @@ class GroupsResponderADMSpec extends CoreSpec with ImplicitSender {
         )
 
         val statusChangeResponse = expectMsgType[GroupOperationResponseADM](timeout)
-
         statusChangeResponse.group.status shouldBe false
 
         appActor ! GroupMembersGetRequestADM(

--- a/webapi/src/it/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
@@ -245,7 +245,8 @@ class GroupsResponderADMSpec extends CoreSpec with ImplicitSender {
           requestingUser = SharedTestDataADM.rootUser
         )
 
-        expectMsg(Failure(NotFoundException("No members found.")))
+        val noMembers: GroupMembersGetResponseADM = expectMsgType[GroupMembersGetResponseADM](timeout)
+        noMembers.members.size shouldBe 0
       }
 
       "return 'NotFound' when the group IRI is unknown" in {

--- a/webapi/src/it/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
@@ -3,14 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * To be able to test UsersResponder, we need to be able to start UsersResponder isolated. Now the UsersResponder
- * extend ResponderADM which messes up testing, as we cannot inject the TestActor system.
- */
 package org.knora.webapi.responders.admin
 
 import akka.actor.Status.Failure
-import akka.testkit.ImplicitSender
 
 import java.util.UUID
 import scala.concurrent.duration._
@@ -29,9 +24,9 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.util.MutableTestIri
 
 /**
- * This spec is used to test the messages received by the [[org.knora.webapi.responders.admin.UsersResponderADM]] actor.
+ * This spec is used to test the messages received by the [[org.knora.webapi.responders.admin.GroupsResponderADMSpec]] actor.
  */
-class GroupsResponderADMSpec extends CoreSpec with ImplicitSender {
+class GroupsResponderADMSpec extends CoreSpec {
   private val timeout             = 5.seconds
   private val imagesProject       = SharedTestDataADM.imagesProject
   private val imagesReviewerGroup = SharedTestDataADM.imagesReviewerGroup

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -370,18 +370,13 @@ class GroupsResponderADM(responderData: ResponderData)
     log.debug("groupMembersGetRequestADM - groupIri: {}", groupIri)
 
     for {
-      maybeMembersListToReturn <-
+      members <-
         groupMembersGetADM(
           groupIri = groupIri,
           requestingUser = requestingUser
         )
 
-      result =
-        maybeMembersListToReturn match {
-          case members: Seq[UserADM] if members.nonEmpty => GroupMembersGetResponseADM(members = members)
-          case _                                         => throw NotFoundException(s"No members found.")
-        }
-    } yield result
+    } yield GroupMembersGetResponseADM(members)
   }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -252,10 +252,11 @@ class GroupsResponderADM(responderData: ResponderData)
           groupIri = groupIri
         )
 
-      result = maybeGroupADM match {
-                 case Some(group) => GroupGetResponseADM(group = group)
-                 case None        => throw NotFoundException(s"Group <$groupIri> not found")
-               }
+      result =
+        maybeGroupADM match {
+          case Some(group) => GroupGetResponseADM(group = group)
+          case None        => throw NotFoundException(s"Group <$groupIri> not found.")
+        }
     } yield result
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -375,8 +375,12 @@ class GroupsResponderADM(responderData: ResponderData)
           requestingUser = requestingUser
         )
 
-      members = maybeMembersListToReturn
-    } yield GroupMembersGetResponseADM(members)
+      result =
+        maybeMembersListToReturn match {
+          case members: Seq[UserADM] if members.nonEmpty => GroupMembersGetResponseADM(members = members)
+          case _                                         => throw NotFoundException(s"No members found.")
+        }
+    } yield result
   }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -194,14 +194,8 @@ class GroupsResponderADM(responderData: ResponderData)
    */
   private def groupsGetRequestADM: Future[GroupsGetResponseADM] =
     for {
-      maybeGroupsListToReturn <-
-        groupsGetADM
-
-      result = maybeGroupsListToReturn match {
-                 case groups: Seq[GroupADM] if groups.nonEmpty => GroupsGetResponseADM(groups = groups)
-                 case _                                        => throw NotFoundException(s"No groups found")
-               }
-    } yield result
+      groups <- groupsGetADM
+    } yield GroupsGetResponseADM(groups)
 
   /**
    * Gets the group with the given group IRI and returns the information as a [[GroupADM]].
@@ -381,11 +375,8 @@ class GroupsResponderADM(responderData: ResponderData)
           requestingUser = requestingUser
         )
 
-      result = maybeMembersListToReturn match {
-                 case members: Seq[UserADM] if members.nonEmpty => GroupMembersGetResponseADM(members = members)
-                 case _                                         => throw NotFoundException(s"No members found.")
-               }
-    } yield result
+      members = maybeMembersListToReturn
+    } yield GroupMembersGetResponseADM(members)
   }
 
   /**


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-1599
The same was applied to `GET: /admin/groups/<groupIri>/members` route.

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [x] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
