### PR TITLE
feat: Add generating OpenApi yamls for the admin api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ dependencies.txt
 # exclude python virtual environments used for serving docs locally
 env/
 venv/
+
+# exclude generated openapi
+docs/03-endpoints/generated-openapi/*.yml
+

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
@@ -49,6 +49,7 @@ import org.knora.webapi.slice.resourceinfo.ResourceInfoLayers
 import org.knora.webapi.slice.resourceinfo.api.service.RestResourceInfoService
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.search.api.SearchApiRoutes
+import org.knora.webapi.slice.search.api.SearchEndpoints
 import org.knora.webapi.store.cache.CacheServiceRequestMessageHandler
 import org.knora.webapi.store.cache.CacheServiceRequestMessageHandlerLive
 import org.knora.webapi.store.cache.api.CacheService
@@ -81,6 +82,8 @@ object LayersTest {
   type CommonR0 = ActorSystem with AppConfigurations with JwtService with SipiService with StringFormatter
   type CommonR =
     ApiRoutes
+      with ApiV2Endpoints
+      with AdminApiEndpoints
       with AppRouter
       with Authenticator
       with AuthorizationRestService
@@ -138,6 +141,8 @@ object LayersTest {
   private val commonLayersForAllIntegrationTests =
     ZLayer.makeSome[CommonR0, CommonR](
       AdminApiRoutes.layer,
+      AdminApiEndpoints.layer,
+      ApiV2Endpoints.layer,
       ApiRoutes.layer,
       AppRouter.layer,
       AuthenticatorLive.layer,
@@ -194,6 +199,7 @@ object LayersTest {
       ResourcesResponderV2Live.layer,
       RestCardinalityServiceLive.layer,
       SearchApiRoutes.layer,
+      SearchEndpoints.layer,
       SearchResponderV2Live.layer,
       SipiResponderADMLive.layer,
       StandoffResponderV2Live.layer,

--- a/justfile
+++ b/justfile
@@ -1,0 +1,12 @@
+openapiDir := "./docs/03-endpoints/generated-openapi"
+
+# List all recipies
+default:
+    @just --list
+
+# Update the OpenApi yml files by generating these from the tAPIr specs
+alias dog := docs-openapi-generate
+docs-openapi-generate:
+    mkdir -p {{openapiDir}}
+    rm {{openapiDir}}/*.yml >> /dev/null 2>&1 || true
+    sbt "webapi/runMain org.knora.webapi.slice.common.api.DocsGenerator {{openapiDir}}"

--- a/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -203,7 +203,7 @@ final case class InstrumentationServerConfig(
 )
 
 object AppConfig {
-  type AppConfigurations = AppConfig & JwtConfig & DspIngestConfig & Triplestore
+  type AppConfigurations = AppConfig & JwtConfig & DspIngestConfig & InstrumentationServerConfig & Triplestore
 
   val descriptor: Config[AppConfig] = deriveConfig[AppConfig].mapKey(toKebabCase)
 
@@ -216,7 +216,10 @@ object AppConfig {
   }
 
   def projectAppConfigurations[R](appConfigLayer: URLayer[R, AppConfig]): URLayer[R, AppConfigurations] =
-    appConfigLayer ++ appConfigLayer.project(_.dspIngest) ++ appConfigLayer.project(_.triplestore) ++
+    appConfigLayer ++
+      appConfigLayer.project(_.dspIngest) ++
+      appConfigLayer.project(_.triplestore) ++
+      appConfigLayer.project(_.instrumentationServerConfig) ++
       appConfigLayer.project { appConfig =>
         val jwtConfig = appConfig.jwt
         val issuerFromConfigOrDefault: Option[String] =

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -10,6 +10,7 @@ import zio.ZLayer
 
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.config.AppConfig.AppConfigurations
+import org.knora.webapi.config.InstrumentationServerConfig
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.*
 import org.knora.webapi.messages.util.search.QueryTraverser
@@ -50,6 +51,7 @@ import org.knora.webapi.slice.resourceinfo.api.service.RestResourceInfoService
 import org.knora.webapi.slice.resourceinfo.api.service.RestResourceInfoServiceLive
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.search.api.SearchApiRoutes
+import org.knora.webapi.slice.search.api.SearchEndpoints
 import org.knora.webapi.store.cache.CacheServiceRequestMessageHandler
 import org.knora.webapi.store.cache.CacheServiceRequestMessageHandlerLive
 import org.knora.webapi.store.cache.api.CacheService
@@ -68,17 +70,18 @@ object LayersLive {
    * The `Environment` that we require to exist at startup.
    */
   type DspEnvironmentLive =
-    ActorSystem & ApiRoutes & AppConfigurations & AppRouter & Authenticator & CacheService &
-      CacheServiceRequestMessageHandler & CardinalityHandler & CardinalityService & ConstructResponseUtilV2 &
-      ConstructTransformer & GravsearchTypeInspectionRunner & GroupsResponderADM & HttpServer &
-      IIIFRequestMessageHandler & InferenceOptimizationService & IriConverter & IriService & JwtService & SipiService &
-      KnoraProjectRepo & ListsResponderADM & ListsResponderV2 & MessageRelay & OntologyCache & OntologyHelpers &
-      OntologyRepo & OntologyResponderV2 & PermissionsResponderADM & PermissionsRestService & PermissionUtilADM & PredicateObjectMapper &
-      ProjectADMRestService & ProjectADMService & ProjectExportService & ProjectExportStorageService &
-      ProjectImportService & ProjectsResponderADM & QueryTraverser & RepositoryUpdater & ResourceUtilV2 &
-      AuthorizationRestService & ResourcesResponderV2 & ResourceUtilV2 & RestCardinalityService & RestResourceInfoService &
-      OntologyInferencer & SearchApiRoutes & SearchResponderV2 & SipiResponderADM & StandoffResponderV2 & StandoffTagUtilV2 & State &
-      StoresResponderADM & StringFormatter & TriplestoreService & UsersResponderADM & ValuesResponderV2
+    ActorSystem & AdminApiEndpoints & ApiRoutes & ApiV2Endpoints & AppConfigurations & AppRouter & Authenticator &
+      AuthorizationRestService & CacheService & CacheServiceRequestMessageHandler & CardinalityHandler &
+      CardinalityService & ConstructResponseUtilV2 & ConstructTransformer & GravsearchTypeInspectionRunner &
+      GroupsResponderADM & HttpServer & IIIFRequestMessageHandler & InferenceOptimizationService &
+      InstrumentationServerConfig & IriConverter & IriService & JwtService & KnoraProjectRepo & ListsResponderADM &
+      ListsResponderV2 & MessageRelay & OntologyCache & OntologyHelpers & OntologyInferencer & OntologyRepo &
+      OntologyResponderV2 & PermissionsResponderADM & PermissionsRestService & PermissionUtilADM &
+      PredicateObjectMapper & ProjectADMRestService & ProjectADMService & ProjectExportService &
+      ProjectExportStorageService & ProjectImportService & ProjectsResponderADM & QueryTraverser & RepositoryUpdater &
+      ResourcesResponderV2 & ResourceUtilV2 & ResourceUtilV2 & RestCardinalityService & RestResourceInfoService &
+      SearchApiRoutes & SearchResponderV2 & SipiResponderADM & SipiService & StandoffResponderV2 & StandoffTagUtilV2 &
+      State & StoresResponderADM & StringFormatter & TriplestoreService & UsersResponderADM & ValuesResponderV2
 
   /**
    * All effect layers needed to provide the `Environment`
@@ -87,6 +90,8 @@ object LayersLive {
     ZLayer.make[DspEnvironmentLive](
       ActorSystem.layer,
       AdminApiRoutes.layer,
+      AdminApiEndpoints.layer,
+      ApiV2Endpoints.layer,
       ApiRoutes.layer,
       AppConfig.layer,
       AppRouter.layer,
@@ -146,6 +151,7 @@ object LayersLive {
       RestCardinalityServiceLive.layer,
       RestResourceInfoServiceLive.layer,
       SearchApiRoutes.layer,
+      SearchEndpoints.layer,
       SearchResponderV2Live.layer,
       SipiResponderADMLive.layer,
       SipiServiceLive.layer,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiEndpoints.scala
@@ -1,0 +1,22 @@
+package org.knora.webapi.slice.admin.api
+
+import sttp.tapir.AnyEndpoint
+import zio.ZLayer
+
+final case class AdminApiEndpoints(
+  maintenanceEndpoints: MaintenanceEndpoints,
+  permissionsEndpoints: PermissionsEndpoints,
+  projectsEndpoints: ProjectsEndpoints,
+  usersEndpoints: UsersEndpoints
+) {
+
+  val endpoints: Seq[AnyEndpoint] =
+    maintenanceEndpoints.endpoints ++
+      permissionsEndpoints.endpoints ++
+      projectsEndpoints.endpoints ++
+      usersEndpoints.endpoints
+}
+
+object AdminApiEndpoints {
+  val layer = ZLayer.derive[AdminApiEndpoints]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiEndpoints.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.admin.api
 
 import sttp.tapir.AnyEndpoint

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/MaintenanceEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/MaintenanceEndpoints.scala
@@ -5,14 +5,13 @@
 
 package org.knora.webapi.slice.admin.api
 
+import org.knora.webapi.slice.common.api.BaseEndpoints
 import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.jsonBody as zioJsonBody
 import zio.ZLayer
 import zio.json.ast.Json
-
-import org.knora.webapi.slice.common.api.BaseEndpoints
 
 final case class MaintenanceEndpoints(baseEndpoints: BaseEndpoints) {
 
@@ -21,21 +20,21 @@ final case class MaintenanceEndpoints(baseEndpoints: BaseEndpoints) {
   val postMaintenance = baseEndpoints.securedEndpoint.post
     .in(
       maintenanceBase / path[String]
-        .name("Maintenance action name")
-        .description("""
-                       |The name of the maintenance action to be executed. 
+        .name("action-name")
+        .description("""The name of the maintenance action to be executed.
                        |Maintenance actions are executed asynchronously in the background.
                        |""".stripMargin)
         .example("fix-top-left-dimensions")
     )
     .in(
       zioJsonBody[Option[Json]]
-        .description("""
-                       |The optional parameters as json for the maintenance action. 
+        .description("""The optional parameters as json for the maintenance action.
                        |May be required by certain actions.
                        |""".stripMargin)
     )
     .out(statusCode(StatusCode.Accepted))
+
+  val endpoints: Seq[AnyEndpoint] = Seq(postMaintenance).map(_.endpoint)
 }
 
 object MaintenanceEndpoints {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/MaintenanceEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/MaintenanceEndpoints.scala
@@ -5,13 +5,14 @@
 
 package org.knora.webapi.slice.admin.api
 
-import org.knora.webapi.slice.common.api.BaseEndpoints
 import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.jsonBody as zioJsonBody
 import zio.ZLayer
 import zio.json.ast.Json
+
+import org.knora.webapi.slice.common.api.BaseEndpoints
 
 final case class MaintenanceEndpoints(baseEndpoints: BaseEndpoints) {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/PermissionsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/PermissionsEndpoints.scala
@@ -94,6 +94,20 @@ final case class PermissionsEndpoints(base: BaseEndpoints) extends PermissionsAD
     .description("Update a permission's property")
     .in(sprayJsonBody[ChangePermissionPropertyApiRequestADM])
     .out(sprayJsonBody[PermissionGetResponseADM])
+
+  val endpoints: Seq[AnyEndpoint] = Seq(
+    postPermissionsAp,
+    getPermissionsApByProjectIri,
+    getPermissionsApByProjectAndGroupIri,
+    getPermissionsDoapByProjectIri,
+    getPermissionsByProjectIri,
+    deletePermission,
+    postPermissionsDoap,
+    putPermissionsProjectIriGroup,
+    putPerrmissionsHasPermissions,
+    putPermisssionsResourceClass,
+    putPermissionsProperty
+  ).map(_.endpoint)
 }
 
 object PermissionsEndpoints {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
@@ -5,25 +5,18 @@
 
 package org.knora.webapi.slice.admin.api
 
+import org.knora.webapi.messages.admin.responder.projectsmessages.*
+import org.knora.webapi.slice.admin.api.AdminPathVariables.{projectIri, projectShortcode, projectShortname}
+import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequests.{ProjectCreateRequest, ProjectSetRestrictedViewSizeRequest, ProjectUpdateRequest}
+import org.knora.webapi.slice.admin.api.model.{ProjectExportInfoResponse, ProjectImportResponse}
+import org.knora.webapi.slice.common.api.BaseEndpoints
 import sttp.capabilities.pekko.PekkoStreams
 import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.spray.jsonBody as sprayJsonBody
 import sttp.tapir.json.zio.jsonBody as zioJsonBody
-import zio.Chunk
-import zio.ZLayer
-
-import org.knora.webapi.messages.admin.responder.projectsmessages.*
-import org.knora.webapi.slice.admin.api.AdminPathVariables.projectIri
-import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortcode
-import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortname
-import org.knora.webapi.slice.admin.api.model.ProjectExportInfoResponse
-import org.knora.webapi.slice.admin.api.model.ProjectImportResponse
-import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequests.ProjectCreateRequest
-import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequests.ProjectSetRestrictedViewSizeRequest
-import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequests.ProjectUpdateRequest
-import org.knora.webapi.slice.common.api.BaseEndpoints
+import zio.{Chunk, ZLayer}
 
 final case class ProjectsEndpoints(
   baseEndpoints: BaseEndpoints
@@ -195,6 +188,35 @@ final case class ProjectsEndpoints(
       .description("Returns all ontologies, data, and configuration belonging to a project identified by the IRI.")
       .tags(tags)
   }
+
+  val endpoints: Seq[AnyEndpoint] =
+    Seq(
+      Public.getAdminProjects,
+      Public.getAdminProjectsByProjectIri,
+      Public.getAdminProjectsByProjectIriRestrictedViewSettings,
+      Public.getAdminProjectsByProjectShortcode,
+      Public.getAdminProjectsByProjectShortcodeRestrictedViewSettings,
+      Public.getAdminProjectsByProjectShortname,
+      Public.getAdminProjectsByProjectShortnameRestrictedViewSettings,
+      Public.getAdminProjectsKeywords,
+      Public.getAdminProjectsKeywordsByProjectIri
+    ) ++ Seq(
+      Secured.deleteAdminProjectsByIri,
+      Secured.getAdminProjectsByIriAllData,
+      Secured.getAdminProjectsByProjectIriAdminMembers,
+      Secured.getAdminProjectsByProjectIriMembers,
+      Secured.getAdminProjectsByProjectShortcodeAdminMembers,
+      Secured.getAdminProjectsByProjectShortcodeMembers,
+      Secured.getAdminProjectsByProjectShortnameAdminMembers,
+      Secured.getAdminProjectsByProjectShortnameMembers,
+      Secured.getAdminProjectsExports,
+      Secured.postAdminProjects,
+      Secured.postAdminProjectsByShortcodeExport,
+      Secured.postAdminProjectsByShortcodeImport,
+      Secured.putAdminProjectsByIri,
+      Secured.setAdminProjectsByProjectIriRestrictedViewSettings,
+      Secured.setAdminProjectsByProjectShortcodeRestrictedViewSettings
+    ).map(_.endpoint)
 }
 
 object ProjectsEndpoints {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
@@ -5,18 +5,25 @@
 
 package org.knora.webapi.slice.admin.api
 
-import org.knora.webapi.messages.admin.responder.projectsmessages.*
-import org.knora.webapi.slice.admin.api.AdminPathVariables.{projectIri, projectShortcode, projectShortname}
-import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequests.{ProjectCreateRequest, ProjectSetRestrictedViewSizeRequest, ProjectUpdateRequest}
-import org.knora.webapi.slice.admin.api.model.{ProjectExportInfoResponse, ProjectImportResponse}
-import org.knora.webapi.slice.common.api.BaseEndpoints
 import sttp.capabilities.pekko.PekkoStreams
 import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.spray.jsonBody as sprayJsonBody
 import sttp.tapir.json.zio.jsonBody as zioJsonBody
-import zio.{Chunk, ZLayer}
+import zio.Chunk
+import zio.ZLayer
+
+import org.knora.webapi.messages.admin.responder.projectsmessages.*
+import org.knora.webapi.slice.admin.api.AdminPathVariables.projectIri
+import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortcode
+import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortname
+import org.knora.webapi.slice.admin.api.model.ProjectExportInfoResponse
+import org.knora.webapi.slice.admin.api.model.ProjectImportResponse
+import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequests.ProjectCreateRequest
+import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequests.ProjectSetRestrictedViewSizeRequest
+import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequests.ProjectUpdateRequest
+import org.knora.webapi.slice.common.api.BaseEndpoints
 
 final case class ProjectsEndpoints(
   baseEndpoints: BaseEndpoints

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/UsersEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/UsersEndpoints.scala
@@ -5,13 +5,14 @@
 
 package org.knora.webapi.slice.admin.api
 
-import org.knora.webapi.messages.admin.responder.usersmessages.UsersADMJsonProtocol.*
-import org.knora.webapi.messages.admin.responder.usersmessages.UsersGetResponseADM
-import org.knora.webapi.slice.common.api.BaseEndpoints
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.spray.jsonBody as sprayJsonBody
 import zio.*
+
+import org.knora.webapi.messages.admin.responder.usersmessages.UsersADMJsonProtocol.*
+import org.knora.webapi.messages.admin.responder.usersmessages.UsersGetResponseADM
+import org.knora.webapi.slice.common.api.BaseEndpoints
 
 final case class UsersEndpoints(baseEndpoints: BaseEndpoints) {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/UsersEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/UsersEndpoints.scala
@@ -5,14 +5,13 @@
 
 package org.knora.webapi.slice.admin.api
 
+import org.knora.webapi.messages.admin.responder.usersmessages.UsersADMJsonProtocol.*
+import org.knora.webapi.messages.admin.responder.usersmessages.UsersGetResponseADM
+import org.knora.webapi.slice.common.api.BaseEndpoints
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.spray.jsonBody as sprayJsonBody
 import zio.*
-
-import org.knora.webapi.messages.admin.responder.usersmessages.UsersADMJsonProtocol.*
-import org.knora.webapi.messages.admin.responder.usersmessages.UsersGetResponseADM
-import org.knora.webapi.slice.common.api.BaseEndpoints
 
 final case class UsersEndpoints(baseEndpoints: BaseEndpoints) {
 
@@ -26,6 +25,7 @@ final case class UsersEndpoints(baseEndpoints: BaseEndpoints) {
     .description("Returns all users.")
     .tags(tags)
 
+  val endpoints: Seq[AnyEndpoint] = Seq(getUsers).map(_.endpoint)
 }
 
 object UsersEndpoints {

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/api/ApiV2Endpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/api/ApiV2Endpoints.scala
@@ -1,17 +1,21 @@
+/*
+ * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.common.api
 
-import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
-import org.knora.webapi.slice.search.api.SearchEndpoints
 import sttp.tapir.AnyEndpoint
 import zio.ZLayer
 
-final case class ApiV2Endpoints(
-  resourceInfoEndpoints: ResourceInfoEndpoints,
-                                 searchEndpoints: SearchEndpoints) {
+import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
+import org.knora.webapi.slice.search.api.SearchEndpoints
+
+final case class ApiV2Endpoints(resourceInfoEndpoints: ResourceInfoEndpoints, searchEndpoints: SearchEndpoints) {
 
   val endpoints: Seq[AnyEndpoint] =
     resourceInfoEndpoints.endpoints ++
-    searchEndpoints.endpoints
+      searchEndpoints.endpoints
 }
 
 object ApiV2Endpoints {

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/api/ApiV2Endpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/api/ApiV2Endpoints.scala
@@ -1,0 +1,19 @@
+package org.knora.webapi.slice.common.api
+
+import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
+import org.knora.webapi.slice.search.api.SearchEndpoints
+import sttp.tapir.AnyEndpoint
+import zio.ZLayer
+
+final case class ApiV2Endpoints(
+  resourceInfoEndpoints: ResourceInfoEndpoints,
+                                 searchEndpoints: SearchEndpoints) {
+
+  val endpoints: Seq[AnyEndpoint] =
+    resourceInfoEndpoints.endpoints ++
+    searchEndpoints.endpoints
+}
+
+object ApiV2Endpoints {
+  val layer = ZLayer.derive[ApiV2Endpoints]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
@@ -1,0 +1,72 @@
+package org.knora.webapi.slice.common.api
+
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.server.RequestContext
+import org.knora.webapi.http.version.BuildInfo
+import org.knora.webapi.messages.admin.responder.usersmessages.UserIdentifierADM
+import org.knora.webapi.messages.v2.routing.authenticationmessages.KnoraCredentialsV2
+import org.knora.webapi.routing.Authenticator
+import org.knora.webapi.slice.admin.api.{AdminApiEndpoints, MaintenanceEndpoints, PermissionsEndpoints, ProjectsEndpoints, UsersEndpoints}
+import org.knora.webapi.slice.admin.domain.model.User
+import sttp.apispec.openapi.Server
+import sttp.apispec.openapi.circe.yaml.RichOpenAPI
+import sttp.tapir.AnyEndpoint
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
+import zio.nio.file.{Files, Path}
+import zio.{Chunk, Task, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
+
+final case class DocsNoopAuthenticator() extends Authenticator {
+  override def getUserADM(requestContext: RequestContext): Task[User]                                    = ???
+  override def calculateCookieName(): String                                                             = "foo"
+  override def getUserADMThroughCredentialsV2(credentials: Option[KnoraCredentialsV2]): Task[User]       = ???
+  override def doLogoutV2(requestContext: RequestContext): Task[HttpResponse]                            = ???
+  override def doLoginV2(credentials: KnoraCredentialsV2.KnoraPasswordCredentialsV2): Task[HttpResponse] = ???
+  override def doAuthenticateV2(requestContext: RequestContext): Task[HttpResponse]                      = ???
+  override def presentLoginFormV2(requestContext: RequestContext): Task[HttpResponse]                    = ???
+  override def authenticateCredentialsV2(credentials: Option[KnoraCredentialsV2]): Task[Boolean]         = ???
+  override def getUserByIdentifier(identifier: UserIdentifierADM): Task[User]                            = ???
+}
+object DocsNoopAuthenticator {
+  val layer = ZLayer.succeed(DocsNoopAuthenticator())
+}
+
+object DocsGenerator extends ZIOAppDefault {
+
+  private val interp: OpenAPIDocsInterpreter = OpenAPIDocsInterpreter()
+  override def run: ZIO[ZIOAppArgs, java.io.IOException, Int] = {
+    for {
+      _              <- ZIO.logInfo("Generating OpenAPI docs")
+      args           <- getArgs
+      adminEndpoints <- ZIO.serviceWith[AdminApiEndpoints](_.endpoints)
+      path            = Path(args.headOption.getOrElse("/tmp"))
+      fileWritten    <- writeToFile(adminEndpoints, path, "maintenance")
+      _              <- ZIO.logInfo(s"Wrote to $fileWritten")
+    } yield 0
+  }.provideSome[ZIOAppArgs](
+    AdminApiEndpoints.layer,
+    BaseEndpoints.layer,
+    DocsNoopAuthenticator.layer,
+    MaintenanceEndpoints.layer,
+    PermissionsEndpoints.layer,
+    ProjectsEndpoints.layer,
+    UsersEndpoints.layer
+    //        ZLayer.Debug.mermaid ,
+  )
+
+  private def writeToFile(endpoints: Seq[AnyEndpoint], path: Path, name: String) = {
+    val content = interp
+      .toOpenAPI(endpoints, s"${BuildInfo.name}-$name", BuildInfo.version)
+      .servers(
+        List(
+          Server(url = "http://localhost:3333", description = Some("Local development server")),
+          Server(url = "https://api.dasch.swiss", description = Some("Production server"))
+        )
+      )
+    for {
+      _     <- ZIO.logInfo(s"Writing to $path")
+      target = path / s"openapi-$name.yml"
+      _     <- Files.deleteIfExists(target) *> Files.createFile(target)
+      _     <- Files.writeBytes(target, Chunk.fromArray(content.toYaml.getBytes))
+    } yield target
+  }
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
@@ -1,34 +1,28 @@
+/*
+ * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.common.api
 
 import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.http.scaladsl.server.RequestContext
-import sttp.apispec.openapi.Server
-import sttp.apispec.openapi.circe.yaml.RichOpenAPI
-import sttp.tapir.AnyEndpoint
-import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
-import zio.Chunk
-import zio.Task
-import zio.ZIO
-import zio.ZIOAppArgs
-import zio.ZIOAppDefault
-import zio.ZLayer
-import zio.nio.file.Files
-import zio.nio.file.Path
-
 import org.knora.webapi.http.version.BuildInfo
 import org.knora.webapi.messages.admin.responder.usersmessages.UserIdentifierADM
 import org.knora.webapi.messages.v2.routing.authenticationmessages.KnoraCredentialsV2
 import org.knora.webapi.routing.Authenticator
-import org.knora.webapi.slice.admin.api.AdminApiEndpoints
-import org.knora.webapi.slice.admin.api.MaintenanceEndpoints
-import org.knora.webapi.slice.admin.api.PermissionsEndpoints
-import org.knora.webapi.slice.admin.api.ProjectsEndpoints
-import org.knora.webapi.slice.admin.api.UsersEndpoints
+import org.knora.webapi.slice.admin.api.{AdminApiEndpoints, MaintenanceEndpoints, PermissionsEndpoints, ProjectsEndpoints, UsersEndpoints}
 import org.knora.webapi.slice.admin.domain.model.User
+import sttp.apispec.openapi.Server
+import sttp.apispec.openapi.circe.yaml.RichOpenAPI
+import sttp.tapir.AnyEndpoint
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
+import zio.{Chunk, Task, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
+import zio.nio.file.{Files, Path}
 
 final case class DocsNoopAuthenticator() extends Authenticator {
   override def getUserADM(requestContext: RequestContext): Task[User]                                    = ???
-  override def calculateCookieName(): String                                                             = "foo"
+  override def calculateCookieName(): String                                                             = "KnoraAuthenticationMFYGSLTEMFZWG2BOON3WS43THI2DIMY9"
   override def getUserADMThroughCredentialsV2(credentials: Option[KnoraCredentialsV2]): Task[User]       = ???
   override def doLogoutV2(requestContext: RequestContext): Task[HttpResponse]                            = ???
   override def doLoginV2(credentials: KnoraCredentialsV2.KnoraPasswordCredentialsV2): Task[HttpResponse] = ???

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
@@ -7,20 +7,31 @@ package org.knora.webapi.slice.common.api
 
 import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.http.scaladsl.server.RequestContext
-import org.knora.webapi.http.version.BuildInfo
-import org.knora.webapi.messages.admin.responder.usersmessages.UserIdentifierADM
-import org.knora.webapi.messages.v2.routing.authenticationmessages.KnoraCredentialsV2
-import org.knora.webapi.routing.Authenticator
-import org.knora.webapi.slice.admin.api.{AdminApiEndpoints, MaintenanceEndpoints, PermissionsEndpoints, ProjectsEndpoints, UsersEndpoints}
-import org.knora.webapi.slice.admin.domain.model.User
-import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
-import org.knora.webapi.slice.search.api.SearchEndpoints
 import sttp.apispec.openapi.Server
 import sttp.apispec.openapi.circe.yaml.RichOpenAPI
 import sttp.tapir.AnyEndpoint
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
-import zio.nio.file.{Files, Path}
-import zio.{Chunk, Task, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
+import zio.Chunk
+import zio.Task
+import zio.ZIO
+import zio.ZIOAppArgs
+import zio.ZIOAppDefault
+import zio.ZLayer
+import zio.nio.file.Files
+import zio.nio.file.Path
+
+import org.knora.webapi.http.version.BuildInfo
+import org.knora.webapi.messages.admin.responder.usersmessages.UserIdentifierADM
+import org.knora.webapi.messages.v2.routing.authenticationmessages.KnoraCredentialsV2
+import org.knora.webapi.routing.Authenticator
+import org.knora.webapi.slice.admin.api.AdminApiEndpoints
+import org.knora.webapi.slice.admin.api.MaintenanceEndpoints
+import org.knora.webapi.slice.admin.api.PermissionsEndpoints
+import org.knora.webapi.slice.admin.api.ProjectsEndpoints
+import org.knora.webapi.slice.admin.api.UsersEndpoints
+import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
+import org.knora.webapi.slice.search.api.SearchEndpoints
 
 final case class DocsNoopAuthenticator() extends Authenticator {
   override def getUserADM(requestContext: RequestContext): Task[User]                                    = ???

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
@@ -2,18 +2,29 @@ package org.knora.webapi.slice.common.api
 
 import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.http.scaladsl.server.RequestContext
-import org.knora.webapi.http.version.BuildInfo
-import org.knora.webapi.messages.admin.responder.usersmessages.UserIdentifierADM
-import org.knora.webapi.messages.v2.routing.authenticationmessages.KnoraCredentialsV2
-import org.knora.webapi.routing.Authenticator
-import org.knora.webapi.slice.admin.api.{AdminApiEndpoints, MaintenanceEndpoints, PermissionsEndpoints, ProjectsEndpoints, UsersEndpoints}
-import org.knora.webapi.slice.admin.domain.model.User
 import sttp.apispec.openapi.Server
 import sttp.apispec.openapi.circe.yaml.RichOpenAPI
 import sttp.tapir.AnyEndpoint
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
-import zio.nio.file.{Files, Path}
-import zio.{Chunk, Task, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
+import zio.Chunk
+import zio.Task
+import zio.ZIO
+import zio.ZIOAppArgs
+import zio.ZIOAppDefault
+import zio.ZLayer
+import zio.nio.file.Files
+import zio.nio.file.Path
+
+import org.knora.webapi.http.version.BuildInfo
+import org.knora.webapi.messages.admin.responder.usersmessages.UserIdentifierADM
+import org.knora.webapi.messages.v2.routing.authenticationmessages.KnoraCredentialsV2
+import org.knora.webapi.routing.Authenticator
+import org.knora.webapi.slice.admin.api.AdminApiEndpoints
+import org.knora.webapi.slice.admin.api.MaintenanceEndpoints
+import org.knora.webapi.slice.admin.api.PermissionsEndpoints
+import org.knora.webapi.slice.admin.api.ProjectsEndpoints
+import org.knora.webapi.slice.admin.api.UsersEndpoints
+import org.knora.webapi.slice.admin.domain.model.User
 
 final case class DocsNoopAuthenticator() extends Authenticator {
   override def getUserADM(requestContext: RequestContext): Task[User]                                    = ???

--- a/webapi/src/main/scala/org/knora/webapi/slice/infrastructure/MetricsServer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/infrastructure/MetricsServer.scala
@@ -5,35 +5,61 @@
 
 package org.knora.webapi.slice.infrastructure
 
+import sttp.tapir.server.ziohttp.ZioHttpInterpreter
+import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import zio.*
 import zio.http.*
 import zio.metrics.connectors.MetricsConfig
 import zio.metrics.connectors.prometheus
 import zio.metrics.jvm.DefaultJvmMetrics
 
-import org.knora.webapi.config.AppConfig
+import org.knora.webapi.config.InstrumentationServerConfig
 import org.knora.webapi.core.State
+import org.knora.webapi.slice.admin.api.AdminApiEndpoints
+import org.knora.webapi.slice.common.api.ApiV2Endpoints
 import org.knora.webapi.slice.infrastructure.api.PrometheusApp
 
 object MetricsServer {
 
-  private val metricsServer = ZIO.serviceWithZIO[PrometheusApp](app => Server.install(app.route)) *> ZIO.never
+  private val metricsServer: ZIO[Server & PrometheusApp & AdminApiEndpoints & ApiV2Endpoints, Nothing, Unit] = for {
+    docs       <- DocsServer.docsEndpoints.map(endpoints => ZioHttpInterpreter().toHttp(endpoints))
+    prometheus <- ZIO.service[PrometheusApp]
+    _          <- Server.install(prometheus.route ++ docs)
+    _          <- ZIO.never
+  } yield ()
 
-  val make: ZIO[State & AppConfig, Throwable, Unit] =
-    ZIO.serviceWithZIO[AppConfig] { config =>
-      val port          = config.instrumentationServerConfig.port
-      val interval      = config.instrumentationServerConfig.interval
-      val metricsConfig = MetricsConfig(interval)
-      ZIO.logInfo(s"Starting instrumentation http server on http://localhost:$port") *>
-        metricsServer
-          .provideSome[State](
-            Server.defaultWithPort(port),
-            prometheus.publisherLayer,
-            ZLayer.succeed(metricsConfig) >>> prometheus.prometheusLayer,
-            Runtime.enableRuntimeMetrics,
-            Runtime.enableFiberRoots,
-            DefaultJvmMetrics.live.unit,
-            PrometheusApp.layer
-          )
-    }
+  val make: ZIO[State & InstrumentationServerConfig & ApiV2Endpoints & AdminApiEndpoints, Throwable, Unit] =
+    for {
+      apiV2Endpoints    <- ZIO.service[ApiV2Endpoints]
+      adminApiEndpoints <- ZIO.service[AdminApiEndpoints]
+      config            <- ZIO.service[InstrumentationServerConfig]
+      port               = config.port
+      interval           = config.interval
+      metricsConfig      = MetricsConfig(interval)
+      _ <- ZIO.logInfo(
+             s"Starting instrumentation http server on http://localhost:$port, find docs on http://localhost:$port/docs"
+           )
+      _ <- metricsServer
+             .provideSome[State](
+               ZLayer.succeed(adminApiEndpoints),
+               ZLayer.succeed(apiV2Endpoints),
+               Server.defaultWithPort(port),
+               prometheus.publisherLayer,
+               ZLayer.succeed(metricsConfig) >>> prometheus.prometheusLayer,
+               Runtime.enableRuntimeMetrics,
+               Runtime.enableFiberRoots,
+               DefaultJvmMetrics.live.unit,
+               PrometheusApp.layer
+             )
+    } yield ()
+}
+
+object DocsServer {
+
+  val docsEndpoints =
+    for {
+      apiV2       <- ZIO.serviceWith[ApiV2Endpoints](_.endpoints)
+      admin       <- ZIO.serviceWith[AdminApiEndpoints](_.endpoints)
+      allEndpoints = (apiV2 ++ admin).toList
+    } yield SwaggerInterpreter().fromEndpoints[Task](allEndpoints, BuildInfo.name, BuildInfo.version)
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/resourceinfo/api/ResourceInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resourceinfo/api/ResourceInfoEndpoints.scala
@@ -5,14 +5,17 @@
 
 package org.knora.webapi.slice.resourceinfo.api
 
-import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM.IriIdentifier
-import org.knora.webapi.slice.common.api.{ApiV2, BaseEndpoints}
-import org.knora.webapi.slice.resourceinfo.api.model.ListResponseDto
-import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.{Order, OrderBy}
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.*
 import zio.ZLayer
+
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM.IriIdentifier
+import org.knora.webapi.slice.common.api.ApiV2
+import org.knora.webapi.slice.common.api.BaseEndpoints
+import org.knora.webapi.slice.resourceinfo.api.model.ListResponseDto
+import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.Order
+import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.OrderBy
 
 final case class ResourceInfoEndpoints(baseEndpoints: BaseEndpoints) {
   val getResourcesInfo = baseEndpoints.publicEndpoint.get

--- a/webapi/src/main/scala/org/knora/webapi/slice/resourceinfo/api/ResourceInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resourceinfo/api/ResourceInfoEndpoints.scala
@@ -5,17 +5,14 @@
 
 package org.knora.webapi.slice.resourceinfo.api
 
+import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM.IriIdentifier
+import org.knora.webapi.slice.common.api.{ApiV2, BaseEndpoints}
+import org.knora.webapi.slice.resourceinfo.api.model.ListResponseDto
+import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.{Order, OrderBy}
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.*
 import zio.ZLayer
-
-import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectIdentifierADM.IriIdentifier
-import org.knora.webapi.slice.common.api.ApiV2
-import org.knora.webapi.slice.common.api.BaseEndpoints
-import org.knora.webapi.slice.resourceinfo.api.model.ListResponseDto
-import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.Order
-import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.OrderBy
 
 final case class ResourceInfoEndpoints(baseEndpoints: BaseEndpoints) {
   val getResourcesInfo = baseEndpoints.publicEndpoint.get
@@ -25,6 +22,9 @@ final case class ResourceInfoEndpoints(baseEndpoints: BaseEndpoints) {
     .in(query[Option[Order]](Order.queryParamKey))
     .in(query[Option[OrderBy]](OrderBy.queryParamKey))
     .out(jsonBody[ListResponseDto])
+
+  val endpoints: Seq[AnyEndpoint] =
+    Seq(getResourcesInfo)
 }
 
 object ResourceInfoEndpoints {

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/api/SearchEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/api/SearchEndpoints.scala
@@ -5,21 +5,33 @@
 
 package org.knora.webapi.slice.search.api
 
-import dsp.valueobjects.Iri
-import eu.timepit.refined.api.{Refined, RefinedTypeOps}
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.api.RefinedTypeOps
 import eu.timepit.refined.numeric.Greater
 import org.apache.pekko.http.scaladsl.server.Route
+import sttp.model.HeaderNames
+import sttp.model.MediaType
+import sttp.tapir.*
+import sttp.tapir.codec.refined.*
+import zio.Task
+import zio.ZIO
+import zio.ZLayer
+
+import dsp.valueobjects.Iri
 import org.knora.webapi.responders.v2.SearchResponderV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.User
-import org.knora.webapi.slice.common.api.KnoraResponseRenderer.{FormatOptions, RenderedResponse}
-import org.knora.webapi.slice.common.api.{ApiV2, BaseEndpoints, HandlerMapper, KnoraResponseRenderer, SecuredEndpointAndZioHandler, TapirToPekkoInterpreter}
+import org.knora.webapi.slice.common.api.ApiV2
+import org.knora.webapi.slice.common.api.BaseEndpoints
+import org.knora.webapi.slice.common.api.HandlerMapper
+import org.knora.webapi.slice.common.api.KnoraResponseRenderer
+import org.knora.webapi.slice.common.api.KnoraResponseRenderer.FormatOptions
+import org.knora.webapi.slice.common.api.KnoraResponseRenderer.RenderedResponse
+import org.knora.webapi.slice.common.api.SecuredEndpointAndZioHandler
+import org.knora.webapi.slice.common.api.TapirToPekkoInterpreter
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-import org.knora.webapi.slice.search.api.SearchEndpointsInputs.{InputIri, Offset}
-import sttp.model.{HeaderNames, MediaType}
-import sttp.tapir.*
-import sttp.tapir.codec.refined.*
-import zio.{Task, ZIO, ZLayer}
+import org.knora.webapi.slice.search.api.SearchEndpointsInputs.InputIri
+import org.knora.webapi.slice.search.api.SearchEndpointsInputs.Offset
 
 object SearchEndpointsInputs {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/api/SearchEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/api/SearchEndpoints.scala
@@ -5,33 +5,21 @@
 
 package org.knora.webapi.slice.search.api
 
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.api.RefinedTypeOps
+import dsp.valueobjects.Iri
+import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.numeric.Greater
 import org.apache.pekko.http.scaladsl.server.Route
-import sttp.model.HeaderNames
-import sttp.model.MediaType
-import sttp.tapir.*
-import sttp.tapir.codec.refined.*
-import zio.Task
-import zio.ZIO
-import zio.ZLayer
-
-import dsp.valueobjects.Iri
 import org.knora.webapi.responders.v2.SearchResponderV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.User
-import org.knora.webapi.slice.common.api.ApiV2
-import org.knora.webapi.slice.common.api.BaseEndpoints
-import org.knora.webapi.slice.common.api.HandlerMapper
-import org.knora.webapi.slice.common.api.KnoraResponseRenderer
-import org.knora.webapi.slice.common.api.KnoraResponseRenderer.FormatOptions
-import org.knora.webapi.slice.common.api.KnoraResponseRenderer.RenderedResponse
-import org.knora.webapi.slice.common.api.SecuredEndpointAndZioHandler
-import org.knora.webapi.slice.common.api.TapirToPekkoInterpreter
+import org.knora.webapi.slice.common.api.KnoraResponseRenderer.{FormatOptions, RenderedResponse}
+import org.knora.webapi.slice.common.api.{ApiV2, BaseEndpoints, HandlerMapper, KnoraResponseRenderer, SecuredEndpointAndZioHandler, TapirToPekkoInterpreter}
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-import org.knora.webapi.slice.search.api.SearchEndpointsInputs.InputIri
-import org.knora.webapi.slice.search.api.SearchEndpointsInputs.Offset
+import org.knora.webapi.slice.search.api.SearchEndpointsInputs.{InputIri, Offset}
+import sttp.model.{HeaderNames, MediaType}
+import sttp.tapir.*
+import sttp.tapir.codec.refined.*
+import zio.{Task, ZIO, ZLayer}
 
 object SearchEndpointsInputs {
 
@@ -154,6 +142,18 @@ final case class SearchEndpoints(baseEndpoints: BaseEndpoints) {
     .out(header[MediaType](HeaderNames.ContentType))
     .tags(tags)
     .description("Search for resources by label.")
+
+  val endpoints: Seq[AnyEndpoint] =
+    Seq(
+      postGravsearch,
+      getGravsearch,
+      postGravsearchCount,
+      getGravsearchCount,
+      getSearchByLabel,
+      getSearchByLabelCount,
+      getFullTextSearch,
+      getFullTextSearchCount
+    ).map(_.endpoint)
 }
 
 object SearchEndpoints {


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

For now the open api documentation is only generated on demand by calling `just dog`.

This should enable @BalduinLandolt  and @mpro7 to integrate their newly migrated endpoints, so that in future we are able to:
1. Integrate all endpoints in the api
2. Create a new /docs endpoint in the dsp-api akin to the dsp-ingest


### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [x] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
