### PR TITLE
fix: Fix UserIri and allow existing values (DEV-3194)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
@@ -33,7 +33,7 @@ import org.knora.webapi.slice.admin.api.service.MaintenanceRestService
 import org.knora.webapi.slice.admin.api.service.PermissionsRestService
 import org.knora.webapi.slice.admin.api.service.ProjectADMRestService
 import org.knora.webapi.slice.admin.api.service.ProjectsADMRestServiceLive
-import org.knora.webapi.slice.admin.api.service.UsersADMRestServiceLive
+import org.knora.webapi.slice.admin.api.service.UsersRestService
 import org.knora.webapi.slice.admin.domain.service.*
 import org.knora.webapi.slice.admin.repo.service.KnoraProjectRepoLive
 import org.knora.webapi.slice.common.api.*
@@ -217,7 +217,7 @@ object LayersTest {
       TapirToPekkoInterpreter.layer,
       TestClientService.layer,
       TriplestoreServiceLive.layer,
-      UsersADMRestServiceLive.layer,
+      UsersRestService.layer,
       UsersEndpoints.layer,
       UsersEndpointsHandler.layer,
       UsersResponderADMLive.layer,

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -34,7 +34,7 @@ import org.knora.webapi.slice.admin.api.service.MaintenanceRestService
 import org.knora.webapi.slice.admin.api.service.PermissionsRestService
 import org.knora.webapi.slice.admin.api.service.ProjectADMRestService
 import org.knora.webapi.slice.admin.api.service.ProjectsADMRestServiceLive
-import org.knora.webapi.slice.admin.api.service.UsersADMRestServiceLive
+import org.knora.webapi.slice.admin.api.service.UsersRestService
 import org.knora.webapi.slice.admin.domain.service.*
 import org.knora.webapi.slice.admin.repo.service.KnoraProjectRepoLive
 import org.knora.webapi.slice.common.api.*
@@ -166,7 +166,7 @@ object LayersLive {
       StringFormatter.live,
       TapirToPekkoInterpreter.layer,
       TriplestoreServiceLive.layer,
-      UsersADMRestServiceLive.layer,
+      UsersRestService.layer,
       UsersEndpoints.layer,
       UsersEndpointsHandler.layer,
       UsersResponderADMLive.layer,

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
@@ -474,7 +474,7 @@ case class UserGroupMembershipsGetResponseADM(groups: Seq[GroupADM]) extends Kno
  *
  * @param user the new user profile of the created/modified user.
  */
-case class UserOperationResponseADM(user: User) extends KnoraResponseADM {
+case class UserOperationResponseADM(user: User) extends AdminKnoraResponseADM {
   def toJsValue: JsValue = UsersADMJsonProtocol.userOperationResponseADMFormat.write(this)
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
@@ -57,6 +57,24 @@ import org.knora.webapi.util.ZioHelper
 @accessible
 trait UsersResponderADM {
   def getAllUserADMRequest(requestingUser: User): Task[UsersGetResponseADM]
+
+  /**
+   * Change the user's status (active / inactive).
+   *
+   * @param userIri        the IRI of the existing user that we want to update.
+   * @param status         the new status.
+   * @param requestingUser the requesting user.
+   * @param apiRequestID   the unique api request ID.
+   * @return a task containing a [[UserOperationResponseADM]].
+   *         fails with a [[BadRequestException]] if necessary parameters are not supplied.
+   *         fails with a [[ForbiddenException]] if the requestingUser doesn't hold the necessary permission for the operation.
+   */
+  def changeUserStatusADM(
+    userIri: IRI,
+    status: UserStatus,
+    requestingUser: User,
+    apiRequestID: UUID
+  ): Task[UserOperationResponseADM]
 }
 
 final case class UsersResponderADMLive(
@@ -601,19 +619,7 @@ final case class UsersResponderADMLive(
     )
   }
 
-  /**
-   * Change the user's status (active / inactive).
-   *
-   * @param userIri              the IRI of the existing user that we want to update.
-   * @param status               the new status.
-   *
-   * @param requestingUser       the requesting user.
-   * @param apiRequestID         the unique api request ID.
-   * @return a future containing a [[UserOperationResponseADM]].
-   *         fails with a [[BadRequestException]] if necessary parameters are not supplied.
-   *         fails with a [[ForbiddenException]] if the user doesn't hold the necessary permission for the operation.
-   */
-  private def changeUserStatusADM(
+  override def changeUserStatusADM(
     userIri: IRI,
     status: UserStatus,
     requestingUser: User,

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
@@ -41,7 +41,6 @@ final case class UsersRouteADM()(
       changeUserBasicInformation() ~
       changeUserPassword() ~
       changeUserStatus() ~
-      deleteUser() ~
       changeUserSystemAdminMembership() ~
       getUsersProjectMemberships() ~
       addUserToProjectMembership() ~
@@ -164,19 +163,6 @@ final case class UsersRouteADM()(
         }
       }
     }
-
-  /**
-   * delete a user identified by iri (change status to false).
-   */
-  private def deleteUser(): Route = path(usersBasePath / "iri" / Segment) { userIri =>
-    delete { requestContext =>
-      val task = for {
-        checkedUserIri <- validateAndEscapeUserIri(userIri)
-        r              <- getUserUuid(requestContext)
-      } yield UserChangeStatusRequestADM(checkedUserIri, UserStatus.from(false), r.user, r.uuid)
-      runJsonRouteZ(task, requestContext)
-    }
-  }
 
   /**
    * Change user's SystemAdmin membership.

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Codecs.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Codecs.scala
@@ -12,6 +12,7 @@ import zio.json.JsonCodec
 import dsp.valueobjects.V2
 import org.knora.webapi.slice.admin.api.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
+import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.Value.BooleanValue
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.SparqlEncodedString
@@ -40,6 +41,7 @@ object Codecs {
     implicit val shortname: StringCodec[Shortname]                     = stringCodec(Shortname.from)
     implicit val sparqlEncodedString: StringCodec[SparqlEncodedString] = stringCodec(SparqlEncodedString.from)
     implicit val status: StringCodec[Status]                           = booleanCodec(Status.from)
+    implicit val userIri: StringCodec[UserIri]                         = stringCodec(UserIri.from)
   }
 
   object ZioJsonCodec {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/UsersEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/UsersEndpoints.scala
@@ -34,7 +34,7 @@ final case class UsersEndpoints(baseEndpoints: BaseEndpoints) {
   val deleteUser = baseEndpoints.securedEndpoint.delete
     .in(base / "iri" / PathVars.userIriPathVar)
     .out(sprayJsonBody[UserOperationResponseADM])
-    .description("Delete a user identified by iri (change status to false).")
+    .description("Delete a user identified by IRI (change status to false).")
     .tags(tags)
 
   val endpoints: Seq[AnyEndpoint] = Seq(getUsers, deleteUser).map(_.endpoint)

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/UsersEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/UsersEndpointsHandler.scala
@@ -9,14 +9,14 @@ import zio.ZLayer
 
 import org.knora.webapi.messages.admin.responder.usersmessages.UserOperationResponseADM
 import org.knora.webapi.messages.admin.responder.usersmessages.UsersGetResponseADM
-import org.knora.webapi.slice.admin.api.service.UsersADMRestService
+import org.knora.webapi.slice.admin.api.service.UsersRestService
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.api.HandlerMapper
 import org.knora.webapi.slice.common.api.SecuredEndpointAndZioHandler
 
 case class UsersEndpointsHandler(
   usersEndpoints: UsersEndpoints,
-  restService: UsersADMRestService,
+  restService: UsersRestService,
   mapper: HandlerMapper
 ) {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/UsersADMRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/UsersADMRestService.scala
@@ -8,15 +8,21 @@ package org.knora.webapi.slice.admin.api.service
 import zio.*
 import zio.macros.accessible
 
+import dsp.errors.BadRequestException
+import org.knora.webapi.messages.admin.responder.usersmessages.UserOperationResponseADM
 import org.knora.webapi.messages.admin.responder.usersmessages.UsersGetResponseADM
 import org.knora.webapi.responders.admin.UsersResponderADM
 import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.admin.domain.model.UserIri
+import org.knora.webapi.slice.admin.domain.model.UserStatus
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer
 
 @accessible
 trait UsersADMRestService {
 
   def listAllUsers(user: User): Task[UsersGetResponseADM]
+
+  def deleteUser(user: User, userIri: UserIri): Task[UserOperationResponseADM]
 }
 
 final case class UsersADMRestServiceLive(
@@ -28,6 +34,14 @@ final case class UsersADMRestServiceLive(
     internal <- responder.getAllUserADMRequest(user)
     external <- format.toExternal(internal)
   } yield external
+
+  override def deleteUser(requestingUser: User, deleteIri: UserIri): Task[UserOperationResponseADM] = for {
+    _ <- ZIO
+           .fail(BadRequestException("Changes to built-in users are not allowed."))
+           .when(deleteIri.isBuiltInUser)
+    uuid     <- Random.nextUUID
+    response <- responder.changeUserStatusADM(deleteIri.value, UserStatus.Inactive, requestingUser, uuid)
+  } yield response
 }
 
 object UsersADMRestServiceLive {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
@@ -154,7 +154,7 @@ object UserIri extends StringValueCompanion[UserIri] {
    *
    * `http://rdfh\.ch/users/`: Matches the specified prefix.
    *
-   * `[a-zA-Z0-9_-]{4,36}`: Matches any alphanumeric character, hyphen, or underscore between 1 and 36 times.
+   * `[a-zA-Z0-9_-]{4,36}`: Matches any alphanumeric character, hyphen, or underscore between 4 and 36 times.
    *
    * `$`: Asserts the end of the string.
    */

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
@@ -142,7 +142,7 @@ final case class UserIri private (value: String) extends AnyVal with StringValue
 object UserIri extends StringValueCompanion[UserIri] {
 
   implicit class UserIriOps(val userIri: UserIri) {
-    def isBuiltInUser: Boolean = builtInIris.contains(Iri.fromSparqlEncodedString(userIri.value))
+    def isBuiltInUser: Boolean = builtInIris.contains(userIri.value)
     def isRegularUser: Boolean = !isBuiltInUser
   }
 
@@ -174,7 +174,7 @@ object UserIri extends StringValueCompanion[UserIri] {
 
   def from(value: String): Either[String, UserIri] = value match {
     case _ if value.isEmpty  => Left("User IRI cannot be empty.")
-    case _ if isValid(value) => Iri.toSparqlEncodedString(value).map(UserIri.apply).toRight(isInvalid)
+    case _ if isValid(value) => Right(UserIri(value))
     case _                   => Left(isInvalid)
   }
   def validationFrom(value: String): Validation[String, UserIri] = Validation.fromEither(from(value))

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
@@ -23,6 +23,7 @@ import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectADM
 import org.knora.webapi.messages.admin.responder.usersmessages.UserInformationTypeADM
 import org.knora.webapi.messages.admin.responder.usersmessages.UsersADMJsonProtocol
 import org.knora.webapi.slice.common.StringValueCompanion
+import org.knora.webapi.slice.common.Value.BooleanValue
 import org.knora.webapi.slice.common.Value.StringValue
 
 /**
@@ -325,10 +326,14 @@ object PasswordStrength {
 
 }
 
-final case class UserStatus private (value: Boolean) extends AnyVal
-object UserStatus {
-  def from(value: Boolean): UserStatus = UserStatus(value)
+final case class UserStatus private (value: Boolean) extends AnyVal with BooleanValue
 
+object UserStatus {
+
+  val Active: UserStatus   = UserStatus(true)
+  val Inactive: UserStatus = UserStatus(false)
+
+  def from(value: Boolean): UserStatus = if (value) Active else Inactive
 }
 
 final case class SystemAdmin private (value: Boolean) extends AnyVal

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
@@ -165,14 +165,16 @@ object UserIri extends StringValueCompanion[UserIri] {
     OntologyConstants.KnoraAdmin.AnonymousUser,
     OntologyConstants.KnoraAdmin.SystemAdmin
   )
+
   private def isValid(iri: String) =
     builtInIris.contains(iri) || (Iri.isIri(iri) && userIriRegEx.matches(iri))
 
   private val isInvalid = "User IRI is invalid."
+
   def from(value: String): Either[String, UserIri] = value match {
-    case _ if value.isEmpty    => Left("User IRI cannot be empty.")
+    case _ if value.isEmpty  => Left("User IRI cannot be empty.")
     case _ if isValid(value) => Iri.toSparqlEncodedString(value).map(UserIri.apply).toRight(isInvalid)
-    case _                     => Left(isInvalid)
+    case _                   => Left(isInvalid)
   }
   def validationFrom(value: String): Validation[String, UserIri] = Validation.fromEither(from(value))
 }


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->
This PR depends on https://github.com/dasch-swiss/dsp-api/pull/2996 being merged first.

Widen the allowed range of UserIris to account for existing iris in our database

* Allows for builtIn UserIris
* Regular UserIris start with `http://rdfh.ch/users/` and then an alphanumeric String containing `-` or `_` is allows, length >=4 and <=36 charaters
* Adds isBuiltInUser and isRegularUser extension methods to UserIri
* Moves creating a new UserIri from the StringFormatter to UserIri.makeNew
* Migrates the `DELETE admin/users/iri/{userIri}` route to tapir

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
