### PR TITLE
refactor: Remove ontology responsibility from AppRouter

### DIFF
--- a/docs/05-internals/design/api-v2/ontology-management.md
+++ b/docs/05-internals/design/api-v2/ontology-management.md
@@ -15,8 +15,7 @@ It is responsible for:
 - Creating and updating ontologies in response to API requests.
 - Ensuring that all user-created ontologies are consistent and conform to [knora-base](../../../02-dsp-ontologies/knora-base.md).
 
-When Knora starts, the ontology responder receives a `LoadOntologiesRequestV2`
-message. It then:
+When Knora starts it will load all ontologies from the triplestore into the ontology cache:
 
 1. Loads all ontologies found in the triplestore into suitable Scala data structures,
    which include indexes of relations between entities (e.g. `rdfs:subClassOf` relations),

--- a/webapi/src/it/scala/org/knora/webapi/CoreSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/CoreSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import zio._
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{FiniteDuration, NANOSECONDS, SECONDS}
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
 
 abstract class CoreSpec
     extends AnyWordSpec

--- a/webapi/src/it/scala/org/knora/webapi/CoreSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/CoreSpec.scala
@@ -7,7 +7,6 @@ package org.knora.webapi
 
 import akka.actor
 import akka.testkit.{ImplicitSender, TestKitBase}
-import akka.util.Timeout
 import com.typesafe.scalalogging.Logger
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.core.LayersTest.DefaultTestEnvironmentWithoutSipi

--- a/webapi/src/it/scala/org/knora/webapi/core/TestStartupUtils.scala
+++ b/webapi/src/it/scala/org/knora/webapi/core/TestStartupUtils.scala
@@ -31,9 +31,7 @@ trait TestStartupUtils extends LazyLogging {
       tss <- ZIO.service[TriplestoreService]
       _   <- tss.resetTripleStoreContent(rdfDataObjects).timeout(480.seconds)
       _   <- ZIO.logInfo("... loading test data done.")
-      _   <- ZIO.logInfo("Loading ontologies into cache started ...")
       _   <- OntologyCache.loadOntologies(KnoraSystemInstances.Users.SystemUser).orDie
-      _   <- ZIO.logInfo("... loading ontologies into cache done.")
     } yield ()
 
 }

--- a/webapi/src/it/scala/org/knora/webapi/e2e/admin/StoreADME2ESpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/e2e/admin/StoreADME2ESpec.scala
@@ -9,9 +9,9 @@ import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.StatusCodes
 import spray.json._
-
 import org.knora.webapi.E2ESpec
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
+import zio.Duration
 
 /**
  * End-to-End (E2E) test specification for testing the 'v1/store' route.
@@ -32,7 +32,7 @@ class StoreADME2ESpec extends E2ESpec with TriplestoreJsonProtocol {
         baseApiUrl + "/admin/store/ResetTriplestoreContent",
         HttpEntity(ContentTypes.`application/json`, rdfDataObjects.toJson.compactPrint)
       )
-      val response = singleAwaitingRequest(request)
+      val response = singleAwaitingRequest(request, Duration.fromSeconds(480))
       assert(response.status === StatusCodes.OK)
     }
   }

--- a/webapi/src/it/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -11,7 +11,6 @@ import dsp.constants.SalsahGui
 import dsp.errors._
 import dsp.valueobjects.Iri
 import dsp.valueobjects.Schema
-
 import org.knora.webapi._
 import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages.OntologyConstants
@@ -28,9 +27,12 @@ import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceReq
 import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.CreateValueInNewResourceV2
 import org.knora.webapi.messages.v2.responder.valuemessages.IntegerValueContentV2
+import org.knora.webapi.routing.UnsafeZioRun
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.ontology.domain.model.Cardinality._
+import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.util.MutableTestIri
+
 import java.time.Instant
 import java.util.UUID
 import scala.concurrent.duration._
@@ -391,12 +393,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
       assert(!cachedMetadataResponse.ontologies.exists(_.ontologyIri == fooIri.get.toSmartIri))
 
       // Reload the ontologies from the triplestore and check again.
-
-      appActor ! LoadOntologiesRequestV2(
-        requestingUser = KnoraSystemInstances.Users.SystemUser
-      )
-
-      expectMsgType[SuccessResponseV2](10.seconds)
+      UnsafeZioRun.runOrThrow(OntologyCache.loadOntologies(KnoraSystemInstances.Users.SystemUser))
 
       appActor ! OntologyMetadataGetByProjectRequestV2(
         requestingUser = imagesUser
@@ -766,12 +763,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
       }
 
       // Reload the ontology cache and see if we get the same result.
-
-      appActor ! LoadOntologiesRequestV2(
-        requestingUser = KnoraSystemInstances.Users.SystemUser
-      )
-
-      expectMsgType[SuccessResponseV2](10.seconds)
+      UnsafeZioRun.runOrThrow(OntologyCache.loadOntologies(KnoraSystemInstances.Users.SystemUser))
 
       appActor ! PropertiesGetRequestV2(
         propertyIris = Set(propertyIri),
@@ -879,12 +871,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
       }
 
       // Reload the ontology cache and see if we get the same result.
-
-      appActor ! LoadOntologiesRequestV2(
-        requestingUser = KnoraSystemInstances.Users.SystemUser
-      )
-
-      expectMsgType[SuccessResponseV2](10.seconds)
+      UnsafeZioRun.runOrThrow(OntologyCache.loadOntologies(KnoraSystemInstances.Users.SystemUser))
 
       appActor ! PropertiesGetRequestV2(
         propertyIris = Set(propertyIri),
@@ -3763,12 +3750,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
       }
 
       // Reload the ontology cache and see if we get the same result.
-
-      appActor ! LoadOntologiesRequestV2(
-        requestingUser = KnoraSystemInstances.Users.SystemUser
-      )
-
-      expectMsgType[SuccessResponseV2](10.seconds)
+      UnsafeZioRun.runOrThrow(OntologyCache.loadOntologies(KnoraSystemInstances.Users.SystemUser))
 
       appActor ! linkPropGetRequest
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -49,14 +49,6 @@ sealed trait OntologiesResponderRequestV2 extends KnoraRequestV2 with RelayedMes
 }
 
 /**
- * Requests that all ontologies in the repository are loaded. This message must be sent only once, when the application
- * starts, before it accepts any API requests. A successful response will be a [[SuccessResponseV2]].
- *
- * @param requestingUser the user making the request.
- */
-case class LoadOntologiesRequestV2(requestingUser: UserADM) extends OntologiesResponderRequestV2
-
-/**
  * Requests the creation of an empty ontology. A successful response will be a [[ReadOntologyV2]].
  *
  * @param ontologyName   the name of the ontology to be created.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/OntologyResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/OntologyResponderV1.scala
@@ -24,7 +24,6 @@ import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.util.ValueUtilV1
 import org.knora.webapi.messages.v1.responder.ontologymessages._
 import org.knora.webapi.messages.v1.responder.resourcemessages.SalsahGuiConversions
-import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.KnoraCardinalityInfo
 import org.knora.webapi.messages.v2.responder.ontologymessages._
 import org.knora.webapi.responders.Responder
@@ -52,7 +51,6 @@ final case class OntologyResponderV1Live(
     message.isInstanceOf[OntologyResponderRequestV1]
 
   override def handle(msg: ResponderRequest): Task[Any] = msg match {
-    case LoadOntologiesRequestV1(userProfile) => loadOntologies(userProfile)
     case EntityInfoGetRequestV1(resourceIris, propertyIris, userProfile) =>
       getEntityInfoResponseV1(resourceIris, propertyIris, userProfile)
     case ResourceTypeGetRequestV1(resourceTypeIri, userProfile) =>
@@ -79,17 +77,6 @@ final case class OntologyResponderV1Live(
   private def noClassConstraintException(iri: IRI) = InconsistentRepositoryDataException(
     s"Property $iri has no knora-base:objectClassConstraint"
   )
-
-  /**
-   * Loads and caches all ontology information.
-   *
-   * @param userProfile          the profile of the user making the request.
-   * @return a [[LoadOntologiesResponse]].
-   */
-  private def loadOntologies(userProfile: UserADM): Task[LoadOntologiesResponse] =
-    messageRelay
-      .ask[SuccessResponseV2](LoadOntologiesRequestV2(userProfile))
-      .as(LoadOntologiesResponse())
 
   /**
    * Given a list of resource IRIs and a list of property IRIs (ontology entities), returns an [[EntityInfoGetResponseV1]] describing both resource and property entities.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -12,6 +12,7 @@ import zio.ZIO
 import zio.ZLayer
 
 import java.time.Instant
+
 import dsp.constants.SalsahGui
 import dsp.errors._
 import org.knora.webapi._

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -12,7 +12,6 @@ import zio.ZIO
 import zio.ZLayer
 
 import java.time.Instant
-
 import dsp.constants.SalsahGui
 import dsp.errors._
 import org.knora.webapi._
@@ -52,7 +51,7 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService
  * - The triplestore.
  * - The constant knora-api v2 ontologies that are defined in Scala rather than in the triplestore, [[KnoraBaseToApiV2SimpleTransformationRules]] and [[KnoraBaseToApiV2ComplexTransformationRules]].
  *
- * It maintains an in-memory cache of all ontology data. This cache can be refreshed by sending a [[LoadOntologiesRequestV2]].
+ * It maintains an in-memory cache of all ontology data. This cache can be refreshed by using [[OntologyCache.loadOntologies]].
  *
  * Read requests to the ontology responder may contain internal or external IRIs as needed. Response messages from the
  * ontology responder will contain internal IRIs and definitions, unless a constant API v2 ontology was requested,
@@ -84,7 +83,6 @@ final case class OntologyResponderV2Live(
     message.isInstanceOf[OntologiesResponderRequestV2]
 
   override def handle(msg: ResponderRequest): Task[Any] = msg match {
-    case r: LoadOntologiesRequestV2 => ontologyCache.loadOntologies(r.requestingUser)
     case EntityInfoGetRequestV2(classIris, propertyIris, requestingUser) =>
       getEntityInfoResponseV2(classIris, propertyIris, requestingUser)
     case StandoffEntityInfoGetRequestV2(standoffClassIris, standoffPropertyIris, requestingUser) =>

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCache.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCache.scala
@@ -24,7 +24,6 @@ import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.util.ErrorHandlingMap
 import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.messages.util.OntologyUtil
-import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality._
 import org.knora.webapi.messages.v2.responder.ontologymessages._
 import org.knora.webapi.responders.v2.ontology.OntologyHelpers

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCacheFake.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCacheFake.scala
@@ -28,7 +28,7 @@ case class OntologyCacheFake(ref: Ref[OntologyCacheData]) extends OntologyCache 
    * @param requestingUser the user making the request.
    * @return a [[SuccessResponseV2]].
    */
-  override def loadOntologies(requestingUser: UserADM): Task[SuccessResponseV2] =
+  override def loadOntologies(requestingUser: UserADM): Task[Unit] =
     throw new UnsupportedOperationException("Not possible in tests. Provide the respective test data as Ref.")
 
   /**

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCacheFake.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCacheFake.scala
@@ -12,7 +12,6 @@ import zio.ZLayer
 
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
-import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadOntologyV2
 import org.knora.webapi.slice.ontology.repo.model.OntologyCacheData
 
@@ -26,7 +25,7 @@ case class OntologyCacheFake(ref: Ref[OntologyCacheData]) extends OntologyCache 
    * Loads and caches all ontology information.
    *
    * @param requestingUser the user making the request.
-   * @return a [[SuccessResponseV2]].
+   * @return a [[Unit]].
    */
   override def loadOntologies(requestingUser: UserADM): Task[Unit] =
     throw new UnsupportedOperationException("Not possible in tests. Provide the respective test data as Ref.")


### PR DESCRIPTION


<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: NO-TICKET

* Use `OntologyCache` directly where `AppRouter` was used before
* Remove unused `LoadOntologiesRequestV2` message

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [x] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [ ] No
