### PR TITLE
fix(performance): Reverse order of topological sorting in Gravsearch queries

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerSpec.scala
@@ -7,8 +7,6 @@ package org.knora.webapi.messages.util.search.gravsearch.prequery
 
 import zio._
 
-import scala.collection.mutable.ArrayBuffer
-
 import dsp.errors.AssertionException
 import org.knora.webapi.CoreSpec
 import org.knora.webapi.core.MessageRelay
@@ -102,7 +100,7 @@ class GravsearchToCountPrequeryTransformerSpec extends CoreSpec {
       groupBy = Nil,
       orderBy = Nil,
       whereClause = WhereClause(
-        patterns = ArrayBuffer(
+        patterns = Vector(
           StatementPattern(
             subj = QueryVariable(variableName = "thing"),
             pred = IriRef(
@@ -201,7 +199,7 @@ class GravsearchToCountPrequeryTransformerSpec extends CoreSpec {
   val transformedQueryWithDecimalOptionalSortCriterionAndFilterComplex: SelectQuery =
     SelectQuery(
       fromClause = None,
-      variables = Vector(
+      variables = List(
         Count(
           outputVariableName = "count",
           distinct = true,
@@ -238,14 +236,6 @@ class GravsearchToCountPrequeryTransformerSpec extends CoreSpec {
           OptionalPattern(
             patterns = Vector(
               StatementPattern(
-                subj = QueryVariable(variableName = "decimal"),
-                pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
-                  propertyPathOperator = None
-                ),
-                obj = QueryVariable(variableName = "decimalVal")
-              ),
-              StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
                 pred = IriRef(
                   iri = "http://www.knora.org/ontology/0001/anything#hasDecimal".toSmartIri,
@@ -263,6 +253,14 @@ class GravsearchToCountPrequeryTransformerSpec extends CoreSpec {
                   value = "false",
                   datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
                 )
+              ),
+              StatementPattern(
+                subj = QueryVariable(variableName = "decimal"),
+                pred = IriRef(
+                  iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
+                  propertyPathOperator = None
+                ),
+                obj = QueryVariable(variableName = "decimalVal")
               ),
               FilterPattern(expression =
                 CompareExpression(

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -1192,14 +1192,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
         StatementPattern(
           subj = QueryVariable(variableName = "book"),
           pred = IriRef(
-            iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "bookLabel")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "book"),
-          pred = IriRef(
             iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
             propertyPathOperator = None
           ),
@@ -1207,6 +1199,14 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
             iri = "http://www.knora.org/ontology/0803/incunabula#book".toSmartIri,
             propertyPathOperator = None
           )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "book"),
+          pred = IriRef(
+            iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "bookLabel")
         ),
         FilterPattern(
           expression = RegexFunction(

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -1131,14 +1131,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
         StatementPattern(
           subj = QueryVariable(variableName = "book"),
           pred = IriRef(
-            iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "label")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "book"),
-          pred = IriRef(
             iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
             propertyPathOperator = None
           ),
@@ -1146,6 +1138,14 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
             iri = "http://www.knora.org/ontology/0803/incunabula#book".toSmartIri,
             propertyPathOperator = None
           )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "book"),
+          pred = IriRef(
+            iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "label")
         ),
         FilterPattern(
           expression = CompareExpression(

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -10,7 +10,10 @@ import org.knora.webapi.CoreSpec
 import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages.util.search._
-import org.knora.webapi.messages.util.search.gravsearch.types.{GravsearchTypeInspectionRunner, GravsearchTypeInspectionUtil}
+import org.knora.webapi.messages.util.search.gravsearch.types.{
+  GravsearchTypeInspectionRunner,
+  GravsearchTypeInspectionUtil
+}
 import org.knora.webapi.messages.util.search.gravsearch.{GravsearchParser, GravsearchQueryChecker}
 import org.knora.webapi.messages.{OntologyConstants, StringFormatter}
 import org.knora.webapi.routing.UnsafeZioRun
@@ -1633,78 +1636,7 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
     whereClause = WhereClause(
       patterns = Vector(
         StatementPattern(
-          subj = QueryVariable(variableName = "gnd2"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#valueHasString".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "(DE-588)118696149",
-            datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "gnd1"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#valueHasString".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "(DE-588)118531379",
-            datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "person2"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "false",
-            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "person2"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/0801/beol#hasIAFIdentifier".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "gnd2")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "gnd2"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "false",
-            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "person1"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "false",
-            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "person1"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/0801/beol#hasIAFIdentifier".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "gnd1")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "gnd1"),
+          subj = QueryVariable(variableName = "letter"),
           pred = IriRef(
             iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
             propertyPathOperator = None
@@ -1716,6 +1648,73 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
         ),
         StatementPattern(
           subj = QueryVariable(variableName = "letter"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/0801/beol#creationDate".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "date")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "date"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "false",
+            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "date"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#valueHasStartJDN".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "date__valueHasStartJDN")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "letter"),
+          pred = QueryVariable(variableName = "linkingProp1"),
+          obj = QueryVariable(variableName = "person1")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "letter"),
+          pred = QueryVariable(variableName = "linkingProp1__hasLinkToValue"),
+          obj = QueryVariable(variableName = "letter__linkingProp1__person1__LinkValue")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "letter__linkingProp1__person1__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#LinkValue".toSmartIri,
+            propertyPathOperator = None
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "letter__linkingProp1__person1__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "false",
+            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "letter__linkingProp1__person1__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#object".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "person1")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "person1"),
           pred = IriRef(
             iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
             propertyPathOperator = None
@@ -1766,28 +1765,7 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           obj = QueryVariable(variableName = "person2")
         ),
         StatementPattern(
-          subj = QueryVariable(variableName = "letter"),
-          pred = QueryVariable(variableName = "linkingProp1"),
-          obj = QueryVariable(variableName = "person1")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "letter"),
-          pred = QueryVariable(variableName = "linkingProp1__hasLinkToValue"),
-          obj = QueryVariable(variableName = "letter__linkingProp1__person1__LinkValue")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "letter__linkingProp1__person1__LinkValue"),
-          pred = IriRef(
-            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#LinkValue".toSmartIri,
-            propertyPathOperator = None
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "letter__linkingProp1__person1__LinkValue"),
+          subj = QueryVariable(variableName = "person2"),
           pred = IriRef(
             iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
             propertyPathOperator = None
@@ -1798,23 +1776,15 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           )
         ),
         StatementPattern(
-          subj = QueryVariable(variableName = "letter__linkingProp1__person1__LinkValue"),
+          subj = QueryVariable(variableName = "person1"),
           pred = IriRef(
-            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#object".toSmartIri,
+            iri = "http://www.knora.org/ontology/0801/beol#hasIAFIdentifier".toSmartIri,
             propertyPathOperator = None
           ),
-          obj = QueryVariable(variableName = "person1")
+          obj = QueryVariable(variableName = "gnd1")
         ),
         StatementPattern(
-          subj = QueryVariable(variableName = "letter"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/0801/beol#creationDate".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "date")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "date"),
+          subj = QueryVariable(variableName = "gnd1"),
           pred = IriRef(
             iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
             propertyPathOperator = None
@@ -1825,12 +1795,45 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           )
         ),
         StatementPattern(
-          subj = QueryVariable(variableName = "date"),
+          subj = QueryVariable(variableName = "person2"),
           pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#valueHasStartJDN".toSmartIri,
+            iri = "http://www.knora.org/ontology/0801/beol#hasIAFIdentifier".toSmartIri,
             propertyPathOperator = None
           ),
-          obj = QueryVariable(variableName = "date__valueHasStartJDN")
+          obj = QueryVariable(variableName = "gnd2")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "gnd2"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "false",
+            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "gnd1"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#valueHasString".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "(DE-588)118531379",
+            datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "gnd2"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#valueHasString".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "(DE-588)118696149",
+            datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
+          )
         ),
         FilterPattern(
           expression = OrExpression(

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -2330,44 +2330,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           blocks = Vector(
             Vector(
               StatementPattern(
-                subj = QueryVariable(variableName = "int"),
-                pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#valueHasInteger".toSmartIri,
-                  propertyPathOperator = None
-                ),
-                obj = XsdLiteral(
-                  value = "1",
-                  datatype = "http://www.w3.org/2001/XMLSchema#integer".toSmartIri
-                )
-              ),
-              StatementPattern(
-                subj = QueryVariable(variableName = "thing"),
-                pred = IriRef(
-                  iri = "http://www.knora.org/ontology/0001/anything#hasInteger".toSmartIri,
-                  propertyPathOperator = None
-                ),
-                obj = QueryVariable(variableName = "int")
-              ),
-              StatementPattern(
-                subj = QueryVariable(variableName = "int"),
-                pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-                  propertyPathOperator = None
-                ),
-                obj = XsdLiteral(
-                  value = "false",
-                  datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-                )
-              ),
-              StatementPattern(
-                subj = QueryVariable(variableName = "int"),
-                pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#valueHasInteger".toSmartIri,
-                  propertyPathOperator = None
-                ),
-                obj = QueryVariable(variableName = "int__valueHasInteger")
-              ),
-              StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
                 pred = IriRef(
                   iri = "http://www.knora.org/ontology/0001/anything#hasRichtext".toSmartIri,
@@ -2387,6 +2349,44 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
                 )
               ),
               StatementPattern(
+                subj = QueryVariable(variableName = "thing"),
+                pred = IriRef(
+                  iri = "http://www.knora.org/ontology/0001/anything#hasInteger".toSmartIri,
+                  propertyPathOperator = None
+                ),
+                obj = QueryVariable(variableName = "int")
+              ),
+              StatementPattern(
+                subj = QueryVariable(variableName = "int"),
+                pred = IriRef(
+                  iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                  propertyPathOperator = None
+                ),
+                obj = XsdLiteral(
+                  value = "false",
+                  datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+                )
+              ),
+              StatementPattern(
+                subj = QueryVariable(variableName = "int"),
+                pred = IriRef(
+                  iri = "http://www.knora.org/ontology/knora-base#valueHasInteger".toSmartIri,
+                  propertyPathOperator = None
+                ),
+                obj = QueryVariable(variableName = "int__valueHasInteger")
+              ),
+              StatementPattern(
+                subj = QueryVariable(variableName = "int"),
+                pred = IriRef(
+                  iri = "http://www.knora.org/ontology/knora-base#valueHasInteger".toSmartIri,
+                  propertyPathOperator = None
+                ),
+                obj = XsdLiteral(
+                  value = "1",
+                  datatype = "http://www.w3.org/2001/XMLSchema#integer".toSmartIri
+                )
+              ),
+              StatementPattern(
                 subj = QueryVariable(variableName = "richtext"),
                 pred = IriRef(OntologyConstants.Fuseki.luceneQueryPredicate.toSmartIri),
                 obj = XsdLiteral(
@@ -2397,14 +2397,22 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
             ),
             Vector(
               StatementPattern(
-                subj = QueryVariable(variableName = "int"),
+                subj = QueryVariable(variableName = "thing"),
                 pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#valueHasInteger".toSmartIri,
+                  iri = "http://www.knora.org/ontology/0001/anything#hasText".toSmartIri,
+                  propertyPathOperator = None
+                ),
+                obj = QueryVariable(variableName = "text")
+              ),
+              StatementPattern(
+                subj = QueryVariable(variableName = "text"),
+                pred = IriRef(
+                  iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
                   propertyPathOperator = None
                 ),
                 obj = XsdLiteral(
-                  value = "3",
-                  datatype = "http://www.w3.org/2001/XMLSchema#integer".toSmartIri
+                  value = "false",
+                  datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
                 )
               ),
               StatementPattern(
@@ -2435,22 +2443,14 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
                 obj = QueryVariable(variableName = "int__valueHasInteger")
               ),
               StatementPattern(
-                subj = QueryVariable(variableName = "thing"),
+                subj = QueryVariable(variableName = "int"),
                 pred = IriRef(
-                  iri = "http://www.knora.org/ontology/0001/anything#hasText".toSmartIri,
-                  propertyPathOperator = None
-                ),
-                obj = QueryVariable(variableName = "text")
-              ),
-              StatementPattern(
-                subj = QueryVariable(variableName = "text"),
-                pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                  iri = "http://www.knora.org/ontology/knora-base#valueHasInteger".toSmartIri,
                   propertyPathOperator = None
                 ),
                 obj = XsdLiteral(
-                  value = "false",
-                  datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+                  value = "3",
+                  datatype = "http://www.w3.org/2001/XMLSchema#integer".toSmartIri
                 )
               ),
               StatementPattern(

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -1019,23 +1019,23 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
         StatementPattern(
           subj = QueryVariable(variableName = "book"),
           pred = IriRef(
-            iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "Zeitgl\u00F6cklein des Lebens und Leidens Christi",
-            datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "book"),
-          pred = IriRef(
             iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
             propertyPathOperator = None
           ),
           obj = IriRef(
             iri = "http://www.knora.org/ontology/0803/incunabula#book".toSmartIri,
             propertyPathOperator = None
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "book"),
+          pred = IriRef(
+            iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "Zeitgl\u00F6cklein des Lebens und Leidens Christi",
+            datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
           )
         )
       ),

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -5,22 +5,23 @@
 
 package org.knora.webapi.messages.util.search.gravsearch.prequery
 
+import zio.ZIO
+
+import scala.collection.mutable.ArrayBuffer
+
 import dsp.errors.AssertionException
 import org.knora.webapi.CoreSpec
 import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions._
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.search._
-import org.knora.webapi.messages.util.search.gravsearch.types.{
-  GravsearchTypeInspectionRunner,
-  GravsearchTypeInspectionUtil
-}
-import org.knora.webapi.messages.util.search.gravsearch.{GravsearchParser, GravsearchQueryChecker}
-import org.knora.webapi.messages.{OntologyConstants, StringFormatter}
+import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
+import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
+import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionRunner
+import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
 import org.knora.webapi.routing.UnsafeZioRun
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.anythingAdminUser
-import zio.ZIO
-
-import scala.collection.mutable.ArrayBuffer
 
 class GravsearchToPrequeryTransformerSpec extends CoreSpec {
 
@@ -1917,7 +1918,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
             datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
           )
         ),
-
         StatementPattern(
           subj = QueryVariable(variableName = "thing2"),
           pred = IriRef(
@@ -1935,7 +1935,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           obj =
             QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue")
         ),
-
         StatementPattern(
           subj =
             QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue"),
@@ -1969,7 +1968,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           ),
           obj = QueryVariable(variableName = "thing")
         ),
-
         StatementPattern(
           subj = QueryVariable(variableName = "thing"),
           pred = IriRef(
@@ -1998,7 +1996,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           obj =
             QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue")
         ),
-
         StatementPattern(
           subj =
             QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue"),
@@ -2092,10 +2089,7 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
             propertyPathOperator = None
           ),
           obj = QueryVariable(variableName = "thing2")
-        ),
-
-
-
+        )
       ),
       positiveEntities = Set(),
       querySchema = None

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -1907,6 +1907,132 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
     whereClause = WhereClause(
       patterns = Vector(
         StatementPattern(
+          subj = QueryVariable(variableName = "thing2"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "false",
+            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+          )
+        ),
+
+        StatementPattern(
+          subj = QueryVariable(variableName = "thing2"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "thing")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "thing2"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/0001/anything#hasOtherThingValue".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj =
+            QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue")
+        ),
+
+        StatementPattern(
+          subj =
+            QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#LinkValue".toSmartIri,
+            propertyPathOperator = None
+          )
+        ),
+        StatementPattern(
+          subj =
+            QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "false",
+            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+          )
+        ),
+        StatementPattern(
+          subj =
+            QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#object".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "thing")
+        ),
+
+        StatementPattern(
+          subj = QueryVariable(variableName = "thing"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "false",
+            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "thing"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "thing1")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "thing"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/0001/anything#hasOtherThingValue".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj =
+            QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue")
+        ),
+
+        StatementPattern(
+          subj =
+            QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#LinkValue".toSmartIri,
+            propertyPathOperator = None
+          )
+        ),
+        StatementPattern(
+          subj =
+            QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = XsdLiteral(
+            value = "false",
+            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+          )
+        ),
+        StatementPattern(
+          subj =
+            QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#object".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "thing1")
+        ),
+        StatementPattern(
           subj = QueryVariable(variableName = "thing1"),
           pred = IriRef(
             iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
@@ -1967,128 +2093,9 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           ),
           obj = QueryVariable(variableName = "thing2")
         ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "thing2"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "false",
-            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "thing"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "false",
-            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "thing"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "thing1")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "thing"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/0001/anything#hasOtherThingValue".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj =
-            QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue")
-        ),
-        StatementPattern(
-          subj =
-            QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue"),
-          pred = IriRef(
-            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#LinkValue".toSmartIri,
-            propertyPathOperator = None
-          )
-        ),
-        StatementPattern(
-          subj =
-            QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "false",
-            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj =
-            QueryVariable(variableName = "thing__httpwwwknoraorgontology0001anythinghasOtherThing__thing1__LinkValue"),
-          pred = IriRef(
-            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#object".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "thing1")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "thing2"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "thing")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "thing2"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/0001/anything#hasOtherThingValue".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj =
-            QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue")
-        ),
-        StatementPattern(
-          subj =
-            QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue"),
-          pred = IriRef(
-            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#LinkValue".toSmartIri,
-            propertyPathOperator = None
-          )
-        ),
-        StatementPattern(
-          subj =
-            QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = XsdLiteral(
-            value = "false",
-            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-          )
-        ),
-        StatementPattern(
-          subj =
-            QueryVariable(variableName = "thing2__httpwwwknoraorgontology0001anythinghasOtherThing__thing__LinkValue"),
-          pred = IriRef(
-            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#object".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "thing")
-        )
+
+
+
       ),
       positiveEntities = Set(),
       querySchema = None

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -9,10 +9,10 @@ import dsp.errors.AssertionException
 import org.knora.webapi.CoreSpec
 import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions._
-import org.knora.webapi.messages.{OntologyConstants, StringFormatter}
 import org.knora.webapi.messages.util.search._
-import org.knora.webapi.messages.util.search.gravsearch.{GravsearchParser, GravsearchQueryChecker}
 import org.knora.webapi.messages.util.search.gravsearch.types.{GravsearchTypeInspectionRunner, GravsearchTypeInspectionUtil}
+import org.knora.webapi.messages.util.search.gravsearch.{GravsearchParser, GravsearchQueryChecker}
+import org.knora.webapi.messages.{OntologyConstants, StringFormatter}
 import org.knora.webapi.routing.UnsafeZioRun
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.anythingAdminUser
 import zio.ZIO
@@ -931,13 +931,10 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
               StatementPattern(
                 subj = QueryVariable(variableName = "decimal"),
                 pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                  iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
                   propertyPathOperator = None
                 ),
-                obj = XsdLiteral(
-                  value = "false",
-                  datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-                )
+                obj = QueryVariable(variableName = "decimal__valueHasDecimal")
               ),
               StatementPattern(
                 subj = QueryVariable(variableName = "decimal"),
@@ -946,14 +943,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
                   propertyPathOperator = None
                 ),
                 obj = QueryVariable(variableName = "decimalVal")
-              ),
-              StatementPattern(
-                subj = QueryVariable(variableName = "decimal"),
-                pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
-                  propertyPathOperator = None
-                ),
-                obj = QueryVariable(variableName = "decimal__valueHasDecimal")
               ),
               FilterPattern(expression =
                 CompareExpression(
@@ -2708,7 +2697,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
 
     "transform an input query with a decimal as an optional sort criterion and a filter (submitted in complex schema)" in {
       val transformedQuery = transformQuery(inputQueryWithDecimalOptionalSortCriterionAndFilterComplex)
-      // TODO: user provided statements and statement generated for sorting should be unified (https://github.com/dhlab-basel/Knora/issues/1195)
       assert(transformedQuery === transformedQueryWithDecimalOptionalSortCriterionAndFilterComplex)
     }
 

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -5,23 +5,19 @@
 
 package org.knora.webapi.messages.util.search.gravsearch.prequery
 
-import zio.ZIO
-
-import scala.collection.mutable.ArrayBuffer
-
 import dsp.errors.AssertionException
 import org.knora.webapi.CoreSpec
 import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions._
-import org.knora.webapi.messages.OntologyConstants
-import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.{OntologyConstants, StringFormatter}
 import org.knora.webapi.messages.util.search._
-import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
-import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
-import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionRunner
-import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
+import org.knora.webapi.messages.util.search.gravsearch.{GravsearchParser, GravsearchQueryChecker}
+import org.knora.webapi.messages.util.search.gravsearch.types.{GravsearchTypeInspectionRunner, GravsearchTypeInspectionUtil}
 import org.knora.webapi.routing.UnsafeZioRun
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.anythingAdminUser
+import zio.ZIO
+
+import scala.collection.mutable.ArrayBuffer
 
 class GravsearchToPrequeryTransformerSpec extends CoreSpec {
 
@@ -864,7 +860,7 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
   val transformedQueryWithDecimalOptionalSortCriterionAndFilterComplex: SelectQuery =
     SelectQuery(
       fromClause = None,
-      variables = Vector(
+      variables = List(
         QueryVariable(variableName = "thing"),
         GroupConcat(
           inputVariable = QueryVariable(variableName = "decimal"),
@@ -914,14 +910,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           OptionalPattern(
             patterns = Vector(
               StatementPattern(
-                subj = QueryVariable(variableName = "decimal"),
-                pred = IriRef(
-                  iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
-                  propertyPathOperator = None
-                ),
-                obj = QueryVariable(variableName = "decimalVal")
-              ),
-              StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
                 pred = IriRef(
                   iri = "http://www.knora.org/ontology/0001/anything#hasDecimal".toSmartIri,
@@ -939,6 +927,25 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
                   value = "false",
                   datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
                 )
+              ),
+              StatementPattern(
+                subj = QueryVariable(variableName = "decimal"),
+                pred = IriRef(
+                  iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                  propertyPathOperator = None
+                ),
+                obj = XsdLiteral(
+                  value = "false",
+                  datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+                )
+              ),
+              StatementPattern(
+                subj = QueryVariable(variableName = "decimal"),
+                pred = IriRef(
+                  iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
+                  propertyPathOperator = None
+                ),
+                obj = QueryVariable(variableName = "decimalVal")
               ),
               StatementPattern(
                 subj = QueryVariable(variableName = "decimal"),
@@ -1250,7 +1257,7 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
 
   val TransformedQueryWithOptional: SelectQuery = SelectQuery(
     fromClause = None,
-    variables = Vector(QueryVariable(variableName = "document")),
+    variables = List(QueryVariable(variableName = "document")),
     offset = 0,
     groupBy = Vector(QueryVariable(variableName = "document")),
     orderBy = Vector(
@@ -1288,36 +1295,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
         ),
         OptionalPattern(
           patterns = Vector(
-            StatementPattern(
-              subj = QueryVariable(variableName = "recipient"),
-              pred = IriRef(
-                iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-                propertyPathOperator = None
-              ),
-              obj = XsdLiteral(
-                value = "false",
-                datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-              )
-            ),
-            StatementPattern(
-              subj = QueryVariable(variableName = "recipient"),
-              pred = IriRef(
-                iri = "http://www.knora.org/ontology/0801/beol#hasFamilyName".toSmartIri,
-                propertyPathOperator = None
-              ),
-              obj = QueryVariable(variableName = "familyName")
-            ),
-            StatementPattern(
-              subj = QueryVariable(variableName = "familyName"),
-              pred = IriRef(
-                iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-                propertyPathOperator = None
-              ),
-              obj = XsdLiteral(
-                value = "false",
-                datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-              )
-            ),
             StatementPattern(
               subj = QueryVariable(variableName = "document"),
               pred = IriRef(
@@ -1371,6 +1348,36 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
                 propertyPathOperator = None
               ),
               obj = QueryVariable(variableName = "recipient")
+            ),
+            StatementPattern(
+              subj = QueryVariable(variableName = "recipient"),
+              pred = IriRef(
+                iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                propertyPathOperator = None
+              ),
+              obj = XsdLiteral(
+                value = "false",
+                datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+              )
+            ),
+            StatementPattern(
+              subj = QueryVariable(variableName = "recipient"),
+              pred = IriRef(
+                iri = "http://www.knora.org/ontology/0801/beol#hasFamilyName".toSmartIri,
+                propertyPathOperator = None
+              ),
+              obj = QueryVariable(variableName = "familyName")
+            ),
+            StatementPattern(
+              subj = QueryVariable(variableName = "familyName"),
+              pred = IriRef(
+                iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                propertyPathOperator = None
+              ),
+              obj = XsdLiteral(
+                value = "false",
+                datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+              )
             ),
             StatementPattern(
               subj = QueryVariable(variableName = "familyName"),

--- a/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerSpec.scala
@@ -2510,44 +2510,6 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
     whereClause = WhereClause(
       patterns = Vector(
         StatementPattern(
-          subj = QueryVariable(variableName = "standoffParagraphTag"),
-          pred = IriRef(
-            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = IriRef(
-            iri = "http://www.knora.org/ontology/standoff#StandoffParagraphTag".toSmartIri,
-            propertyPathOperator = None
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "standoffDateTag"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#standoffTagHasStartAncestor".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "standoffParagraphTag")
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "standoffDateTag"),
-          pred = IriRef(
-            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#StandoffDateTag".toSmartIri,
-            propertyPathOperator = None
-          )
-        ),
-        StatementPattern(
-          subj = QueryVariable(variableName = "text"),
-          pred = IriRef(
-            iri = "http://www.knora.org/ontology/knora-base#valueHasStandoff".toSmartIri,
-            propertyPathOperator = None
-          ),
-          obj = QueryVariable(variableName = "standoffDateTag")
-        ),
-        StatementPattern(
           subj = QueryVariable(variableName = "thing"),
           pred = IriRef(
             iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
@@ -2575,6 +2537,44 @@ class GravsearchToPrequeryTransformerSpec extends CoreSpec {
           obj = XsdLiteral(
             value = "false",
             datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "text"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#valueHasStandoff".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "standoffDateTag")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "standoffDateTag"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#StandoffDateTag".toSmartIri,
+            propertyPathOperator = None
+          )
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "standoffDateTag"),
+          pred = IriRef(
+            iri = "http://www.knora.org/ontology/knora-base#standoffTagHasStartAncestor".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = QueryVariable(variableName = "standoffParagraphTag")
+        ),
+        StatementPattern(
+          subj = QueryVariable(variableName = "standoffParagraphTag"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+            propertyPathOperator = None
+          ),
+          obj = IriRef(
+            iri = "http://www.knora.org/ontology/standoff#StandoffParagraphTag".toSmartIri,
+            propertyPathOperator = None
           )
         ),
         StatementPattern(

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/GravsearchQueryChecker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/GravsearchQueryChecker.scala
@@ -23,7 +23,7 @@ object GravsearchQueryChecker {
    * Checks that the correct schema is used in a statement pattern and that the predicate is allowed in Gravsearch.
    * If the statement is in the CONSTRUCT clause in the complex schema, non-property variables may refer only to resources or Knora values.
    *
-   * @param statementPattern     the statement pattern to be checked.
+   * @param      the statement pattern to be checked.
    * @param querySchema          the API v2 ontology schema used in the query.
    * @param typeInspectionResult the type inspection result.
    * @param inConstructClause    `true` if the statement is in the CONSTRUCT clause.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/GravsearchQueryChecker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/GravsearchQueryChecker.scala
@@ -23,7 +23,7 @@ object GravsearchQueryChecker {
    * Checks that the correct schema is used in a statement pattern and that the predicate is allowed in Gravsearch.
    * If the statement is in the CONSTRUCT clause in the complex schema, non-property variables may refer only to resources or Knora values.
    *
-   * @param statementPattern     statement pattern to be checked.
+   * @param statementPattern     the statement pattern to be checked.
    * @param querySchema          the API v2 ontology schema used in the query.
    * @param typeInspectionResult the type inspection result.
    * @param inConstructClause    `true` if the statement is in the CONSTRUCT clause.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/GravsearchQueryChecker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/GravsearchQueryChecker.scala
@@ -23,7 +23,7 @@ object GravsearchQueryChecker {
    * Checks that the correct schema is used in a statement pattern and that the predicate is allowed in Gravsearch.
    * If the statement is in the CONSTRUCT clause in the complex schema, non-property variables may refer only to resources or Knora values.
    *
-   * @param      the statement pattern to be checked.
+   * @param statementPattern     statement pattern to be checked.
    * @param querySchema          the API v2 ontology schema used in the query.
    * @param typeInspectionResult the type inspection result.
    * @param inConstructClause    `true` if the statement is in the CONSTRUCT clause.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchQueryOptimisation.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchQueryOptimisation.scala
@@ -5,14 +5,18 @@
 
 package org.knora.webapi.messages.util.search.gravsearch.prequery
 
-import org.knora.webapi.messages.{OntologyConstants, SmartIri}
+import scalax.collection.Graph
+import scalax.collection.GraphEdge.DiHyperEdge
+
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.util.search._
 import org.knora.webapi.messages.util.search.gravsearch.prequery.RemoveEntitiesInferredFromProperty.removeEntitiesInferredFromProperty
 import org.knora.webapi.messages.util.search.gravsearch.prequery.RemoveRedundantKnoraApiResource.removeRedundantKnoraApiResource
 import org.knora.webapi.messages.util.search.gravsearch.prequery.ReorderPatternsByDependency.reorderPatternsByDependency
-import org.knora.webapi.messages.util.search.gravsearch.types.{GravsearchTypeInspectionResult, GravsearchTypeInspectionUtil, TypeableEntity}
-import scalax.collection.Graph
-import scalax.collection.GraphEdge.DiHyperEdge
+import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionResult
+import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
+import org.knora.webapi.messages.util.search.gravsearch.types.TypeableEntity
 
 /**
  * A feature factory that constructs Gravsearch query optimisation algorithms.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchQueryOptimisation.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchQueryOptimisation.scala
@@ -5,18 +5,14 @@
 
 package org.knora.webapi.messages.util.search.gravsearch.prequery
 
-import scalax.collection.Graph
-import scalax.collection.GraphEdge.DiHyperEdge
-
-import org.knora.webapi.messages.OntologyConstants
-import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.messages.{OntologyConstants, SmartIri}
 import org.knora.webapi.messages.util.search._
 import org.knora.webapi.messages.util.search.gravsearch.prequery.RemoveEntitiesInferredFromProperty.removeEntitiesInferredFromProperty
 import org.knora.webapi.messages.util.search.gravsearch.prequery.RemoveRedundantKnoraApiResource.removeRedundantKnoraApiResource
 import org.knora.webapi.messages.util.search.gravsearch.prequery.ReorderPatternsByDependency.reorderPatternsByDependency
-import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionResult
-import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
-import org.knora.webapi.messages.util.search.gravsearch.types.TypeableEntity
+import org.knora.webapi.messages.util.search.gravsearch.types.{GravsearchTypeInspectionResult, GravsearchTypeInspectionUtil, TypeableEntity}
+import scalax.collection.Graph
+import scalax.collection.GraphEdge.DiHyperEdge
 
 /**
  * A feature factory that constructs Gravsearch query optimisation algorithms.
@@ -326,7 +322,8 @@ private object ReorderPatternsByDependency {
       if (topologicalOrder.nonEmpty) {
         // Yes. Sort the statement patterns according to the reverse topological order.
         topologicalOrder.foldRight(Vector.empty[QueryPattern]) { (node, sortedStatements) =>
-          statementPatterns.filter(_.obj.toSparql.equals(node.value)).toVector ++ sortedStatements
+          val nextStatements = statementPatterns.filter(_.obj.toSparql.equals(node.value)).toVector
+          nextStatements ++ sortedStatements
         }
       } else {
         // No topological order found.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchQueryOptimisation.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchQueryOptimisation.scala
@@ -324,13 +324,9 @@ private object ReorderPatternsByDependency {
 
       // Was a topological order found?
       if (topologicalOrder.nonEmpty) {
-        // Start from the end of the ordered list (the nodes with lowest degree).
-        // For each node, find statements which have the node as object and bring them to top.
+        // Yes. Sort the statement patterns according to the reverse topological order.
         topologicalOrder.foldRight(Vector.empty[QueryPattern]) { (node, sortedStatements) =>
-          val statementsOfNode: Set[QueryPattern] = statementPatterns
-            .filter(p => p.obj.toSparql.equals(node.value))
-            .toSet[QueryPattern]
-          sortedStatements ++ statementsOfNode.toVector
+          statementPatterns.filter(_.obj.toSparql.equals(node.value)).toVector ++ sortedStatements
         }
       } else {
         // No topological order found.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchQueryOptimisation.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchQueryOptimisation.scala
@@ -104,12 +104,6 @@ private object RemoveRedundantKnoraApiResource {
  */
 private object RemoveEntitiesInferredFromProperty {
 
-  /**
-   * Performs the optimisation.
-   *
-   * @param patterns the query patterns.
-   * @return the optimised query patterns.
-   */
   def removeEntitiesInferredFromProperty(
     patterns: Seq[QueryPattern],
     typeInspectionResult: GravsearchTypeInspectionResult


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

I have tested this change with a couple of queries, e.g. from DEV-2675, DEV-2699.
It seems like these queries benefit drastically from the change.
     
However, I am not sure about the affect of all kinds of queries. This might even slow down other searches.

### PR Type

- [x] fix: represents bug fixes
- [ ] refactor: represents production code refactoring
- [ ] feat: represents a new feature
- [ ] docs: documentation changes (no production code change)
- [ ] chore: maintenance tasks (no production code change)
- [ ] test: all about tests: adding, refactoring tests (no production code change)
- [ ] other... Please describe:

### Basic Requirements for bug fixes and features

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
