### PR TITLE
feat: Add metrics to TriplestoreService SparqlQuery execution DEV-2627

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
@@ -221,18 +221,5 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
         actual should ===(1)
       }
     }
-
-    "put the graph data as turtle" in {
-      UnsafeZioRun.runOrThrow(
-        TriplestoreService
-          .insertDataGraphRequest(graphContent = graphDataContent, "http://jedi.org/graph")
-          .timeout(java.time.Duration.ofSeconds(10))
-      )
-    }
-
-    "read the graph data as turtle" in {
-      val response = UnsafeZioRun.runOrThrow(TriplestoreService.sparqlHttpGraphData("http://jedi.org/graph"))
-      response.turtle.length should be > 0
-    }
   }
 }

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -470,6 +470,8 @@ app {
             username = ${?KNORA_WEBAPI_TRIPLESTORE_FUSEKI_USERNAME}
             password = "test"
             password = ${?KNORA_WEBAPI_TRIPLESTORE_FUSEKI_PASSWORD}
+            query-logging-threshold = 1s
+            query-logging-threshold = ${?KNORA_WEBAPI_TRIPLESTORE_FUSEKI_QUERY_LOGGING_THRESHOLD}
         }
 
         // If true, the time taken by each SPARQL query is logged at DEBUG level. To see these messages,

--- a/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -185,7 +185,8 @@ final case class Fuseki(
   port: Int,
   repositoryName: String,
   username: String,
-  password: String
+  password: String,
+  queryLoggingThreshold: Duration = Duration.ofMillis(1000)
 )
 
 final case class CacheService(

--- a/webapi/src/main/scala/org/knora/webapi/core/AppServer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/AppServer.scala
@@ -43,7 +43,7 @@ final case class AppServer(
   private val checkTriplestoreService: Task[Unit] =
     for {
       _      <- state.set(AppState.WaitingForTriplestore)
-      status <- ts.checkTriplestore().map(_.triplestoreStatus)
+      status <- ts.checkTriplestore()
       _ <- status match {
              case TriplestoreStatus.Available           => ZIO.unit
              case TriplestoreStatus.NotInitialized(msg) => ZIO.die(new Exception(msg))

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
@@ -312,7 +312,7 @@ case class ListItemDeleteRequestADM(
 case class CanDeleteListRequestADM(iri: IRI, requestingUser: UserADM) extends ListsResponderRequestADM
 
 /**
- * Requests deletion of all list node comments. A successful response will be a [[ListNodeCommentsDeleteADM]]
+ * Requests deletion of all list node comments. A successful response will be a [[ListNodeCommentsDeleteResponseADM]]
  *
  * @param iri                  the IRI of the list node (root or child).
  * @param requestingUser       the user making the request.
@@ -358,14 +358,14 @@ case class ListsGetResponseADM(lists: Seq[ListNodeInfoADM]) extends KnoraRespons
   def toJsValue: JsValue = listsGetResponseADMFormat.write(this)
 }
 
-abstract class ListItemGetResponseADM(listItem: ListItemADM) extends KnoraResponseADM with ListADMJsonProtocol
+abstract class ListItemGetResponseADM() extends KnoraResponseADM with ListADMJsonProtocol
 
 /**
  * Provides completes information about the list. The basic information (rood node) and all the child nodes.
  *
  * @param list the complete list.
  */
-case class ListGetResponseADM(list: ListADM) extends ListItemGetResponseADM(list) {
+case class ListGetResponseADM(list: ListADM) extends ListItemGetResponseADM() {
 
   def toJsValue: JsValue = listGetResponseADMFormat.write(this)
 }
@@ -375,7 +375,7 @@ case class ListGetResponseADM(list: ListADM) extends ListItemGetResponseADM(list
  *
  * @param node the node.
  */
-case class ListNodeGetResponseADM(node: NodeADM) extends ListItemGetResponseADM(node) {
+case class ListNodeGetResponseADM(node: NodeADM) extends ListItemGetResponseADM() {
 
   def toJsValue: JsValue = listNodeGetResponseADMFormat.write(this)
 }
@@ -452,36 +452,26 @@ case class NodePositionChangeResponseADM(node: ListNodeADM) extends KnoraRespons
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Components of messages
-abstract class ListItemADM(info: ListNodeInfoADM, children: Seq[ListChildNodeADM])
+abstract class ListItemADM()
 
-case class ListADM(listinfo: ListRootNodeInfoADM, children: Seq[ListChildNodeADM])
-    extends ListItemADM(listinfo, children) {
+case class ListADM(listinfo: ListRootNodeInfoADM, children: Seq[ListChildNodeADM]) extends ListItemADM() {
 
   /**
    * Sorts the whole hierarchy.
    *
    * @return a sorted [[List]].
    */
-  def sorted: ListADM =
-    ListADM(
-      listinfo = listinfo,
-      children = children.sortBy(_.position).map(_.sorted)
-    )
+  def sorted: ListADM = this.copy(children = children.sortBy(_.position).map(_.sorted))
 }
 
-case class NodeADM(nodeinfo: ListChildNodeInfoADM, children: Seq[ListChildNodeADM])
-    extends ListItemADM(nodeinfo, children) {
+case class NodeADM(nodeinfo: ListChildNodeInfoADM, children: Seq[ListChildNodeADM]) extends ListItemADM() {
 
   /**
    * Sorts the whole hierarchy.
    *
    * @return a sorted [[List]].
    */
-  def sorted: NodeADM =
-    NodeADM(
-      nodeinfo = nodeinfo,
-      children = children.sortBy(_.position).map(_.sorted)
-    )
+  def sorted: NodeADM = this.copy(children = children.sortBy(_.position).map(_.sorted))
 }
 
 /**
@@ -507,8 +497,6 @@ abstract class ListNodeInfoADM(
   def sorted: ListNodeInfoADM
 
   def getName: Option[String] = name
-
-  def getLabels: StringLiteralSequenceV2 = labels
 
   def getComments: StringLiteralSequenceV2 = comments
 
@@ -682,8 +670,6 @@ abstract class ListNodeADM(
   def sorted: ListNodeADM
 
   def getName: Option[String] = name
-
-  def getLabels: StringLiteralSequenceV2 = labels
 
   def getComments: StringLiteralSequenceV2 = comments
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
@@ -143,11 +143,6 @@ object SparqlExtendedConstructResponse {
 }
 
 /**
- * A graph of triples in Turtle format.
- */
-case class NamedGraphDataResponse(turtle: String)
-
-/**
  * Response indicating whether the triplestore has finished initialization and is ready for processing messages
  *
  * @param triplestoreStatus the state of the triplestore.

--- a/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
@@ -143,16 +143,6 @@ object SparqlExtendedConstructResponse {
 }
 
 /**
- * Response indicating whether the triplestore has finished initialization and is ready for processing messages
- *
- * @param triplestoreStatus the state of the triplestore.
- */
-case class CheckTriplestoreResponse(triplestoreStatus: domain.TriplestoreStatus)
-object CheckTriplestoreResponse {
-  val Available: CheckTriplestoreResponse = CheckTriplestoreResponse(TriplestoreStatus.Available)
-}
-
-/**
  * Indicates whether the repository is up to date.
  *
  * @param message a message providing details of what was done.

--- a/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
@@ -19,8 +19,6 @@ import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages._
 import org.knora.webapi.messages.util.ErrorHandlingMap
 import org.knora.webapi.messages.util.rdf._
-import org.knora.webapi.store.triplestore.domain
-import org.knora.webapi.store.triplestore.domain.TriplestoreStatus
 
 /**
  * A response to a [[org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct]] query.

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectExportService.scala
@@ -24,7 +24,7 @@ import zio.nio.file.Path
 import java.io.OutputStream
 import scala.collection.mutable
 
-import org.knora.webapi.messages.twirl.queries.sparql.admin.txt._
+import org.knora.webapi.messages.twirl.queries._
 import org.knora.webapi.messages.util.rdf.TriG
 import org.knora.webapi.slice.admin.AdminConstants.adminDataNamedGraph
 import org.knora.webapi.slice.admin.AdminConstants.permissionsDataNamedGraph
@@ -148,9 +148,8 @@ final case class ProjectExportServiceLive(
   private def downloadOntologyAndData(project: KnoraProject, tempDir: Path): Task[List[NamedGraphTrigFile]] = for {
     allGraphsTrigFile <-
       projectService.getNamedGraphsForProject(project).map(_.map(NamedGraphTrigFile(_, tempDir)))
-    files <- ZIO.foreach(allGraphsTrigFile)(file =>
-               triplestore.downloadGraph(file.graphIri, file.dataFile, TriG).as(file)
-             )
+    files <-
+      ZIO.foreach(allGraphsTrigFile)(file => triplestore.downloadGraph(file.graphIri, file.dataFile, TriG).as(file))
   } yield files
 
   /**
@@ -167,14 +166,14 @@ final case class ProjectExportServiceLive(
   private def downloadProjectAdminData(project: KnoraProject, targetDir: Path): Task[NamedGraphTrigFile] = {
     val graphIri = adminDataNamedGraph
     val file     = NamedGraphTrigFile(graphIri, targetDir)
-    val query    = Construct(getProjectAdminData(project.id.value))
+    val query    = Construct(sparql.admin.txt.getProjectAdminData(project.id.value))
     triplestore.queryToFile(query, graphIri, file.dataFile, TriG).as(file)
   }
 
   private def downloadPermissionData(project: KnoraProject, tempDir: Path) = {
     val graphIri = permissionsDataNamedGraph
     val file     = NamedGraphTrigFile(graphIri, tempDir)
-    val query    = Construct(getProjectPermissions(project.id.value))
+    val query    = Construct(sparql.admin.txt.getProjectPermissions(project.id.value))
     triplestore.queryToFile(query, graphIri, file.dataFile, TriG).as(file)
   }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectExportService.scala
@@ -149,7 +149,7 @@ final case class ProjectExportServiceLive(
     allGraphsTrigFile <-
       projectService.getNamedGraphsForProject(project).map(_.map(NamedGraphTrigFile(_, tempDir)))
     files <- ZIO.foreach(allGraphsTrigFile)(file =>
-               triplestore.sparqlHttpGraphFile(file.graphIri, file.dataFile, TriG).as(file)
+               triplestore.downloadGraph(file.graphIri, file.dataFile, TriG).as(file)
              )
   } yield files
 

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -157,9 +157,14 @@ trait TriplestoreService {
 object TriplestoreService {
   object Queries {
 
-    sealed trait SparqlQuery { val sparql: String }
+    sealed trait SparqlQuery {
+      val sparql: String
+      val isGravsearch: Boolean
+    }
 
-    case class Ask(sparql: String) extends SparqlQuery
+    case class Ask(sparql: String) extends SparqlQuery {
+      override val isGravsearch: Boolean = false
+    }
     object Ask {
       def apply(sparql: TxtFormat.Appendable): Ask = Ask(sparql.toString)
     }
@@ -180,7 +185,9 @@ object TriplestoreService {
       def apply(sparql: String): Construct = Construct(sparql, isGravsearch = false)
     }
 
-    case class Update(sparql: String) extends SparqlQuery
+    case class Update(sparql: String) extends SparqlQuery {
+      override val isGravsearch: Boolean = false
+    }
     object Update {
       def apply(sparql: TxtFormat.Appendable): Update = Update(sparql.toString())
     }

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -79,7 +79,7 @@ trait TriplestoreService {
    * @param outputFile           the file to be written.
    * @param outputFormat         the output file format.
    */
-  def sparqlHttpGraphFile(graphIri: InternalIri, outputFile: zio.nio.file.Path, outputFormat: QuadFormat): Task[Unit]
+  def downloadGraph(graphIri: InternalIri, outputFile: zio.nio.file.Path, outputFormat: QuadFormat): Task[Unit]
 
   /**
    * Resets the content of the triplestore with the data supplied with the request.

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -10,7 +10,6 @@ import zio._
 import zio.macros.accessible
 
 import java.nio.file.Path
-
 import org.knora.webapi.messages.store.triplestoremessages._
 import org.knora.webapi.messages.util.rdf.QuadFormat
 import org.knora.webapi.messages.util.rdf.SparqlSelectResult
@@ -19,6 +18,7 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
+import org.knora.webapi.store.triplestore.domain.TriplestoreStatus
 
 @accessible
 trait TriplestoreService {
@@ -115,7 +115,7 @@ trait TriplestoreService {
    * Checks the Fuseki triplestore if it is available and configured correctly. If it is not
    * configured, tries to automatically configure () the required dataset.
    */
-  def checkTriplestore(): Task[CheckTriplestoreResponse]
+  def checkTriplestore(): Task[TriplestoreStatus]
 
   /**
    * Dumps the whole repository in N-Quads format, saving the response in a file.

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -11,7 +11,6 @@ import zio.macros.accessible
 
 import java.nio.file.Path
 
-import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages._
 import org.knora.webapi.messages.util.rdf.QuadFormat
 import org.knora.webapi.messages.util.rdf.SparqlSelectResult
@@ -81,13 +80,6 @@ trait TriplestoreService {
    */
   def sparqlHttpGraphFile(graphIri: InternalIri, outputFile: zio.nio.file.Path, outputFormat: QuadFormat): Task[Unit]
 
-  /**
-   * Requests the contents of a named graph, returning the response as Turtle.
-   *
-   * @param graphIri the IRI of the named graph.
-   * @return a string containing the contents of the graph in Turtle format.
-   */
-  def sparqlHttpGraphData(graphIri: IRI): Task[NamedGraphDataResponse]
 
   /**
    * Resets the content of the triplestore with the data supplied with the request.
@@ -143,15 +135,6 @@ trait TriplestoreService {
    * @param inputFile an N-Quads file containing the content to be uploaded to the repository.
    */
   def uploadRepository(inputFile: Path): Task[Unit]
-
-  /**
-   * Puts a data graph into the repository.
-   *
-   * @param graphContent a data graph in Turtle format to be inserted into the repository.
-   * @param graphName    the name of the graph.
-   */
-  def insertDataGraphRequest(graphContent: String, graphName: String): Task[Unit]
-
 }
 
 object TriplestoreService {

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -10,6 +10,7 @@ import zio._
 import zio.macros.accessible
 
 import java.nio.file.Path
+
 import org.knora.webapi.messages.store.triplestoremessages._
 import org.knora.webapi.messages.util.rdf.QuadFormat
 import org.knora.webapi.messages.util.rdf.SparqlSelectResult
@@ -79,7 +80,6 @@ trait TriplestoreService {
    * @param outputFormat         the output file format.
    */
   def sparqlHttpGraphFile(graphIri: InternalIri, outputFile: zio.nio.file.Path, outputFormat: QuadFormat): Task[Unit]
-
 
   /**
    * Resets the content of the triplestore with the data supplied with the request.

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -94,11 +94,6 @@ trait TriplestoreService {
   ): Task[Unit]
 
   /**
-   * Drops (deletes) all data from the triplestore using "DROP ALL" SPARQL query.
-   */
-  def dropAllTriplestoreContent(): Task[Unit]
-
-  /**
    * Wipes all triplestore data out using HTTP requests.
    */
   def dropDataGraphByGraph(): Task[Unit]

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
@@ -28,10 +28,8 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.jdk.CollectionConverters.IteratorHasAsScala
-
 import org.knora.webapi.IRI
 import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.messages.store.triplestoremessages.CheckTriplestoreResponse
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.messages.store.triplestoremessages.SparqlConstructResponse
 import org.knora.webapi.messages.util.rdf.QuadFormat
@@ -51,6 +49,8 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory.createEmptyDataset
 import org.knora.webapi.store.triplestore.defaults.DefaultRdfData
+import org.knora.webapi.store.triplestore.domain.TriplestoreStatus
+import org.knora.webapi.store.triplestore.domain.TriplestoreStatus.Available
 import org.knora.webapi.store.triplestore.errors.TriplestoreResponseException
 import org.knora.webapi.store.triplestore.errors.TriplestoreTimeoutException
 import org.knora.webapi.store.triplestore.errors.TriplestoreUnsupportedFeatureException
@@ -232,7 +232,7 @@ final case class TriplestoreServiceInMemory(datasetRef: Ref[Dataset], implicit v
       ZIO.succeed(graphName)
     }
 
-  override def checkTriplestore(): Task[CheckTriplestoreResponse] = ZIO.succeed(CheckTriplestoreResponse.Available)
+  override def checkTriplestore(): Task[TriplestoreStatus] = ZIO.succeed(Available)
 
   override def downloadRepository(outputFile: Path): Task[Unit] =
     ZIO.fail(new UnsupportedOperationException("Not implemented in TriplestoreServiceInMemory."))

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
@@ -184,13 +184,11 @@ final case class TriplestoreServiceInMemory(datasetRef: Ref[Dataset], implicit v
     rdfDataObjects: List[RdfDataObject],
     prependDefaults: Boolean
   ): Task[Unit] = for {
-    _ <- dropAllTriplestoreContent()
+    _ <- dropDataGraphByGraph()
     _ <- insertDataIntoTriplestore(rdfDataObjects, prependDefaults)
   } yield ()
 
-  override def dropAllTriplestoreContent(): Task[Unit] = createEmptyDataset.flatMap(datasetRef.set(_)).unit
-
-  override def dropDataGraphByGraph(): Task[Unit] = dropAllTriplestoreContent()
+  override def dropDataGraphByGraph(): Task[Unit] = createEmptyDataset.flatMap(datasetRef.set(_)).unit
 
   override def insertDataIntoTriplestore(
     rdfDataObjects: List[RdfDataObject],

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
@@ -28,6 +28,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.jdk.CollectionConverters.IteratorHasAsScala
+
 import org.knora.webapi.IRI
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
@@ -164,7 +164,7 @@ final case class TriplestoreServiceInMemory(datasetRef: Ref[Dataset], implicit v
     ZIO.scoped(getDataSetWithTransaction(ReadWrite.WRITE).flatMap(doUpdate)).unit
   }
 
-  override def sparqlHttpGraphFile(
+  override def downloadGraph(
     graphIri: InternalIri,
     outputFile: zio.nio.file.Path,
     outputFormat: QuadFormat

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -169,18 +169,8 @@ case class TriplestoreServiceLive(
   ): Task[Unit] =
     for {
       _ <- ZIO.logDebug("resetTripleStoreContent")
-      _ <- dropAllTriplestoreContent()
+      _ <- dropDataGraphByGraph()
       _ <- insertDataIntoTriplestore(rdfDataObjects, prependDefaults)
-    } yield ()
-
-  /**
-   * Drops (deletes) all data from the triplestore using "DROP ALL" SPARQL query.
-   */
-  def dropAllTriplestoreContent(): Task[Unit] =
-    for {
-      _      <- ZIO.logDebug("==>> Drop All Data Start")
-      result <- query(Update("DROP ALL"))
-      _      <- ZIO.logDebug(s"==>> Drop All Data End, Result: $result")
     } yield ()
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -400,7 +400,7 @@ case class TriplestoreServiceLive(
   }
 
   private def trackQueryDuration[T](query: SparqlQuery, reqTask: Task[T]): Task[T] = {
-    val trackingThreshold = 500.millis
+    val trackingThreshold = fusekiConfig.queryLoggingThreshold
     val startTime         = java.lang.System.nanoTime()
     for {
       result <- reqTask @@ requestTimer

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -42,6 +42,7 @@ import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.time.temporal.ChronoUnit
 import java.util
+
 import dsp.errors._
 import org.knora.webapi._
 import org.knora.webapi.config.Triplestore
@@ -58,7 +59,9 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.SparqlQ
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.defaults.DefaultRdfData
 import org.knora.webapi.store.triplestore.domain.TriplestoreStatus
-import org.knora.webapi.store.triplestore.domain.TriplestoreStatus.{Available, NotInitialized, Unavailable}
+import org.knora.webapi.store.triplestore.domain.TriplestoreStatus.Available
+import org.knora.webapi.store.triplestore.domain.TriplestoreStatus.NotInitialized
+import org.knora.webapi.store.triplestore.domain.TriplestoreStatus.Unavailable
 import org.knora.webapi.store.triplestore.errors._
 import org.knora.webapi.util.FileUtil
 

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -143,7 +143,7 @@ case class TriplestoreServiceLive(
   override def query(query: Update): Task[Unit] = {
     val request = new HttpPost(paths.update)
     request.setEntity(new StringEntity(query.sparql, ContentType.create(mimeTypeApplicationSparqlUpdate, Consts.UTF_8)))
-    doHttpRequest(request, returnResponseAsString).unit
+    trackQueryDuration(query, doHttpRequest(request, returnResponseAsString)).unit
   }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -143,7 +143,7 @@ case class TriplestoreServiceLive(
   override def query(query: Update): Task[Unit] = {
     val request = new HttpPost(paths.update)
     request.setEntity(new StringEntity(query.sparql, ContentType.create(mimeTypeApplicationSparqlUpdate, Consts.UTF_8)))
-    trackQueryDuration(query, doHttpRequest(request, returnResponseAsString)).unit
+    trackQueryDuration(query, doHttpRequest(request, _ => ZIO.unit))
   }
 
   /**
@@ -178,8 +178,6 @@ case class TriplestoreServiceLive(
 
   /**
    * Drops all triplestore data graph by graph using "DROP GRAPH" SPARQL query.
-   * This method is useful in cases with large amount of data (over 10 million statements),
-   * where the method [[dropAllTriplestoreContent()]] could create timeout issues.
    */
   def dropDataGraphByGraph(): Task[Unit] =
     for {

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -370,7 +370,7 @@ case class TriplestoreServiceLive(
    * @param outputFormat         the output file format.
    * @return a string containing the contents of the graph in N-Quads format.
    */
-  override def sparqlHttpGraphFile(
+  override def downloadGraph(
     graphIri: InternalIri,
     outputFile: zio.nio.file.Path,
     outputFormat: QuadFormat

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -42,7 +42,6 @@ import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.time.temporal.ChronoUnit
 import java.util
-
 import dsp.errors._
 import org.knora.webapi._
 import org.knora.webapi.config.Triplestore
@@ -59,6 +58,7 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.SparqlQ
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.defaults.DefaultRdfData
 import org.knora.webapi.store.triplestore.domain.TriplestoreStatus
+import org.knora.webapi.store.triplestore.domain.TriplestoreStatus.{Available, NotInitialized, Unavailable}
 import org.knora.webapi.store.triplestore.errors._
 import org.knora.webapi.util.FileUtil
 
@@ -280,34 +280,27 @@ case class TriplestoreServiceLive(
    * Checks the Fuseki triplestore if it is available and configured correctly. If it is not
    * configured, tries to automatically configure (initialize) the required dataset.
    */
-  def checkTriplestore(): Task[CheckTriplestoreResponse] = {
-    val triplestoreNotInitializedResponse =
-      ZIO.succeed(
-        CheckTriplestoreResponse(
-          TriplestoreStatus.NotInitialized(
-            s"None of the active datasets meet our requirement of name: ${fusekiConfig.repositoryName}"
-          )
-        )
-      )
+  def checkTriplestore(): Task[TriplestoreStatus] = {
+    val notInitialized =
+      NotInitialized(s"None of the active datasets meet our requirement of name: ${fusekiConfig.repositoryName}")
 
-    def triplestoreUnavailableResponse(cause: String) = CheckTriplestoreResponse(
-      TriplestoreStatus.Unavailable(s"Triplestore not available: $cause")
-    )
+    def unavailable(cause: String) =
+      Unavailable(s"Triplestore not available: $cause")
 
     ZIO
       .ifZIO(checkTriplestoreInitialized())(
-        ZIO.succeed(CheckTriplestoreResponse.Available),
+        ZIO.succeed(Available),
         if (triplestoreConfig.autoInit) {
           ZIO
             .ifZIO(initJenaFusekiTriplestore() *> checkTriplestoreInitialized())(
-              ZIO.succeed(CheckTriplestoreResponse.Available),
-              triplestoreNotInitializedResponse
+              ZIO.succeed(Available),
+              ZIO.succeed(notInitialized)
             )
         } else {
-          triplestoreNotInitializedResponse
+          ZIO.succeed(notInitialized)
         }
       )
-      .catchAll(ex => ZIO.succeed(triplestoreUnavailableResponse(ex.getMessage)))
+      .catchAll(ex => ZIO.succeed(unavailable(ex.getMessage)))
   }
 
   /**

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemorySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemorySpec.scala
@@ -55,19 +55,6 @@ object TriplestoreServiceInMemorySpec extends ZIOSpecDefault {
   val spec: Spec[Any, Throwable] =
     suite("TriplestoreServiceFake")(
       suite("DROP")(
-        test("dropAllTriplestoreContent") {
-          for {
-            _ <- TriplestoreService.dropAllTriplestoreContent()
-            query = s"""
-                       |PREFIX rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                       |
-                       |ASK WHERE {
-                       |  <http://anArticle> a <${Biblio.Class.Article.value}> .
-                       |}
-                       |""".stripMargin
-            result <- TriplestoreService.query(Ask(query))
-          } yield assertTrue(!result)
-        },
         test("dropDataGraphByGraph") {
           for {
             _ <- TriplestoreService.dropDataGraphByGraph()

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemorySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemorySpec.scala
@@ -289,7 +289,7 @@ object TriplestoreServiceInMemorySpec extends ZIOSpecDefault {
                    ),
                    prependDefaults = false
                  )
-            _ <- TriplestoreService.sparqlHttpGraphFile(
+            _ <- TriplestoreService.downloadGraph(
                    InternalIri("http://www.knora.org/ontology/knora-base"),
                    testFile,
                    TriG


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->
Adds metrics timer for query execution time, metrics key is`fuseki_request_duration`, tags are the `isGravSearch=[true|false]` and `type=[Ask|Construct|Select|Update]`.

Queries which take longer than a configurable threshold (`KNORA_WEBAPI_TRIPLESTORE_FUSEKI_QUERY_LOGGING_THRESHOLD`) are logged as info. Default threshold is one second.

Removes unused methods from `TriplestoreService`: `insertDataGraphRequest`, `dropAllTriplestoreContent` and `sparqlHttpGraphData`.
Renames `sparqlHttpGraphFile` to `downloadGraph`.
Simplifies return type of `checkTriplestore()` to `Task[TriplestoreStatus]`.

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [x] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
