### PR TITLE
refactor: Replace spray json with zio-json for FileMetadataSipiResponse

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/store/iiif/impl/SipiServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/iiif/impl/SipiServiceLive.scala
@@ -5,26 +5,22 @@
 
 package org.knora.webapi.store.iiif.impl
 
-import dsp.errors.{BadRequestException, NotFoundException}
-import org.apache.http.{Consts, HttpEntity, HttpHost, HttpRequest, HttpResponse, NameValuePair}
+import org.apache.http.Consts
+import org.apache.http.HttpEntity
+import org.apache.http.HttpHost
+import org.apache.http.HttpRequest
+import org.apache.http.HttpResponse
+import org.apache.http.NameValuePair
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.entity.UrlEncodedFormEntity
 import org.apache.http.client.methods.*
 import org.apache.http.client.protocol.HttpClientContext
 import org.apache.http.config.SocketConfig
-import org.apache.http.impl.client.{CloseableHttpClient, HttpClients}
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClients
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
 import org.apache.http.message.BasicNameValuePair
 import org.apache.http.util.EntityUtils
-import org.knora.webapi.config.{AppConfig, Sipi}
-import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
-import org.knora.webapi.messages.store.sipimessages.*
-import org.knora.webapi.messages.v2.responder.SuccessResponseV2
-import org.knora.webapi.routing.{Jwt, JwtService}
-import org.knora.webapi.slice.admin.domain.service.Asset
-import org.knora.webapi.store.iiif.api.{FileMetadataSipiResponse, SipiService}
-import org.knora.webapi.store.iiif.errors.SipiException
-import org.knora.webapi.util.{SipiUtil, ZScopedJavaIoStreams}
 import spray.json.*
 import zio.*
 import zio.json.DecoderOps
@@ -32,6 +28,22 @@ import zio.nio.file.Path
 
 import java.net.URI
 import java.util
+
+import dsp.errors.BadRequestException
+import dsp.errors.NotFoundException
+import org.knora.webapi.config.AppConfig
+import org.knora.webapi.config.Sipi
+import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
+import org.knora.webapi.messages.store.sipimessages.*
+import org.knora.webapi.messages.v2.responder.SuccessResponseV2
+import org.knora.webapi.routing.Jwt
+import org.knora.webapi.routing.JwtService
+import org.knora.webapi.slice.admin.domain.service.Asset
+import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
+import org.knora.webapi.store.iiif.api.SipiService
+import org.knora.webapi.store.iiif.errors.SipiException
+import org.knora.webapi.util.SipiUtil
+import org.knora.webapi.util.ZScopedJavaIoStreams
 
 /**
  * Makes requests to Sipi.

--- a/webapi/src/main/scala/org/knora/webapi/store/iiif/impl/SipiServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/iiif/impl/SipiServiceLive.scala
@@ -5,44 +5,33 @@
 
 package org.knora.webapi.store.iiif.impl
 
-import org.apache.http.Consts
-import org.apache.http.HttpEntity
-import org.apache.http.HttpHost
-import org.apache.http.HttpRequest
-import org.apache.http.HttpResponse
-import org.apache.http.NameValuePair
+import dsp.errors.{BadRequestException, NotFoundException}
+import org.apache.http.{Consts, HttpEntity, HttpHost, HttpRequest, HttpResponse, NameValuePair}
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.entity.UrlEncodedFormEntity
 import org.apache.http.client.methods.*
 import org.apache.http.client.protocol.HttpClientContext
 import org.apache.http.config.SocketConfig
-import org.apache.http.impl.client.CloseableHttpClient
-import org.apache.http.impl.client.HttpClients
+import org.apache.http.impl.client.{CloseableHttpClient, HttpClients}
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
 import org.apache.http.message.BasicNameValuePair
 import org.apache.http.util.EntityUtils
+import org.knora.webapi.config.{AppConfig, Sipi}
+import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
+import org.knora.webapi.messages.store.sipimessages.*
+import org.knora.webapi.messages.v2.responder.SuccessResponseV2
+import org.knora.webapi.routing.{Jwt, JwtService}
+import org.knora.webapi.slice.admin.domain.service.Asset
+import org.knora.webapi.store.iiif.api.{FileMetadataSipiResponse, SipiService}
+import org.knora.webapi.store.iiif.errors.SipiException
+import org.knora.webapi.util.{SipiUtil, ZScopedJavaIoStreams}
 import spray.json.*
 import zio.*
+import zio.json.DecoderOps
 import zio.nio.file.Path
 
 import java.net.URI
 import java.util
-
-import dsp.errors.BadRequestException
-import dsp.errors.NotFoundException
-import org.knora.webapi.config.AppConfig
-import org.knora.webapi.config.Sipi
-import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
-import org.knora.webapi.messages.store.sipimessages.*
-import org.knora.webapi.messages.v2.responder.SuccessResponseV2
-import org.knora.webapi.routing.Jwt
-import org.knora.webapi.routing.JwtService
-import org.knora.webapi.slice.admin.domain.service.Asset
-import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
-import org.knora.webapi.store.iiif.api.SipiService
-import org.knora.webapi.store.iiif.errors.SipiException
-import org.knora.webapi.util.SipiUtil
-import org.knora.webapi.util.ZScopedJavaIoStreams
 
 /**
  * Makes requests to Sipi.
@@ -73,7 +62,11 @@ final case class SipiServiceLive(
    */
   override def getFileMetadata(filePath: String): Task[FileMetadataSipiResponse] =
     doSipiRequest(new HttpGet(sipiConfig.internalBaseUrl + filePath + "/knora.json"))
-      .mapAttempt(_.parseJson.convertTo[FileMetadataSipiResponse])
+      .flatMap(bodyStr =>
+        ZIO
+          .fromEither(bodyStr.fromJson[FileMetadataSipiResponse])
+          .mapError(e => SipiException(s"Invalid response from Sipi: $e, $bodyStr"))
+      )
 
   /**
    * Asks Sipi to move a file from temporary storage to permanent storage.


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Spray json is able to parse `42.0` as an `Int`, zio-json is more strict fails, see also https://github.com/zio/zio-json/issues/1049. Hence, we have to add a custom decoder for `Int`.

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [x] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
