### PR TITLE
chore: Successfully skip `check-formatting` job on releases PR

### DIFF
--- a/.github/workflows/build-and-test-empty.yml
+++ b/.github/workflows/build-and-test-empty.yml
@@ -7,6 +7,15 @@ on:
       - "release-*"
 
 jobs:
+  check-formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip with success
+        run: |
+          echo "skipped"
+          exit 0
+          
   build-and-test:
     name: Build and test
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

This PR adds `check-formatting` job to skipped ones on the release PRs. Additionally it not only skips the job to be run on the release PRs, but also mark it as finished with success status. This should fix current problem on those branches, where due to the defined `main` branch rules status is required to be successful, but because of being skipped the job is hanging in "Waiting for status to be reported" state.

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
