### PR TITLE
fix: Multiple cookies are separated by `; ` not by `,` (DEV-2271)

### DIFF
--- a/sipi/scripts/authentication.lua
+++ b/sipi/scripts/authentication.lua
@@ -173,15 +173,13 @@ function _get_jwt_token_from_cookie()
         log("authentication: no cookie header found", server.loglevel.LOG_DEBUG)
         return nil
     end
-    log("authentication: cookie header found: " .. cookies, server.loglevel.LOG_DEBUG)
 
     cookie_name = cookie_name:lower()
-    for entry in cookies:gmatch("([^,]+)") do
+    for entry in cookies:gmatch("([^; ]+)") do
         local key, value = entry:match("([^=]+)=(.+)")
         if key and value then
             if key:lower() == cookie_name then
-                log("authentication: found cookie name '" .. cookie_name .. "', value: '" .. value .. "'", server.loglevel.LOG_DEBUG)
-                return value
+                return str_trim(value)
             end
         end
     end

--- a/sipi/scripts/strings.lua
+++ b/sipi/scripts/strings.lua
@@ -49,6 +49,17 @@ function str_strip_prefix(str, prefix)
     end
 end
 
+function str_trim(str)
+    local _, i = string.find(str, "^%s*") -- Find the starting whitespace
+    local j, _ = string.find(str, "%s*$") -- Find the trailing whitespace
+
+    if i == nil or j == nil then
+        return str -- No whitespace found at either end, return the original string
+    else
+        return string.sub(str, i + 1, j - 1) -- Return the trimmed string
+    end
+end
+
 --- Transforms a table into a string.
 -- @param tbl the table to transform.
 -- @return a string representation of the table.

--- a/webapi/src/it/scala/org/knora/sipi/SipiIT.scala
+++ b/webapi/src/it/scala/org/knora/sipi/SipiIT.scala
@@ -48,9 +48,10 @@ object SipiIT extends ZIOSpecDefault {
     "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiIwLjAuMC4wOjMzMzMiLCJzdWIiOiJodHRwOi8vcmRmaC5jaC91c2Vycy9yb290IiwiYXVkIjpbIktub3JhIiwiU2lwaSJdLCJleHAiOjE2ODk3NTY1MzksImlhdCI6MTY4NzE2NDUzOSwianRpIjoiSG9SSFg5V1lSZHV6VnVmTXZFT1c4USJ9.tlTqr1NGjsOqnMRxjDW1TokDjGAPO5nvG-pcbn09Hrw"
 
   private val cookiesSuite =
-    suite("Given a Request contains multiple auth cookies")(
+    suite("Given a request is authorized using cookies")(
       test(
-        "When getting an existing file, " +
+        "And Given the request contains multiple cookies " +
+          "When getting an existing file, " +
           "then Sipi should extract the correct cookie, send it to dsp-api " +
           "and responds with Ok"
       ) {
@@ -67,8 +68,41 @@ object SipiIT extends ZIOSpecDefault {
               .map { url =>
                 Request
                   .get(url)
-                  .withCookie(s"KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999aSecondCookie=anotherValueShouldBeIgnored; KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999=$jwt")
+                  .withCookie(
+                    s"KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999aSecondCookie=anotherValueShouldBeIgnored; KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999=$jwt"
+                  )
               }
+              .flatMap(Client.request(_))
+          requestToDspApiContainsJwt <- ZIO
+                                          .attempt(
+                                            mockServer.verify(
+                                              // Number of times the request should be received (in this case, only once)
+                                              1,
+                                              // The expected request with header and value
+                                              newRequestPattern().withHeader("Authorization", equalTo(s"Bearer $jwt"))
+                                            )
+                                          )
+                                          .logError
+                                          .fold(err => false, succ => true)
+        } yield assertTrue(response.status == Status.Ok, requestToDspApiContainsJwt)
+      },
+      test(
+        "And Given the request contains a single cookie " +
+          "When getting an existing file, " +
+          "then Sipi should send it to dsp-api " +
+          "and responds with Ok"
+      ) {
+        for {
+          _ <- copyTestFilesToSipi
+          mockServer <- MockDspApiServer.resetAndStubGetResponse(
+                          s"/admin/files/$prefix/$imageTestfile",
+                          200,
+                          SipiFileInfoGetResponseADM(permissionCode = 2, restrictedViewSettings = None)
+                        )
+          response <-
+            SipiTestContainer
+              .resolveUrl(s"/$prefix/$imageTestfile/file")
+              .map(url => Request.get(url).withCookie(s"KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999=$jwt"))
               .flatMap(Client.request(_))
           requestToDspApiContainsJwt <- ZIO
                                           .attempt(

--- a/webapi/src/it/scala/org/knora/sipi/SipiIT.scala
+++ b/webapi/src/it/scala/org/knora/sipi/SipiIT.scala
@@ -14,13 +14,10 @@ import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
-import org.apache.commons.codec.binary.Base32
-import spray.json.JsString
 import zio._
 import zio.http._
 import zio.http.model.Status
 import zio.json.DecoderOps
-import zio.json.EncoderOps
 import zio.json.ast.Json
 import zio.test._
 import scala.util.Failure
@@ -28,17 +25,11 @@ import scala.util.Success
 import scala.util.Try
 
 import org.knora.sipi.MockDspApiServer.verify._
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.admin.responder.KnoraResponseADM
 import org.knora.webapi.messages.admin.responder.sipimessages._
-import org.knora.webapi.routing.JwtService
-import org.knora.webapi.routing.JwtServiceLive
-import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.testcontainers.SipiTestContainer
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern
-
-import org.knora.sipi.SipiIT.fileEndpointSuite
 
 object SipiIT extends ZIOSpecDefault {
 
@@ -76,8 +67,7 @@ object SipiIT extends ZIOSpecDefault {
               .map { url =>
                 Request
                   .get(url)
-                  .withCookie(s"KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999aSecondCookie=anotherValueShouldBeIgnored")
-                  .withCookie(s"KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999=$jwt")
+                  .withCookie(s"KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999aSecondCookie=anotherValueShouldBeIgnored; KnoraAuthenticationGAXDALRQFYYDUMZTGMZQ9999=$jwt")
               }
               .flatMap(Client.request(_))
           requestToDspApiContainsJwt <- ZIO


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

fix: Make Sipi split multiple cookies by ; as defined in the Cookie spec

The `Cookie` header value may contain a list of name value pairs.
A list of name-value pairs in the form of `<cookie-name>=<cookie-value>`.
Pairs in the list are separated by a semicolon and a space (`; `).
[ https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie ]
### Basic Requirements

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [x] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [ ] No
