### PR TITLE
fix: deleted properties in cardinalities should be included in the count query (DEV-1878)

### DIFF
--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/countPropertyUsedWithClass.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/countPropertyUsedWithClass.scala.txt
@@ -20,16 +20,18 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
 
-SELECT ?subject (COUNT(?o) as ?count)
+SELECT ?subject (COUNT(?object) as ?count)
 WHERE {
 
    BIND(IRI("@{propertyIri.value}") AS ?propertyIri)
    BIND(IRI("@{classIri.value}") AS ?classIri)
 
-   ?subject  a                     ?classIri .
+   ?subject a ?classIri .
+   MINUS { ?subject knora-base:isDeleted true }.
 
-   OPTIONAL { ?subject  ?propertyIri          ?o . }.
-   MINUS    { ?subject  knora-base:isDeleted  true }.
-   MINUS    { ?o        knora-base:isDeleted  true }.
+   OPTIONAL {
+     ?subject ?propertyIri ?object .
+     MINUS { ?object knora-base:isDeleted true }.
+   }.
 }
 GROUP by ?subject

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/CardinalityServiceLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/CardinalityServiceLiveSpec.scala
@@ -475,6 +475,49 @@ object CardinalityServiceLiveSpec extends ZIOSpecDefault {
                                   |
                                   |""".stripMargin)
       ),
+      suite("canSetCardinality with deleted object in property reference")(
+        test("given a deleted property was used") {
+          val propertyCardinality =
+            OntologyCacheDataBuilder.cardinalitiesMap(Anything.Property.hasOtherThing, Unbounded)
+          val data = OntologyCacheDataBuilder.builder
+            .addOntology(
+              ReadOntologyV2Builder
+                .builder(Anything.Ontology)
+                .addClassInfo(
+                  ReadClassInfoV2Builder
+                    .builder(Anything.Class.Thing)
+                    .setDirectCardinalities(propertyCardinality)
+                )
+            )
+          check(cardinalitiesGen(AtLeastOne)) { newCardinality =>
+            for {
+              _ <- OntologyCacheFake.set(data.build)
+              actual <-
+                CardinalityService.canSetCardinality(
+                  Anything.Class.Thing,
+                  Anything.Property.hasOtherThing,
+                  newCardinality
+                )
+            } yield assertTrue(actual.isLeft)
+          }
+        }.provide(
+          commonLayers,
+          datasetLayerFromTurtle(s"""
+                                    |@prefix rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                                    |@prefix rdfs:        <http://www.w3.org/2000/01/rdf-schema#> .
+                                    |@prefix knora-base:  <http://www.knora.org/ontology/knora-base#> .
+                                    |
+                                    |<http://aThing>
+                                    |  a <${Anything.Class.Thing.value}> ;
+                                    |  <${Anything.Property.hasOtherThing.value}> <http://aDeletedThing>.
+                                    |
+                                    |<http://aDeletedThing>
+                                    |  a <${Anything.Class.Thing.value}> ;
+                                    |  knora-base:isDeleted true .
+                                    |
+                                    |""".stripMargin)
+        )
+      ),
       suite("canSetCardinality with property in use once")(
         test(s"""
                 |Given the previous cardinality on the class/property


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-1878

Adds a test for the case that the object of a property was deleted.
Given a deleted property the count query should count instances with deleted properties with a count of zero instead of removing the instance from the result set entirely.

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [x] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
