### PR TITLE
chore: Update 'fuseki_request_duration' histogram bucket boundaries

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -74,7 +74,14 @@ case class TriplestoreServiceLive(
     with FusekiTriplestore {
 
   private val rdfFormatUtil: RdfFormatUtil = RdfFeatureFactory.getRdfFormatUtil()
-  private val requestTimer                 = Metric.timer("fuseki_request_duration", ChronoUnit.MILLIS)
+  private val requestTimer =
+    Metric.timer(
+      "fuseki_request_duration",
+      ChronoUnit.MILLIS,
+      // 7 buckets for upper bounds 10ms, 100ms, 1s, 10s, 1.6m, 16.6m, inf
+      Chunk.iterate(10.0, 6)(_ * 10)
+    )
+
   private def processError(sparql: String, response: String): IO[TriplestoreException, Nothing] =
     if (response.contains("##  Query cancelled due to timeout during execution")) {
       val msg: String = "Triplestore timed out while sending a response, after sending statuscode 200."


### PR DESCRIPTION
Create 7 buckets for upper bounds 10ms, 100ms, 1s, 10s, 1.6m, 16.6m, inf

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-2627

### Basic Requirements

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

- [ ] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [x] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
- [ ] Maybe (not 100% sure => check with FE)

### Does this PR change client-test-data?

- [ ] Yes (don't forget to update the JS-LIB team about the change)
- [x] No
