### PR TITLE
fix: doSipiPostUpdate to evaluate provided task only once (NO-TICKET)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
@@ -816,10 +816,9 @@ final case class ValuesResponderV1Live(
         projectADM = projectADM
       )
       resourceUtilV2.doSipiPostUpdate(
-        updateFuture = triplestoreUpdateFuture,
-        valueContent = fileValueContent,
-        requestingUser = changeFileValueRequest.userProfile,
-        log = logger
+        triplestoreUpdateFuture,
+        List(fileValueContent),
+        changeFileValueRequest.userProfile
       )
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
@@ -94,7 +94,7 @@ trait ResourceUtilV2 {
   /**
    * Given an update task which changes [[FileValueContentV2]] values the related files need to be finalized.
    * If the update was successful the temporary files are moved to permanent storage.
-   * If the update failed the temporary files are deleted.
+   * If the update failed the temporary files are deleted silently.
    *
    * @param updateTask     the [[Task]] that updates the triplestore.
    * @param fileValues     the values which the task updates.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
@@ -94,7 +94,7 @@ trait ResourceUtilV2 {
   /**
    * Given an update task which changes [[FileValueContentV2]] values the related files need to be finalized.
    * If the update was successful the temporary files are moved to permanent storage.
-   * If the update was not successful the temporary files are deleted.
+   * If the update failed the temporary files are deleted.
    *
    * @param updateTask     the [[Task]] that updates the triplestore.
    * @param fileValues     the values which the task updates.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
@@ -93,8 +93,8 @@ trait ResourceUtilV2 {
 
   /**
    * Given an update task which changes [[FileValueContentV2]] values the related files need to be finalized.
-   * If the update was successful the temporary file is moved to permanent storage.
-   * If the update was not successful the temporary file is deleted.
+   * If the update was successful the temporary files are moved to permanent storage.
+   * If the update was not successful the temporary files are deleted.
    *
    * @param updateTask     the [[Task]] that updates the triplestore.
    * @param fileValues     the values which the task updates.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -397,10 +397,11 @@ class ValuesResponderV2(
     UnsafeZioRun.runToFuture(
       ZIO.serviceWithZIO[ResourceUtilV2](
         _.doSipiPostUpdate(
-          updateFuture = ZIO.fromFuture(ec => triplestoreUpdateFuture),
-          valueContent = createValueRequest.createValue.valueContent,
-          requestingUser = createValueRequest.requestingUser,
-          log = log
+          ZIO.fromFuture(ec => triplestoreUpdateFuture),
+          List(createValueRequest.createValue.valueContent)
+            .filter(_.isInstanceOf[FileValueContentV2])
+            .map(_.asInstanceOf[FileValueContentV2]),
+          createValueRequest.requestingUser
         )
       )
     )
@@ -1378,10 +1379,11 @@ class ValuesResponderV2(
           UnsafeZioRun.runToFuture(
             ZIO.serviceWithZIO[ResourceUtilV2](
               _.doSipiPostUpdate(
-                updateFuture = ZIO.fromFuture(_ => triplestoreUpdateFuture),
-                valueContent = updateValueContentV2.valueContent,
-                requestingUser = updateValueRequest.requestingUser,
-                log = log
+                ZIO.fromFuture(_ => triplestoreUpdateFuture),
+                List(updateValueContentV2.valueContent)
+                  .filter(_.isInstanceOf[FileValueContentV2])
+                  .map(_.asInstanceOf[FileValueContentV2]),
+                updateValueRequest.requestingUser
               )
             )
           )


### PR DESCRIPTION
Fix ResourceUtilV2.doSipiPostUpdate so that it does not evaluate the provided `updateTask` multiple times but folds over the result instead.

This problem does not occur if the provided task is coming from a future as then it is containing simply a value and evaluating the value twice does not change the outcome. But will be a problem once the updateTask is coming from a real ZIO which contains instructions being evaluated multiple times then.

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: NO-TICKET

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [x] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
