### PR TITLE
fix: Temporarily bring back support for `isSequenceOf` while it exists in data

### DIFF
--- a/test_data/generated_test_data/ontologyR2RV2/knoraApiOntologySimple.jsonld
+++ b/test_data/generated_test_data/ontologyR2RV2/knoraApiOntologySimple.jsonld
@@ -1286,6 +1286,18 @@
             "@id": "knora-api:hasSegmentBounds"
         },
         {
+            "rdfs:label": "Sequence Bounds",
+            "rdfs:subPropertyOf": {
+                "@id": "knora-api:hasValue"
+            },
+            "rdfs:comment": "Indicates the bounds of a sequence, i.e. the start and end point in the containing resource.",
+            "@type": "owl:DatatypeProperty",
+            "knora-api:objectType": {
+                "@id": "knora-api:Interval"
+            },
+            "@id": "knora-api:hasSequenceBounds"
+        },
+        {
             "rdfs:label": "has Standoff Link to",
             "rdfs:subPropertyOf": {
                 "@id": "knora-api:hasLinkTo"
@@ -1431,6 +1443,21 @@
                 "@id": "knora-api:Representation"
             },
             "@id": "knora-api:isSegmentOf"
+        },
+        {
+            "rdfs:label": "is sequence of",
+            "rdfs:subPropertyOf": {
+                "@id": "knora-api:hasLinkTo"
+            },
+            "rdfs:comment": "Deprecated in favour of :Segment",
+            "@type": "owl:ObjectProperty",
+            "knora-api:subjectType": {
+                "@id": "knora-api:Resource"
+            },
+            "knora-api:objectType": {
+                "@id": "knora-api:Resource"
+            },
+            "@id": "knora-api:isSequenceOf"
         },
         {
             "rdfs:label": "is video segment of",

--- a/test_data/generated_test_data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/test_data/generated_test_data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -8185,6 +8185,20 @@
             "rdfs:comment": "Indicates the bounds of a segment, i.e. the start and end point in the containing resource."
         },
         {
+            "rdfs:label": "Sequence Bounds",
+            "rdfs:subPropertyOf": {
+                "@id": "knora-api:hasValue"
+            },
+            "knora-api:isEditable": true,
+            "knora-api:isResourceProperty": true,
+            "rdfs:comment": "Indicates the bounds of a sequence, i.e. the start and end point in the containing resource.",
+            "@type": "owl:ObjectProperty",
+            "knora-api:objectType": {
+                "@id": "knora-api:IntervalValue"
+            },
+            "@id": "knora-api:hasSequenceBounds"
+        },
+        {
             "rdfs:label": "has Standoff Link to",
             "rdfs:subPropertyOf": {
                 "@id": "knora-api:hasLinkTo"
@@ -8580,6 +8594,41 @@
                 "@id": "knora-api:LinkValue"
             },
             "@id": "knora-api:isSegmentOfValue"
+        },
+        {
+            "rdfs:label": "is sequence of",
+            "rdfs:subPropertyOf": {
+                "@id": "knora-api:hasLinkTo"
+            },
+            "knora-api:isEditable": true,
+            "knora-api:isResourceProperty": true,
+            "@type": "owl:ObjectProperty",
+            "knora-api:objectType": {
+                "@id": "knora-api:Resource"
+            },
+            "@id": "knora-api:isSequenceOf",
+            "knora-api:subjectType": {
+                "@id": "knora-api:Resource"
+            },
+            "knora-api:isLinkProperty": true,
+            "rdfs:comment": "Deprecated in favour of :Segment"
+        },
+        {
+            "knora-api:isLinkValueProperty": true,
+            "rdfs:subPropertyOf": {
+                "@id": "knora-api:hasLinkToValue"
+            },
+            "knora-api:isEditable": true,
+            "knora-api:isResourceProperty": true,
+            "@type": "owl:ObjectProperty",
+            "knora-api:objectType": {
+                "@id": "knora-api:LinkValue"
+            },
+            "@id": "knora-api:isSequenceOfValue",
+            "knora-api:subjectType": {
+                "@id": "knora-api:Resource"
+            },
+            "rdfs:comment": "Deprecated in favour of :Segment"
         },
         {
             "rdfs:label": "is shared",

--- a/webapi/src/main/resources/knora-ontologies/knora-base.ttl
+++ b/webapi/src/main/resources/knora-ontologies/knora-base.ttl
@@ -20,7 +20,7 @@
     rdf:type           owl:Ontology ;
     rdfs:label         "The Knora base ontology"@en ;
     :attachedToProject knora-admin:SystemProject ;
-    :ontologyVersion   "knora-base v33" .
+    :ontologyVersion   "knora-base v34" .
 
 
 #################################################################

--- a/webapi/src/main/resources/knora-ontologies/knora-base.ttl
+++ b/webapi/src/main/resources/knora-ontologies/knora-base.ttl
@@ -2366,3 +2366,40 @@
                        "Video Segment"@en ;
     :canBeInstantiated true ;
     rdfs:comment       "A segment of a video resource"@en .
+
+###  http://www.knora.org/ontology/knora-base#isSequenceOf
+
+:isSequenceOf
+    rdf:type                owl:ObjectProperty ;
+    rdfs:label              "ist Sequenz von"@de,
+                            "is sequence of"@en,
+                            "fait partie de"@fr,
+                            "fa parte di"@it ;
+    rdfs:comment            "Deprecated in favour of :Segment"@en ;
+    :subjectClassConstraint :Resource ;
+    :objectClassConstraint  :Resource ;
+    :isEditable             true ;
+    rdfs:subPropertyOf      :hasLinkTo .
+
+
+###  http://www.knora.org/ontology/knora-base#isSequenceOfValue
+
+:isSequenceOfValue
+    rdf:type                owl:ObjectProperty ;
+    :objectClassConstraint  :LinkValue ;
+    :subjectClassConstraint :Resource ;
+    :isEditable             true ;
+    rdfs:comment            "Deprecated in favour of :Segment"@en ;
+    rdfs:subPropertyOf      :hasLinkToValue .
+
+###  http://www.knora.org/ontology/knora-base#hasSequenceBounds
+
+:hasSequenceBounds
+    rdf:type               owl:ObjectProperty ;
+    :objectClassConstraint :IntervalValue ;
+    :isEditable            true ;
+    rdfs:subPropertyOf     :hasValue ;
+    rdfs:label             "Sequenz-Grenzen"@de,
+                           "Sequence Bounds"@en ;
+    rdfs:comment           "Deprecated in favour of :Segment"@en ;
+    rdfs:comment           "Indicates the bounds of a sequence, i.e. the start and end point in the containing resource."@en .

--- a/webapi/src/main/scala/org/knora/webapi/package.scala
+++ b/webapi/src/main/scala/org/knora/webapi/package.scala
@@ -11,7 +11,7 @@ package object webapi {
    * The version of `knora-base` and of the other built-in ontologies that this version of Knora requires.
    * Must be the same as the object of `knora-base:ontologyVersion` in the `knora-base` ontology being used.
    */
-  val KnoraBaseVersion: String = "knora-base v33"
+  val KnoraBaseVersion: String = "knora-base v34"
 
   /**
    * `IRI` is a synonym for `String`, used to improve code readability.

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/RepositoryUpdatePlan.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/RepositoryUpdatePlan.scala
@@ -49,6 +49,7 @@ object RepositoryUpdatePlan {
       PluginForKnoraBaseVersion(versionNumber = 31, plugin = new UpgradePluginPR3112()),
       PluginForKnoraBaseVersion(versionNumber = 32, plugin = new MigrateOnlyBuiltInGraphs()),
       PluginForKnoraBaseVersion(versionNumber = 33, plugin = new MigrateOnlyBuiltInGraphs()),
+      PluginForKnoraBaseVersion(versionNumber = 34, plugin = new MigrateOnlyBuiltInGraphs()),
     )
 
   /**


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
