### PR TITLE
refactor: Ziofy ProjectsResponderADM DEV-1728

### DIFF
--- a/webapi/src/it/scala/org/knora/webapi/core/LayersTest.scala
+++ b/webapi/src/it/scala/org/knora/webapi/core/LayersTest.scala
@@ -4,12 +4,11 @@ import org.knora.webapi.auth.JWTService
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.config.AppConfigForTestContainers
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.responders.ActorDeps
+import org.knora.webapi.responders.ActorToZioBridge
 import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.admin.ProjectsResponderADM
 import org.knora.webapi.responders.admin.ProjectsResponderADMLive
-import org.knora.webapi.responders.ActorDeps
-import org.knora.webapi.responders.ActorToZioBridge
-import org.knora.webapi.responders.EntityAndClassIriService
 import org.knora.webapi.routing.ApiRoutes
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
@@ -52,7 +51,6 @@ object LayersTest {
     with CacheService
     with CacheServiceManager
     with CardinalityService
-    with EntityAndClassIriService
     with HttpServer
     with IIIFServiceManager
     with IriConverter
@@ -79,7 +77,6 @@ object LayersTest {
       CacheServiceInMemImpl.layer,
       CacheServiceManager.layer,
       CardinalityService.layer,
-      EntityAndClassIriService.layer,
       HttpServer.layer,
       IIIFServiceManager.layer,
       IriConverter.layer,

--- a/webapi/src/it/scala/org/knora/webapi/core/LayersTest.scala
+++ b/webapi/src/it/scala/org/knora/webapi/core/LayersTest.scala
@@ -1,27 +1,37 @@
 package org.knora.webapi.core
 
 import org.knora.webapi.auth.JWTService
-import org.knora.webapi.config.{AppConfig, AppConfigForTestContainers}
+import org.knora.webapi.config.AppConfig
+import org.knora.webapi.config.AppConfigForTestContainers
 import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.responders.admin.{ProjectsResponderADM, ProjectsResponderADMLive}
-import org.knora.webapi.responders.{ActorDeps, ActorToZioBridge, EntityAndClassIriService}
+import org.knora.webapi.responders.IriService
+import org.knora.webapi.responders.admin.ProjectsResponderADM
+import org.knora.webapi.responders.admin.ProjectsResponderADMLive
+import org.knora.webapi.responders.ActorDeps
+import org.knora.webapi.responders.ActorToZioBridge
+import org.knora.webapi.responders.EntityAndClassIriService
 import org.knora.webapi.routing.ApiRoutes
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
-import org.knora.webapi.slice.ontology.repo.service.{OntologyCache, OntologyRepoLive, PredicateRepositoryLive}
+import org.knora.webapi.slice.ontology.repo.service.OntologyCache
+import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
+import org.knora.webapi.slice.ontology.repo.service.PredicateRepositoryLive
 import org.knora.webapi.slice.resourceinfo.api.RestResourceInfoService
-import org.knora.webapi.slice.resourceinfo.domain.{IriConverter, ResourceInfoRepo}
+import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.resourceinfo.domain.ResourceInfoRepo
 import org.knora.webapi.store.cache.CacheServiceManager
 import org.knora.webapi.store.cache.api.CacheService
 import org.knora.webapi.store.cache.impl.CacheServiceInMemImpl
 import org.knora.webapi.store.iiif.IIIFServiceManager
 import org.knora.webapi.store.iiif.api.IIIFService
-import org.knora.webapi.store.iiif.impl.{IIIFServiceMockImpl, IIIFServiceSipiImpl}
+import org.knora.webapi.store.iiif.impl.IIIFServiceMockImpl
+import org.knora.webapi.store.iiif.impl.IIIFServiceSipiImpl
 import org.knora.webapi.store.triplestore.TriplestoreServiceManager
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.impl.TriplestoreServiceLive
 import org.knora.webapi.store.triplestore.upgrade.RepositoryUpdater
-import org.knora.webapi.testcontainers.{FusekiTestContainer, SipiTestContainer}
+import org.knora.webapi.testcontainers.FusekiTestContainer
+import org.knora.webapi.testcontainers.SipiTestContainer
 import org.knora.webapi.testservices.TestClientService
 import zio._
 
@@ -46,6 +56,7 @@ object LayersTest {
     with HttpServer
     with IIIFServiceManager
     with IriConverter
+    with IriService
     with MessageRelay
     with ProjectsResponderADM
     with RepositoryUpdater
@@ -72,6 +83,7 @@ object LayersTest {
       HttpServer.layer,
       IIIFServiceManager.layer,
       IriConverter.layer,
+      IriService.layer,
       MessageRelayLive.layer,
       OntologyCache.layer,
       OntologyRepoLive.layer,

--- a/webapi/src/it/scala/org/knora/webapi/core/LayersTest.scala
+++ b/webapi/src/it/scala/org/knora/webapi/core/LayersTest.scala
@@ -3,7 +3,8 @@ package org.knora.webapi.core
 import org.knora.webapi.auth.JWTService
 import org.knora.webapi.config.{AppConfig, AppConfigForTestContainers}
 import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.responders.{ActorDeps, ActorToZioBridge}
+import org.knora.webapi.responders.admin.{ProjectsResponderADM, ProjectsResponderADMLive}
+import org.knora.webapi.responders.{ActorDeps, ActorToZioBridge, EntityAndClassIriService}
 import org.knora.webapi.routing.ApiRoutes
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
@@ -41,10 +42,12 @@ object LayersTest {
     with CacheService
     with CacheServiceManager
     with CardinalityService
+    with EntityAndClassIriService
     with HttpServer
     with IIIFServiceManager
     with IriConverter
     with MessageRelay
+    with ProjectsResponderADM
     with RepositoryUpdater
     with ResourceInfoRepo
     with RestCardinalityService
@@ -65,12 +68,14 @@ object LayersTest {
       CacheServiceInMemImpl.layer,
       CacheServiceManager.layer,
       CardinalityService.layer,
+      EntityAndClassIriService.layer,
       HttpServer.layer,
       IIIFServiceManager.layer,
       IriConverter.layer,
       MessageRelayLive.layer,
       OntologyCache.layer,
       OntologyRepoLive.layer,
+      ProjectsResponderADMLive.layer,
       PredicateRepositoryLive.layer,
       RepositoryUpdater.layer,
       ResourceInfoRepo.layer,

--- a/webapi/src/it/scala/org/knora/webapi/responders/admin/ProjectsResponderADMSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/responders/admin/ProjectsResponderADMSpec.scala
@@ -11,11 +11,17 @@ package org.knora.webapi.responders.admin
 
 import akka.actor.Status.Failure
 import akka.testkit.ImplicitSender
-import dsp.errors.{BadRequestException, DuplicateValueException, NotFoundException}
+import java.util.UUID
+import scala.concurrent.duration._
+import dsp.errors.BadRequestException
+import dsp.errors.DuplicateValueException
+import dsp.errors.NotFoundException
 import dsp.valueobjects.Project._
 import dsp.valueobjects.V2
+
 import org.knora.webapi._
-import org.knora.webapi.messages.{OntologyConstants, StringFormatter}
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.admin.responder.permissionsmessages._
 import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM._
 import org.knora.webapi.messages.admin.responder.projectsmessages._
@@ -23,16 +29,13 @@ import org.knora.webapi.messages.admin.responder.usersmessages.UserInformationTy
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.util.MutableTestIri
 
-import java.util.UUID
-import scala.concurrent.duration._
-
 /**
  * This spec is used to test the messages received by the [[ProjectsResponderADM]] actor.
  */
 class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
 
   private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
-  private val timeout                                   = 600.seconds
+  private val timeout                                   = 5.seconds
 
   private val rootUser = SharedTestDataADM.rootUser
 
@@ -413,7 +416,7 @@ class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
         expectMsg(
           Failure(
             NotFoundException(
-              s"Project '$notExistingProjectButValidProjectIri' not found. Aborting update request."
+              s"Project '${notExistingProjectButValidProjectIri}' not found. Aborting update request."
             )
           )
         )

--- a/webapi/src/it/scala/org/knora/webapi/responders/admin/ProjectsResponderADMSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/responders/admin/ProjectsResponderADMSpec.scala
@@ -11,17 +11,11 @@ package org.knora.webapi.responders.admin
 
 import akka.actor.Status.Failure
 import akka.testkit.ImplicitSender
-import java.util.UUID
-import scala.concurrent.duration._
-import dsp.errors.BadRequestException
-import dsp.errors.DuplicateValueException
-import dsp.errors.NotFoundException
+import dsp.errors.{BadRequestException, DuplicateValueException, NotFoundException}
 import dsp.valueobjects.Project._
 import dsp.valueobjects.V2
-
 import org.knora.webapi._
-import org.knora.webapi.messages.OntologyConstants
-import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.{OntologyConstants, StringFormatter}
 import org.knora.webapi.messages.admin.responder.permissionsmessages._
 import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM._
 import org.knora.webapi.messages.admin.responder.projectsmessages._
@@ -29,13 +23,16 @@ import org.knora.webapi.messages.admin.responder.usersmessages.UserInformationTy
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.util.MutableTestIri
 
+import java.util.UUID
+import scala.concurrent.duration._
+
 /**
  * This spec is used to test the messages received by the [[ProjectsResponderADM]] actor.
  */
 class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
 
   private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
-  private val timeout                                   = 5.seconds
+  private val timeout                                   = 600.seconds
 
   private val rootUser = SharedTestDataADM.rootUser
 
@@ -416,7 +413,7 @@ class ProjectsResponderADMSpec extends CoreSpec with ImplicitSender {
         expectMsg(
           Failure(
             NotFoundException(
-              s"Project '${notExistingProjectButValidProjectIri}' not found. Aborting update request."
+              s"Project '$notExistingProjectButValidProjectIri' not found. Aborting update request."
             )
           )
         )

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -14,7 +14,6 @@ import org.knora.webapi.http.middleware.AuthenticationMiddleware
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.responders.ActorDeps
 import org.knora.webapi.responders.ActorToZioBridge
-import org.knora.webapi.responders.EntityAndClassIriService
 import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.admin.ProjectsResponderADM
 import org.knora.webapi.responders.admin.ProjectsResponderADMLive
@@ -55,7 +54,6 @@ object LayersLive {
       with AppRouterRelayingMessageHandler
       with CacheServiceManager
       with CacheService
-      with EntityAndClassIriService
       with HttpServer
       with IIIFServiceManager
       with IIIFService
@@ -87,7 +85,6 @@ object LayersLive {
       CacheServiceInMemImpl.layer,
       CacheServiceManager.layer,
       CardinalityService.layer,
-      EntityAndClassIriService.layer,
       HttpServer.layer,
       HttpServerZ.layer, // this is the new ZIO HTTP server layer
       IIIFServiceManager.layer,

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -14,6 +14,9 @@ import org.knora.webapi.http.middleware.AuthenticationMiddleware
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.responders.ActorDeps
 import org.knora.webapi.responders.ActorToZioBridge
+import org.knora.webapi.responders.EntityAndClassIriService
+import org.knora.webapi.responders.admin.ProjectsResponderADM
+import org.knora.webapi.responders.admin.ProjectsResponderADMLive
 import org.knora.webapi.responders.admin.ProjectsService
 import org.knora.webapi.routing.ApiRoutes
 import org.knora.webapi.routing.admin.AuthenticatorService
@@ -51,11 +54,13 @@ object LayersLive {
       with AppRouterRelayingMessageHandler
       with CacheServiceManager
       with CacheService
+      with EntityAndClassIriService
       with HttpServer
       with IIIFServiceManager
       with IIIFService
       with JWTService
       with MessageRelay
+      with ProjectsResponderADM
       with RepositoryUpdater
       with RestResourceInfoService
       with RestCardinalityService
@@ -80,6 +85,7 @@ object LayersLive {
       CacheServiceInMemImpl.layer,
       CacheServiceManager.layer,
       CardinalityService.layer,
+      EntityAndClassIriService.layer,
       HttpServer.layer,
       HttpServerZ.layer, // this is the new ZIO HTTP server layer
       IIIFServiceManager.layer,
@@ -91,6 +97,7 @@ object LayersLive {
       OntologyRepoLive.layer,
       PredicateRepositoryLive.layer,
       ProjectsRouteZ.layer,
+      ProjectsResponderADMLive.layer,
       ProjectsService.live,
       RepositoryUpdater.layer,
       ResourceInfoRepo.layer,

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -15,6 +15,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.responders.ActorDeps
 import org.knora.webapi.responders.ActorToZioBridge
 import org.knora.webapi.responders.EntityAndClassIriService
+import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.admin.ProjectsResponderADM
 import org.knora.webapi.responders.admin.ProjectsResponderADMLive
 import org.knora.webapi.responders.admin.ProjectsService
@@ -58,6 +59,7 @@ object LayersLive {
       with HttpServer
       with IIIFServiceManager
       with IIIFService
+      with IriService
       with JWTService
       with MessageRelay
       with ProjectsResponderADM
@@ -91,6 +93,7 @@ object LayersLive {
       IIIFServiceManager.layer,
       IIIFServiceSipiImpl.layer,
       IriConverter.layer,
+      IriService.layer,
       JWTService.layer,
       MessageRelayLive.layer,
       OntologyCache.layer,

--- a/webapi/src/main/scala/org/knora/webapi/core/actors/RoutingActor.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/actors/RoutingActor.scala
@@ -17,7 +17,6 @@ import org.knora.webapi.core.RelayedMessage
 import org.knora.webapi.messages.admin.responder.groupsmessages.GroupsResponderRequestADM
 import org.knora.webapi.messages.admin.responder.listsmessages.ListsResponderRequestADM
 import org.knora.webapi.messages.admin.responder.permissionsmessages.PermissionsResponderRequestADM
-import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectsResponderRequestADM
 import org.knora.webapi.messages.admin.responder.sipimessages.SipiResponderRequestADM
 import org.knora.webapi.messages.admin.responder.storesmessages.StoreResponderRequestADM
 import org.knora.webapi.messages.admin.responder.usersmessages.UsersResponderRequestADM
@@ -46,7 +45,6 @@ import org.knora.webapi.responders.v1._
 import org.knora.webapi.responders.v2._
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.store.cache.CacheServiceManager
-import org.knora.webapi.store.cache.settings.CacheServiceSettings
 import org.knora.webapi.store.iiif.IIIFServiceManager
 import org.knora.webapi.store.triplestore.TriplestoreServiceManager
 import org.knora.webapi.util.ActorUtil
@@ -62,7 +60,6 @@ final case class RoutingActor(
 
   private val log: Logger                                 = Logger(this.getClass)
   private val actorDeps: ActorDeps                        = ActorDeps(context.system, self, appConfig.defaultTimeoutAsDuration)
-  private val cacheServiceSettings: CacheServiceSettings  = new CacheServiceSettings(appConfig)
   private val responderData: ResponderData                = ResponderData(actorDeps, appConfig)
   private implicit val executionContext: ExecutionContext = actorDeps.executionContext
 
@@ -89,7 +86,6 @@ final case class RoutingActor(
   private val groupsResponderADM: GroupsResponderADM           = new GroupsResponderADM(responderData)
   private val listsResponderADM: ListsResponderADM             = new ListsResponderADM(responderData)
   private val permissionsResponderADM: PermissionsResponderADM = new PermissionsResponderADM(responderData)
-  private val projectsResponderADM: ProjectsResponderADM       = ProjectsResponderADM(actorDeps, cacheServiceSettings)
   private val storeResponderADM: StoresResponderADM            = new StoresResponderADM(responderData)
   private val usersResponderADM: UsersResponderADM             = new UsersResponderADM(responderData)
   private val sipiRouterADM: SipiResponderADM                  = new SipiResponderADM(responderData)
@@ -139,8 +135,6 @@ final case class RoutingActor(
       ActorUtil.future2Message(sender(), listsResponderADM.receive(listsResponderRequest), log)
     case permissionsResponderRequestADM: PermissionsResponderRequestADM =>
       ActorUtil.future2Message(sender(), permissionsResponderADM.receive(permissionsResponderRequestADM), log)
-    case projectsResponderRequestADM: ProjectsResponderRequestADM =>
-      ActorUtil.future2Message(sender(), projectsResponderADM.receive(projectsResponderRequestADM), log)
     case storeResponderRequestADM: StoreResponderRequestADM =>
       ActorUtil.future2Message(sender(), storeResponderADM.receive(storeResponderRequestADM), log)
     case usersResponderRequestADM: UsersResponderRequestADM =>

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/projectsmessages/ProjectsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/projectsmessages/ProjectsMessagesADM.scala
@@ -23,6 +23,7 @@ import dsp.valueobjects.Iri.ProjectIri
 import dsp.valueobjects.Project._
 import dsp.valueobjects.V2
 import org.knora.webapi.IRI
+import org.knora.webapi.core.RelayedMessage
 import org.knora.webapi.messages.ResponderRequest.KnoraRequestADM
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.admin.responder.KnoraResponseADM
@@ -158,7 +159,7 @@ case class ChangeProjectApiRequestADM(
 /**
  * An abstract trait representing a request message that can be sent to [[org.knora.webapi.responders.admin.ProjectsResponderADM]].
  */
-sealed trait ProjectsResponderRequestADM extends KnoraRequestADM
+sealed trait ProjectsResponderRequestADM extends KnoraRequestADM with RelayedMessage
 
 // Requests
 
@@ -266,7 +267,7 @@ case class ProjectCreateRequestADM(
  * Requests updating an existing project.
  *
  * @param projectIri            the IRI of the project to be updated.
- * @param projectUpdatePayload  the [[ProjectUpdatePayload]]
+ * @param projectUpdatePayload  the [[ProjectUpdatePayloadADM]]
  * @param requestingUser        the user making the request.
  * @param apiRequestID          the ID of the API request.
  */

--- a/webapi/src/main/scala/org/knora/webapi/messages/store/StoreRequest.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/store/StoreRequest.scala
@@ -5,4 +5,6 @@
 
 package org.knora.webapi.messages.store
 
-trait StoreRequest
+import org.knora.webapi.messages.ResponderRequest
+
+trait StoreRequest extends ResponderRequest

--- a/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
@@ -20,6 +20,7 @@ import dsp.valueobjects.V2
 import org.knora.webapi._
 import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.ResponderRequest
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.StoreRequest
@@ -221,6 +222,7 @@ case class NamedGraphFileRequest(
   outputFile: Path,
   outputFormat: QuadFormat
 ) extends TriplestoreRequest
+    with ResponderRequest
 
 /**
  * Requests a named graph, which will be returned as Turtle. A successful response

--- a/webapi/src/main/scala/org/knora/webapi/responders/EntityAndClassIriService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/EntityAndClassIriService.scala
@@ -8,6 +8,10 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 import dsp.errors.BadRequestException
 import dsp.errors.DuplicateValueException
 import org.knora.webapi.IRI
@@ -15,9 +19,6 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.SparqlSelectRequest
 import org.knora.webapi.messages.util.rdf.SparqlSelectResult
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 /**
  * This service somewhat handles checking of ontology entities and some creation of entity IRIs.

--- a/webapi/src/main/scala/org/knora/webapi/responders/EntityAndClassIriService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/EntityAndClassIriService.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
-import zio.ZLayer
+import zio._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -106,6 +106,17 @@ final case class EntityAndClassIriService(
     val query = org.knora.webapi.messages.twirl.queries.sparql.v2.txt.isClassUsedInData(classIri = classIri).toString()
     appActor.ask(SparqlSelectRequest(query)).mapTo[SparqlSelectResult].map(_.results.bindings.nonEmpty)
   }
+
+  /**
+   * Checks whether an entity with the provided custom IRI exists in the triplestore. If yes, throws an exception.
+   * If no custom IRI was given, creates a random unused IRI.
+   *
+   * @param entityIri    the optional custom IRI of the entity.
+   * @param iriFormatter the stringFormatter method that must be used to create a random IRI.
+   * @return IRI of the entity.
+   */
+  def checkOrCreateEntityIriTask(entityIri: Option[SmartIri], iriFormatter: => IRI): Task[IRI] =
+    ZIO.fromFuture(ec => checkOrCreateEntityIri(entityIri, iriFormatter))
 
   /**
    * Checks whether an entity with the provided custom IRI exists in the triplestore. If yes, throws an exception.

--- a/webapi/src/main/scala/org/knora/webapi/responders/EntityAndClassIriService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/EntityAndClassIriService.scala
@@ -8,11 +8,6 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
-import zio._
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-
 import dsp.errors.BadRequestException
 import dsp.errors.DuplicateValueException
 import org.knora.webapi.IRI
@@ -20,6 +15,9 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.SparqlSelectRequest
 import org.knora.webapi.messages.util.rdf.SparqlSelectResult
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 /**
  * This service somewhat handles checking of ontology entities and some creation of entity IRIs.
@@ -115,17 +113,6 @@ final case class EntityAndClassIriService(
    * @param iriFormatter the stringFormatter method that must be used to create a random IRI.
    * @return IRI of the entity.
    */
-  def checkOrCreateEntityIriTask(entityIri: Option[SmartIri], iriFormatter: => IRI): Task[IRI] =
-    ZIO.fromFuture(ec => checkOrCreateEntityIri(entityIri, iriFormatter))
-
-  /**
-   * Checks whether an entity with the provided custom IRI exists in the triplestore. If yes, throws an exception.
-   * If no custom IRI was given, creates a random unused IRI.
-   *
-   * @param entityIri    the optional custom IRI of the entity.
-   * @param iriFormatter the stringFormatter method that must be used to create a random IRI.
-   * @return IRI of the entity.
-   */
   def checkOrCreateEntityIri(entityIri: Option[SmartIri], iriFormatter: => IRI): Future[IRI] =
     entityIri match {
       case Some(customEntityIri: SmartIri) =>
@@ -147,9 +134,4 @@ final case class EntityAndClassIriService(
 
       case None => stringFormatter.makeUnusedIri(iriFormatter, appActor, logger)
     }
-}
-
-object EntityAndClassIriService {
-  val layer: ZLayer[ActorDeps with StringFormatter, Nothing, EntityAndClassIriService] =
-    ZLayer.fromFunction(EntityAndClassIriService.apply _)
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/IriLocker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/IriLocker.scala
@@ -5,15 +5,18 @@
 
 package org.knora.webapi.responders
 
-import dsp.errors.ApplicationLockException
-import org.knora.webapi.IRI
-import org.knora.webapi.util.JavaUtil
-import zio.{Task, ZIO}
+import zio.Task
+import zio.ZIO
 
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import scala.annotation.tailrec
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import dsp.errors.ApplicationLockException
+import org.knora.webapi.IRI
+import org.knora.webapi.util.JavaUtil
 
 /**
  * Implements JVM-wide, reentrant, application-level update locks on data represented by IRIs, such as Knora

--- a/webapi/src/main/scala/org/knora/webapi/responders/IriService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/IriService.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.responders
+
+import com.typesafe.scalalogging.LazyLogging
+import zio.ZIO
+import zio._
+
+import dsp.errors._
+import org.knora.webapi.IRI
+import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.StringFormatter.MAX_IRI_ATTEMPTS
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+
+/**
+ * This service somewhat handles checking of ontology entities and some creation of entity IRIs.
+ *
+ * It was extracted from the base class of all responders in order to be able to break up the inheritance hierarchy
+ * in the future - once we are porting more responders to the zio world.
+ *
+ * It is by no means complete, has already too many responsibilities and
+ * will be subject to further refactoring once we extract more services.
+ */
+final case class IriService(
+  triplestoreService: TriplestoreService,
+  stringFormatter: StringFormatter
+) extends LazyLogging {
+
+  /**
+   * Checks whether an entity with the provided custom IRI exists in the triplestore. If yes, throws an exception.
+   * If no custom IRI was given, creates a random unused IRI.
+   *
+   * @param entityIri    the optional custom IRI of the entity.
+   * @param iriFormatter the stringFormatter method that must be used to create a random IRI.
+   * @return IRI of the entity.
+   */
+  def checkOrCreateEntityIriTask(entityIri: Option[SmartIri], iriFormatter: => IRI): Task[IRI] =
+    entityIri match {
+      case Some(customEntityIri: SmartIri) =>
+        val entityIriAsString = customEntityIri.toString
+        for {
+          _ <- ZIO
+                 .fail(DuplicateValueException(s"IRI: '$entityIriAsString' already exists, try another one."))
+                 .whenZIO(checkIriExists(entityIriAsString))
+
+          // Check that given entityIRI ends with a UUID
+          ending: String = entityIriAsString.split('/').last
+          _ <- ZIO.attempt(
+                 stringFormatter.validateBase64EncodedUuid(
+                   ending,
+                   throw BadRequestException(s"IRI: '$entityIriAsString' must end with a valid base 64 UUID.")
+                 )
+               )
+
+        } yield entityIriAsString
+
+      case None => makeUnusedIri(iriFormatter)
+    }
+
+  def makeUnusedIri(iriFun: => IRI): Task[IRI] = {
+    def makeUnusedIriRec(attempts: Int): Task[IRI] = {
+      val newIri = iriFun
+      for {
+        iriExists <- checkIriExists(newIri)
+        result <- if (!iriExists) {
+                    ZIO.succeed(newIri)
+                  } else if (attempts == 0) {
+                    ZIO.fail(
+                      UpdateNotPerformedException(s"Could not make an unused new IRI after $MAX_IRI_ATTEMPTS attempts")
+                    )
+                  } else {
+                    makeUnusedIriRec(attempts - 1)
+                  }
+      } yield result
+    }
+    makeUnusedIriRec(attempts = MAX_IRI_ATTEMPTS)
+  }
+
+  private def checkIriExists(entityIriAsString: IRI): Task[Boolean] = {
+    val query = org.knora.webapi.messages.twirl.queries.sparql.admin.txt.checkIriExists(entityIriAsString).toString
+    triplestoreService.sparqlHttpAsk(query).map(_.result)
+  }
+}
+
+object IriService {
+  val layer: ZLayer[TriplestoreService with StringFormatter, Nothing, IriService] =
+    ZLayer.fromFunction(IriService.apply _)
+}

--- a/webapi/src/main/scala/org/knora/webapi/responders/Responder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/Responder.scala
@@ -12,12 +12,15 @@ import akka.http.scaladsl.util.FastFuture
 import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
 import com.typesafe.scalalogging.Logger
+import zio.Task
+import zio.ZIO
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import dsp.errors._
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.responders.Responder.unexpectedMessageException
 
 /**
  * An abstract class providing values that are commonly used in responders.
@@ -42,9 +45,15 @@ abstract class Responder(actorDeps: ActorDeps) extends LazyLogging {
    * @param who     the responder receiving the message.
    */
   protected def handleUnexpectedMessage(message: Any, log: Logger, who: String): Future[Nothing] =
-    FastFuture.failed(
-      UnexpectedMessageException(
-        s"$who received an unexpected message $message of type ${message.getClass.getCanonicalName}"
-      )
+    FastFuture.failed(unexpectedMessageException(message: Any, who: IRI))
+}
+
+object Responder {
+
+  def handleUnexpectedMessage(message: Any, who: String): Task[Nothing] =
+    ZIO.fail(unexpectedMessageException(message, who))
+  private def unexpectedMessageException(message: Any, who: IRI) =
+    UnexpectedMessageException(
+      s"$who received an unexpected message $message of type ${message.getClass.getCanonicalName}"
     )
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -5,6 +5,17 @@
 
 package org.knora.webapi.responders.admin
 import com.typesafe.scalalogging.LazyLogging
+import zio._
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
 import dsp.errors._
 import dsp.valueobjects.Iri
 import dsp.valueobjects.V2
@@ -32,22 +43,12 @@ import org.knora.webapi.messages.util.rdf._
 import org.knora.webapi.messages.v2.responder.ontologymessages.OntologyMetadataGetByProjectRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.OntologyMetadataV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadOntologyMetadataV2
-import org.knora.webapi.responders.EntityAndClassIriService
 import org.knora.webapi.responders.IriLocker
+import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.Responder
 import org.knora.webapi.store.cache.settings.CacheServiceSettings
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.util.ZioHelper
-import zio._
-
-import java.io.BufferedInputStream
-import java.io.BufferedOutputStream
-import java.nio.file.Files
-import java.nio.file.Path
-import java.util.UUID
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 
 /**
  * Returns information about projects.
@@ -194,7 +195,7 @@ trait ProjectsResponderADM {
 final case class ProjectsResponderADMLive(
   triplestoreService: TriplestoreService,
   messageRelay: MessageRelay,
-  iriService: EntityAndClassIriService,
+  iriService: IriService,
   cacheServiceSettings: CacheServiceSettings,
   implicit val stringFormatter: StringFormatter
 ) extends ProjectsResponderADM
@@ -1283,13 +1284,13 @@ final case class ProjectsResponderADMLive(
 
 object ProjectsResponderADMLive {
   val layer: ZLayer[
-    MessageRelay with TriplestoreService with StringFormatter with EntityAndClassIriService with AppConfig,
+    MessageRelay with TriplestoreService with StringFormatter with IriService with AppConfig,
     Nothing,
     ProjectsResponderADM
   ] = ZLayer.fromZIO {
     for {
       c       <- ZIO.service[AppConfig].map(new CacheServiceSettings(_))
-      iris    <- ZIO.service[EntityAndClassIriService]
+      iris    <- ZIO.service[IriService]
       sf      <- ZIO.service[StringFormatter]
       ts      <- ZIO.service[TriplestoreService]
       mr      <- ZIO.service[MessageRelay]

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -6,10 +6,12 @@
 package org.knora.webapi.responders.admin
 import com.typesafe.scalalogging.LazyLogging
 import dsp.errors._
-import dsp.valueobjects.{Iri, V2}
+import dsp.valueobjects.Iri
+import dsp.valueobjects.V2
 import org.knora.webapi._
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.{MessageHandler, MessageRelay}
+import org.knora.webapi.core.MessageHandler
+import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.instrumentation.InstrumentationSupport
 import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages.OntologyConstants.KnoraAdmin._
@@ -17,35 +19,35 @@ import org.knora.webapi.messages._
 import org.knora.webapi.messages.admin.responder.permissionsmessages._
 import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM._
 import org.knora.webapi.messages.admin.responder.projectsmessages._
-import org.knora.webapi.messages.admin.responder.usersmessages.{
-  UserADM,
-  UserGetADM,
-  UserIdentifierADM,
-  UserInformationTypeADM
-}
-import org.knora.webapi.messages.store.cacheservicemessages.{
-  CacheServiceFlushDB,
-  CacheServiceGetProjectADM,
-  CacheServicePutProjectADM
-}
+import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
+import org.knora.webapi.messages.admin.responder.usersmessages.UserGetADM
+import org.knora.webapi.messages.admin.responder.usersmessages.UserIdentifierADM
+import org.knora.webapi.messages.admin.responder.usersmessages.UserInformationTypeADM
+import org.knora.webapi.messages.store.cacheservicemessages.CacheServiceFlushDB
+import org.knora.webapi.messages.store.cacheservicemessages.CacheServiceGetProjectADM
+import org.knora.webapi.messages.store.cacheservicemessages.CacheServicePutProjectADM
 import org.knora.webapi.messages.store.triplestoremessages._
 import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.messages.util.rdf._
-import org.knora.webapi.messages.v2.responder.ontologymessages.{
-  OntologyMetadataGetByProjectRequestV2,
-  OntologyMetadataV2,
-  ReadOntologyMetadataV2
-}
-import org.knora.webapi.responders.{EntityAndClassIriService, IriLocker, Responder}
+import org.knora.webapi.messages.v2.responder.ontologymessages.OntologyMetadataGetByProjectRequestV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.OntologyMetadataV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.ReadOntologyMetadataV2
+import org.knora.webapi.responders.EntityAndClassIriService
+import org.knora.webapi.responders.IriLocker
+import org.knora.webapi.responders.Responder
 import org.knora.webapi.store.cache.settings.CacheServiceSettings
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.util.ZioHelper
 import zio._
 
-import java.io.{BufferedInputStream, BufferedOutputStream}
-import java.nio.file.{Files, Path}
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.UUID
-import scala.util.{Failure, Success, Try}
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 trait ProjectsResponderADM {}
 
@@ -63,13 +65,13 @@ final case class ProjectsResponderADMLive(
     with LazyLogging
     with InstrumentationSupport {
 
-  override def isResponsibleFor(message: ResponderRequest): Boolean = message.isInstanceOf[ProjectsResponderRequestADM]
-
   // Global lock IRI used for project creation and update
   private val PROJECTS_GLOBAL_LOCK_IRI = "http://rdfh.ch/projects"
 
   private val ADMIN_DATA_GRAPH       = "http://www.knora.org/data/admin"
   private val PERMISSIONS_DATA_GRAPH = "http://www.knora.org/data/permissions"
+
+  override def isResponsibleFor(message: ResponderRequest): Boolean = message.isInstanceOf[ProjectsResponderRequestADM]
 
   /**
    * Receives a message extending [[ProjectsResponderRequestADM]], and returns an appropriate response message.
@@ -170,7 +172,8 @@ final case class ProjectsResponderADMLive(
    * Gets all the projects and returns them as a [[ProjectADM]].
    *
    * @return all the projects as a [[ProjectADM]].
-   * @throws NotFoundException if no projects are found.
+   *
+   *         NotFoundException if no projects are found.
    */
   private def projectsGetRequestADM(): Task[ProjectsGetResponseADM] =
     for {
@@ -213,8 +216,9 @@ final case class ProjectsResponderADMLive(
    * as a [[ProjectGetResponseADM]].
    *
    * @param identifier           the IRI, shortname, shortcode or UUID of the project.
-   * @return information about the project as a [[ProjectGetResponseADM]].
-   * @throws NotFoundException when no project for the given IRI can be found
+   * @return Information about the project as a [[ProjectGetResponseADM]].
+   *
+   *         [[NotFoundException]] When no project for the given IRI can be found.
    */
   def getSingleProjectADMRequest(identifier: ProjectIdentifierADM): Task[ProjectGetResponseADM] = for {
     maybeProject <- getSingleProjectADM(identifier)
@@ -633,8 +637,9 @@ final case class ProjectsResponderADMLive(
    * @param projectUpdatePayload the update payload.
    * @param requestingUser       the user making the request.
    * @param apiRequestID         the unique api request ID.
-   * @return a [[ProjectOperationResponseADM]].
-   * @throws ForbiddenException in the case that the user is not allowed to perform the operation.
+   * @return A [[ProjectOperationResponseADM]].
+   *
+   *         [[ForbiddenException]] In the case that the user is not allowed to perform the operation.
    */
   private def changeBasicInformationRequestADM(
     projectIri: Iri.ProjectIri,
@@ -677,8 +682,9 @@ final case class ProjectsResponderADMLive(
    *                             this data. If only some parts of the data need to be changed, then this needs to
    *                             be prepared in the step before this one.
    *
-   * @return a [[ProjectOperationResponseADM]].
-   * @throws NotFoundException in the case that the project's IRI is not found.
+   * @return A [[ProjectOperationResponseADM]].
+   *
+   *         [[NotFoundException]] In the case that the project's IRI is not found.
    */
   private def updateProjectADM(
     projectIri: Iri.ProjectIri,
@@ -741,9 +747,10 @@ final case class ProjectsResponderADMLive(
    * Checks if all fields of a projectUpdatePayload are represented in the updated [[ProjectADM]]. If so, the
    * update is considered successful.
    *
-   * @param updatedProject       the updated project against which the projectUpdatePayload is compared
-   * @param projectUpdatePayload the payload which defines what should have been updated
-   * @throws UpdateNotPerformedException if one of the fields was not updated
+   * @param updatedProject       The updated project against which the projectUpdatePayload is compared.
+   * @param projectUpdatePayload The payload which defines what should have been updated.
+   *
+   *         [[UpdateNotPerformedException]] If one of the fields was not updated.
    */
   private def checkProjectUpdate(
     updatedProject: ProjectADM,
@@ -840,10 +847,13 @@ final case class ProjectsResponderADMLive(
    *
    * @param requestingUser       the user that is making the request.
    * @param apiRequestID         the unique api request ID.
-   * @return a [[ProjectOperationResponseADM]].
-   * @throws ForbiddenException      in the case that the user is not allowed to perform the operation.
-   * @throws DuplicateValueException in the case when either the shortname or shortcode are not unique.
-   * @throws BadRequestException     in the case when the shortcode is invalid.
+   * @return A [[ProjectOperationResponseADM]].
+   *
+   *         [[ForbiddenException]]      In the case that the user is not allowed to perform the operation.
+   *
+   *         [[DuplicateValueException]] In the case when either the shortname or shortcode are not unique.
+   *
+   *         [[BadRequestException]]     In the case when the shortcode is invalid.
    */
   private def projectCreateRequestADM(
     createProjectRequest: ProjectCreatePayloadADM,
@@ -857,8 +867,9 @@ final case class ProjectsResponderADMLive(
      * view, and restricted view of all new resources and values that belong to this project.
      * 2. Permissions for project members to create, modify, view and restricted view of all new resources and values that belong to this project.
      *
-     * @param projectIri the IRI of the new project.
-     * @throws BadRequestException if a permission is not created.
+     * @param projectIri The IRI of the new project.
+     *
+     *         [[BadRequestException]] If a permission is not created.
      */
     def createPermissionsForAdminsAndMembersOfNewProject(projectIri: IRI): Task[Unit] =
       for {

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -1146,7 +1146,6 @@ final case class ProjectsResponderADMLive(
                        .checkProjectExistsByShortname(shortname = shortname)
                        .toString
                    )
-      // _ = log.debug("projectExists - query: {}", askString)
 
       checkProjectExistsResponse <- triplestoreService.sparqlHttpAsk(askString)
       result                      = checkProjectExistsResponse.result

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -4,29 +4,28 @@
  */
 
 package org.knora.webapi.responders.admin
-
-import akka.http.scaladsl.util.FastFuture
-import akka.pattern._
+import com.typesafe.scalalogging.LazyLogging
+import zio._
 
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
-import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import dsp.errors.NotFoundException
 import dsp.errors._
 import dsp.valueobjects.Iri
 import dsp.valueobjects.V2
 import org.knora.webapi._
+import org.knora.webapi.config.AppConfig
+import org.knora.webapi.core.MessageHandler
+import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.instrumentation.InstrumentationSupport
 import org.knora.webapi.messages.IriConversions._
-import org.knora.webapi.messages.OntologyConstants
-import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.messages._
 import org.knora.webapi.messages.admin.responder.permissionsmessages._
 import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM._
 import org.knora.webapi.messages.admin.responder.projectsmessages._
@@ -43,17 +42,30 @@ import org.knora.webapi.messages.util.rdf._
 import org.knora.webapi.messages.v2.responder.ontologymessages.OntologyMetadataGetByProjectRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.OntologyMetadataV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadOntologyMetadataV2
-import org.knora.webapi.responders.ActorDeps
+import org.knora.webapi.responders.EntityAndClassIriService
 import org.knora.webapi.responders.IriLocker
 import org.knora.webapi.responders.Responder
 import org.knora.webapi.store.cache.settings.CacheServiceSettings
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+import org.knora.webapi.util.ZioHelper
+
+trait ProjectsResponderADM {}
 
 /**
  * Returns information about projects.
  */
-final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings: CacheServiceSettings)
-    extends Responder(actorDeps)
+final case class ProjectsResponderADMLive(
+  triplestoreService: TriplestoreService,
+  messageRelay: MessageRelay,
+  iriService: EntityAndClassIriService,
+  cacheServiceSettings: CacheServiceSettings,
+  implicit val stringFormatter: StringFormatter
+) extends ProjectsResponderADM
+    with MessageHandler
+    with LazyLogging
     with InstrumentationSupport {
+
+  override def isResponsibleFor(message: ResponderRequest): Boolean = message.isInstanceOf[ProjectsResponderRequestADM]
 
   // Global lock IRI used for project creation and update
   private val PROJECTS_GLOBAL_LOCK_IRI = "http://rdfh.ch/projects"
@@ -64,7 +76,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
   /**
    * Receives a message extending [[ProjectsResponderRequestADM]], and returns an appropriate response message.
    */
-  def receive(msg: ProjectsResponderRequestADM) = msg match {
+  override def handle(msg: ResponderRequest): Task[Any] = msg match {
     case ProjectsGetRequestADM()          => projectsGetRequestADM()
     case ProjectGetADM(identifier)        => getSingleProjectADM(identifier)
     case ProjectGetRequestADM(identifier) => getSingleProjectADMRequest(identifier)
@@ -95,7 +107,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
       )
     case ProjectDataGetRequestADM(projectIdentifier, requestingUser) =>
       projectDataGetRequestADM(projectIdentifier, requestingUser)
-    case other => handleUnexpectedMessage(other, log, this.getClass.getName)
+    case other => Responder.handleUnexpectedMessage(other, this.getClass.getName)
   }
 
   /**
@@ -103,11 +115,11 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    *
    * @return all the projects as a sequence containing [[ProjectADM]].
    */
-  private def projectsGetADM(): Future[Seq[ProjectADM]] =
+  private def projectsGetADM(): Task[Seq[ProjectADM]] =
     for {
       sparqlQueryString <-
-        Future(
-          org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+        ZIO.succeed(
+          twirl.queries.sparql.admin.txt
             .getProjects(
               maybeIri = None,
               maybeShortname = None,
@@ -115,10 +127,9 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
             )
             .toString()
         )
-      request                                    = SparqlExtendedConstructRequest(sparql = sparqlQueryString)
-      projectsResponse                          <- appActor.ask(request).mapTo[SparqlExtendedConstructResponse]
-      projectIris                                = projectsResponse.statements.keySet.map(_.toString)
-      ontologiesForProjects: Map[IRI, Seq[IRI]] <- getOntologiesForProjects(projectIris)
+      projectsResponse      <- triplestoreService.sparqlHttpExtendedConstruct(sparqlQueryString)
+      projectIris            = projectsResponse.statements.keySet.map(_.toString)
+      ontologiesForProjects <- getOntologiesForProjects(projectIris)
       projects =
         projectsResponse.statements.toList.map {
           case (projectIriSubject: SubjectV2, propsMap: Map[SmartIri, Seq[LiteralV2]]) =>
@@ -138,7 +149,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    * @param projectIris    a set of project IRIs. If empty, returns the ontologies for all projects.
    * @return a map of project IRIs to sequences of ontology IRIs.
    */
-  private def getOntologiesForProjects(projectIris: Set[IRI]): Future[Map[IRI, Seq[IRI]]] = {
+  private def getOntologiesForProjects(projectIris: Set[IRI]): Task[Map[IRI, Seq[IRI]]] = {
     def getIriPair(ontology: OntologyMetadataV2) =
       ontology.projectIri.fold(
         throw InconsistentRepositoryDataException(s"Ontology ${ontology.ontologyIri} has no project")
@@ -150,9 +161,9 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
     )
 
     for {
-      ontologyMetadataResponse <- appActor.ask(request).mapTo[ReadOntologyMetadataV2]
+      ontologyMetadataResponse <- messageRelay.ask[ReadOntologyMetadataV2](request)
       ontologies                = ontologyMetadataResponse.ontologies.toList
-      iriPairs                  = ontologies.map(getIriPair(_))
+      iriPairs                  = ontologies.map(getIriPair)
       projectToOntologyMap      = iriPairs.groupMap { case (project, _) => project } { case (_, onto) => onto }
     } yield projectToOntologyMap
   }
@@ -163,7 +174,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    * @return all the projects as a [[ProjectADM]].
    * @throws NotFoundException if no projects are found.
    */
-  private def projectsGetRequestADM(): Future[ProjectsGetResponseADM] =
+  private def projectsGetRequestADM(): Task[ProjectsGetResponseADM] =
     for {
       projects <- projectsGetADM()
       result = if (projects.nonEmpty) { ProjectsGetResponseADM(projects = projects) }
@@ -177,37 +188,27 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    * @param skipCache            if `true`, doesn't check the cache and tries to retrieve the project directly from the triplestore
    * @return information about the project as an optional [[ProjectADM]].
    */
-  def getSingleProjectADM(
+  private def getSingleProjectADM(
     identifier: ProjectIdentifierADM,
     skipCache: Boolean = false
-  ): Future[Option[ProjectADM]] =
-    tracedFuture("admin-get-project") {
+  ): Task[Option[ProjectADM]] = {
 
-      log.debug(
-        s"getSingleProjectADM - id: {}, skipCache: {}",
-        getId(identifier),
-        skipCache
-      )
+    logger.debug(
+      s"getSingleProjectADM - id: {}, skipCache: {}",
+      getId(identifier),
+      skipCache
+    )
 
-      for {
-        maybeProjectADM <-
-          if (skipCache) {
-            // getting directly from triplestore
-            getProjectFromTriplestore(identifier = identifier)
-          } else {
-            // getting from cache or triplestore
-            getProjectFromCacheOrTriplestore(identifier = identifier)
-          }
-
-        _ =
-          if (maybeProjectADM.nonEmpty) {
-            log.debug("getSingleProjectADM - successfully retrieved project: {}", getId(identifier))
-          } else {
-            log.debug("getSingleProjectADM - could not retrieve project: {}", getId(identifier))
-          }
-
-      } yield maybeProjectADM
-    }
+    for {
+      maybeProjectADM <-
+        if (skipCache) {
+          getProjectFromTriplestore(identifier = identifier)
+        } else {
+          // getting from cache or triplestore
+          getProjectFromCacheOrTriplestore(identifier = identifier)
+        }
+    } yield maybeProjectADM
+  }
 
   /**
    * Gets the project with the given project IRI, shortname, shortcode or UUID and returns the information
@@ -217,7 +218,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    * @return information about the project as a [[ProjectGetResponseADM]].
    * @throws NotFoundException when no project for the given IRI can be found
    */
-  def getSingleProjectADMRequest(identifier: ProjectIdentifierADM): Future[ProjectGetResponseADM] = for {
+  def getSingleProjectADMRequest(identifier: ProjectIdentifierADM): Task[ProjectGetResponseADM] = for {
     maybeProject <- getSingleProjectADM(identifier)
     project       = maybeProject.getOrElse(throw NotFoundException(s"Project '${getId(identifier)}' not found"))
   } yield ProjectGetResponseADM(project)
@@ -233,7 +234,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
   private def projectMembersGetRequestADM(
     identifier: ProjectIdentifierADM,
     requestingUser: UserADM
-  ): Future[ProjectMembersGetResponseADM] =
+  ): Task[ProjectMembersGetResponseADM] =
     for {
 
       /* Get project and verify permissions. */
@@ -254,8 +255,8 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
           }
         }
 
-      sparqlQueryString <- Future(
-                             org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+      sparqlQueryString <- ZIO.succeed(
+                             twirl.queries.sparql.admin.txt
                                .getProjectMembers(
                                  maybeIri = identifier.asIriIdentifierOption,
                                  maybeShortname = identifier.asShortnameIdentifierOption,
@@ -264,15 +265,8 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                                .toString()
                            )
 
-      projectMembersResponse <- appActor
-                                  .ask(
-                                    SparqlExtendedConstructRequest(
-                                      sparql = sparqlQueryString
-                                    )
-                                  )
-                                  .mapTo[SparqlExtendedConstructResponse]
-
-      statements = projectMembersResponse.statements.toList
+      projectMembersResponse <- triplestoreService.sparqlHttpExtendedConstruct(sparqlQueryString)
+      statements              = projectMembersResponse.statements.toList
 
       // get project member IRI from results rows
       userIris: Seq[IRI] =
@@ -282,20 +276,19 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
           Seq.empty[IRI]
         }
 
-      maybeUserFutures: Seq[Future[Option[UserADM]]] =
+      maybeUserFutures: Seq[Task[Option[UserADM]]] =
         userIris.map { userIri =>
-          appActor
-            .ask(
+          messageRelay
+            .ask[Option[UserADM]](
               UserGetADM(
                 identifier = UserIdentifierADM(maybeIri = Some(userIri)),
                 userInformationTypeADM = UserInformationTypeADM.Restricted,
                 requestingUser = KnoraSystemInstances.Users.SystemUser
               )
             )
-            .mapTo[Option[UserADM]]
         }
-      maybeUsers: Seq[Option[UserADM]] <- Future.sequence(maybeUserFutures)
-      users: Seq[UserADM]               = maybeUsers.flatten
+      maybeUsers         <- ZioHelper.sequence(maybeUserFutures)
+      users: Seq[UserADM] = maybeUsers.flatten
 
     } yield ProjectMembersGetResponseADM(members = users)
 
@@ -310,7 +303,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
   private def projectAdminMembersGetRequestADM(
     identifier: ProjectIdentifierADM,
     requestingUser: UserADM
-  ): Future[ProjectAdminMembersGetResponseADM] =
+  ): Task[ProjectAdminMembersGetResponseADM] =
     for {
       /* Get project and verify permissions. */
       project <- getSingleProjectADM(
@@ -326,8 +319,8 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
           }
         }
 
-      sparqlQueryString <- Future(
-                             org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+      sparqlQueryString <- ZIO.succeed(
+                             twirl.queries.sparql.admin.txt
                                .getProjectAdminMembers(
                                  maybeIri = identifier.asIriIdentifierOption,
                                  maybeShortname = identifier.asShortnameIdentifierOption,
@@ -336,13 +329,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                                .toString()
                            )
 
-      projectAdminMembersResponse <- appActor
-                                       .ask(
-                                         SparqlExtendedConstructRequest(
-                                           sparql = sparqlQueryString
-                                         )
-                                       )
-                                       .mapTo[SparqlExtendedConstructResponse]
+      projectAdminMembersResponse <- triplestoreService.sparqlHttpExtendedConstruct(sparqlQueryString)
 
       statements = projectAdminMembersResponse.statements.toList
 
@@ -354,20 +341,18 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
           Seq.empty[IRI]
         }
 
-      maybeUserFutures: Seq[Future[Option[UserADM]]] = userIris.map { userIri =>
-                                                         appActor
-                                                           .ask(
-                                                             UserGetADM(
-                                                               identifier = UserIdentifierADM(maybeIri = Some(userIri)),
-                                                               userInformationTypeADM =
-                                                                 UserInformationTypeADM.Restricted,
-                                                               requestingUser = KnoraSystemInstances.Users.SystemUser
-                                                             )
-                                                           )
-                                                           .mapTo[Option[UserADM]]
-                                                       }
-      maybeUsers: Seq[Option[UserADM]] <- Future.sequence(maybeUserFutures)
-      users: Seq[UserADM]               = maybeUsers.flatten
+      maybeUserTasks: Seq[Task[Option[UserADM]]] = userIris.map { userIri =>
+                                                     messageRelay
+                                                       .ask[Option[UserADM]](
+                                                         UserGetADM(
+                                                           identifier = UserIdentifierADM(maybeIri = Some(userIri)),
+                                                           userInformationTypeADM = UserInformationTypeADM.Restricted,
+                                                           requestingUser = KnoraSystemInstances.Users.SystemUser
+                                                         )
+                                                       )
+                                                   }
+      maybeUsers         <- ZioHelper.sequence(maybeUserTasks)
+      users: Seq[UserADM] = maybeUsers.flatten
 
     } yield ProjectAdminMembersGetResponseADM(members = users)
 
@@ -376,7 +361,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    *
    * @return all keywords for all projects as [[ProjectsKeywordsGetResponseADM]]
    */
-  private def projectsKeywordsGetRequestADM(): Future[ProjectsKeywordsGetResponseADM] =
+  private def projectsKeywordsGetRequestADM(): Task[ProjectsKeywordsGetResponseADM] =
     for {
       projects <- projectsGetADM()
 
@@ -392,7 +377,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    */
   private def projectKeywordsGetRequestADM(
     projectIri: Iri.ProjectIri
-  ): Future[ProjectKeywordsGetResponseADM] =
+  ): Task[ProjectKeywordsGetResponseADM] =
     for {
       maybeProject <- getSingleProjectADM(
                         identifier = IriIdentifier
@@ -410,7 +395,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
   private def projectDataGetRequestADM(
     projectIdentifier: ProjectIdentifierADM,
     requestingUser: UserADM
-  ): Future[ProjectDataGetResponseADM] = {
+  ): Task[ProjectDataGetResponseADM] = {
 
     /**
      * Represents a named graph to be saved to a TriG file.
@@ -503,9 +488,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
 
     for {
       // Get the project info.
-      maybeProject: Option[ProjectADM] <- getSingleProjectADM(
-                                            identifier = projectIdentifier
-                                          )
+      maybeProject <- getSingleProjectADM(projectIdentifier)
 
       project: ProjectADM = maybeProject.getOrElse(
                               throw NotFoundException(s"Project '${getId(projectIdentifier)}' not found.")
@@ -520,7 +503,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
 
       // Make a temporary directory for the downloaded data.
       tempDir = Files.createTempDirectory(project.shortname)
-      _       = log.info("Downloading project data to temporary directory " + tempDir.toAbsolutePath)
+      _      <- ZIO.logInfo("Downloading project data to temporary directory " + tempDir.toAbsolutePath)
 
       // Download the project's named graphs.
 
@@ -529,65 +512,54 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
       projectSpecificNamedGraphTrigFiles: Seq[NamedGraphTrigFile] =
         graphsToDownload.map(graphIri => NamedGraphTrigFile(graphIri = graphIri, tempDir = tempDir))
 
-      projectSpecificNamedGraphTrigFileWriteFutures: Seq[Future[FileWrittenResponse]] =
+      projectSpecificNamedGraphTrigFileWriteFutures: Seq[Task[FileWrittenResponse]] =
         projectSpecificNamedGraphTrigFiles.map { trigFile =>
           for {
-            fileWrittenResponse: FileWrittenResponse <-
-              appActor
-                .ask(
-                  NamedGraphFileRequest(
-                    graphIri = trigFile.graphIri,
-                    outputFile = trigFile.dataFile,
-                    outputFormat = TriG
-                  )
-                )
-                .mapTo[FileWrittenResponse]
+            fileWrittenResponse <- messageRelay.ask[FileWrittenResponse](
+                                     NamedGraphFileRequest(
+                                       graphIri = trigFile.graphIri,
+                                       outputFile = trigFile.dataFile,
+                                       outputFormat = TriG
+                                     )
+                                   )
           } yield fileWrittenResponse
         }
 
-      _: Seq[FileWrittenResponse] <- Future.sequence(projectSpecificNamedGraphTrigFileWriteFutures)
+      _ <- ZioHelper.sequence(projectSpecificNamedGraphTrigFileWriteFutures)
 
       // Download the project's admin data.
 
       adminDataNamedGraphTrigFile = NamedGraphTrigFile(graphIri = ADMIN_DATA_GRAPH, tempDir = tempDir)
 
-      adminDataSparql: String = org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+      adminDataSparql: String = twirl.queries.sparql.admin.txt
                                   .getProjectAdminData(
                                     projectIri = project.id
                                   )
                                   .toString()
 
-      _: FileWrittenResponse <- appActor
-                                  .ask(
-                                    SparqlConstructFileRequest(
-                                      sparql = adminDataSparql,
-                                      graphIri = adminDataNamedGraphTrigFile.graphIri,
-                                      outputFile = adminDataNamedGraphTrigFile.dataFile,
-                                      outputFormat = TriG
-                                    )
-                                  )
-                                  .mapTo[FileWrittenResponse]
+      _ <- triplestoreService.sparqlHttpConstructFile(
+             sparql = adminDataSparql,
+             graphIri = adminDataNamedGraphTrigFile.graphIri,
+             outputFile = adminDataNamedGraphTrigFile.dataFile,
+             outputFormat = TriG
+           )
 
       // Download the project's permission data.
 
       permissionDataNamedGraphTrigFile = NamedGraphTrigFile(graphIri = PERMISSIONS_DATA_GRAPH, tempDir = tempDir)
 
-      permissionDataSparql: String = org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+      permissionDataSparql: String = twirl.queries.sparql.admin.txt
                                        .getProjectPermissions(
                                          projectIri = project.id
                                        )
                                        .toString()
 
-      _: FileWrittenResponse <- appActor
-                                  .ask(
-                                    SparqlConstructFileRequest(
-                                      sparql = permissionDataSparql,
-                                      graphIri = permissionDataNamedGraphTrigFile.graphIri,
-                                      outputFile = permissionDataNamedGraphTrigFile.dataFile,
-                                      outputFormat = TriG
-                                    )
-                                  )
-                                  .mapTo[FileWrittenResponse]
+      _ <- triplestoreService.sparqlHttpConstructFile(
+             sparql = permissionDataSparql,
+             graphIri = permissionDataNamedGraphTrigFile.graphIri,
+             outputFile = permissionDataNamedGraphTrigFile.dataFile,
+             outputFormat = TriG
+           )
 
       // Stream the combined results into the output file.
 
@@ -607,11 +579,11 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    */
   private def projectRestrictedViewSettingsGetADM(
     identifier: ProjectIdentifierADM
-  ): Future[Option[ProjectRestrictedViewSettingsADM]] =
+  ): Task[Option[ProjectRestrictedViewSettingsADM]] =
     // ToDo: We have two possible NotFound scenarios: 1. Project, 2. ProjectRestrictedViewSettings resource. How to send the client the correct NotFound reply?
     for {
-      sparqlQuery <- Future(
-                       org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+      sparqlQuery <- ZIO.succeed(
+                       twirl.queries.sparql.admin.txt
                          .getProjects(
                            maybeIri = identifier.asIriIdentifierOption,
                            maybeShortname = identifier.asShortnameIdentifierOption,
@@ -620,13 +592,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                          .toString()
                      )
 
-      projectResponse <- appActor
-                           .ask(
-                             SparqlExtendedConstructRequest(
-                               sparql = sparqlQuery
-                             )
-                           )
-                           .mapTo[SparqlExtendedConstructResponse]
+      projectResponse <- triplestoreService.sparqlHttpExtendedConstruct(sparqlQuery)
 
       restrictedViewSettings =
         if (projectResponse.statements.nonEmpty) {
@@ -656,7 +622,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    */
   private def projectRestrictedViewSettingsGetRequestADM(
     identifier: ProjectIdentifierADM
-  ): Future[ProjectRestrictedViewSettingsGetResponseADM] =
+  ): Task[ProjectRestrictedViewSettingsGetResponseADM] =
     for {
       maybeSettings <- projectRestrictedViewSettingsGetADM(identifier)
       settings       = maybeSettings.getOrElse(throw NotFoundException(s"Project '${getId(identifier)}' not found."))
@@ -677,7 +643,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
     projectUpdatePayload: ProjectUpdatePayloadADM,
     requestingUser: UserADM,
     apiRequestID: UUID
-  ): Future[ProjectOperationResponseADM] = {
+  ): Task[ProjectOperationResponseADM] = {
 
     /**
      * The actual change project task run with an IRI lock.
@@ -686,31 +652,23 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
       projectIri: Iri.ProjectIri,
       projectUpdatePayload: ProjectUpdatePayloadADM,
       requestingUser: UserADM
-    ): Future[ProjectOperationResponseADM] = {
+    ): Task[ProjectOperationResponseADM] =
       // check if the requesting user is allowed to perform updates
       if (!requestingUser.permissions.isProjectAdmin(projectIri.value) && !requestingUser.permissions.isSystemAdmin) {
-        throw ForbiddenException("Project's information can only be changed by a project or system admin.")
+        ZIO.fail(ForbiddenException("Project's information can only be changed by a project or system admin."))
+      } else {
+        for {
+          result <- updateProjectADM(
+                      projectIri = projectIri,
+                      projectUpdatePayload = projectUpdatePayload,
+                      requestingUser = KnoraSystemInstances.Users.SystemUser
+                    )
+
+        } yield result
       }
 
-      for {
-        result <- updateProjectADM(
-                    projectIri = projectIri,
-                    projectUpdatePayload = projectUpdatePayload,
-                    requestingUser = KnoraSystemInstances.Users.SystemUser
-                  )
-
-      } yield result
-    }
-
-    for {
-      // run the change status task with an IRI lock
-      taskResult <- IriLocker.runWithIriLock(
-                      apiRequestID,
-                      projectIri.value,
-                      () => changeProjectTask(projectIri, projectUpdatePayload, requestingUser)
-                    )
-    } yield taskResult
-
+    val task = changeProjectTask(projectIri, projectUpdatePayload, requestingUser)
+    IriLocker.runWithIriLock(apiRequestID, projectIri.value, task)
   }
 
   /**
@@ -728,73 +686,57 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
     projectIri: Iri.ProjectIri,
     projectUpdatePayload: ProjectUpdatePayloadADM,
     requestingUser: UserADM
-  ): Future[ProjectOperationResponseADM] = {
+  ): Task[ProjectOperationResponseADM] = {
 
     val areAllParamsNone: Boolean = projectUpdatePayload.productIterator.forall {
       case param: Option[Any] => param.isEmpty
       case _                  => false
     }
 
-    if (areAllParamsNone) { throw BadRequestException("No data would be changed. Aborting update request.") }
+    if (areAllParamsNone) { ZIO.fail(BadRequestException("No data would be changed. Aborting update request.")) }
+    else {
+      val projectId = IriIdentifier(projectIri)
+      for {
+        maybeCurrentProject <- getSingleProjectADM(projectId, skipCache = true)
+        _ <- ZIO
+               .fromOption(maybeCurrentProject)
+               .orElseFail(NotFoundException(s"Project '${projectIri.value}' not found. Aborting update request."))
 
-    for {
-      maybeCurrentProject <- getSingleProjectADM(
-                               identifier = IriIdentifier
-                                 .fromString(projectIri.value)
-                                 .getOrElseWith(e => throw BadRequestException(e.head.getMessage)),
-                               skipCache = true
-                             )
+        // we are changing the project, so lets get rid of the cached copy
+        _ <- messageRelay.ask[Any](CacheServiceFlushDB(KnoraSystemInstances.Users.SystemUser))
 
-      _ = maybeCurrentProject.getOrElse(
-            throw NotFoundException(s"Project '${projectIri.value}' not found. Aborting update request.")
-          )
+        /* Update project */
+        updateQuery = twirl.queries.sparql.admin.txt
+                        .updateProject(
+                          adminNamedGraphIri = "http://www.knora.org/data/admin",
+                          projectIri = projectIri.value,
+                          maybeShortname = projectUpdatePayload.shortname.map(_.value),
+                          maybeLongname = projectUpdatePayload.longname.map(_.value),
+                          maybeDescriptions = projectUpdatePayload.description.map(_.value),
+                          maybeKeywords = projectUpdatePayload.keywords.map(_.value),
+                          maybeLogo = projectUpdatePayload.logo.map(_.value),
+                          maybeStatus = projectUpdatePayload.status.map(_.value),
+                          maybeSelfjoin = projectUpdatePayload.selfjoin.map(_.value)
+                        )
 
-      // we are changing the project, so lets get rid of the cached copy
-      _ = appActor.ask(CacheServiceFlushDB(KnoraSystemInstances.Users.SystemUser))
+        _ <- triplestoreService.sparqlHttpUpdate(updateQuery.toString)
 
-      /* Update project */
-      updateProjectSparqlString <- Future(
-                                     org.knora.webapi.messages.twirl.queries.sparql.admin.txt
-                                       .updateProject(
-                                         adminNamedGraphIri = "http://www.knora.org/data/admin",
-                                         projectIri = projectIri.value,
-                                         maybeShortname = projectUpdatePayload.shortname.map(_.value),
-                                         maybeLongname = projectUpdatePayload.longname.map(_.value),
-                                         maybeDescriptions = projectUpdatePayload.description.map(_.value),
-                                         maybeKeywords = projectUpdatePayload.keywords.map(_.value),
-                                         maybeLogo = projectUpdatePayload.logo.map(_.value),
-                                         maybeStatus = projectUpdatePayload.status.map(_.value),
-                                         maybeSelfjoin = projectUpdatePayload.selfjoin.map(_.value)
-                                       )
-                                       .toString
-                                   )
+        /* Verify that the project was updated. */
+        maybeUpdatedProject <- getSingleProjectADM(projectId, skipCache = true)
 
-      _ <- appActor
-             .ask(SparqlUpdateRequest(updateProjectSparqlString))
-             .mapTo[SparqlUpdateResponse]
+        updatedProject <-
+          ZIO
+            .fromOption(maybeUpdatedProject)
+            .orElseFail(UpdateNotPerformedException("Project was not updated. Please report this as a possible bug."))
 
-      /* Verify that the project was updated. */
-      maybeUpdatedProject <- getSingleProjectADM(
-                               identifier = IriIdentifier
-                                 .fromString(projectIri.value)
-                                 .getOrElseWith(e => throw BadRequestException(e.head.getMessage)),
-                               skipCache = true
-                             )
+        _ <- ZIO.logDebug(
+               s"updateProjectADM - projectUpdatePayload: $projectUpdatePayload /  updatedProject: $updatedProject"
+             )
 
-      updatedProject =
-        maybeUpdatedProject.getOrElse(
-          throw UpdateNotPerformedException("Project was not updated. Please report this as a possible bug.")
-        )
+        _ = checkProjectUpdate(updatedProject, projectUpdatePayload)
 
-      _ = log.debug(
-            "updateProjectADM - projectUpdatePayload: {} /  updatedProject: {}",
-            projectUpdatePayload,
-            updatedProject
-          )
-
-      _ = checkProjectUpdate(updatedProject, projectUpdatePayload)
-
-    } yield ProjectOperationResponseADM(project = updatedProject)
+      } yield ProjectOperationResponseADM(project = updatedProject)
+    }
   }
 
   /**
@@ -812,7 +754,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
     if (projectUpdatePayload.shortname.nonEmpty) {
       projectUpdatePayload.shortname
         .map(_.value)
-        .map(stringFormatter.fromSparqlEncodedString(_))
+        .map(stringFormatter.fromSparqlEncodedString)
         .filter(_ == updatedProject.shortname)
         .getOrElse(
           throw UpdateNotPerformedException(
@@ -824,8 +766,8 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
     if (projectUpdatePayload.shortname.nonEmpty) {
       projectUpdatePayload.longname
         .map(_.value)
-        .map(stringFormatter.fromSparqlEncodedString(_))
-        .filter(Some(_) == updatedProject.longname)
+        .map(stringFormatter.fromSparqlEncodedString)
+        .filter(updatedProject.longname.contains(_))
         .getOrElse(
           throw UpdateNotPerformedException(
             "Project's 'longname' was not updated. Please report this as a possible bug."
@@ -860,8 +802,8 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
     if (projectUpdatePayload.logo.nonEmpty) {
       projectUpdatePayload.logo
         .map(_.value)
-        .map(stringFormatter.fromSparqlEncodedString(_))
-        .filter(Some(_) == updatedProject.logo)
+        .map(stringFormatter.fromSparqlEncodedString)
+        .filter(updatedProject.logo.contains(_))
         .getOrElse(
           throw UpdateNotPerformedException(
             "Project's 'logo' was not updated. Please report this as a possible bug."
@@ -909,7 +851,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
     createProjectRequest: ProjectCreatePayloadADM,
     requestingUser: UserADM,
     apiRequestID: UUID
-  ): Future[ProjectOperationResponseADM] = {
+  ): Task[ProjectOperationResponseADM] = {
 
     /**
      * Creates following permissions for the new project
@@ -920,11 +862,11 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
      * @param projectIri the IRI of the new project.
      * @throws BadRequestException if a permission is not created.
      */
-    def createPermissionsForAdminsAndMembersOfNewProject(projectIri: IRI, projectShortCode: String): Future[Unit] =
+    def createPermissionsForAdminsAndMembersOfNewProject(projectIri: IRI): Task[Unit] =
       for {
         // Give the admins of the new project rights for any operation in project level, and rights to create resources.
-        _ <- appActor
-               .ask(
+        _ <- messageRelay
+               .ask[AdministrativePermissionCreateResponseADM](
                  AdministrativePermissionCreateRequestADM(
                    createRequest = CreateAdministrativePermissionAPIRequestADM(
                      forProject = projectIri,
@@ -936,11 +878,10 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                    apiRequestID = UUID.randomUUID()
                  )
                )
-               .mapTo[AdministrativePermissionCreateResponseADM]
 
         // Give the members of the new project rights to create resources.
-        _ <- appActor
-               .ask(
+        _ <- messageRelay
+               .ask[AdministrativePermissionCreateResponseADM](
                  AdministrativePermissionCreateRequestADM(
                    createRequest = CreateAdministrativePermissionAPIRequestADM(
                      forProject = projectIri,
@@ -951,12 +892,11 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                    apiRequestID = UUID.randomUUID()
                  )
                )
-               .mapTo[AdministrativePermissionCreateResponseADM]
 
         // Give the admins of the new project rights to change rights, modify, delete, view,
         // and restricted view of all resources and values that belong to the project.
-        _ <- appActor
-               .ask(
+        _ <- messageRelay
+               .ask[DefaultObjectAccessPermissionCreateResponseADM](
                  DefaultObjectAccessPermissionCreateRequestADM(
                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
                      forProject = projectIri,
@@ -970,12 +910,11 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                    apiRequestID = UUID.randomUUID()
                  )
                )
-               .mapTo[DefaultObjectAccessPermissionCreateResponseADM]
 
         // Give the members of the new project rights to modify, view, and restricted view of all resources and values
         // that belong to the project.
-        _ <- appActor
-               .ask(
+        _ <- messageRelay
+               .ask[DefaultObjectAccessPermissionCreateResponseADM](
                  DefaultObjectAccessPermissionCreateRequestADM(
                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
                      forProject = projectIri,
@@ -989,13 +928,12 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                    apiRequestID = UUID.randomUUID()
                  )
                )
-               .mapTo[DefaultObjectAccessPermissionCreateResponseADM]
       } yield ()
 
     def projectCreateTask(
       createProjectRequest: ProjectCreatePayloadADM,
       requestingUser: UserADM
-    ): Future[ProjectOperationResponseADM] =
+    ): Task[ProjectOperationResponseADM] =
       for {
         // check if the supplied shortname is unique
         shortnameExists <- projectByShortnameExists(createProjectRequest.shortname.value)
@@ -1022,10 +960,10 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
 
         // check the custom IRI; if not given, create an unused IRI
         customProjectIri: Option[SmartIri] = createProjectRequest.id.map(_.value).map(_.toSmartIri)
-        newProjectIRI: IRI <- iriService.checkOrCreateEntityIri(
-                                customProjectIri,
-                                stringFormatter.makeRandomProjectIri
-                              )
+        newProjectIRI <- iriService.checkOrCreateEntityIriTask(
+                           customProjectIri,
+                           stringFormatter.makeRandomProjectIri
+                         )
 
         maybeLongname = createProjectRequest.longname match {
                           case Some(value) => Some(value.value)
@@ -1037,7 +975,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                       case None        => None
                     }
 
-        createNewProjectSparqlString = org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+        createNewProjectSparqlString = twirl.queries.sparql.admin.txt
                                          .createNewProject(
                                            adminNamedGraphIri = OntologyConstants.NamedGraphs.AdminNamedGraph,
                                            projectIri = newProjectIRI,
@@ -1057,9 +995,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                                          )
                                          .toString
 
-        _ <- appActor
-               .ask(SparqlUpdateRequest(createNewProjectSparqlString))
-               .mapTo[SparqlUpdateResponse]
+        _ <- triplestoreService.sparqlHttpUpdate(createNewProjectSparqlString)
 
         // try to retrieve newly created project (will also add to cache)
         maybeNewProjectADM <-
@@ -1077,18 +1013,12 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
                           )
                         )
         // create permissions for admins and members of the new group
-        _ <- createPermissionsForAdminsAndMembersOfNewProject(newProjectIRI, newProjectADM.shortcode)
+        _ <- createPermissionsForAdminsAndMembersOfNewProject(newProjectIRI)
 
       } yield ProjectOperationResponseADM(project = newProjectADM.unescape)
 
-    for {
-      // run user creation with an global IRI lock
-      taskResult <- IriLocker.runWithIriLock(
-                      apiRequestID,
-                      PROJECTS_GLOBAL_LOCK_IRI,
-                      () => projectCreateTask(createProjectRequest, requestingUser)
-                    )
-    } yield taskResult
+    val task = projectCreateTask(createProjectRequest, requestingUser)
+    IriLocker.runWithIriLock(apiRequestID, PROJECTS_GLOBAL_LOCK_IRI, task)
   }
 
   ////////////////////
@@ -1101,7 +1031,7 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    */
   private def getProjectFromCacheOrTriplestore(
     identifier: ProjectIdentifierADM
-  ): Future[Option[ProjectADM]] =
+  ): Task[Option[ProjectADM]] =
     if (cacheServiceSettings.cacheServiceEnabled) {
       // caching enabled
       getProjectFromCache(identifier).flatMap {
@@ -1110,23 +1040,25 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
           getProjectFromTriplestore(identifier = identifier).flatMap {
             case None =>
               // also none found in triplestore. finally returning none.
-              log.debug("getProjectFromCacheOrTriplestore - not found in cache and in triplestore")
-              FastFuture.successful(None)
+              logger.debug("getProjectFromCacheOrTriplestore - not found in cache and in triplestore")
+              ZIO.succeed(None)
             case Some(project) =>
               // found a project in the triplestore. need to write to cache.
-              log.debug(
+              logger.debug(
                 "getProjectFromCacheOrTriplestore - not found in cache but found in triplestore. need to write to cache."
               )
               // writing project to cache and afterwards returning the project found in the triplestore
-              writeProjectADMToCache(project).map(_ => Some(project))
+              messageRelay
+                .ask[Unit](CacheServicePutProjectADM(project))
+                .as(Some(project))
           }
         case Some(project) =>
-          log.debug("getProjectFromCacheOrTriplestore - found in cache. returning project.")
-          FastFuture.successful(Some(project))
+          logger.debug("getProjectFromCacheOrTriplestore - found in cache. returning project.")
+          ZIO.succeed(Some(project))
       }
     } else {
       // caching disabled
-      log.debug("getProjectFromCacheOrTriplestore - caching disabled. getting from triplestore.")
+      logger.debug("getProjectFromCacheOrTriplestore - caching disabled. getting from triplestore.")
       getProjectFromTriplestore(identifier = identifier)
     }
 
@@ -1135,45 +1067,34 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    */
   private def getProjectFromTriplestore(
     identifier: ProjectIdentifierADM
-  ): Future[Option[ProjectADM]] =
+  ): Task[Option[ProjectADM]] = {
+    val query = twirl.queries.sparql.admin.txt
+      .getProjects(
+        maybeIri = identifier.asIriIdentifierOption,
+        maybeShortname = identifier.asShortnameIdentifierOption,
+        maybeShortcode = identifier.asShortcodeIdentifierOption
+      )
     for {
-      sparqlQuery <- Future(
-                       org.knora.webapi.messages.twirl.queries.sparql.admin.txt
-                         .getProjects(
-                           maybeIri = identifier.asIriIdentifierOption,
-                           maybeShortname = identifier.asShortnameIdentifierOption,
-                           maybeShortcode = identifier.asShortcodeIdentifierOption
-                         )
-                         .toString()
-                     )
-
-      projectResponse <- appActor
-                           .ask(
-                             SparqlExtendedConstructRequest(
-                               sparql = sparqlQuery
-                             )
-                           )
-                           .mapTo[SparqlExtendedConstructResponse]
+      projectResponse <- triplestoreService.sparqlHttpExtendedConstruct(query.toString())
 
       projectIris = projectResponse.statements.keySet.map(_.toString)
-
-      ontologies <-
-        if (projectResponse.statements.nonEmpty) {
-          getOntologiesForProjects(projectIris)
-        } else {
-          FastFuture.successful(Map.empty[IRI, Seq[IRI]])
-        }
+      ontologies <- if (projectResponse.statements.nonEmpty) {
+                      getOntologiesForProjects(projectIris)
+                    } else {
+                      ZIO.succeed(Map.empty[IRI, Seq[IRI]])
+                    }
 
       maybeProjectADM: Option[ProjectADM] =
         if (projectResponse.statements.nonEmpty) {
-          log.debug("getProjectFromTriplestore - triplestore hit for: {}", getId(identifier))
+          logger.debug("getProjectFromTriplestore - triplestore hit for: {}", getId(identifier))
           val projectOntologies = ontologies.getOrElse(projectIris.head, Seq.empty[IRI])
           Some(statements2ProjectADM(statements = projectResponse.statements.head, ontologies = projectOntologies))
         } else {
-          log.debug("getProjectFromTriplestore - no triplestore hit for: {}", getId(identifier))
+          logger.debug("getProjectFromTriplestore - no triplestore hit for: {}", getId(identifier))
           None
         }
     } yield maybeProjectADM
+  }
 
   /**
    * Helper method that turns SPARQL result rows into a [[ProjectADM]].
@@ -1255,16 +1176,16 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    * @param shortname the shortname of the project.
    * @return a [[Boolean]].
    */
-  private def projectByShortnameExists(shortname: String): Future[Boolean] =
+  private def projectByShortnameExists(shortname: String): Task[Boolean] =
     for {
-      askString <- Future(
-                     org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+      askString <- ZIO.succeed(
+                     twirl.queries.sparql.admin.txt
                        .checkProjectExistsByShortname(shortname = shortname)
                        .toString
                    )
       // _ = log.debug("projectExists - query: {}", askString)
 
-      checkProjectExistsResponse <- appActor.ask(SparqlAskRequest(askString)).mapTo[SparqlAskResponse]
+      checkProjectExistsResponse <- triplestoreService.sparqlHttpAsk(askString)
       result                      = checkProjectExistsResponse.result
 
     } yield result
@@ -1275,46 +1196,36 @@ final case class ProjectsResponderADM(actorDeps: ActorDeps, cacheServiceSettings
    * @param shortcode the shortcode of the project.
    * @return a [[Boolean]].
    */
-  private def projectByShortcodeExists(shortcode: String): Future[Boolean] =
+  private def projectByShortcodeExists(shortcode: String): Task[Boolean] =
     for {
-      askString <- Future(
-                     org.knora.webapi.messages.twirl.queries.sparql.admin.txt
+      askString <- ZIO.succeed(
+                     twirl.queries.sparql.admin.txt
                        .checkProjectExistsByShortcode(shortcode = shortcode)
                        .toString
                    )
-      // _ = log.debug("projectExists - query: {}", askString)
 
-      checkProjectExistsResponse <- appActor.ask(SparqlAskRequest(askString)).mapTo[SparqlAskResponse]
+      checkProjectExistsResponse <- triplestoreService.sparqlHttpAsk(askString)
       result                      = checkProjectExistsResponse.result
 
     } yield result
 
-  /**
-   * Tries to retrieve a [[ProjectADM]] from the cache.
-   */
-  private def getProjectFromCache(identifier: ProjectIdentifierADM): Future[Option[ProjectADM]] = {
-    val result = appActor.ask(CacheServiceGetProjectADM(identifier)).mapTo[Option[ProjectADM]]
-    result.map {
-      case Some(project) =>
-        log.debug("getProjectFromCache - cache hit for: {}", getId(identifier))
-        Some(project.unescape)
-      case None =>
-        log.debug("getUserProjectCache - no cache hit for: {}", getId(identifier))
-        None
-    }
-  }
+  private def getProjectFromCache(identifier: ProjectIdentifierADM): Task[Option[ProjectADM]] =
+    messageRelay.ask[Option[ProjectADM]](CacheServiceGetProjectADM(identifier)).map(_.map(_.unescape))
+}
 
-  /**
-   * Writes the project to cache.
-   *
-   * @param project a [[ProjectADM]].
-   * @return true if writing was successful.
-   */
-  private def writeProjectADMToCache(project: ProjectADM): Future[Unit] = {
-    val result = appActor.ask(CacheServicePutProjectADM(project)).mapTo[Unit]
-    result.map { res =>
-      log.debug("writeProjectADMToCache - result: {}", result)
-      res
-    }
+object ProjectsResponderADMLive {
+  val layer: ZLayer[
+    MessageRelay with TriplestoreService with StringFormatter with EntityAndClassIriService with AppConfig,
+    Nothing,
+    ProjectsResponderADM
+  ] = ZLayer.fromZIO {
+    for {
+      c       <- ZIO.service[AppConfig].map(new CacheServiceSettings(_))
+      iris    <- ZIO.service[EntityAndClassIriService]
+      sf      <- ZIO.service[StringFormatter]
+      ts      <- ZIO.service[TriplestoreService]
+      mr      <- ZIO.service[MessageRelay]
+      handler <- mr.subscribe(ProjectsResponderADMLive(ts, mr, iris, c, sf))
+    } yield handler
   }
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -1229,10 +1229,11 @@ final case class ProjectsResponderADMLive(
     statements: (SubjectV2, Map[SmartIri, Seq[LiteralV2]]),
     ontologies: Seq[IRI]
   ): ProjectADM = {
-    val projectIri: IRI = statements._1.toString
+    val projectIri: IRI                            = statements._1.toString
+    val propertiesMap: Map[SmartIri, Seq[LiteralV2]] = statements._2
 
     def getOption[A <: LiteralV2](key: IRI): Option[Seq[A]] =
-      statements._2.get(key.toSmartIri).map(_.map(_.asInstanceOf[A]))
+      propertiesMap.get(key.toSmartIri).map(_.map(_.asInstanceOf[A]))
 
     def getOrThrow[A <: LiteralV2](
       key: IRI

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -1229,7 +1229,7 @@ final case class ProjectsResponderADMLive(
     statements: (SubjectV2, Map[SmartIri, Seq[LiteralV2]]),
     ontologies: Seq[IRI]
   ): ProjectADM = {
-    val projectIri: IRI                            = statements._1.toString
+    val projectIri: IRI                              = statements._1.toString
     val propertiesMap: Map[SmartIri, Seq[LiteralV2]] = statements._2
 
     def getOption[A <: LiteralV2](key: IRI): Option[Seq[A]] =

--- a/webapi/src/main/scala/org/knora/webapi/routing/UnsafeZioRun.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/UnsafeZioRun.scala
@@ -23,6 +23,16 @@ object UnsafeZioRun {
 
   /**
    * Executes the effect synchronously and returns its result as a
+   * [[A]] value or throws a [[FiberFailure]].
+   *
+   * This method is effectful and should only be used at the edges of your
+   * application.
+   */
+  def runOrThrow[R, E, A](effect: ZIO[R, E, A])(implicit r: Runtime[R]): A =
+    Unsafe.unsafe(implicit u => r.unsafe.run(effect).getOrThrowFiberFailure())
+
+  /**
+   * Executes the effect synchronously and returns its result as a
    * [[Future]].
    *
    * This method is effectful and should only be used at the edges of your

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -55,6 +55,10 @@ trait TriplestoreService {
     sparqlExtendedConstructRequest: SparqlExtendedConstructRequest
   ): UIO[SparqlExtendedConstructResponse]
 
+  def sparqlHttpExtendedConstruct(query: String): UIO[SparqlExtendedConstructResponse] = sparqlHttpExtendedConstruct(
+    SparqlExtendedConstructRequest(query)
+  )
+
   /**
    * Given a SPARQL CONSTRUCT query string, runs the query, saving the result in a file.
    *

--- a/webapi/src/main/scala/org/knora/webapi/util/ActorUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/ActorUtil.scala
@@ -9,7 +9,6 @@ import akka.actor.ActorRef
 import akka.http.scaladsl.util.FastFuture
 import akka.util.Timeout
 import com.typesafe.scalalogging.Logger
-import zio.Cause._
 import zio._
 
 import scala.concurrent.ExecutionContext
@@ -19,55 +18,19 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import dsp.errors.ExceptionUtil
-import dsp.errors.RequestRejectedException
-import dsp.errors.UnexpectedMessageException
+import dsp.errors._
 
 object ActorUtil {
 
   /**
-   * Transforms ZIO Task returned to the receive method of an actor to a message. Used mainly during the refactoring
-   * phase, to be able to return ZIO inside an Actor.
-   *
-   * It performs the same functionality as [[future2Message]] does, rewritten completely uzing ZIOs.
-   *
-   * BEST PRACTICE:
-   * Do not log in the middle, only log at the edge. Trust the ZIO error model to propagate errors losslessly.
-   *
-   * Since this is the "edge" of the ZIO world for now, we need to log all errors that ZIO has potentially accumulated
+   * _Unsafely_ runs a ZIO workflow and sends the result to the `sender` actor as a message or a failure.
+   * Used mainly during the refactoring phase, to be able to return ZIO inside an Actor.
    */
-  def zio2Message[A](
-    sender: ActorRef,
-    zioTask: zio.Task[A],
-    log: Logger,
-    runtime: Runtime[Any]
-  ): Unit =
+  def zio2Message[R, A](sender: ActorRef, zioTask: ZIO[R, Throwable, A])(implicit runtime: Runtime[R]): Unit =
     Unsafe.unsafe { implicit u =>
-      runtime.unsafe
-        .run(
-          zioTask.foldCause(cause => handleCause(cause, sender, log), success => sender ! success)
-        )
-    }
-
-  /**
-   * The "cause" handling part of `zio2Message`. It analyses the kind of failures and defects
-   * that where accumulated and sends the actor, that made the request in the `ask` pattern,
-   * the failure response.
-   *
-   * @param cause the failures and defects that need to be handled.
-   * @param sender the actor that made the request in the `ask` pattern.
-   */
-  private def handleCause(cause: Cause[Throwable], sender: ActorRef, log: Logger): Unit =
-    cause match {
-      case Fail(failCause: RequestRejectedException, _) => sender ! akka.actor.Status.Failure(failCause)
-      case Die(dieCause, _) =>
-        dieCause match {
-          case _: RequestRejectedException => sender ! akka.actor.Status.Failure(dieCause)
-          case _ =>
-            log.error(s"This error is presumably NOT the clients fault: $dieCause", dieCause)
-            sender ! akka.actor.Status.Failure(dieCause)
-        }
-      case other => log.error(s"handleCause() expects a ZIO.Die, but got $other", other)
+      runtime.unsafe.run(
+        zioTask.foldCause(cause => sender ! akka.actor.Status.Failure(cause.squash), success => sender ! success)
+      )
     }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/util/ZioHelper.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/ZioHelper.scala
@@ -1,0 +1,16 @@
+package org.knora.webapi.util
+
+import zio.Task
+import zio.ZIO
+
+object ZioHelper {
+
+  def sequence[A](x: Seq[Task[A]]): Task[List[A]] =
+    x.map(_.map(x => List[A](x)))
+      .fold(ZIO.succeed(List.empty[A]))((x, y) => x.flatMap(a => y.map(b => a ++ b)))
+
+  def sequence[A](x: Set[Task[A]]): Task[Set[A]] =
+    x.map(_.map(x => Set[A](x)))
+      .fold(ZIO.succeed(Set.empty[A]))((x, y) => x.flatMap(a => y.map(b => a ++ b)))
+
+}

--- a/webapi/src/test/scala/org/knora/webapi/util/ZioHelperSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/ZioHelperSpec.scala
@@ -1,0 +1,38 @@
+package org.knora.webapi.util
+
+import zio._
+import zio.test._
+
+object ZioHelperSpec extends ZIOSpecDefault {
+
+  val spec: Spec[Any, Throwable] = suite("ZioHelper")(
+    suite(".sequence(List)")(
+      test("should sequence a List of ZIOs") {
+        val list = List(ZIO.succeed("1"), ZIO.succeed("2"))
+        for {
+          actual <- ZioHelper.sequence(list)
+        } yield assertTrue(actual == List("1", "2"))
+      },
+      test("should sequence an empty List") {
+        val list: List[Task[String]] = List.empty
+        for {
+          actual <- ZioHelper.sequence(list)
+        } yield assertTrue(actual == List.empty[String])
+      }
+    ),
+    suite("sequence(Set)")(
+      test("should sequence a Set of ZIOs") {
+        val set: Set[Task[String]] = Set(ZIO.succeed("1"), ZIO.succeed("2"))
+        for {
+          actual <- ZioHelper.sequence(set)
+        } yield assertTrue(actual == Set("1", "2"))
+      },
+      test("should sequence an empty Set") {
+        val set: Set[Task[String]] = Set.empty
+        for {
+          actual <- ZioHelper.sequence(set)
+        } yield assertTrue(actual == Set.empty[String])
+      }
+    )
+  )
+}


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-1728

Migrates the `ProjectsResponderADM` into ZIO land.

* Introduces `ProjectsResponderADM` trait which exposes the methods from the receive/handle to the outside world for possible direct use
* Adds a live implementation and layer for above trait
* Adds a ZIO implementation for the `IriLocker`
* Adds a `ZioHelper` object which implements functions for `ZIO`s akin to Scala's `Future#sequence` functions
* Adds overloaded `Triplestore#sparqlHttpExtendedConstruct` methods which accepts a `String`
* Fixes handling of errors in `ActorUtil#zio2Message`, all causes are sent back to the actor as failure

PR is based on https://github.com/dasch-swiss/dsp-api/pull/2453 that is why I have set this as the merge target for now so that you do not have to review the other PR twice.

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [x] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
