### PR TITLE
refactor: Use sttp client for dsp-ingest download

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ Global / cancelable := true
 Global / scalaVersion                                   := Dependencies.ScalaVersion
 Global / semanticdbEnabled                              := true
 Global / semanticdbVersion                              := scalafixSemanticdb.revision
-Global / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
 
 lazy val aggregatedProjects: Seq[ProjectReference] = Seq(webapi, sipi, integration)
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,9 @@ import scala.language.postfixOps
 // use Ctrl-c to stop current task but not quit SBT
 Global / cancelable := true
 
-Global / scalaVersion                                   := Dependencies.ScalaVersion
-Global / semanticdbEnabled                              := true
-Global / semanticdbVersion                              := scalafixSemanticdb.revision
+Global / scalaVersion      := Dependencies.ScalaVersion
+Global / semanticdbEnabled := true
+Global / semanticdbVersion := scalafixSemanticdb.revision
 
 lazy val aggregatedProjects: Seq[ProjectReference] = Seq(webapi, sipi, integration)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@
 
 package org.knora
 
-import sbt._
+import sbt.*
 
 object Dependencies {
 
@@ -31,20 +31,21 @@ object Dependencies {
   val ZioVersion                  = "2.0.15"
 
   // ZIO - all Scala 3 compatible
-  val zio                           = "dev.zio" %% "zio"                               % ZioVersion
-  val zioConfig                     = "dev.zio" %% "zio-config"                        % ZioConfigVersion
-  val zioConfigMagnolia             = "dev.zio" %% "zio-config-magnolia"               % ZioConfigVersion
-  val zioConfigTypesafe             = "dev.zio" %% "zio-config-typesafe"               % ZioConfigVersion
-  val zioHttpOld                    = "io.d11"  %% "zhttp"                             % ZioHttpVersionOld
-  val zioHttp                       = "dev.zio" %% "zio-http"                          % ZioHttpVersion
-  val zioJson                       = "dev.zio" %% "zio-json"                          % ZioJsonVersion
-  val zioLogging                    = "dev.zio" %% "zio-logging"                       % ZioLoggingVersion
-  val zioLoggingSlf4jBridge         = "dev.zio" %% "zio-logging-slf4j2-bridge"         % ZioLoggingVersion
-  val zioNio                        = "dev.zio" %% "zio-nio"                           % ZioNioVersion
-  val zioMacros                     = "dev.zio" %% "zio-macros"                        % ZioVersion
-  val zioMetricsConnectors          = "dev.zio" %% "zio-metrics-connectors"            % ZioMetricsConnectorsVersion
-  val zioMetricsPrometheusConnector = "dev.zio" %% "zio-metrics-connectors-prometheus" % ZioMetricsConnectorsVersion
-  val zioPrelude                    = "dev.zio" %% "zio-prelude"                       % ZioPreludeVersion
+  val zio                           = "dev.zio"                       %% "zio"                               % ZioVersion
+  val zioConfig                     = "dev.zio"                       %% "zio-config"                        % ZioConfigVersion
+  val zioConfigMagnolia             = "dev.zio"                       %% "zio-config-magnolia"               % ZioConfigVersion
+  val zioConfigTypesafe             = "dev.zio"                       %% "zio-config-typesafe"               % ZioConfigVersion
+  val zioHttpOld                    = "io.d11"                        %% "zhttp"                             % ZioHttpVersionOld
+  val zioHttp                       = "dev.zio"                       %% "zio-http"                          % ZioHttpVersion
+  val zioJson                       = "dev.zio"                       %% "zio-json"                          % ZioJsonVersion
+  val zioLogging                    = "dev.zio"                       %% "zio-logging"                       % ZioLoggingVersion
+  val zioLoggingSlf4jBridge         = "dev.zio"                       %% "zio-logging-slf4j2-bridge"         % ZioLoggingVersion
+  val zioNio                        = "dev.zio"                       %% "zio-nio"                           % ZioNioVersion
+  val zioMacros                     = "dev.zio"                       %% "zio-macros"                        % ZioVersion
+  val zioMetricsConnectors          = "dev.zio"                       %% "zio-metrics-connectors"            % ZioMetricsConnectorsVersion
+  val zioMetricsPrometheusConnector = "dev.zio"                       %% "zio-metrics-connectors-prometheus" % ZioMetricsConnectorsVersion
+  val zioPrelude                    = "dev.zio"                       %% "zio-prelude"                       % ZioPreludeVersion
+  val zioSttp                       = "com.softwaremill.sttp.client3" %% "zio"                               % "3.8.16"
 
   // zio-test and friends
   val zioTest    = "dev.zio" %% "zio-test"     % ZioVersion
@@ -133,7 +134,7 @@ object Dependencies {
     zioTestSbt
   ).map(_ % Test)
 
-  val webapiTestDependencies = Seq(zioTest, zioTestSbt, zioMock).map(_ % Test)
+  val webapiTestDependencies = Seq(zioTest, zioTestSbt, zioMock, wiremock).map(_ % Test)
 
   val webapiDependencies = Seq(
     akkaActor,
@@ -175,6 +176,7 @@ object Dependencies {
     zioMacros,
     zioMetricsConnectors,
     zioMetricsPrometheusConnector,
-    zioPrelude
+    zioPrelude,
+    zioSttp
   )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.admin.domain.service
 
 import com.github.tomakehurst.wiremock.WireMockServer

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
@@ -2,23 +2,35 @@ package org.knora.webapi.slice.admin.domain.service
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalTo, postRequestedFor, urlPathEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import spray.json.JsValue
+import zio.Random
+import zio.Scope
+import zio.Task
+import zio.UIO
+import zio.ULayer
+import zio.ZIO
+import zio.ZLayer
+import zio.nio.file.Files
+import zio.test.Spec
+import zio.test.TestEnvironment
+import zio.test.ZIOSpecDefault
+import zio.test.assertTrue
+
 import dsp.valueobjects.Project.Shortcode
 import org.knora.webapi.IRI
 import org.knora.webapi.config.DspIngestConfig
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
-import org.knora.webapi.routing.{Jwt, JwtService}
-import org.knora.webapi.slice.admin.domain.service.DspIngestClientLiveSpecLayers.{
-  dspIngestConfigLayer,
-  mockJwtServiceLayer,
-  testPortLayer,
-  wireMockServerLayer
-}
-import spray.json.JsValue
-import zio.nio.file.Files
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
-import zio.{Random, Scope, Task, UIO, ULayer, ZIO, ZLayer}
+import org.knora.webapi.routing.Jwt
+import org.knora.webapi.routing.JwtService
+import org.knora.webapi.slice.admin.domain.service.DspIngestClientLiveSpecLayers.dspIngestConfigLayer
+import org.knora.webapi.slice.admin.domain.service.DspIngestClientLiveSpecLayers.mockJwtServiceLayer
+import org.knora.webapi.slice.admin.domain.service.DspIngestClientLiveSpecLayers.testPortLayer
+import org.knora.webapi.slice.admin.domain.service.DspIngestClientLiveSpecLayers.wireMockServerLayer
 
 object DspIngestClientLiveSpec extends ZIOSpecDefault {
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
@@ -1,0 +1,100 @@
+package org.knora.webapi.slice.admin.domain.service
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalTo, postRequestedFor, urlPathEqualTo}
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import dsp.valueobjects.Project.Shortcode
+import org.knora.webapi.IRI
+import org.knora.webapi.config.DspIngestConfig
+import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
+import org.knora.webapi.routing.{Jwt, JwtService}
+import org.knora.webapi.slice.admin.domain.service.DspIngestClientLiveSpecLayers.{
+  dspIngestConfigLayer,
+  mockJwtServiceLayer,
+  testPortLayer,
+  wireMockServerLayer
+}
+import spray.json.JsValue
+import zio.nio.file.Files
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.{Random, Scope, Task, UIO, ULayer, ZIO, ZLayer}
+
+object DspIngestClientLiveSpec extends ZIOSpecDefault {
+
+  private val testShortCodeStr = "0001"
+  private val testProject      = Shortcode.make(testShortCodeStr).toOption.orNull
+  private val testContent      = "testContent".getBytes()
+  private val expectedPath     = s"/projects/$testShortCodeStr/export"
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("DspIngestClientLive")(test("should download a project export") {
+      ZIO.scoped {
+        for {
+          wiremock <- ZIO.service[WireMockServer]
+          _ = wiremock.stubFor(
+                WireMock
+                  .post(urlPathEqualTo(expectedPath))
+                  .willReturn(
+                    aResponse()
+                      .withHeader("Content-Type", "application/zip")
+                      .withHeader("Content-Disposition", s"export-$testShortCodeStr.zip")
+                      .withBody(testContent)
+                      .withStatus(200)
+                  )
+              )
+          path                <- DspIngestClient.exportProject(testProject)
+          contentIsDownloaded <- Files.readAllBytes(path).map(_.toArray).map(_ sameElements testContent)
+          // Verify the request is valid
+          mockJwt <- ZIO.serviceWithZIO[JwtService](_.createJwtForDspIngest())
+          _ = wiremock.verify(
+                postRequestedFor(urlPathEqualTo(expectedPath))
+                  .withHeader("Authorization", equalTo(s"Bearer ${mockJwt.jwtString}"))
+              )
+        } yield assertTrue(contentIsDownloaded)
+      }
+    }).provide(
+      DspIngestClientLive.layer,
+      dspIngestConfigLayer,
+      mockJwtServiceLayer,
+      testPortLayer,
+      wireMockServerLayer
+    )
+}
+
+object DspIngestClientLiveSpecLayers {
+  val mockJwtServiceLayer: ULayer[JwtService] = ZLayer.succeed(new JwtService {
+    override def createJwt(user: UserADM, content: Map[String, JsValue]): UIO[Jwt] =
+      throw new UnsupportedOperationException("not implemented")
+    override def createJwtForDspIngest(): UIO[Jwt] = ZIO.succeed(Jwt("mock-jwt-string-value", Long.MaxValue))
+    override def validateToken(token: String): Task[Boolean] =
+      throw new UnsupportedOperationException("not implemented")
+    override def extractUserIriFromToken(token: String): Task[Option[IRI]] =
+      throw new UnsupportedOperationException("not implemented")
+  })
+  case class Testport(port: Int) extends AnyVal
+
+  val testPortLayer: ULayer[Testport] = ZLayer.fromZIO(for {
+    port <- Random.nextIntBetween(1000, 10_000)
+  } yield Testport(port))
+
+  val dspIngestConfigLayer: ZLayer[Testport, Nothing, DspIngestConfig] = ZLayer.fromZIO(
+    ZIO
+      .serviceWith[Testport](_.port)
+      .map(port => DspIngestConfig(baseUrl = s"http://localhost:$port", audience = "audience"))
+  )
+
+  private def acquireWireMockServer(port: Int): Task[WireMockServer] = ZIO.attempt {
+    val server = new WireMockServer(options().port(port))
+    server.start()
+    server
+  }
+  private def releaseWireMockServer(server: WireMockServer) = ZIO.attempt(server.stop()).logError.ignore
+
+  val wireMockServerLayer: ZLayer[Testport, Throwable, WireMockServer] =
+    ZLayer.scoped {
+      for {
+        port   <- ZIO.serviceWith[Testport](_.port)
+        server <- ZIO.acquireRelease(acquireWireMockServer(port))(releaseWireMockServer)
+      } yield server
+    }
+}


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

For some reason the zio-http `Client` fails to download a 23 GB+ project from ingest with an `OutOfMemoryException` even though it should be streaming the response directly into the file.

`java.lang.OutOfMemoryError: Cannot reserve 1052352512 bytes of direct buffer memory (allocated: 1078845448, limit: 2126512128)`

Exchange the http client with an `sttp` implementation which uses the standard Java `HttpClient` under the hood.
Set the maximum time to wait for the download to 30 minutes (the 23 GB took around 22 minutes to create).

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [x] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [ ] No
