### PR TITLE
chore: Remove GitHub action which tests zio-http routes 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,36 +70,6 @@ jobs:
         with:
           files: ./target/scala-2.13/coverage-report/cobertura.xml
 
-  zio-http-test:
-    name: Build and zio-http-test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ "17", "21" ]
-    steps:
-      - name: Run preparatory steps
-        uses: dasch-swiss/dsp-api/.github/actions/preparation@main
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Run all ZioHttp tests
-        run: make zio-http-test
-      - name: ZIO-Http Routes Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: ZIO-Http Routes Test Report
-          path: ./integration/target/test-reports/TEST-*.xml
-          reporter: java-junit
-      - name: Upload coverage data to codacy
-        uses: codacy/codacy-coverage-reporter-action@v1
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ./target/scala-2.13/coverage-report/cobertura.xml
-      - name: Upload coverage data to codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./target/scala-2.13/coverage-report/cobertura.xml
-
   test-client-test-data:
     name: Test client-test-data
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ test-repository-upgrade: build init-db-test-minimal ## runs DB upgrade integrati
 	@$(MAKE) -f $(THIS_FILE) stack-up
 
 .PHONY: test-all
-test-all: test integration-test zio-http-test
+test-all: test integration-test
 
 .PHONY: test
 test: ## runs all unit tests
@@ -217,10 +217,6 @@ test: ## runs all unit tests
 .PHONY: integration-test
 integration-test: docker-build-sipi-image ## runs all integration tests
 	$(SBTX) -v coverage "integration/test" coverageAggregate
-
-.PHONY: zio-http-test
-zio-http-test: ## runs tests against ZIO HTTP routes
-	$(SBTX) -v coverage "integration/testOnly *ZioHttpSpec" -Dkey=zio coverageAggregate
 
 
 #################################

--- a/integration/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
@@ -38,7 +38,7 @@ import pekko.util.Timeout
 /**
  * End-to-End (E2E) test specification for testing groups endpoint.
  */
-class ProjectsADME2EZioHttpSpec extends E2ESpec with ProjectsADMJsonProtocol {
+class ProjectsADME2ESpec extends E2ESpec with ProjectsADMJsonProtocol {
 
   private val rootEmail        = SharedTestDataADM.rootUser.email
   private val testPass         = SharedTestDataADM.testPass


### PR DESCRIPTION
The dedicated zio-http routes do not exist anymore.

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [x] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Basic Requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
