### PR TITLE
fix: Fix bad substitution in export-moving-image-frames.sh

### DIFF
--- a/sipi/scripts/export-moving-image-frames.sh
+++ b/sipi/scripts/export-moving-image-frames.sh
@@ -7,7 +7,7 @@
 # - max. 36 frames per matrix
 # - one matrix file corresponds to 6 minutes of film
 
-if [ "${DEBUG:false}" == true ]; then
+if [ "${DEBUG:-false}" == true ]; then
   set -ex
 else
   set -e


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

In DSP-TOOLS e2e Tests, there is a "Bad substitution" warning in this part of the code. This fixes it.

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [x] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
