### PR TITLE
refactor: KnoraSipiIntegrationV2ITSpec simplifications (DEV-3504)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/it/v2/KnoraSipiIntegrationV2ITSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/it/v2/KnoraSipiIntegrationV2ITSpec.scala
@@ -363,6 +363,9 @@ class KnoraSipiIntegrationV2ITSpec
     )
   }
 
+  protected def requestJsonLDWithAuth(request: HttpRequest): JsonLDDocument =
+    getResponseJsonLD(request ~> addAuthorization)
+
   "The Knora/Sipi integration" should {
     var loginToken: String = ""
 
@@ -463,8 +466,7 @@ class KnoraSipiIntegrationV2ITSpec
           ontologyName = "anything",
         )
 
-      val request         = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
+      val responseJsonDoc = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
       stillImageResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
@@ -608,9 +610,8 @@ class KnoraSipiIntegrationV2ITSpec
             ontologyName = "anything",
           )
 
-      val request         = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      pdfResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
+      pdfResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest          = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(pdfResourceIri.get, "UTF-8")}")
@@ -661,9 +662,8 @@ class KnoraSipiIntegrationV2ITSpec
         )
         .toJsonLd
 
-      val request         = Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      pdfValueIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)))
+      pdfValueIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(pdfResourceIri.get, "UTF-8")}")
@@ -758,17 +758,12 @@ class KnoraSipiIntegrationV2ITSpec
       // Create the resource in the API.
 
       val jsonLdEntity = UploadFileRequest
-        .make(
-          fileType = FileType.TextFile,
-          internalFilename = uploadedFile.internalFilename,
-        )
+        .make(fileType = FileType.TextFile, internalFilename = uploadedFile.internalFilename)
         .toJsonLd()
 
-      val request         = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      val resourceIri: IRI =
-        responseJsonDoc.body.requireStringWithValidation(JsonLDKeywords.ID, validationFun)
-      csvResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response    = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
+      val resourceIri = response.body.requireStringWithValidation(JsonLDKeywords.ID, validationFun)
+      csvResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(resourceIri, "UTF-8")}")
@@ -813,9 +808,8 @@ class KnoraSipiIntegrationV2ITSpec
         )
         .toJsonLd
 
-      val request         = Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      csvValueIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)))
+      csvValueIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(csvResourceIri.get, "UTF-8")}")
@@ -874,11 +868,9 @@ class KnoraSipiIntegrationV2ITSpec
         .make(fileType = FileType.TextFile, internalFilename = uploadedFile.internalFilename)
         .toJsonLd()
 
-      val request                         = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc: JsonLDDocument = getResponseJsonLD(request)
-      val resourceIri: IRI =
-        responseJsonDoc.body.requireStringWithValidation(JsonLDKeywords.ID, validationFun)
-      xmlResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response         = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
+      val resourceIri: IRI = response.body.requireStringWithValidation(JsonLDKeywords.ID, validationFun)
+      xmlResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(resourceIri, "UTF-8")}")
@@ -923,9 +915,8 @@ class KnoraSipiIntegrationV2ITSpec
         )
         .toJsonLd
 
-      val request         = Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      xmlValueIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)))
+      xmlValueIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(xmlResourceIri.get, "UTF-8")}")
@@ -987,9 +978,8 @@ class KnoraSipiIntegrationV2ITSpec
         .make(fileType = FileType.ArchiveFile, internalFilename = uploadedFile.internalFilename)
         .toJsonLd()
 
-      val request         = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      zipResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
+      zipResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest          = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(zipResourceIri.get, "UTF-8")}")
@@ -1040,9 +1030,8 @@ class KnoraSipiIntegrationV2ITSpec
         )
         .toJsonLd
 
-      val request         = Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      zipValueIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)))
+      zipValueIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(zipResourceIri.get, "UTF-8")}")
@@ -1084,9 +1073,8 @@ class KnoraSipiIntegrationV2ITSpec
         .make(fileType = FileType.ArchiveFile, internalFilename = uploadedFile.internalFilename)
         .toJsonLd()
 
-      val request         = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      zipResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
+      zipResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest          = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(zipResourceIri.get, "UTF-8")}")
@@ -1130,9 +1118,8 @@ class KnoraSipiIntegrationV2ITSpec
         .make(fileType = FileType.AudioFile, internalFilename = uploadedFile.internalFilename)
         .toJsonLd()
 
-      val request         = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      wavResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
+      wavResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest          = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(wavResourceIri.get, "UTF-8")}")
@@ -1183,9 +1170,8 @@ class KnoraSipiIntegrationV2ITSpec
         )
         .toJsonLd
 
-      val request         = Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      wavValueIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)))
+      wavValueIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(wavResourceIri.get, "UTF-8")}")
@@ -1222,9 +1208,8 @@ class KnoraSipiIntegrationV2ITSpec
         .make(fileType = FileType.MovingImageFile(), internalFilename = uploadedFile.internalFilename)
         .toJsonLd()
 
-      val request         = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      videoResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
+      videoResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest          = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(videoResourceIri.get, "UTF-8")}")
@@ -1275,9 +1260,8 @@ class KnoraSipiIntegrationV2ITSpec
         )
         .toJsonLd
 
-      val request         = Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
-      val responseJsonDoc = getResponseJsonLD(request)
-      videoValueIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Put(s"$baseApiUrl/v2/values", jsonLdHttpEntity(jsonLdEntity)))
+      videoValueIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
       val knoraGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(videoResourceIri.get, "UTF-8")}")

--- a/integration/src/test/scala/org/knora/webapi/it/v2/KnoraSipiIntegrationV2ITSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/it/v2/KnoraSipiIntegrationV2ITSpec.scala
@@ -123,6 +123,11 @@ class KnoraSipiIntegrationV2ITSpec
 
   private val validationFun: (String, => Nothing) => String = (s, e) => Iri.validateAndEscapeIri(s).getOrElse(e)
 
+  private def assertingUnique[A](l: Seq[A]): A = l.toList match {
+    case h :: Nil => h
+    case _        => throw AssertionException(s"value not unique out of ${l.length}, value: $l")
+  }
+
   /**
    * Represents the information that Knora returns about an image file value that was created.
    *
@@ -406,7 +411,8 @@ class KnoraSipiIntegrationV2ITSpec
           ontologyName = "anything",
         )
 
-      val responseJsonDoc = getResponseJsonLD(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization)
+      val responseJsonDoc =
+        getResponseJsonLD(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization)
       stillImageResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       // Get the resource from Knora.
@@ -425,17 +431,7 @@ class KnoraSipiIntegrationV2ITSpec
         propertyIriInResult = OntologyConstants.KnoraApiV2Complex.HasStillImageFileValue.toSmartIri,
       )
 
-      val savedValue: JsonLDValue = if (savedValues.value.size == 1) {
-        savedValues.value.head
-      } else {
-        throw AssertionException(s"Expected one file value, got ${savedValues.value.size}")
-      }
-
-      val savedValueObj: JsonLDObject = savedValue match {
-        case jsonLDObject: JsonLDObject => jsonLDObject
-        case other                      => throw AssertionException(s"Invalid value object: $other")
-      }
-
+      val savedValueObj: JsonLDObject = assertingUnique(savedValues.value).asOpt[JsonLDObject].get
       stillImageFileValueIri.set(UnsafeZioRun.runOrThrow(savedValueObj.getRequiredIdValueAsKnoraDataIri).toString)
 
       val savedImage = savedValueToSavedImage(savedValueObj)
@@ -643,17 +639,7 @@ class KnoraSipiIntegrationV2ITSpec
         propertyIriInResult = OntologyConstants.KnoraApiV2Complex.HasDocumentFileValue.toSmartIri,
       )
 
-      val savedValue: JsonLDValue = if (savedValues.value.size == 1) {
-        savedValues.value.head
-      } else {
-        throw AssertionException(s"Expected one file value, got ${savedValues.value.size}")
-      }
-
-      val savedValueObj: JsonLDObject = savedValue match {
-        case jsonLDObject: JsonLDObject => jsonLDObject
-        case other                      => throw AssertionException(s"Invalid value object: $other")
-      }
-
+      val savedValueObj: JsonLDObject = assertingUnique(savedValues.value).asOpt[JsonLDObject].get
       pdfValueIri.set(UnsafeZioRun.runOrThrow(savedValueObj.getRequiredIdValueAsKnoraDataIri).toString)
 
       val savedDocument: SavedDocument = savedValueToSavedDocument(savedValueObj)
@@ -818,17 +804,7 @@ class KnoraSipiIntegrationV2ITSpec
         propertyIriInResult = OntologyConstants.KnoraApiV2Complex.HasTextFileValue.toSmartIri,
       )
 
-      val savedValue: JsonLDValue = if (savedValues.value.size == 1) {
-        savedValues.value.head
-      } else {
-        throw AssertionException(s"Expected one file value, got ${savedValues.value.size}")
-      }
-
-      val savedValueObj: JsonLDObject = savedValue match {
-        case jsonLDObject: JsonLDObject => jsonLDObject
-        case other                      => throw AssertionException(s"Invalid value object: $other")
-      }
-
+      val savedValueObj: JsonLDObject = assertingUnique(savedValues.value).asOpt[JsonLDObject].get
       csvValueIri.set(UnsafeZioRun.runOrThrow(savedValueObj.getRequiredIdValueAsKnoraDataIri).toString)
 
       val savedTextFile: SavedTextFile = savedValueToSavedTextFile(savedValueObj)
@@ -945,17 +921,7 @@ class KnoraSipiIntegrationV2ITSpec
         propertyIriInResult = OntologyConstants.KnoraApiV2Complex.HasTextFileValue.toSmartIri,
       )
 
-      val savedValue: JsonLDValue = if (savedValues.value.size == 1) {
-        savedValues.value.head
-      } else {
-        throw AssertionException(s"Expected one file value, got ${savedValues.value.size}")
-      }
-
-      val savedValueObj: JsonLDObject = savedValue match {
-        case jsonLDObject: JsonLDObject => jsonLDObject
-        case other                      => throw AssertionException(s"Invalid value object: $other")
-      }
-
+      val savedValueObj: JsonLDObject = assertingUnique(savedValues.value).asOpt[JsonLDObject].get
       xmlValueIri.set(UnsafeZioRun.runOrThrow(savedValueObj.getRequiredIdValueAsKnoraDataIri).toString)
 
       val savedTextFile: SavedTextFile = savedValueToSavedTextFile(savedValueObj)
@@ -1077,17 +1043,7 @@ class KnoraSipiIntegrationV2ITSpec
         propertyIriInResult = OntologyConstants.KnoraApiV2Complex.HasArchiveFileValue.toSmartIri,
       )
 
-      val savedValue: JsonLDValue = if (savedValues.value.size == 1) {
-        savedValues.value.head
-      } else {
-        throw AssertionException(s"Expected one file value, got ${savedValues.value.size}")
-      }
-
-      val savedValueObj: JsonLDObject = savedValue match {
-        case jsonLDObject: JsonLDObject => jsonLDObject
-        case other                      => throw AssertionException(s"Invalid value object: $other")
-      }
-
+      val savedValueObj: JsonLDObject = assertingUnique(savedValues.value).asOpt[JsonLDObject].get
       zipValueIri.set(UnsafeZioRun.runOrThrow(savedValueObj.getRequiredIdValueAsKnoraDataIri).toString)
 
       val savedDocument: SavedDocument = savedValueToSavedDocument(savedValueObj)
@@ -1188,17 +1144,7 @@ class KnoraSipiIntegrationV2ITSpec
         propertyIriInResult = OntologyConstants.KnoraApiV2Complex.HasArchiveFileValue.toSmartIri,
       )
 
-      val savedValue: JsonLDValue = if (savedValues.value.size == 1) {
-        savedValues.value.head
-      } else {
-        throw AssertionException(s"Expected one file value, got ${savedValues.value.size}")
-      }
-
-      val savedValueObj: JsonLDObject = savedValue match {
-        case jsonLDObject: JsonLDObject => jsonLDObject
-        case other                      => throw AssertionException(s"Invalid value object: $other")
-      }
-
+      val savedValueObj: JsonLDObject = assertingUnique(savedValues.value).asOpt[JsonLDObject].get
       zipValueIri.set(UnsafeZioRun.runOrThrow(savedValueObj.getRequiredIdValueAsKnoraDataIri).toString)
 
       val savedDocument: SavedDocument = savedValueToSavedDocument(savedValueObj)
@@ -1248,17 +1194,7 @@ class KnoraSipiIntegrationV2ITSpec
         propertyIriInResult = OntologyConstants.KnoraApiV2Complex.HasAudioFileValue.toSmartIri,
       )
 
-      val savedValue: JsonLDValue = if (savedValues.value.size == 1) {
-        savedValues.value.head
-      } else {
-        throw AssertionException(s"Expected one file value, got ${savedValues.value.size}")
-      }
-
-      val savedValueObj: JsonLDObject = savedValue match {
-        case jsonLDObject: JsonLDObject => jsonLDObject
-        case other                      => throw AssertionException(s"Invalid value object: $other")
-      }
-
+      val savedValueObj: JsonLDObject = assertingUnique(savedValues.value).asOpt[JsonLDObject].get
       wavValueIri.set(UnsafeZioRun.runOrThrow(savedValueObj.getRequiredIdValueAsKnoraDataIri).toString)
 
       val savedAudioFile: SavedAudioFile = savedValueToSavedAudioFile(savedValueObj)
@@ -1354,17 +1290,7 @@ class KnoraSipiIntegrationV2ITSpec
         propertyIriInResult = OntologyConstants.KnoraApiV2Complex.HasMovingImageFileValue.toSmartIri,
       )
 
-      val savedValue: JsonLDValue = if (savedValues.value.size == 1) {
-        savedValues.value.head
-      } else {
-        throw AssertionException(s"Expected one file value, got ${savedValues.value.size}")
-      }
-
-      val savedValueObj: JsonLDObject = savedValue match {
-        case jsonLDObject: JsonLDObject => jsonLDObject
-        case other                      => throw AssertionException(s"Invalid value object: $other")
-      }
-
+      val savedValueObj: JsonLDObject = assertingUnique(savedValues.value).asOpt[JsonLDObject].get
       videoValueIri.set(UnsafeZioRun.runOrThrow(savedValueObj.getRequiredIdValueAsKnoraDataIri).toString)
 
       val savedVideoFile: SavedVideoFile = savedValueToSavedVideoFile(savedValueObj)

--- a/integration/src/test/scala/org/knora/webapi/it/v2/KnoraSipiIntegrationV2ITSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/it/v2/KnoraSipiIntegrationV2ITSpec.scala
@@ -127,7 +127,7 @@ class KnoraSipiIntegrationV2ITSpec
 
   private def assertingUnique[A](l: Seq[A]): A = l.toList match {
     case h :: Nil => h
-    case _        => throw AssertionException(s"value not unique out of ${l.length}, value: $l")
+    case _        => throw AssertionException(s"Not unique value: $l out of ${l.length} values.")
   }
 
   /**

--- a/integration/src/test/scala/org/knora/webapi/it/v2/KnoraSipiIntegrationV2ITSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/it/v2/KnoraSipiIntegrationV2ITSpec.scala
@@ -406,18 +406,11 @@ class KnoraSipiIntegrationV2ITSpec
       // Create the resource in the API.
 
       val jsonLdEntity = UploadFileRequest
-        .make(
-          fileType = FileType.StillImageFile(),
-          internalFilename = uploadedFile.internalFilename,
-        )
-        .toJsonLd(
-          className = Some("ThingPicture"),
-          ontologyName = "anything",
-        )
+        .make(FileType.StillImageFile(), uploadedFile.internalFilename)
+        .toJsonLd(className = Some("ThingPicture"), ontologyName = "anything")
 
-      val responseJsonDoc =
-        getResponseJsonLD(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization)
-      stillImageResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
+      val response = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
+      stillImageResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
 
       val resource = getResponseJsonLD(Get(s"$baseApiUrl/v2/resources/${encodeUTF8(stillImageResourceIri.get)}"))
       assert(
@@ -456,14 +449,8 @@ class KnoraSipiIntegrationV2ITSpec
       // Create the resource in the API.
 
       val jsonLdEntity = UploadFileRequest
-        .make(
-          fileType = FileType.StillImageFile(),
-          internalFilename = uploadedFile.filename,
-        )
-        .toJsonLd(
-          className = Some("ThingPicture"),
-          ontologyName = "anything",
-        )
+        .make(fileType = FileType.StillImageFile(), internalFilename = uploadedFile.filename)
+        .toJsonLd(className = Some("ThingPicture"), ontologyName = "anything")
 
       val responseJsonDoc = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
       stillImageResourceIri.set(UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString)
@@ -494,12 +481,11 @@ class KnoraSipiIntegrationV2ITSpec
       val jsonLdEntity = UploadFileRequest
         .make(fileType = FileType.StillImageFile(), internalFilename = "De6XyNL4H71-D9QxghOuOPJ.jp2")
         .toJsonLd(className = Some("ThingPicture"), ontologyName = "anything")
-      val request = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity))
-        ~> addAuthorization
-        ~> addAssetIngested
-      val responseJsonDoc: JsonLDDocument = getResponseJsonLD(request)
-      val resIri                          = UnsafeZioRun.runOrThrow(responseJsonDoc.body.getRequiredIdValueAsKnoraDataIri).toString
-      val getRequest                      = Get(s"$baseApiUrl/v2/resources/${encodeUTF8(resIri)}")
+      val response = requestJsonLDWithAuth(
+        Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAssetIngested,
+      )
+      val resIri     = UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString
+      val getRequest = Get(s"$baseApiUrl/v2/resources/${encodeUTF8(resIri)}")
       checkResponseOK(getRequest)
     }
 
@@ -596,14 +582,8 @@ class KnoraSipiIntegrationV2ITSpec
 
       val jsonLdEntity =
         UploadFileRequest
-          .make(
-            fileType = FileType.DocumentFile(),
-            internalFilename = uploadedFile.internalFilename,
-          )
-          .toJsonLd(
-            className = Some("ThingDocument"),
-            ontologyName = "anything",
-          )
+          .make(fileType = FileType.DocumentFile(), internalFilename = uploadedFile.internalFilename)
+          .toJsonLd(className = Some("ThingDocument"), ontologyName = "anything")
 
       val response = requestJsonLDWithAuth(Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)))
       pdfResourceIri.set(UnsafeZioRun.runOrThrow(response.body.getRequiredIdValueAsKnoraDataIri).toString)
@@ -721,14 +701,8 @@ class KnoraSipiIntegrationV2ITSpec
       // Create the resource in the API.
 
       val jsonLdEntity = UploadFileRequest
-        .make(
-          fileType = FileType.DocumentFile(),
-          internalFilename = uploadedFile.internalFilename,
-        )
-        .toJsonLd(
-          className = Some("ThingDocument"),
-          ontologyName = "anything",
-        )
+        .make(fileType = FileType.DocumentFile(), internalFilename = uploadedFile.internalFilename)
+        .toJsonLd(className = Some("ThingDocument"), ontologyName = "anything")
 
       val request = Post(s"$baseApiUrl/v2/resources", jsonLdHttpEntity(jsonLdEntity)) ~> addAuthorization
       assert(singleAwaitingRequest(request).status == StatusCodes.BadRequest)

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/JsonLDUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/JsonLDUtil.scala
@@ -34,6 +34,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.routing.RouteUtilZ
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.util.WithAsIs
 
 /*
 
@@ -71,7 +72,7 @@ object JsonLDKeywords {
 /**
  * Represents a value in a JSON-LD document.
  */
-sealed trait JsonLDValue extends Ordered[JsonLDValue] {
+sealed trait JsonLDValue extends Ordered[JsonLDValue] with WithAsIs[JsonLDValue] {
 
   /**
    * Converts this JSON-LD value to a `jakarta.json` [[JsonValue]].

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -10,7 +10,6 @@ import zio.ZIO
 import java.net.URI
 import java.time.Instant
 import java.util.UUID
-import scala.reflect.ClassTag
 
 import dsp.errors.AssertionException
 import dsp.errors.BadRequestException
@@ -52,8 +51,7 @@ import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.api.SipiService
-
-import PartialFunction.condOpt
+import org.knora.webapi.util.WithAsIs
 
 /**
  * A tagging trait for requests handled by [[org.knora.webapi.responders.v2.ValuesResponderV2]].
@@ -980,7 +978,7 @@ case class UnverifiedValueV2(
 /**
  * The content of the value of a Knora property.
  */
-sealed trait ValueContentV2 extends KnoraContentV2[ValueContentV2] {
+sealed trait ValueContentV2 extends KnoraContentV2[ValueContentV2] with WithAsIs[ValueContentV2] {
   protected implicit def stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
   /**
@@ -1044,8 +1042,6 @@ sealed trait ValueContentV2 extends KnoraContentV2[ValueContentV2] {
    * @return `true` if this [[ValueContentV2]] would duplicate `currentVersion`.
    */
   def wouldDuplicateCurrentVersion(currentVersion: ValueContentV2): Boolean
-
-  def asOpt[T <: ValueContentV2: ClassTag]: Option[T] = condOpt(this) { case a: T => a }
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/util/WithAsIs.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/WithAsIs.scala
@@ -1,0 +1,14 @@
+/*
+ * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.util
+
+import PartialFunction.{condOpt, cond}
+import scala.reflect.ClassTag
+
+trait WithAsIs[A] {
+  def asOpt[T <: A: ClassTag]: Option[T] = condOpt(this) { case a: T => a }
+  def is[T <: A: ClassTag]: Boolean      = cond(this) { case _: T => true }
+}

--- a/webapi/src/main/scala/org/knora/webapi/util/WithAsIs.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/WithAsIs.scala
@@ -5,8 +5,9 @@
 
 package org.knora.webapi.util
 
-import PartialFunction.{condOpt, cond}
 import scala.reflect.ClassTag
+
+import PartialFunction.{condOpt, cond}
 
 trait WithAsIs[A] {
   def asOpt[T <: A: ClassTag]: Option[T] = condOpt(this) { case a: T => a }


### PR DESCRIPTION
## Pull Request Checklist

### Task Description/Number

Refactoring changes are split per commits whose descriptions are (time ascending order):
* reuse header adding code, reuse jsonLdHttpEntity
* add WithAsIs(asOpt) and create assertingUnique
* actually use jsonLdHttpEntity everywhere
* def requestJsonLdWithAuth(request) = request with "~> addAuthorization"
* reuse URLencode + getResponseJsonLD inlining
* flatten some UploadFileRequest.make().toJsonLd calls
* import OntologyConstants._ and the resulting changes
* moving around a few things (diff: +10, -41)

Issues in tests discovered while working on DEV-3504.

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [x] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)