### PR TITLE
fix: Disable broken upgrade plugins

### DIFF
--- a/webapi/src/main/resources/knora-ontologies/knora-base.ttl
+++ b/webapi/src/main/resources/knora-ontologies/knora-base.ttl
@@ -19,7 +19,7 @@
     rdf:type           owl:Ontology ;
     rdfs:label         "The Knora base ontology"@en ;
     :attachedToProject knora-admin:SystemProject ;
-    :ontologyVersion   "knora-base v30" .
+    :ontologyVersion   "knora-base v28" .
 
 
 #################################################################

--- a/webapi/src/main/scala/org/knora/webapi/package.scala
+++ b/webapi/src/main/scala/org/knora/webapi/package.scala
@@ -11,7 +11,7 @@ package object webapi {
    * The version of `knora-base` and of the other built-in ontologies that this version of Knora requires.
    * Must be the same as the object of `knora-base:ontologyVersion` in the `knora-base` ontology being used.
    */
-  val KnoraBaseVersion: String = "knora-base v30"
+  val KnoraBaseVersion: String = "knora-base v28"
 
   /**
    * `IRI` is a synonym for `String`, used to improve code readability.

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/RepositoryUpdatePlan.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/RepositoryUpdatePlan.scala
@@ -8,7 +8,6 @@ package org.knora.webapi.store.triplestore.upgrade
 import com.typesafe.scalalogging.Logger
 
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
-import org.knora.webapi.store.triplestore.upgrade.plugins.UpgradePluginPR3110
 import org.knora.webapi.store.triplestore.upgrade.plugins.*
 
 /**
@@ -64,8 +63,8 @@ object RepositoryUpdatePlan {
       PluginForKnoraBaseVersion(versionNumber = 26, plugin = new MigrateOnlyBuiltInGraphs), // PR 3003
       PluginForKnoraBaseVersion(versionNumber = 27, plugin = new MigrateOnlyBuiltInGraphs), // PR 3026
       PluginForKnoraBaseVersion(versionNumber = 28, plugin = new MigrateOnlyBuiltInGraphs), // PR 3038
-      PluginForKnoraBaseVersion(versionNumber = 29, plugin = new UpgradePluginPR3110()),
-      PluginForKnoraBaseVersion(versionNumber = 30, plugin = new UpgradePluginPR3111()),
+//      PluginForKnoraBaseVersion(versionNumber = 29, plugin = new UpgradePluginPR3110()),
+//      PluginForKnoraBaseVersion(versionNumber = 30, plugin = new UpgradePluginPR3111()),
       // KEEP IT ON THE BOTTOM
       // From "versionNumber = 6" don't use prBasedVersionString!
     )


### PR DESCRIPTION
When using more than the built-in graphs the RepositoryUpdater fails to append data in the downloaded files.
Until this is resolved we need to disable the plugins and remain on knora-base version 28.

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
