### PR TITLE
chore: Rename TestDataFactory -> ITTestDataFactory

### DIFF
--- a/webapi/src/it/scala/org/knora/webapi/ITTestDataFactory.scala
+++ b/webapi/src/it/scala/org/knora/webapi/ITTestDataFactory.scala
@@ -8,7 +8,7 @@ import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentif
 /**
  * Helps in creating value objects for tests.
  */
-object TestDataFactory {
+object ITTestDataFactory {
   def projectShortcodeIdentifier(shortcode: String): ShortcodeIdentifier =
     ShortcodeIdentifier
       .fromString(shortcode)

--- a/webapi/src/it/scala/org/knora/webapi/responders/admin/ProjectsResponderADMSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/responders/admin/ProjectsResponderADMSpec.scala
@@ -11,15 +11,14 @@ package org.knora.webapi.responders.admin
 
 import akka.actor.Status.Failure
 import akka.testkit.ImplicitSender
-
 import java.util.UUID
 import scala.concurrent.duration._
-
 import dsp.errors.BadRequestException
 import dsp.errors.DuplicateValueException
 import dsp.errors.NotFoundException
 import dsp.valueobjects.Project._
 import dsp.valueobjects.V2
+
 import org.knora.webapi._
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.StringFormatter
@@ -363,15 +362,15 @@ class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
       }
 
       "UPDATE a project" in {
-        val iri             = TestDataFactory.projectIri(newProjectIri.get)
-        val updatedLongname = TestDataFactory.projectName("updated project longname")
-        val updatedDescription = TestDataFactory.projectDescription(
+        val iri             = ITTestDataFactory.projectIri(newProjectIri.get)
+        val updatedLongname = ITTestDataFactory.projectName("updated project longname")
+        val updatedDescription = ITTestDataFactory.projectDescription(
           Seq(V2.StringLiteralV2("""updated project description with "quotes" and <html tags>""", Some("en")))
         )
-        val updatedKeywords = TestDataFactory.projectKeywords(Seq("updated", "keywords"))
-        val updatedLogo     = TestDataFactory.projectLogo("/fu/bar/baz-updated.jpg")
-        val projectStatus   = TestDataFactory.projectStatus(true)
-        val selfJoin        = TestDataFactory.projectSelfJoin(true)
+        val updatedKeywords = ITTestDataFactory.projectKeywords(Seq("updated", "keywords"))
+        val updatedLogo     = ITTestDataFactory.projectLogo("/fu/bar/baz-updated.jpg")
+        val projectStatus   = ITTestDataFactory.projectStatus(true)
+        val selfJoin        = ITTestDataFactory.projectSelfJoin(true)
 
         appActor ! ProjectChangeRequestADM(
           projectIri = iri,
@@ -406,8 +405,8 @@ class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
       }
 
       "return 'NotFound' if a not existing project IRI is submitted during update" in {
-        val longname = TestDataFactory.projectName("longname")
-        val iri      = TestDataFactory.projectIri(notExistingProjectButValidProjectIri)
+        val longname = ITTestDataFactory.projectName("longname")
+        val iri      = ITTestDataFactory.projectIri(notExistingProjectButValidProjectIri)
         appActor ! ProjectChangeRequestADM(
           projectIri = iri,
           projectUpdatePayload = ProjectUpdatePayloadADM(longname = Some(longname)),
@@ -652,7 +651,7 @@ class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
       }
 
       "return all keywords for a single project" in {
-        val iri = TestDataFactory.projectIri(SharedTestDataADM.incunabulaProject.id)
+        val iri = ITTestDataFactory.projectIri(SharedTestDataADM.incunabulaProject.id)
         appActor ! ProjectKeywordsGetRequestADM(
           projectIri = iri
         )
@@ -661,7 +660,7 @@ class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
       }
 
       "return empty list for a project without keywords" in {
-        val iri = TestDataFactory.projectIri(SharedTestDataADM.dokubibProject.id)
+        val iri = ITTestDataFactory.projectIri(SharedTestDataADM.dokubibProject.id)
         appActor ! ProjectKeywordsGetRequestADM(
           projectIri = iri
         )
@@ -670,7 +669,7 @@ class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
       }
 
       "return 'NotFound' when the project IRI is unknown" in {
-        val iri = TestDataFactory.projectIri(notExistingProjectButValidProjectIri)
+        val iri = ITTestDataFactory.projectIri(notExistingProjectButValidProjectIri)
         appActor ! ProjectKeywordsGetRequestADM(
           projectIri = iri
         )


### PR DESCRIPTION
In IntelliJ IDEA the compile does not separate the source sets of test and it so it would fail with a duplicate class being present.

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

In IntelliJ IDEA the compile does not separate the source sets of test and it so it would fail with a duplicate class being present.
### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [x] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
