### PR TITLE
chore: add some OCI docker image labels to DSP-API for DataDog source code linking (INFRA-328)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,9 +240,9 @@ lazy val webapi: Project = Project(id = "webapi", base = file("webapi"))
     Docker / dockerExposedPorts ++= Seq(3333, 3339),
     Docker / defaultLinuxInstallLocation := "/opt/docker",
     dockerLabels := Map[String, Option[String]](
-      "org.opencontainers.image.version" -> (ThisBuild / version).value.some,
+      "org.opencontainers.image.version"  -> (ThisBuild / version).value.some,
       "org.opencontainers.image.revision" -> git.gitHeadCommit.value,
-      "org.opencontainers.image.source" -> Some("github.com/dasch-swiss/dsp-api")
+      "org.opencontainers.image.source"   -> Some("github.com/dasch-swiss/dsp-api")
     ).collect { case (key, Some(value)) => (key, value) },
     dockerCommands += Cmd(
       "RUN",

--- a/build.sbt
+++ b/build.sbt
@@ -239,6 +239,11 @@ lazy val webapi: Project = Project(id = "webapi", base = file("webapi"))
     Docker / maintainer       := "support@dasch.swiss",
     Docker / dockerExposedPorts ++= Seq(3333, 3339),
     Docker / defaultLinuxInstallLocation := "/opt/docker",
+    dockerLabels := Map[String, Option[String]](
+      "org.opencontainers.image.version" -> (ThisBuild / version).value.some,
+      "org.opencontainers.image.revision" -> git.gitHeadCommit.value,
+      "org.opencontainers.image.source" -> Some("github.com/dasch-swiss/dsp-api")
+    ).collect { case (key, Some(value)) => (key, value) },
     dockerCommands += Cmd(
       "RUN",
       "apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*"


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

We need to add two new labels to our DSP-API images to make source code linking work on DataDog.
https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=errortracking#tag-your-telemetry

I've also added `org.opencontainers.image.version` so that we overwrite the inherited version of the ubuntu base image (= "20.04") with the version/tag of DSP-API image.

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: INFRA-328

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [x] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
