### PR TITLE
refactor: improve lucene handling in gravsearch (DEV-2148)

### DIFF
--- a/webapi/src/it/scala/org/knora/webapi/messages/util/search/SparqlTransformerSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/messages/util/search/SparqlTransformerSpec.scala
@@ -10,9 +10,8 @@ import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.search._
-import org.knora.webapi.routing.UnsafeZioRun
-import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 import org.knora.webapi.messages.util.search.gravsearch.transformers._
+import org.knora.webapi.routing.UnsafeZioRun
 
 /**
  * Tests [[SparqlTransformer]].
@@ -139,11 +138,13 @@ class SparqlTransformerSpec extends CoreSpec {
           pred = IriRef(OntologyConstants.KnoraBase.ValueHasString.toSmartIri),
           QueryVariable("text__valueHasString")
         )
-      val luceneQueryPattern = LuceneQueryPattern(
+      val luceneQueryPattern = StatementPattern(
         subj = QueryVariable("text"),
-        obj = QueryVariable("text__valueHasString"),
-        queryString = LuceneQueryString("Zeitglöcklein"),
-        literalStatement = Some(valueHasStringStatement)
+        pred = IriRef(OntologyConstants.Fuseki.luceneQueryPredicate.toSmartIri),
+        obj = XsdLiteral(
+          value = "Zeitglöcklein",
+          datatype = OntologyConstants.Xsd.String.toSmartIri
+        )
       )
       val patterns: Seq[QueryPattern] = Seq(
         hasValueStatement,

--- a/webapi/src/it/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -1,12 +1,14 @@
 package org.knora.webapi.messages.util.search.gravsearch.prequery
 
-import scala.collection.mutable.ArrayBuffer
-import dsp.errors.AssertionException
 import zio.ZIO
 
+import scala.collection.mutable.ArrayBuffer
+
+import dsp.errors.AssertionException
 import org.knora.webapi.CoreSpec
 import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions._
+import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.search._
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
@@ -15,7 +17,6 @@ import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInsp
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
 import org.knora.webapi.routing.UnsafeZioRun
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.anythingAdminUser
-import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 
 class GravsearchToPrequeryTransformerSpec extends CoreSpec {
 
@@ -1366,19 +1367,12 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
               ),
               obj = QueryVariable(variableName = "recipient")
             ),
-            LuceneQueryPattern(
+            StatementPattern(
               subj = QueryVariable(variableName = "familyName"),
-              obj = QueryVariable(variableName = "familyName__valueHasString"),
-              queryString = LuceneQueryString(queryString = "Bernoulli"),
-              literalStatement = Some(
-                StatementPattern(
-                  subj = QueryVariable(variableName = "familyName"),
-                  pred = IriRef(
-                    iri = "http://www.knora.org/ontology/knora-base#valueHasString".toSmartIri,
-                    propertyPathOperator = None
-                  ),
-                  obj = QueryVariable(variableName = "familyName__valueHasString")
-                )
+              pred = IriRef(OntologyConstants.Fuseki.luceneQueryPredicate.toSmartIri),
+              obj = XsdLiteral(
+                value = "Bernoulli",
+                datatype = OntologyConstants.Xsd.String.toSmartIri
               )
             )
           )
@@ -2377,19 +2371,12 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
                   datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
                 )
               ),
-              LuceneQueryPattern(
+              StatementPattern(
                 subj = QueryVariable(variableName = "richtext"),
-                obj = QueryVariable(variableName = "richtext__valueHasString"),
-                queryString = LuceneQueryString(queryString = "test"),
-                literalStatement = Some(
-                  StatementPattern(
-                    subj = QueryVariable(variableName = "richtext"),
-                    pred = IriRef(
-                      iri = "http://www.knora.org/ontology/knora-base#valueHasString".toSmartIri,
-                      propertyPathOperator = None
-                    ),
-                    obj = QueryVariable(variableName = "richtext__valueHasString")
-                  )
+                pred = IriRef(OntologyConstants.Fuseki.luceneQueryPredicate.toSmartIri),
+                obj = XsdLiteral(
+                  value = "test",
+                  datatype = OntologyConstants.Xsd.String.toSmartIri
                 )
               )
             ),
@@ -2451,19 +2438,12 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
                   datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
                 )
               ),
-              LuceneQueryPattern(
+              StatementPattern(
                 subj = QueryVariable(variableName = "text"),
-                obj = QueryVariable(variableName = "text__valueHasString"),
-                queryString = LuceneQueryString(queryString = "test"),
-                literalStatement = Some(
-                  StatementPattern(
-                    subj = QueryVariable(variableName = "text"),
-                    pred = IriRef(
-                      iri = "http://www.knora.org/ontology/knora-base#valueHasString".toSmartIri,
-                      propertyPathOperator = None
-                    ),
-                    obj = QueryVariable(variableName = "text__valueHasString")
-                  )
+                pred = IriRef(OntologyConstants.Fuseki.luceneQueryPredicate.toSmartIri),
+                obj = XsdLiteral(
+                  value = "test",
+                  datatype = OntologyConstants.Xsd.String.toSmartIri
                 )
               )
             )

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -588,10 +588,6 @@ object OntologyConstants {
     val StandoffStyleElementTag: IRI  = StandoffPrefixExpansion + "StandoffStyleTag"
   }
 
-  object Ontotext {
-    val LuceneFulltext = "http://www.ontotext.com/owlim/lucene#fullTextSearchIndex"
-  }
-
   object XPathFunctions {
     val XPathPrefixExpansion: IRI = "http://www.w3.org/2005/xpath-functions#"
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -1118,4 +1118,8 @@ object OntologyConstants {
   object NamedGraphs {
     val DataNamedGraphStart: IRI = "http://www.knora.org/data"
   }
+
+  object Fuseki {
+    val luceneQueryPredicate = "http://jena.apache.org/text#query"
+  }
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
@@ -139,9 +139,6 @@ final case class QueryTraverser(
                                  }
                                  ZIO.collectAll(transformedBlocks).map(blocks => Seq(UnionPattern(blocks)))
 
-                               case luceneQueryPattern: LuceneQueryPattern =>
-                                 whereTransformer.transformLuceneQueryPattern(luceneQueryPattern)
-
                                case valuesPattern: ValuesPattern => ZIO.succeed(Seq(valuesPattern))
 
                                case bindPattern: BindPattern => ZIO.succeed(Seq(bindPattern))

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlQuery.scala
@@ -8,14 +8,12 @@ package org.knora.webapi.messages.util.search
 import akka.http.scaladsl.model.HttpCharsets
 import akka.http.scaladsl.model.MediaType
 
-import dsp.errors.AssertionException
 import dsp.errors.GravsearchException
 import org.knora.webapi._
 import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 
 /**
  * Constants used in processing SPARQL queries.
@@ -180,26 +178,6 @@ case class StatementPattern(subj: Entity, pred: Entity, obj: Entity) extends Que
       case iriRef: IriRef => iriRef.toOntologySchema(targetSchema)
       case other          => other
     }
-}
-
-/**
- * A virtual query pattern representing a Lucene full-text index search. Will be replaced by triplestore-specific
- * statements during Gravsearch processing.
- *
- * @param subj        a variable representing the subject to be found.
- * @param obj         a variable representing the literal that is indexed.
- * @param queryString the Lucene query string to be matched.
- * @param literalStatement a statement that connects `subj` to `obj`. Needed with some triplestores but not others.
- *                         Will be defined only if it has not already been added to the generated SPARQL.
- */
-case class LuceneQueryPattern(
-  subj: QueryVariable,
-  obj: QueryVariable,
-  queryString: LuceneQueryString,
-  literalStatement: Option[StatementPattern]
-) extends QueryPattern {
-  override def toSparql: String =
-    throw AssertionException("LuceneQueryPattern should have been transformed into statements")
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -156,7 +156,7 @@ abstract class AbstractPrequeryGenerator(
     )
 
   override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Task[Seq[QueryPattern]] =
-    ZIO.succeed(Seq(luceneQueryPattern))
+    ZIO.fail(GravsearchException("Unexpected LuceneQueryPattern in prequery generator"))
 
   /**
    * Transforms a [[org.knora.webapi.messages.util.search.FilterPattern]] in a WHERE clause into zero or more statement patterns.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/InferenceOptimizationService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/InferenceOptimizationService.scala
@@ -20,7 +20,6 @@ import org.knora.webapi.messages.util.search.BindPattern
 import org.knora.webapi.messages.util.search.Entity
 import org.knora.webapi.messages.util.search.FilterNotExistsPattern
 import org.knora.webapi.messages.util.search.IriRef
-import org.knora.webapi.messages.util.search.LuceneQueryPattern
 import org.knora.webapi.messages.util.search.MinusPattern
 import org.knora.webapi.messages.util.search.OptionalPattern
 import org.knora.webapi.messages.util.search.QueryPattern
@@ -101,15 +100,14 @@ final case class InferenceOptimizationServiceLive(
     def getEntities(patterns: Seq[QueryPattern]): Seq[Entity] =
       patterns.flatMap { pattern =>
         pattern match {
-          case ValuesPattern(_, values)            => values.toSeq
-          case BindPattern(_, expression)          => List(expression.asInstanceOf[Entity])
-          case UnionPattern(blocks)                => blocks.flatMap(block => getEntities(block))
-          case StatementPattern(subj, pred, obj)   => List(subj, pred, obj)
-          case LuceneQueryPattern(subj, obj, _, _) => List(subj, obj)
-          case FilterNotExistsPattern(patterns)    => getEntities(patterns)
-          case MinusPattern(patterns)              => getEntities(patterns)
-          case OptionalPattern(patterns)           => getEntities(patterns)
-          case _                                   => List.empty
+          case ValuesPattern(_, values)          => values.toSeq
+          case BindPattern(_, expression)        => List(expression.asInstanceOf[Entity])
+          case UnionPattern(blocks)              => blocks.flatMap(block => getEntities(block))
+          case StatementPattern(subj, pred, obj) => List(subj, pred, obj)
+          case FilterNotExistsPattern(patterns)  => getEntities(patterns)
+          case MinusPattern(patterns)            => getEntities(patterns)
+          case OptionalPattern(patterns)         => getEntities(patterns)
+          case _                                 => List.empty
         }
       }
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/ConstructTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/ConstructTransformer.scala
@@ -7,7 +7,6 @@ package org.knora.webapi.messages.util.search.gravsearch.transformers
 
 import zio._
 
-import dsp.errors.GravsearchException
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.util.search._
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
@@ -64,8 +63,6 @@ final case class ConstructTransformer(
       case OptionalPattern(patterns) => ZIO.foreach(patterns)(transformPattern(_, limit).map(OptionalPattern))
       case UnionPattern(blocks) =>
         ZIO.foreach(blocks)(optimizeAndTransformPatterns(_, limit)).map(block => Seq(UnionPattern(block)))
-      case _: LuceneQueryPattern =>
-        ZIO.fail(GravsearchException("Unexpected LuceneQueryPattern in construct transformer"))
       case pattern: QueryPattern => ZIO.succeed(Seq(pattern))
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/OntologyInferencer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/OntologyInferencer.scala
@@ -148,26 +148,6 @@ final case class OntologyInferencer(
         // The predicate isn't a property IRI or no inference should be done, so no expansion needed.
         ZIO.succeed(Seq(statementPattern))
     }
-
-  /**
-   * Transforms a [[LuceneQueryPattern]] for Fuseki.
-   *
-   * @param luceneQueryPattern the query pattern.
-   * @return Fuseki-specific statements implementing the query.
-   */
-  def transformLuceneQueryPatternForFuseki(luceneQueryPattern: LuceneQueryPattern): Task[Seq[StatementPattern]] =
-    ZIO.attempt(
-      Seq(
-        StatementPattern(
-          subj = luceneQueryPattern.subj, // In Fuseki, an index entry is associated with an entity that has a literal.
-          pred = IriRef("http://jena.apache.org/text#query".toSmartIri),
-          obj = XsdLiteral(
-            value = luceneQueryPattern.queryString.getQueryString,
-            datatype = OntologyConstants.Xsd.String.toSmartIri
-          )
-        )
-      )
-    )
 }
 
 object OntologyInferencer {

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SelectTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SelectTransformer.scala
@@ -42,9 +42,6 @@ class SelectTransformer(
     moveBindToBeginning(optimiseIsDeletedWithFilter(moveLuceneToBeginning(patterns)))
   }
 
-  override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Task[Seq[QueryPattern]] =
-    sparqlTransformerLive.transformLuceneQueryPatternForFuseki(luceneQueryPattern)
-
   /**
    * Specifies a FROM clause, if needed.
    *

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SparqlTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SparqlTransformer.scala
@@ -146,9 +146,9 @@ object SparqlTransformer {
    * @return the result of the optimisation.
    */
   def moveLuceneToBeginning(patterns: Seq[QueryPattern]): Seq[QueryPattern] = {
-    val (luceneQueryPatterns: Seq[QueryPattern], otherPatterns: Seq[QueryPattern]) = patterns.partition {
-      case _: LuceneQueryPattern => true
-      case _                     => false
+    val (luceneQueryPatterns, otherPatterns) = patterns.partition {
+      case StatementPattern(_, IriRef(pred, _), _) => pred.toIri == OntologyConstants.Fuseki.luceneQueryPredicate
+      case _                                       => false
     }
 
     luceneQueryPatterns ++ otherPatterns

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/WhereTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/WhereTransformer.scala
@@ -9,7 +9,6 @@ import zio._
 
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.util.search.FilterPattern
-import org.knora.webapi.messages.util.search.LuceneQueryPattern
 import org.knora.webapi.messages.util.search.OrderCriterion
 import org.knora.webapi.messages.util.search.QueryPattern
 import org.knora.webapi.messages.util.search.StatementPattern
@@ -56,12 +55,4 @@ trait WhereTransformer {
    * @return the result of the transformation.
    */
   def transformFilter(filterPattern: FilterPattern): Task[Seq[QueryPattern]] = ZIO.succeed(Seq(filterPattern))
-
-  /**
-   * Transforms a [[LuceneQueryPattern]] into one or more query patterns.
-   *
-   * @param luceneQueryPattern the query pattern to be transformed.
-   * @return the transformed pattern.
-   */
-  def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Task[Seq[QueryPattern]]
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
@@ -244,7 +244,6 @@ object GravsearchTypeInspectionUtil {
       case optionalPattern: OptionalPattern => Seq(OptionalPattern(optionalPattern.patterns.flatMap(transformPattern)))
       case unionPattern: UnionPattern       => Seq(UnionPattern(unionPattern.blocks.map(_.flatMap(transformPattern))))
       case filterPattern: FilterPattern     => Seq(filterPattern)
-      case _: LuceneQueryPattern            => Seq.empty[QueryPattern]
       case valuesPattern: ValuesPattern     => Seq(valuesPattern)
       case bindPattern: BindPattern         => Seq(bindPattern)
       case statementPattern: StatementPattern =>

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
@@ -240,13 +240,13 @@ object GravsearchTypeInspectionUtil {
     pattern match {
       case filterNotExistsPattern: FilterNotExistsPattern =>
         Seq(FilterNotExistsPattern(filterNotExistsPattern.patterns.flatMap(transformPattern)))
-      case minusPattern: MinusPattern             => Seq(MinusPattern(minusPattern.patterns.flatMap(transformPattern)))
-      case optionalPattern: OptionalPattern       => Seq(OptionalPattern(optionalPattern.patterns.flatMap(transformPattern)))
-      case unionPattern: UnionPattern             => Seq(UnionPattern(unionPattern.blocks.map(_.flatMap(transformPattern))))
-      case filterPattern: FilterPattern           => Seq(filterPattern)
-      case luceneQueryPattern: LuceneQueryPattern => Seq(luceneQueryPattern)
-      case valuesPattern: ValuesPattern           => Seq(valuesPattern)
-      case bindPattern: BindPattern               => Seq(bindPattern)
+      case minusPattern: MinusPattern       => Seq(MinusPattern(minusPattern.patterns.flatMap(transformPattern)))
+      case optionalPattern: OptionalPattern => Seq(OptionalPattern(optionalPattern.patterns.flatMap(transformPattern)))
+      case unionPattern: UnionPattern       => Seq(UnionPattern(unionPattern.blocks.map(_.flatMap(transformPattern))))
+      case filterPattern: FilterPattern     => Seq(filterPattern)
+      case _: LuceneQueryPattern            => Seq.empty[QueryPattern]
+      case valuesPattern: ValuesPattern     => Seq(valuesPattern)
+      case bindPattern: BindPattern         => Seq(bindPattern)
       case statementPattern: StatementPattern =>
         if (mustBeAnnotationStatement(statementPattern)) Seq.empty[QueryPattern]
         else Seq(statementPattern)


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

Currently, `LuceneQueryPattern` is the only type in the Gravsearch AST which doesn't correspond to valid SPARQL, and it always gets transformed away into the same statement.  
This PR removes the unnecessary type from the AST system.

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [x] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
