### PR TITLE
fix: Invalidate cached project information when adding an ontology to a project (DEV-2926)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -20,6 +20,11 @@ import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectADM
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectGetRequestADM
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectGetResponseADM
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM
+import org.knora.webapi.messages.store.cacheservicemessages.CacheServiceGetProjectADM
 import org.knora.webapi.messages.store.triplestoremessages._
 import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.messages.v2.responder.CanDoResponseV2
@@ -40,11 +45,6 @@ import org.knora.webapi.util.MutableTestIri
 
 import pekko.pattern.ask
 import pekko.testkit.ImplicitSender
-import org.knora.webapi.messages.store.cacheservicemessages.CacheServiceGetProjectADM
-import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM
-import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectADM
-import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectGetRequestADM
-import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectGetResponseADM
 
 /**
  * Tests [[OntologyResponderV2]].
@@ -163,7 +163,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
 
     "invalidate cached project information when adding an ontology to a project" in {
       // ernsure that the project is cached
-      appActor ! ProjectGetRequestADM(ProjectIdentifierADM.IriIdentifier.unsafeFrom(imagesProjectIri.toString)      )
+      appActor ! ProjectGetRequestADM(ProjectIdentifierADM.IriIdentifier.unsafeFrom(imagesProjectIri.toString))
       val projectResponse = expectMsgType[ProjectGetResponseADM](timeout)
       appActor ! CacheServiceGetProjectADM(ProjectIdentifierADM.IriIdentifier.unsafeFrom(imagesProjectIri.toString))
       val cachedProjectBefore = expectMsgType[Option[ProjectADM]](timeout)

--- a/integration/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -40,6 +40,11 @@ import org.knora.webapi.util.MutableTestIri
 
 import pekko.pattern.ask
 import pekko.testkit.ImplicitSender
+import org.knora.webapi.messages.store.cacheservicemessages.CacheServiceGetProjectADM
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectADM
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectGetRequestADM
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectGetResponseADM
 
 /**
  * Tests [[OntologyResponderV2]].
@@ -154,6 +159,28 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
       fooLastModDate = metadata.lastModificationDate.getOrElse(
         throw AssertionException(s"${metadata.ontologyIri} has no last modification date")
       )
+    }
+
+    "invalidate cached project information when adding an ontology to a project" in {
+      // ernsure that the project is cached
+      appActor ! ProjectGetRequestADM(ProjectIdentifierADM.IriIdentifier.unsafeFrom(imagesProjectIri.toString)      )
+      val projectResponse = expectMsgType[ProjectGetResponseADM](timeout)
+      appActor ! CacheServiceGetProjectADM(ProjectIdentifierADM.IriIdentifier.unsafeFrom(imagesProjectIri.toString))
+      val cachedProjectBefore = expectMsgType[Option[ProjectADM]](timeout)
+      assert(cachedProjectBefore.isDefined)
+      // create an ontology
+      appActor ! CreateOntologyRequestV2(
+        ontologyName = "foo-two",
+        projectIri = imagesProjectIri,
+        label = "The foo-two ontology",
+        apiRequestID = UUID.randomUUID,
+        requestingUser = imagesUser
+      )
+      val response = expectMsgType[ReadOntologyMetadataV2](timeout)
+      // ensure that the project is no longer cached
+      appActor ! CacheServiceGetProjectADM(ProjectIdentifierADM.IriIdentifier.unsafeFrom(imagesProjectIri.toString))
+      val cachedProject = expectMsgType[Option[ProjectADM]](timeout)
+      assert(cachedProject.isEmpty)
     }
 
     "change the label in the metadata of 'foo'" in {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -36,15 +36,15 @@ import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.Responder
 import org.knora.webapi.responders.v2.ontology.CardinalityHandler
 import org.knora.webapi.responders.v2.ontology.OntologyHelpers
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectRepo
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache.ONTOLOGY_CACHE_LOCK_IRI
+import org.knora.webapi.store.cache.api.CacheService
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
-import org.knora.webapi.store.cache.api.CacheService
-import org.knora.webapi.slice.admin.domain.model.KnoraProject
 
 /**
  * Responds to requests dealing with ontologies.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -513,7 +513,7 @@ final case class OntologyResponderV2Live(
           )
 
         projectIri <- KnoraProject.ProjectIri.from(createOntologyRequest.projectIri.toString).toZIO
-        _          <- cacheService.invalidateProjectADM(projectIri).ignore
+        _          <- cacheService.invalidateProjectADM(projectIri)
 
       } yield ReadOntologyMetadataV2(ontologies = Set(unescapedNewMetadata))
 

--- a/webapi/src/main/scala/org/knora/webapi/store/cache/api/CacheService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/cache/api/CacheService.scala
@@ -24,7 +24,7 @@ trait CacheService {
   def getUserADM(identifier: UserIdentifierADM): Task[Option[UserADM]]
   def putProjectADM(value: ProjectADM): Task[Unit]
   def getProjectADM(identifier: ProjectIdentifierADM): Task[Option[ProjectADM]]
-  def invalidateProjectADM(identifier: KnoraProject.ProjectIri): IO[Option[Nothing], Unit]
+  def invalidateProjectADM(identifier: KnoraProject.ProjectIri): UIO[Unit]
   def putStringValue(key: String, value: String): Task[Unit]
   def getStringValue(key: String): Task[Option[String]]
   def removeValues(keys: Set[String]): Task[Unit]

--- a/webapi/src/main/scala/org/knora/webapi/store/cache/api/CacheService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/cache/api/CacheService.scala
@@ -13,6 +13,7 @@ import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentif
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.admin.responder.usersmessages.UserIdentifierADM
 import org.knora.webapi.messages.store.cacheservicemessages.CacheServiceStatusResponse
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
 
 /**
  * Cache Service Interface
@@ -23,29 +24,10 @@ trait CacheService {
   def getUserADM(identifier: UserIdentifierADM): Task[Option[UserADM]]
   def putProjectADM(value: ProjectADM): Task[Unit]
   def getProjectADM(identifier: ProjectIdentifierADM): Task[Option[ProjectADM]]
+  def invalidateProjectADM(identifier: KnoraProject.ProjectIri): IO[Option[Nothing], Unit]
   def putStringValue(key: String, value: String): Task[Unit]
   def getStringValue(key: String): Task[Option[String]]
   def removeValues(keys: Set[String]): Task[Unit]
   def flushDB(requestingUser: UserADM): Task[Unit]
   val getStatus: UIO[CacheServiceStatusResponse]
 }
-
-/**
- * Cache Service companion object using [[Accessible]].
- * To use, simply call `Companion(_.someMethod)`, to return a ZIO
- * effect that requires the Service in its environment.
- *
- * Example:
- * {{{
- *   trait CacheService {
- *     def ping(): Task[CacheServiceStatusResponse]
- *   }
- *
- *   object CacheService extends Accessible[CacheService]
- *
- *   val example: ZIO[CacheService, Nothing, Unit] =
- *     for {
- *       _  <- CacheService(_.ping())
- *     } yield ()
- * }}}
- */

--- a/webapi/src/main/scala/org/knora/webapi/store/cache/impl/CacheServiceInMemImpl.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/cache/impl/CacheServiceInMemImpl.scala
@@ -132,18 +132,18 @@ case class CacheServiceInMemImpl(
    * This includes removing the the IRI, Shortcode, and Shortname keys.
    * @param iri the project's IRI.
    */
-  def invalidateProjectADM(iri: ProjectIri): IO[Option[Nothing], Unit] =
+  def invalidateProjectADM(iri: ProjectIri): UIO[Unit] =
     (for {
+      _        <- projects.delete(iri.value)
+      _        <- lut.delete(iri.value)
       project  <- projects.get(iri.value).some
       shortcode = project.shortcode
       shortname = project.shortname
-      _        <- projects.delete(iri.value)
       _        <- projects.delete(shortcode)
       _        <- projects.delete(shortname)
-      _        <- lut.delete(iri.value)
       _        <- lut.delete(shortcode)
       _        <- lut.delete(shortname)
-    } yield ()).commit
+    } yield ()).commit.ignore
 
   /**
    * Retrieves the project by the IRI.

--- a/webapi/src/main/scala/org/knora/webapi/store/cache/impl/CacheServiceInMemImpl.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/cache/impl/CacheServiceInMemImpl.scala
@@ -129,7 +129,7 @@ case class CacheServiceInMemImpl(
 
   /**
    * Invalidates the project stored under the IRI.
-   * This includes removing the the IRI, Shortcode, and Shortname keys.
+   * This includes removing the IRI, Shortcode and Shortname keys.
    * @param iri the project's IRI.
    */
   def invalidateProjectADM(iri: ProjectIri): UIO[Unit] =

--- a/webapi/src/main/scala/org/knora/webapi/store/cache/impl/CacheServiceInMemImpl.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/cache/impl/CacheServiceInMemImpl.scala
@@ -134,13 +134,13 @@ case class CacheServiceInMemImpl(
    */
   def invalidateProjectADM(iri: ProjectIri): UIO[Unit] =
     (for {
-      _        <- projects.delete(iri.value)
-      _        <- lut.delete(iri.value)
       project  <- projects.get(iri.value).some
       shortcode = project.shortcode
       shortname = project.shortname
+      _        <- projects.delete(iri.value)
       _        <- projects.delete(shortcode)
       _        <- projects.delete(shortname)
+      _        <- lut.delete(iri.value)
       _        <- lut.delete(shortcode)
       _        <- lut.delete(shortname)
     } yield ()).commit.ignore

--- a/webapi/src/main/scala/org/knora/webapi/store/cache/impl/CacheServiceInMemImpl.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/cache/impl/CacheServiceInMemImpl.scala
@@ -128,6 +128,24 @@ case class CacheServiceInMemImpl(
     }).tap(_ => ZIO.logDebug(s"Retrieved ProjectADM from Cache: $identifier"))
 
   /**
+   * Invalidates the project stored under the IRI.
+   * This includes removing the the IRI, Shortcode, and Shortname keys.
+   * @param iri the project's IRI.
+   */
+  def invalidateProjectADM(iri: ProjectIri): IO[Option[Nothing], Unit] =
+    (for {
+      project  <- projects.get(iri.value).some
+      shortcode = project.shortcode
+      shortname = project.shortname
+      _        <- projects.delete(iri.value)
+      _        <- projects.delete(shortcode)
+      _        <- projects.delete(shortname)
+      _        <- lut.delete(iri.value)
+      _        <- lut.delete(shortcode)
+      _        <- lut.delete(shortname)
+    } yield ()).commit
+
+  /**
    * Retrieves the project by the IRI.
    *
    * @param iri the project's IRI


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
