### PR TITLE
chore: Start release PRs as drafts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: google-github-actions/release-please-action@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
+          draft-pull-request: true
           release-type: simple
           package-name: dsp-api
           pull-request-title-pattern: "chore${scope}: Release${component} ${version}"


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

This should prevent to keep release PRs opened as ready for review for entire cycle.

### PR Type

- [x] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
