### PR TITLE
refactor(/admin/groups/): Move parameter check from responder to endpoint

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
@@ -186,20 +186,6 @@ class GroupsResponderADMSpec extends CoreSpec {
           s"Group with the name '${groupName.value}' already exists.",
         )
       }
-
-      "return 'BadRequest' if nothing would be changed during the update" in {
-        val exit = UnsafeZioRun.run(
-          GroupsResponderADM.updateGroup(
-            GroupIri.unsafeFrom(newGroupIri.get),
-            GroupUpdateRequest(None, None, None, None),
-            UUID.randomUUID,
-          ),
-        )
-        assertFailsWithA[BadRequestException](
-          exit,
-          "No data would be changed. Aborting update request.",
-        )
-      }
     }
 
     "used to query members" should {

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -414,18 +414,6 @@ final case class GroupsResponderADMLive(
    */
   private def updateGroupHelper(groupIri: GroupIri, request: GroupUpdateRequest) =
     for {
-      _ <- ZIO
-             .fail(BadRequestException("No data would be changed. Aborting update request."))
-             .when(
-               // parameter list is empty
-               List(
-                 request.name,
-                 request.descriptions,
-                 request.status,
-                 request.selfjoin,
-               ).flatten.isEmpty,
-             )
-
       /* Verify that the group exists. */
       groupADM <-
         groupGetADM(groupIri.value)

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/GroupsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/GroupsEndpoints.scala
@@ -96,8 +96,17 @@ object GroupsRequests {
     status: Option[GroupStatus] = None,
     selfjoin: Option[GroupSelfJoin] = None,
   )
+
   object GroupUpdateRequest {
-    implicit val jsonCodec: JsonCodec[GroupUpdateRequest] = DeriveJsonCodec.gen[GroupUpdateRequest]
+    implicit val jsonCodec: JsonCodec[GroupUpdateRequest] = DeriveJsonCodec
+      .gen[GroupUpdateRequest]
+      .transformOrFail(
+        request =>
+          if (List(request.name, request.descriptions, request.status, request.selfjoin).flatten.isEmpty)
+            Left("At least one field must be present.")
+          else Right(request),
+        identity,
+      )
   }
 
   final case class GroupStatusUpdateRequest(


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Small PR which relates to DEV-3292 and two questions.
1. Should we move checks which could be done ASAP to the endpoint or handler side instead of having them in responder/service?
2. Does it make sense to test it on the endpoint side?

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [x] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
