### PR TITLE
chore: Remove duplicate 'gravsearch' metrics

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -6,36 +6,56 @@
 package org.knora.webapi.responders.v2
 
 import com.typesafe.scalalogging.LazyLogging
-import dsp.errors.{AssertionException, BadRequestException, GravsearchException, InconsistentRepositoryDataException}
+import zio.*
+
+import dsp.errors.AssertionException
+import dsp.errors.BadRequestException
+import dsp.errors.GravsearchException
+import dsp.errors.InconsistentRepositoryDataException
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.{MessageHandler, MessageRelay}
+import org.knora.webapi.core.MessageHandler
+import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions.*
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.ResponderRequest
+import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.store.triplestoremessages.*
 import org.knora.webapi.messages.twirl.queries.sparql
+import org.knora.webapi.messages.util.ConstructResponseUtilV2
 import org.knora.webapi.messages.util.ConstructResponseUtilV2.MappingAndXSLTransformation
-import org.knora.webapi.messages.util.rdf.{SparqlSelectResult, SparqlSelectResultBody, VariableResultsRow}
+import org.knora.webapi.messages.util.ErrorHandlingMap
+import org.knora.webapi.messages.util.rdf.SparqlSelectResult
+import org.knora.webapi.messages.util.rdf.SparqlSelectResultBody
+import org.knora.webapi.messages.util.rdf.VariableResultsRow
 import org.knora.webapi.messages.util.search.*
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
 import org.knora.webapi.messages.util.search.gravsearch.mainquery.GravsearchMainQueryGenerator
-import org.knora.webapi.messages.util.search.gravsearch.prequery.{AbstractPrequeryGenerator, GravsearchToCountPrequeryTransformer, GravsearchToPrequeryTransformer, InferenceOptimizationService}
-import org.knora.webapi.messages.util.search.gravsearch.transformers.{ConstructTransformer, OntologyInferencer, SelectTransformer}
+import org.knora.webapi.messages.util.search.gravsearch.prequery.AbstractPrequeryGenerator
+import org.knora.webapi.messages.util.search.gravsearch.prequery.GravsearchToCountPrequeryTransformer
+import org.knora.webapi.messages.util.search.gravsearch.prequery.GravsearchToPrequeryTransformer
+import org.knora.webapi.messages.util.search.gravsearch.prequery.InferenceOptimizationService
+import org.knora.webapi.messages.util.search.gravsearch.transformers.ConstructTransformer
+import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
+import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
 import org.knora.webapi.messages.util.search.gravsearch.types.*
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
-import org.knora.webapi.messages.util.{ConstructResponseUtilV2, ErrorHandlingMap}
 import org.knora.webapi.messages.v2.responder.KnoraJsonLDResponseV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.{EntityInfoGetRequestV2, EntityInfoGetResponseV2, ReadClassInfoV2, ReadPropertyInfoV2}
+import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetRequestV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetResponseV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.*
 import org.knora.webapi.messages.v2.responder.searchmessages.*
-import org.knora.webapi.messages.{OntologyConstants, ResponderRequest, SmartIri, StringFormatter}
 import org.knora.webapi.responders.Responder
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
-import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.{Construct, Select}
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 import org.knora.webapi.util.ApacheLuceneSupport.*
-import zio.*
 
 trait SearchResponderV2
 final case class SearchResponderV2Live(

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -6,56 +6,36 @@
 package org.knora.webapi.responders.v2
 
 import com.typesafe.scalalogging.LazyLogging
-import zio.*
-
-import dsp.errors.AssertionException
-import dsp.errors.BadRequestException
-import dsp.errors.GravsearchException
-import dsp.errors.InconsistentRepositoryDataException
+import dsp.errors.{AssertionException, BadRequestException, GravsearchException, InconsistentRepositoryDataException}
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageHandler
-import org.knora.webapi.core.MessageRelay
+import org.knora.webapi.core.{MessageHandler, MessageRelay}
 import org.knora.webapi.messages.IriConversions.*
-import org.knora.webapi.messages.OntologyConstants
-import org.knora.webapi.messages.ResponderRequest
-import org.knora.webapi.messages.SmartIri
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.store.triplestoremessages.*
 import org.knora.webapi.messages.twirl.queries.sparql
-import org.knora.webapi.messages.util.ConstructResponseUtilV2
 import org.knora.webapi.messages.util.ConstructResponseUtilV2.MappingAndXSLTransformation
-import org.knora.webapi.messages.util.ErrorHandlingMap
-import org.knora.webapi.messages.util.rdf.SparqlSelectResult
-import org.knora.webapi.messages.util.rdf.SparqlSelectResultBody
-import org.knora.webapi.messages.util.rdf.VariableResultsRow
+import org.knora.webapi.messages.util.rdf.{SparqlSelectResult, SparqlSelectResultBody, VariableResultsRow}
 import org.knora.webapi.messages.util.search.*
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
 import org.knora.webapi.messages.util.search.gravsearch.mainquery.GravsearchMainQueryGenerator
-import org.knora.webapi.messages.util.search.gravsearch.prequery.AbstractPrequeryGenerator
-import org.knora.webapi.messages.util.search.gravsearch.prequery.GravsearchToCountPrequeryTransformer
-import org.knora.webapi.messages.util.search.gravsearch.prequery.GravsearchToPrequeryTransformer
-import org.knora.webapi.messages.util.search.gravsearch.prequery.InferenceOptimizationService
-import org.knora.webapi.messages.util.search.gravsearch.transformers.ConstructTransformer
-import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
-import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
+import org.knora.webapi.messages.util.search.gravsearch.prequery.{AbstractPrequeryGenerator, GravsearchToCountPrequeryTransformer, GravsearchToPrequeryTransformer, InferenceOptimizationService}
+import org.knora.webapi.messages.util.search.gravsearch.transformers.{ConstructTransformer, OntologyInferencer, SelectTransformer}
 import org.knora.webapi.messages.util.search.gravsearch.types.*
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
+import org.knora.webapi.messages.util.{ConstructResponseUtilV2, ErrorHandlingMap}
 import org.knora.webapi.messages.v2.responder.KnoraJsonLDResponseV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetResponseV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.{EntityInfoGetRequestV2, EntityInfoGetResponseV2, ReadClassInfoV2, ReadPropertyInfoV2}
 import org.knora.webapi.messages.v2.responder.resourcemessages.*
 import org.knora.webapi.messages.v2.responder.searchmessages.*
+import org.knora.webapi.messages.{OntologyConstants, ResponderRequest, SmartIri, StringFormatter}
 import org.knora.webapi.responders.Responder
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
-import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
-import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.{Construct, Select}
 import org.knora.webapi.util.ApacheLuceneSupport.*
+import zio.*
 
 trait SearchResponderV2
 final case class SearchResponderV2Live(
@@ -484,16 +464,10 @@ final case class SearchResponderV2Live(
 
       prequerySparql = transformedPrequery.toSparql
 
-      start <- Clock.instant.map(_.toEpochMilli)
       prequeryResponseNotMerged <-
         triplestore
           .query(Select(prequerySparql, isGravsearch = true))
           .logError(s"Gravsearch timed out for prequery:\n$prequerySparql")
-
-      end     <- Clock.instant.map(_.toEpochMilli)
-      duration = (end - start) / 1000.0
-      _ = if (duration < 3) logger.debug(s"Prequery took: ${duration}s")
-          else logger.warn(s"Slow Prequery ($duration):\n$prequerySparql")
 
       pageSizeBeforeFiltering: Int = prequeryResponseNotMerged.results.bindings.size
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
@@ -5,20 +5,25 @@
 
 package org.knora.webapi.routing.v2
 
+import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.apache.pekko.http.scaladsl.server.RequestContext
+import org.apache.pekko.http.scaladsl.server.Route
+import zio.*
+
 import dsp.errors.BadRequestException
 import dsp.valueobjects.Iri
-import org.apache.pekko.http.scaladsl.server.Directives.*
-import org.apache.pekko.http.scaladsl.server.{RequestContext, Route}
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.core.MessageRelay
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.messages.ValuesValidator
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
 import org.knora.webapi.messages.v2.responder.KnoraResponseV2
 import org.knora.webapi.messages.v2.responder.searchmessages.*
-import org.knora.webapi.messages.{OntologyConstants, SmartIri, ValuesValidator}
-import org.knora.webapi.routing.{Authenticator, RouteUtilV2}
+import org.knora.webapi.routing.Authenticator
+import org.knora.webapi.routing.RouteUtilV2
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-import zio.*
 
 /**
  * Provides a function for API routes that deal with search.

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
@@ -5,31 +5,20 @@
 
 package org.knora.webapi.routing.v2
 
-import org.apache.pekko
-import zio.*
-import zio.metrics.*
-
-import java.time.temporal.ChronoUnit
-
 import dsp.errors.BadRequestException
 import dsp.valueobjects.Iri
+import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.apache.pekko.http.scaladsl.server.{RequestContext, Route}
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.core.MessageRelay
-import org.knora.webapi.messages.OntologyConstants
-import org.knora.webapi.messages.SmartIri
-import org.knora.webapi.messages.ValuesValidator
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
 import org.knora.webapi.messages.v2.responder.KnoraResponseV2
 import org.knora.webapi.messages.v2.responder.searchmessages.*
-import org.knora.webapi.routing.Authenticator
-import org.knora.webapi.routing.RouteUtilV2
+import org.knora.webapi.messages.{OntologyConstants, SmartIri, ValuesValidator}
+import org.knora.webapi.routing.{Authenticator, RouteUtilV2}
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-import org.knora.webapi.store.triplestore.errors.TriplestoreTimeoutException
-
-import pekko.http.scaladsl.server.Directives.*
-import pekko.http.scaladsl.server.RequestContext
-import pekko.http.scaladsl.server.Route
+import zio.*
 
 /**
  * Provides a function for API routes that deal with search.
@@ -242,27 +231,16 @@ final case class SearchRouteV2(searchValueMinLength: Int)(
     post(entity(as[String])(query => requestContext => gravsearch(query, requestContext)))
   }
 
-  private val gravsearchDuration = Metric.timer("gravsearch", ChronoUnit.MILLIS, Chunk.iterate(1.0, 17)(_ * 2))
-  private val gravsearchDurationSummary =
-    Metric.summary("gravsearch_summary", 1.day, 100, 0.03d, Chunk(0.01, 0.1, 0.2, 0.5, 0.8, 0.9, 0.99))
-  private val gravsearchFailCounter    = Metric.counter("gravsearch_fail").fromConst(1)
-  private val gravsearchTimeoutCounter = Metric.counter("gravsearch_timeout").fromConst(1)
-
   private def gravsearch(query: String, requestContext: RequestContext) = {
     val constructQuery    = GravsearchParser.parseQuery(query)
     val targetSchemaTask  = RouteUtilV2.getOntologySchema(requestContext)
     val schemaOptionsTask = RouteUtilV2.getSchemaOptions(requestContext)
     val task = for {
-      start          <- Clock.instant.map(_.toEpochMilli).map(_.toDouble)
       targetSchema   <- targetSchemaTask
       requestingUser <- Authenticator.getUserADM(requestContext)
       schemaOptions  <- schemaOptionsTask
-      request         = GravsearchRequestV2(constructQuery, targetSchema, schemaOptions, requestingUser)
-      response <- MessageRelay.ask[KnoraResponseV2](request).tapError {
-                    case _: TriplestoreTimeoutException => ZIO.unit @@ gravsearchTimeoutCounter
-                    case _                              => ZIO.unit @@ gravsearchFailCounter
-                  } @@ gravsearchDuration.trackDuration
-      _ <- Clock.instant.map(_.toEpochMilli).map(_.-(start)) @@ gravsearchDurationSummary
+      gravsearchReq   = GravsearchRequestV2(constructQuery, targetSchema, schemaOptions, requestingUser)
+      response       <- MessageRelay.ask[KnoraResponseV2](gravsearchReq)
     } yield response
     RouteUtilV2.completeResponse(task, requestContext, targetSchemaTask, schemaOptionsTask.map(Some(_)))
   }


### PR DESCRIPTION
Relates to DEV-2151

The removes metrics which are redundant since the introduction of `fuseki_request_duration` metric.

Collecting the metrics is removed in https://github.com/dasch-swiss/ops-deploy/pull/560

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [x] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
