### PR TITLE
fix: Align path variable for export and import routes to use Shortcode

### DIFF
--- a/webapi/src/main/scala/dsp/valueobjects/Project.scala
+++ b/webapi/src/main/scala/dsp/valueobjects/Project.scala
@@ -70,12 +70,6 @@ object Project {
           case true  => Validation.succeed(new Shortcode(value.toUpperCase) {})
         }
       }
-
-    def make(value: Option[String]): Validation[ValidationException, Option[Shortcode]] =
-      value match {
-        case Some(v) => self.make(v).map(Some(_))
-        case None    => Validation.succeed(None)
-      }
   }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteZ.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteZ.scala
@@ -36,6 +36,7 @@ final case class ProjectsRouteZ(
   private val projectRoutes: Http[Any, Nothing, (Request, UserADM), Response] =
     Http
       .collectZIO[(Request, UserADM)] {
+        // project crud
         case (Method.GET -> !! / "admin" / "projects", _)                           => getProjects()
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded, _)   => getProjectByIri(iriUrlEncoded)
         case (Method.GET -> !! / "admin" / "projects" / "shortname" / shortname, _) => getProjectByShortname(shortname)
@@ -49,27 +50,34 @@ final case class ProjectsRouteZ(
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "AllData", requestingUser) =>
           getAllProjectData(iriUrlEncoded, requestingUser)
 
+        // export/import endpoints
         case (Method.GET -> !! / "admin" / "projects" / "exports", requestingUser) =>
           getProjectExports(requestingUser)
+        case (Method.POST -> !! / "admin" / "projects" / "shortcode" / shortcode / "import", requestingUser) =>
+          postImportProject(shortcode, requestingUser)
+        case (Method.POST -> !! / "admin" / "projects" / "shortcode" / shortcode / "export", requestingUser) =>
+          postExportProject(shortcode, requestingUser)
+
+        // project members
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "members", requestingUser) =>
           getProjectMembersByIri(iriUrlEncoded, requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "shortname" / shortname / "members", requestingUser) =>
           getProjectMembersByShortname(shortname, requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "shortcode" / shortcode / "members", requestingUser) =>
           getProjectMembersByShortcode(shortcode, requestingUser)
-        case (Method.POST -> !! / "admin" / "projects" / "shortcode" / shortcode / "import", requestingUser) =>
-          postImportProject(shortcode, requestingUser)
-        case (Method.POST -> !! / "admin" / "projects" / "iri" / shortcode / "export", requestingUser) =>
-          postExportProject(shortcode, requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "admin-members", requestingUser) =>
           getProjectAdminsByIri(iriUrlEncoded, requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "shortname" / shortname / "admin-members", requestingUser) =>
           getProjectAdminsByShortname(shortname, requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "shortcode" / shortcode / "admin-members", requestingUser) =>
           getProjectAdminsByShortcode(shortcode, requestingUser)
+
+        // keywords
         case (Method.GET -> !! / "admin" / "projects" / "Keywords", _) => getKeywords()
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "Keywords", _) =>
           getKeywordsByProjectIri(iriUrlEncoded)
+
+        // view settings
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "RestrictedViewSettings", _) =>
           getRestrictedViewSettingsByProjectIri(iriUrlEncoded)
         case (Method.GET -> !! / "admin" / "projects" / "shortname" / shortname / "RestrictedViewSettings", _) =>

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteZ.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteZ.scala
@@ -147,7 +147,7 @@ final case class ProjectsRouteZ(
     } yield r
 
   private def postExportProject(shortcode: String, requestingUser: UserADM): Task[Response] = for {
-    result     <- projectsService.exportProject(shortcode, requestingUser)
+    result <- projectsService.exportProject(shortcode, requestingUser)
   } yield Response.json(result.toJson)
 
   private def postImportProject(shortcode: String, requestingUser: UserADM): Task[Response] = for {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteZ.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteZ.scala
@@ -48,8 +48,7 @@ final case class ProjectsRouteZ(
           updateProject(iriUrlEncoded, request, requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "AllData", requestingUser) =>
           getAllProjectData(iriUrlEncoded, requestingUser)
-        case (Method.POST -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "export", requestingUser) =>
-          postExportProject(iriUrlEncoded, requestingUser)
+
         case (Method.GET -> !! / "admin" / "projects" / "exports", requestingUser) =>
           getProjectExports(requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "members", requestingUser) =>
@@ -60,6 +59,8 @@ final case class ProjectsRouteZ(
           getProjectMembersByShortcode(shortcode, requestingUser)
         case (Method.POST -> !! / "admin" / "projects" / "shortcode" / shortcode / "import", requestingUser) =>
           postImportProject(shortcode, requestingUser)
+        case (Method.POST -> !! / "admin" / "projects" / "iri" / shortcode / "export", requestingUser) =>
+          postExportProject(shortcode, requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "iri" / iriUrlEncoded / "admin-members", requestingUser) =>
           getProjectAdminsByIri(iriUrlEncoded, requestingUser)
         case (Method.GET -> !! / "admin" / "projects" / "shortname" / shortname / "admin-members", requestingUser) =>
@@ -145,9 +146,8 @@ final case class ProjectsRouteZ(
           )
     } yield r
 
-  private def postExportProject(iriUrlEncoded: String, requestingUser: UserADM): Task[Response] = for {
-    projectIri <- RouteUtilZ.urlDecode(iriUrlEncoded)
-    result     <- projectsService.exportProject(projectIri, requestingUser)
+  private def postExportProject(shortcode: String, requestingUser: UserADM): Task[Response] = for {
+    result     <- projectsService.exportProject(shortcode, requestingUser)
   } yield Response.json(result.toJson)
 
   private def postImportProject(shortcode: String, requestingUser: UserADM): Task[Response] = for {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteZ.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteZ.scala
@@ -154,16 +154,14 @@ final case class ProjectsRouteZ(
           )
     } yield r
 
-  private def postExportProject(shortcode: String, requestingUser: UserADM): Task[Response] = for {
-    result <- projectsService.exportProject(shortcode, requestingUser)
-  } yield Response.json(result.toJson)
+  private def postExportProject(shortcode: String, requestingUser: UserADM): Task[Response] =
+    projectsService.exportProject(shortcode, requestingUser).map(_.toJson).map(Response.json(_))
 
-  private def postImportProject(shortcode: String, requestingUser: UserADM): Task[Response] = for {
-    result <- projectsService.importProject(shortcode, requestingUser)
-  } yield Response.json(result.toJson)
+  private def postImportProject(shortcode: String, requestingUser: UserADM): Task[Response] =
+    projectsService.importProject(shortcode, requestingUser).map(_.toJson).map(Response.json(_))
 
   private def getProjectExports(requestingUser: UserADM): Task[Response] =
-    projectsService.listExports(requestingUser).map(chunk => Response.json(chunk.toJson)).logError
+    projectsService.listExports(requestingUser).map(_.toJson).map(Response.json(_))
 
   private def getProjectMembersByIri(iriUrlEncoded: String, requestingUser: UserADM): Task[Response] =
     for {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsADMRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsADMRestService.scala
@@ -13,7 +13,6 @@ import dsp.errors.NotFoundException
 import dsp.valueobjects.Iri.ProjectIri
 import dsp.valueobjects.Project
 import dsp.valueobjects.Project.Shortcode
-import org.knora.webapi.IRI
 import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM._
 import org.knora.webapi.messages.admin.responder.projectsmessages._
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
@@ -46,8 +45,8 @@ trait ProjectADMRestService {
     iriIdentifier: IriIdentifier,
     requestingUser: UserADM
   ): Task[ProjectDataGetResponseADM]
-  def exportProject(shortcode: IRI, requestingUser: UserADM): Task[ProjectExportResponse]
-  def importProject(shortcode: IRI, requestingUser: UserADM): Task[ProjectImportResponse]
+  def exportProject(shortcode: String, requestingUser: UserADM): Task[ProjectExportResponse]
+  def importProject(shortcode: String, requestingUser: UserADM): Task[ProjectImportResponse]
   def listExports(requestingUser: UserADM): Task[Chunk[ProjectExportInfoResponse]]
   def getProjectMembers(
     projectIdentifier: ProjectIdentifierADM,
@@ -248,7 +247,7 @@ final case class ProjectsADMRestServiceLive(
     zipFile   <- projectExportService.exportProject(project)
   } yield ProjectExportResponse(zipFile.toString)
 
-  private def convertStringToShortcode(shortcodeStr: IRI): IO[BadRequestException, Shortcode] =
+  private def convertStringToShortcode(shortcodeStr: String): IO[BadRequestException, Shortcode] =
     Shortcode.make(shortcodeStr).toZIO.mapError(err => BadRequestException(err.msg))
 
   override def importProject(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsADMRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsADMRestService.scala
@@ -47,8 +47,8 @@ trait ProjectADMRestService {
     iriIdentifier: IriIdentifier,
     requestingUser: UserADM
   ): Task[ProjectDataGetResponseADM]
-  def exportProject(projectIri: IRI, requestingUser: UserADM): Task[ProjectExportResponse]
-  def importProject(projectIri: IRI, requestingUser: UserADM): Task[ProjectImportResponse]
+  def exportProject(shortcode: IRI, requestingUser: UserADM): Task[ProjectExportResponse]
+  def importProject(shortcode: IRI, requestingUser: UserADM): Task[ProjectImportResponse]
   def listExports(requestingUser: UserADM): Task[Chunk[ProjectExportInfoResponse]]
   def getProjectMembers(
     projectIdentifier: ProjectIdentifierADM,
@@ -242,25 +242,22 @@ final case class ProjectsADMRestServiceLive(
   def getProjectRestrictedViewSettings(id: ProjectIdentifierADM): Task[ProjectRestrictedViewSettingsGetResponseADM] =
     responder.projectRestrictedViewSettingsGetRequestADM(id)
 
-  override def exportProject(projectIri: String, requestingUser: UserADM): Task[ProjectExportResponse] = for {
-    _       <- permissionService.ensureSystemAdmin(requestingUser)
-    project <- findProject(projectIri)
-    zipFile <- projectExportService.exportProject(project)
+  override def exportProject(shortcodeStr: String, requestingUser: UserADM): Task[ProjectExportResponse] = for {
+    _         <- permissionService.ensureSystemAdmin(requestingUser)
+    shortcode <- convertStringToShortcode(shortcodeStr)
+    project   <- projectRepo.findByShortcode(shortcode).someOrFail(NotFoundException(s"Project $shortcode not found."))
+    zipFile   <- projectExportService.exportProject(project)
   } yield ProjectExportResponse(zipFile.toString)
 
-  private def findProject(iri: String): Task[KnoraProject] =
-    IriIdentifier
-      .fromString(iri)
-      .toZIO
-      .orElseFail(BadRequestException(s"Invalid project IRI: $iri"))
-      .flatMap(projectIri => projectRepo.findById(projectIri).someOrFail(NotFoundException(s"Project $iri not found.")))
+  private def convertStringToShortcode(shortcodeStr: IRI): IO[BadRequestException, Shortcode] =
+    Shortcode.make(shortcodeStr).toZIO.mapError(err => BadRequestException(err.msg))
 
   override def importProject(
-    projectShortcode: String,
+    shortcodeStr: String,
     requestingUser: UserADM
   ): Task[ProjectImportResponse] = for {
     _         <- permissionService.ensureSystemAdmin(requestingUser)
-    shortcode <- Shortcode.make(projectShortcode).toZIO
+    shortcode <- convertStringToShortcode(shortcodeStr)
     path <-
       projectImportService
         .importProject(shortcode, requestingUser)

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsADMRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsADMRestService.scala
@@ -22,7 +22,6 @@ import org.knora.webapi.slice.admin.api.model.ProjectDataGetResponseADM
 import org.knora.webapi.slice.admin.api.model.ProjectExportInfoResponse
 import org.knora.webapi.slice.admin.api.model.ProjectExportResponse
 import org.knora.webapi.slice.admin.api.model.ProjectImportResponse
-import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectExportService
 import org.knora.webapi.slice.admin.domain.service.ProjectImportService

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
@@ -4,8 +4,9 @@
  */
 
 package org.knora.webapi.slice.admin.domain.service
-import dsp.valueobjects.Project.Shortcode
 import zio.Task
+
+import dsp.valueobjects.Project.Shortcode
 import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM
 import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM.ShortcodeIdentifier
 import org.knora.webapi.slice.admin.domain.model.KnoraProject

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
@@ -4,13 +4,15 @@
  */
 
 package org.knora.webapi.slice.admin.domain.service
+import dsp.valueobjects.Project.Shortcode
 import zio.Task
-
 import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM.ShortcodeIdentifier
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.common.repo.service.Repository
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
 
 trait KnoraProjectRepo extends Repository[KnoraProject, InternalIri] {
   def findById(id: ProjectIdentifierADM): Task[Option[KnoraProject]]
+  def findByShortcode(shortcode: Shortcode) = findById(ShortcodeIdentifier(shortcode))
 }

--- a/webapi/src/test/scala/dsp/valueobjects/ProjectSpec.scala
+++ b/webapi/src/test/scala/dsp/valueobjects/ProjectSpec.scala
@@ -42,41 +42,27 @@ object ProjectSpec extends ZIOSpecDefault {
   private val shortcodeTest = suite("ProjectSpec - Shortcode")(
     test("pass an empty value and return an error") {
       assertTrue(
-        Shortcode.make("") == Validation.fail(ValidationException(ProjectErrorMessages.ShortcodeMissing)),
-        Shortcode.make(Some("")) == Validation.fail(ValidationException(ProjectErrorMessages.ShortcodeMissing))
+        Shortcode.make("") == Validation.fail(ValidationException(ProjectErrorMessages.ShortcodeMissing))
       )
     },
     test("pass an invalid value and return an error") {
       assertTrue(
         Shortcode.make(invalidShortcode) == Validation.fail(
           ValidationException(ProjectErrorMessages.ShortcodeInvalid(invalidShortcode))
-        ),
-        Shortcode.make(Some(invalidShortcode)) == Validation.fail(
-          ValidationException(ProjectErrorMessages.ShortcodeInvalid(invalidShortcode))
         )
       )
     },
     test("pass a valid value and successfully create value object") {
       for {
-        shortcode           <- Shortcode.make(validShortcode).toZIO
-        optionalShortcode   <- Shortcode.make(Option(validShortcode)).toZIO
-        shortcodeFromOption <- ZIO.fromOption(optionalShortcode)
-      } yield assertTrue(shortcode.value == validShortcode) &&
-        assert(optionalShortcode)(isSome(isSubtype[Shortcode](Assertion.anything))) &&
-        assertTrue(shortcodeFromOption.value == validShortcode)
-    },
-    test("successfully validate passing None") {
-      assertTrue(
-        Shortcode.make(None) == Validation.succeed(None)
-      )
+        shortcode <- Shortcode.make(validShortcode).toZIO
+      } yield assertTrue(shortcode.value == validShortcode)
     }
   )
 
   private val shortnameTest = suite("ProjectSpec - Shortname")(
     test("pass an empty value and return an error") {
       assertTrue(
-        Shortname.make("") == Validation.fail(ValidationException(ProjectErrorMessages.ShortnameMissing)),
-        Shortname.make(Some("")) == Validation.fail(ValidationException(ProjectErrorMessages.ShortnameMissing))
+        Shortname.make("") == Validation.fail(ValidationException(ProjectErrorMessages.ShortnameMissing))
       )
     },
     test("pass an invalid value and return an error") {
@@ -140,11 +126,6 @@ object ProjectSpec extends ZIOSpecDefault {
       } yield assertTrue(name.value == validName) &&
         assert(optionalName)(isSome(isSubtype[Name](Assertion.anything))) &&
         assertTrue(nameFromOption.value == validName)
-    },
-    test("successfully validate passing None") {
-      assertTrue(
-        Shortcode.make(None) == Validation.succeed(None)
-      )
     }
   )
 
@@ -153,9 +134,7 @@ object ProjectSpec extends ZIOSpecDefault {
       assertTrue(
         ProjectDescription.make(Seq.empty) == Validation.fail(
           ValidationException(ProjectErrorMessages.ProjectDescriptionsMissing)
-        )
-      ) &&
-      assertTrue(
+        ),
         ProjectDescription.make(Some(Seq.empty)) == Validation.fail(
           ValidationException(ProjectErrorMessages.ProjectDescriptionsMissing)
         )


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-2399

Align import and export endpoint to use `Shortcode` as identifier in both routes.

Remove unused factory method `Shortcode.make(Option[String])`.

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [ ] No
