### PR TITLE
fix: Allow hyphens in usernames (DEV-3306)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/User.scala
@@ -176,12 +176,22 @@ object Username extends StringValueCompanion[Username] {
   /**
    * A regex that matches a valid username
    * - 4 - 50 characters long
-   * - Only contains alphanumeric characters, underscore and dot.
-   * - Underscore and dot can't be at the end or start of a username
-   * - Underscore or dot can't be used multiple times in a row
+   * - Only contains alphanumeric characters, underscore, hyphen and dot.
+   * - Underscore, hyphen and dot can't be at the end or start of a username
+   * - Underscore, hyphen or dot can't be used multiple times in a row
    */
-  private val UsernameRegex: Regex =
-    """^(?=.{4,50}$)(?![_.])(?!.*[_.]{2})[a-zA-Z0-9._]+(?<![_.])$""".r
+  private val UsernameRegex: Regex = (
+    "^(?=.{4,50}$)" +
+      // 4 - 50 characters long
+      "(?![_.-])" +
+      // Underscore, hyphen and dot can't be at the start of a username
+      "(?!.*[_.-]{2})" +
+      // Underscore, hyphen or dot can't be used multiple times in a row
+      "[a-zA-Z0-9._-]+" +
+      // Only contains alphanumeric characters, underscore, hyphen and dot.
+      "(?<![_.-])$"
+        // Underscore, hyphen and dot can't be at the end of a username
+  ).r
 
   def from(value: String): Either[String, Username] =
     if (value.isEmpty) {

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/UserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/UserSpec.scala
@@ -18,8 +18,8 @@ object UserSpec extends ZIOSpecDefault {
     test("Username must not be empty") {
       assertTrue(Username.from("") == Left("Username cannot be empty."))
     },
-    test("Username may contain alphanumeric characters, underscore and dot") {
-      assertTrue(Username.from("a_2.3").isRight)
+    test("Username may contain alphanumeric characters, underscore, hyphen and dot") {
+      assertTrue(Username.from("a_2.3-4").isRight)
     },
     test("Username has to be at least 4 characters long") {
       assertTrue(Username.from("abc") == Left("Username is invalid."))
@@ -30,7 +30,7 @@ object UserSpec extends ZIOSpecDefault {
       )
     },
     test("Username must not contain other characters") {
-      val invalid = List("a_2.3!", "a_2-3", "a.b@example.com")
+      val invalid = List("a_2.3!", "a_2,3", "a.b@example.com")
       check(Gen.fromIterable(invalid)) { i =>
         assertTrue(Username.from(i) == Left("Username is invalid."))
       }
@@ -52,6 +52,15 @@ object UserSpec extends ZIOSpecDefault {
     },
     test("Username must not contain two underscores in a row") {
       assertTrue(Username.from("a__bc") == Left("Username is invalid."))
+    },
+    test("Username must not start with an hyphen") {
+      assertTrue(Username.from("-abc") == Left("Username is invalid."))
+    },
+    test("Username must not end with an hyphen") {
+      assertTrue(Username.from("abc-") == Left("Username is invalid."))
+    },
+    test("Username must not contain two hyphen in a row") {
+      assertTrue(Username.from("a--bc") == Left("Username is invalid."))
     }
   )
 


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/dsp/contribution/ -->

## Pull Request Checklist

### Task Description/Number

The user `images-reviewer-user` is failing Username validation leading to the `/admin/users` view not being available. There are more users with hyphens on both prods, so they'll now be allowed unless the db is cleaned up at some later point.

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
