### PR TITLE
feat: X-Asset-Ingested: skip Sipi temp move for updates (DEV-3504)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -27,7 +27,7 @@ import org.knora.webapi.messages.util.DatePrecisionYear
 import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.messages.util.PermissionUtilADM
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState
+import org.knora.webapi.routing.v2.AssetIngestState
 import org.knora.webapi.messages.v2.responder.resourcemessages._
 import org.knora.webapi.messages.v2.responder.standoffmessages._
 import org.knora.webapi.messages.v2.responder.valuemessages._

--- a/integration/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -27,13 +27,13 @@ import org.knora.webapi.messages.util.DatePrecisionYear
 import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.messages.util.PermissionUtilADM
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
-import org.knora.webapi.routing.v2.AssetIngestState
 import org.knora.webapi.messages.v2.responder.resourcemessages._
 import org.knora.webapi.messages.v2.responder.standoffmessages._
 import org.knora.webapi.messages.v2.responder.valuemessages._
 import org.knora.webapi.models.filemodels.FileModelUtil
 import org.knora.webapi.models.filemodels.FileType
 import org.knora.webapi.routing.UnsafeZioRun
+import org.knora.webapi.routing.v2.AssetIngestState
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.store.iiif.errors.SipiException

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -30,9 +30,9 @@ import org.knora.webapi.messages.util.standoff.XMLUtil
 import org.knora.webapi.messages.v2.responder._
 import org.knora.webapi.messages.v2.responder.standoffmessages.MappingXMLtoStandoff
 import org.knora.webapi.messages.v2.responder.valuemessages._
-import org.knora.webapi.slice.admin.api.model.Project
 import org.knora.webapi.routing.v2.AssetIngestState
-import org.knora.webapi.routing.v2.AssetIngestState.*
+import org.knora.webapi.routing.v2.AssetIngestState._
+import org.knora.webapi.slice.admin.api.model.Project
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.Permission
 import org.knora.webapi.slice.admin.domain.model.User

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -28,11 +28,11 @@ import org.knora.webapi.messages.util.rdf._
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.messages.util.standoff.XMLUtil
 import org.knora.webapi.messages.v2.responder._
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState.AssetInTemp
 import org.knora.webapi.messages.v2.responder.standoffmessages.MappingXMLtoStandoff
 import org.knora.webapi.messages.v2.responder.valuemessages._
 import org.knora.webapi.slice.admin.api.model.Project
+import org.knora.webapi.routing.v2.AssetIngestState
+import org.knora.webapi.routing.v2.AssetIngestState.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.Permission
 import org.knora.webapi.slice.admin.domain.model.User
@@ -652,11 +652,6 @@ case class CreateResourceRequestV2(
 ) extends ResourcesResponderRequestV2
 
 object CreateResourceRequestV2 {
-  sealed trait AssetIngestState
-  object AssetIngestState {
-    case object AssetIngested extends AssetIngestState
-    case object AssetInTemp   extends AssetIngestState
-  }
 
   /**
    * Converts JSON-LD input to a [[CreateResourceRequestV2]].

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -10,6 +10,7 @@ import zio.ZIO
 import java.net.URI
 import java.time.Instant
 import java.util.UUID
+import scala.reflect.ClassTag
 
 import dsp.errors.AssertionException
 import dsp.errors.BadRequestException
@@ -36,8 +37,6 @@ import org.knora.webapi.messages.util.standoff.StandoffStringUtil
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.messages.util.standoff.XMLUtil
 import org.knora.webapi.messages.v2.responder._
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState.AssetInTemp
 import org.knora.webapi.messages.v2.responder.resourcemessages.ReadResourceV2
 import org.knora.webapi.messages.v2.responder.standoffmessages._
 import org.knora.webapi.routing.RouteUtilV2
@@ -51,6 +50,10 @@ import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.api.SipiService
+import org.knora.webapi.routing.v2.AssetIngestState
+import org.knora.webapi.routing.v2.AssetIngestState.*
+
+import PartialFunction.condOpt
 
 /**
  * A tagging trait for requests handled by [[org.knora.webapi.responders.v2.ValuesResponderV2]].
@@ -705,10 +708,8 @@ object CreateValueV2 {
     }
 }
 
-/**
- * A trait for classes representing information to be updated in a value.
- */
-trait UpdateValueV2 {
+/** A trait for classes representing information to be updated in a value. */
+sealed trait UpdateValueV2 {
 
   /**
    * The IRI of the resource containing the value.
@@ -735,6 +736,7 @@ trait UpdateValueV2 {
    */
   val valueCreationDate: Option[Instant]
 }
+
 object UpdateValueV2 {
 
   /**
@@ -745,6 +747,7 @@ object UpdateValueV2 {
    * @return a case class instance representing the input.
    */
   def fromJsonLd(
+    ingestState: AssetIngestState,
     jsonLdString: String,
     requestingUser: User,
   ): ZIO[IriConverter & SipiService & StringFormatter & MessageRelay, Throwable, UpdateValueV2] =
@@ -766,7 +769,7 @@ object UpdateValueV2 {
               jsonLDObject.maybeStringWithValidation(HasPermissions, validationFun)
             }
           shortcode    <- ZIO.fromOption(resourceIri.getProjectCode).orElseFail(NotFoundException("Shortcode not found."))
-          fileInfo     <- ValueContentV2.getFileInfo(shortcode, AssetIngestState.AssetInTemp, jsonLDObject).option
+          fileInfo     <- ValueContentV2.getFileInfo(shortcode, ingestState, jsonLDObject).option
           valueContent <- ValueContentV2.fromJsonLdObject(jsonLDObject, requestingUser, fileInfo)
         } yield UpdateValueContentV2(
           resourceIri = resourceIri.toString,
@@ -777,6 +780,7 @@ object UpdateValueV2 {
           permissions = maybePermissions,
           valueCreationDate = maybeValueCreationDate,
           newValueVersionIri = maybeNewIri,
+          ingestState = ingestState,
         )
 
       def makeUpdateValuePermissionsV2(
@@ -927,6 +931,7 @@ case class UpdateValueContentV2(
   permissions: Option[String] = None,
   valueCreationDate: Option[Instant] = None,
   newValueVersionIri: Option[SmartIri] = None,
+  ingestState: AssetIngestState = AssetInTemp,
 ) extends UpdateValueV2
 
 /**
@@ -1039,6 +1044,8 @@ sealed trait ValueContentV2 extends KnoraContentV2[ValueContentV2] {
    * @return `true` if this [[ValueContentV2]] would duplicate `currentVersion`.
    */
   def wouldDuplicateCurrentVersion(currentVersion: ValueContentV2): Boolean
+
+  def asOpt[T <: ValueContentV2: ClassTag]: Option[T] = condOpt(this) { case a: T => a }
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -41,6 +41,8 @@ import org.knora.webapi.messages.v2.responder.resourcemessages.ReadResourceV2
 import org.knora.webapi.messages.v2.responder.standoffmessages._
 import org.knora.webapi.routing.RouteUtilV2
 import org.knora.webapi.routing.RouteUtilZ
+import org.knora.webapi.routing.v2.AssetIngestState
+import org.knora.webapi.routing.v2.AssetIngestState._
 import org.knora.webapi.slice.admin.api.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.admin.api.model.Project
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
@@ -50,8 +52,6 @@ import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.api.SipiService
-import org.knora.webapi.routing.v2.AssetIngestState
-import org.knora.webapi.routing.v2.AssetIngestState.*
 
 import PartialFunction.condOpt
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
@@ -29,7 +29,7 @@ import org.knora.webapi.messages.v2.responder.valuemessages.FileValueContentV2
 import org.knora.webapi.messages.v2.responder.valuemessages.ReadValueV2
 import org.knora.webapi.messages.v2.responder.valuemessages.StillImageExternalFileValueContentV2
 import org.knora.webapi.routing.v2.AssetIngestState
-import org.knora.webapi.routing.v2.AssetIngestState.*
+import org.knora.webapi.routing.v2.AssetIngestState._
 import org.knora.webapi.slice.admin.domain.model.Permission
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.store.triplestore.api.TriplestoreService

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -357,11 +357,12 @@ final case class ValuesResponderV2Live(
 
     // If we were creating a file value, have Sipi move the file to permanent storage if the update
     // was successful, or delete the temporary file if the update failed.
-    val fileValue = List(valueToCreate.valueContent)
-      .filter(_.isInstanceOf[FileValueContentV2])
-      .map(_.asInstanceOf[FileValueContentV2])
-
-    resourceUtilV2.doSipiPostUpdate(triplestoreUpdateFuture, fileValue, requestingUser)
+    resourceUtilV2.doSipiPostUpdateIfInTemp(
+      valueToCreate.ingestState,
+      triplestoreUpdateFuture,
+      valueToCreate.valueContent.asOpt[FileValueContentV2].toSeq,
+      requestingUser,
+    )
   }
 
   private def ifIsListValueThenCheckItPointsToListNodeWhichIsNotARootNode(valueContent: ValueContentV2) =
@@ -958,13 +959,13 @@ final case class ValuesResponderV2Live(
               ),
             )
         isSameType = currentValue.valueContent.valueType == submittedInternalValueType
-        isStillImageTypes = {
-          val stillImageFileValues = List(StillImageExternalFileValue, StillImageFileValue)
-          stillImageFileValues.contains(submittedInternalValueType.toInternalIri.value) &&
-          stillImageFileValues.contains(currentValue.valueContent.valueType.toInternalIri.value)
-        }
+        isStillImageTypes =
+          Set(
+            submittedInternalValueType.toInternalIri.value,
+            currentValue.valueContent.valueType.toInternalIri.value,
+          ).subsetOf(Set(StillImageExternalFileValue, StillImageFileValue))
         _ <-
-          ZIO.when(!(isSameType || isStillImageTypes))(
+          ZIO.unless(isSameType || isStillImageTypes)(
             ZIO.fail(
               BadRequestException(
                 s"Value <$valueIri> has type <${currentValue.valueContent.valueType.toOntologySchema(ApiV2Complex)}>, but the submitted type was <$submittedExternalValueType>",
@@ -1229,17 +1230,18 @@ final case class ValuesResponderV2Live(
       updateValue match {
         case updateValueContentV2: UpdateValueContentV2 =>
           // This is a request to update the content of a value.
-          val triplestoreUpdateFuture = IriLocker.runWithIriLock(
+          val triplestoreUpdate = IriLocker.runWithIriLock(
             apiRequestId,
             updateValueContentV2.resourceIri,
             makeTaskFutureToUpdateValueContent(updateValueContentV2),
           )
 
-          val fileValue = List(updateValueContentV2.valueContent)
-            .filter(_.isInstanceOf[FileValueContentV2])
-            .map(_.asInstanceOf[FileValueContentV2])
-
-          resourceUtilV2.doSipiPostUpdate(triplestoreUpdateFuture, fileValue, requestingUser)
+          resourceUtilV2.doSipiPostUpdateIfInTemp(
+            updateValueContentV2.ingestState,
+            triplestoreUpdate,
+            updateValueContentV2.valueContent.asOpt[FileValueContentV2].toSeq,
+            requestingUser,
+          )
 
         case updateValuePermissionsV2: UpdateValuePermissionsV2 =>
           // This is a request to update the permissions attached to a value.

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/AssetIngestedState.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/AssetIngestedState.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.routing.v2
+
+import org.apache.pekko.http.scaladsl.model.HttpHeader
+
+sealed trait AssetIngestState
+
+object AssetIngestState {
+  case object AssetIngested extends AssetIngestState
+  case object AssetInTemp   extends AssetIngestState
+
+  def headerAssetIngestState(headers: Seq[HttpHeader]): AssetIngestState =
+    if (headers.exists(_.name == "X-Asset-Ingested")) AssetIngested
+    else AssetInTemp
+}

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
@@ -27,8 +27,6 @@ import org.knora.webapi.messages.ValuesValidator
 import org.knora.webapi.messages.ValuesValidator.arkTimestampToInstant
 import org.knora.webapi.messages.ValuesValidator.xsdDateTimeStampToInstant
 import org.knora.webapi.messages.util.rdf.JsonLDUtil
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState.AssetInTemp
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState.AssetIngested
 import org.knora.webapi.messages.v2.responder.resourcemessages._
 import org.knora.webapi.messages.v2.responder.valuemessages._
 import org.knora.webapi.responders.v2.SearchResponderV2
@@ -103,9 +101,7 @@ final case class ResourcesRouteV2(appConfig: AppConfig)(
             requestDoc     <- RouteUtilV2.parseJsonLd(jsonRequest)
             requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
             apiRequestId   <- RouteUtilZ.randomUuid()
-            header          = "X-Asset-Ingested"
-            ingestState = if (requestContext.request.headers.exists(_.name == header)) AssetIngested
-                          else AssetInTemp
+            ingestState     = AssetIngestState.headerAssetIngestState(requestContext.request.headers)
             requestMessage <- CreateResourceRequestV2.fromJsonLd(requestDoc, apiRequestId, requestingUser, ingestState)
             // check for each value which represents a file value if the file's MIME type is allowed
             _ <- checkMimeTypesForFileValueContents(requestMessage.createResource.flatValues)

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
@@ -16,7 +16,6 @@ import org.knora.webapi.config.AppConfig
 import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.ValuesValidator
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState
 import org.knora.webapi.messages.v2.responder.resourcemessages.ResourcesGetRequestV2
 import org.knora.webapi.messages.v2.responder.valuemessages._
 import org.knora.webapi.responders.v2.ValuesResponderV2
@@ -84,7 +83,8 @@ final case class ValuesRouteV2()(
             for {
               requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(ctx))
               apiRequestId   <- Random.nextUUID
-              valueToCreate  <- CreateValueV2.fromJsonLd(AssetIngestState.AssetInTemp, jsonLdString, requestingUser)
+              ingestState     = AssetIngestState.headerAssetIngestState(ctx.request.headers)
+              valueToCreate  <- CreateValueV2.fromJsonLd(ingestState, jsonLdString, requestingUser)
               response <-
                 ZIO.serviceWithZIO[ValuesResponderV2](_.createValueV2(valueToCreate, requestingUser, apiRequestId))
             } yield response,
@@ -103,7 +103,8 @@ final case class ValuesRouteV2()(
             for {
               requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(ctx))
               apiRequestId   <- Random.nextUUID
-              updateValue    <- UpdateValueV2.fromJsonLd(jsonLdString, requestingUser)
+              ingestState     = AssetIngestState.headerAssetIngestState(ctx.request.headers)
+              updateValue    <- UpdateValueV2.fromJsonLd(ingestState, jsonLdString, requestingUser)
               response <-
                 ZIO.serviceWithZIO[ValuesResponderV2](_.updateValueV2(updateValue, requestingUser, apiRequestId))
             } yield response,

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueContentV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueContentV2Spec.scala
@@ -22,9 +22,8 @@ import org.knora.webapi.messages.store.sipimessages.SipiGetTextFileRequest
 import org.knora.webapi.messages.store.sipimessages.SipiGetTextFileResponse
 import org.knora.webapi.messages.util.rdf.JsonLDUtil
 import org.knora.webapi.messages.v2.responder.SuccessResponseV2
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState.AssetInTemp
-import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceRequestV2.AssetIngestState.AssetIngested
+import org.knora.webapi.routing.v2.AssetIngestState
+import org.knora.webapi.routing.v2.AssetIngestState.*
 import org.knora.webapi.slice.admin.api.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.User

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueContentV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueContentV2Spec.scala
@@ -23,7 +23,7 @@ import org.knora.webapi.messages.store.sipimessages.SipiGetTextFileResponse
 import org.knora.webapi.messages.util.rdf.JsonLDUtil
 import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.routing.v2.AssetIngestState
-import org.knora.webapi.routing.v2.AssetIngestState.*
+import org.knora.webapi.routing.v2.AssetIngestState._
 import org.knora.webapi.slice.admin.api.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.User


### PR DESCRIPTION
### Task Description

* Same mechanism skipping temp file removal for UpdateValueV2 as for CreateResource
* Also for CreateValueV2, but tests are missing for now, because I couldn't figure out where to add them
* Minor: refactored two lines `.exists` in the vicinity of pertaining changes

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [x] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes

### Does this PR change client-test-data?

- [ ] Yes
