### PR TITLE
refactor: Speedup /projects endpoint

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
@@ -15,6 +15,6 @@ import org.knora.webapi.slice.resourceinfo.domain.InternalIri
 
 trait KnoraProjectRepo extends Repository[KnoraProject, InternalIri] {
   def findById(id: ProjectIdentifierADM): Task[Option[KnoraProject]]
-  def findByShortcode(shortcode: Shortcode) = findById(ShortcodeIdentifier(shortcode))
+  def findByShortcode(shortcode: Shortcode): Task[Option[KnoraProject]] = findById(ShortcodeIdentifier(shortcode))
   def findOntologies(project: KnoraProject): Task[List[InternalIri]]
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
@@ -16,4 +16,5 @@ import org.knora.webapi.slice.resourceinfo.domain.InternalIri
 trait KnoraProjectRepo extends Repository[KnoraProject, InternalIri] {
   def findById(id: ProjectIdentifierADM): Task[Option[KnoraProject]]
   def findByShortcode(shortcode: Shortcode) = findById(ShortcodeIdentifier(shortcode))
+  def findOntologies(project: KnoraProject): Task[List[InternalIri]]
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
@@ -90,8 +90,7 @@ final case class KnoraProjectRepoLive(
     val query =
       s"""
          |PREFIX owl: <http://www.w3.org/2002/07/owl#>
-         |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-         |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+         |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
          |PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>  
          |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>  
          |

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
@@ -98,7 +98,7 @@ final case class KnoraProjectRepoLive(
          |  BIND(<${project.id.value}> AS ?projectIri)
          |  ?ontologyIri a owl:Ontology .
          |  ?ontologyIri knora-base:attachedToProject ?projectIri .
-         |  ?projectIri  rdf:type knora-admin:knoraProject .
+         |  ?projectIri  a knora-admin:knoraProject .
          |} order by ?projectIri""".stripMargin
     triplestore
       .query(Select(query))

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
@@ -32,6 +32,7 @@ import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 
 final case class KnoraProjectRepoLive(
   private val triplestore: TriplestoreService,
@@ -83,6 +84,26 @@ final case class KnoraProjectRepoLive(
       status   <- mapper.getSingleOrFail[BooleanLiteralV2](Status, propsMap).map(_.value)
       selfjoin <- mapper.getSingleOrFail[BooleanLiteralV2](HasSelfJoinEnabled, propsMap).map(_.value)
     } yield KnoraProject(projectIri, shortname, shortcode, longname, description, keywords, logo, status, selfjoin)
+  }
+
+  override def findOntologies(project: KnoraProject): Task[List[InternalIri]] = {
+    val query =
+      s"""
+         |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+         |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+         |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+         |PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>  
+         |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>  
+         |
+         |SELECT ?ontologyIri  WHERE {
+         |  BIND(<${project.id.value}> AS ?projectIri)
+         |  ?ontologyIri a owl:Ontology .
+         |  ?ontologyIri knora-base:attachedToProject ?projectIri .
+         |  ?projectIri  rdf:type knora-admin:knoraProject .
+         |} order by ?projectIri""".stripMargin
+    triplestore
+      .query(Select(query))
+      .map(_.results.bindings.flatMap(_.rowMap.get("ontologyIri")).map(InternalIri).toList)
   }
 }
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/repo/service/KnoraProjectRepoInMemory.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/repo/service/KnoraProjectRepoInMemory.scala
@@ -29,6 +29,9 @@ final case class KnoraProjectRepoInMemory(projects: Ref[List[KnoraProject]])
       }
     )
   )
+
+  override def findOntologies(project: KnoraProject): Task[List[InternalIri]] =
+    throw new UnsupportedOperationException("not implemented (yet)")
 }
 
 object KnoraProjectRepoInMemory {

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepoInMemory.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepoInMemory.scala
@@ -29,6 +29,9 @@ final case class KnoraProjectRepoInMemory(projects: Ref[List[KnoraProject]])
       case IriIdentifier(iri)             => _.id.value == iri.value
     })
   )
+
+  override def findOntologies(project: KnoraProject): Task[List[InternalIri]] =
+    throw new UnsupportedOperationException("not yet implemented")
 }
 
 object KnoraProjectRepoInMemory {


### PR DESCRIPTION
Load Ontologies from db with single query and parallelise converting `KnoraProject` to `ProjectADM`

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

NO-TICKET

I found that loading the start page with the project overview takes very long.
This is partly due to the fact that the app is loading the projects list with  `/project` which is a slow endpoint, which is also called twice during initial loading.

This change speeding up the conversion of a `KnoraProject` to a richer `ProjectADM` by parallelising the lookup of the ontology a project is attached to. Since the cache and an actual database lookup are pretty similar I have also removed the dependency on the `OntologyCache`.


### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [x] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [x] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
