### PR TITLE
refactor: Introduce SparqlTimeOut, preparation to allow different timeouts for maintenance queries

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectImportServiceIT.scala
+++ b/integration/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectImportServiceIT.scala
@@ -40,6 +40,7 @@ object ProjectImportServiceIT extends ZIOSpecDefault {
           useHttps = false,
           host = container.getHost,
           queryTimeout = java.time.Duration.ofSeconds(5),
+          maintenanceTimeout = java.time.Duration.ofSeconds(5),
           gravsearchTimeout = java.time.Duration.ofSeconds(5),
           autoInit = false,
           fuseki = Fuseki(

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -410,6 +410,9 @@ app {
         // timeout for triplestore queries. can be same or lower then pekko.http.server.request-timeout.
         query-timeout = 20 seconds
 
+        // timeout for triplestore queries for maintenance actions. can be same or lower then pekko.http.server.request-timeout.
+        maintenance-timeout = 120 seconds
+
         // timeout for Gravsearch queries. can be same or lower then pekko.http.server.request-timeout.
         gravsearch-timeout = 120 seconds
 

--- a/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -153,6 +153,7 @@ final case class Triplestore(
   host: String,
   queryTimeout: Duration,
   gravsearchTimeout: Duration,
+  maintenanceTimeout: Duration,
   autoInit: Boolean,
   fuseki: Fuseki,
   profileQueries: Boolean,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -374,7 +374,7 @@ final case class SearchResponderV2Live(
 
           for {
             query          <- constructTransformer.transform(mainQuery).map(_.toSparql)
-            searchResponse <- triplestore.query(Construct(query, isGravsearch = true)).flatMap(_.asExtended)
+            searchResponse <- triplestore.query(Construct.gravsearch(query)).flatMap(_.asExtended)
             // separate resources and value objects
             queryResultsSep = constructResponseUtilV2.splitMainResourcesAndValueRdfData(searchResponse, requestingUser)
           } yield queryResultsSep
@@ -467,7 +467,7 @@ final case class SearchResponderV2Live(
                       ontologiesForInferenceMaybe,
                     )
 
-      countResponse <- triplestore.query(Select(countQuery.toSparql, isGravsearch = true))
+      countResponse <- triplestore.query(Select.gravsearch(countQuery.toSparql))
 
       _ <- // query response should contain one result with one row with the name "count"
         ZIO
@@ -543,7 +543,7 @@ final case class SearchResponderV2Live(
 
       prequeryResponseNotMerged <-
         triplestore
-          .query(Select(prequerySparql, isGravsearch = true))
+          .query(Select.gravsearch(prequerySparql))
           .logError(s"Gravsearch timed out for prequery:\n$prequerySparql")
 
       pageSizeBeforeFiltering: Int = prequeryResponseNotMerged.results.bindings.size
@@ -621,7 +621,7 @@ final case class SearchResponderV2Live(
 
           for {
             mainQuery         <- constructTransformer.transform(mainQuery, ontologiesForInferenceMaybe).map(_.toSparql)
-            mainQueryResponse <- triplestore.query(Construct(mainQuery, isGravsearch = true)).flatMap(_.asExtended)
+            mainQueryResponse <- triplestore.query(Construct.gravsearch(mainQuery)).flatMap(_.asExtended)
 
             // Filter out values that the user doesn't have permission to see.
             queryResultsFilteredForPermissions =

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -209,7 +209,7 @@ case class TriplestoreServiceLive(
    */
   private def getAllGraphs: Task[Seq[String]] =
     for {
-      res     <- query(Select("select ?g {graph ?g {?s ?p ?o}} group by ?g", isGravsearch = false))
+      res     <- query(Select("select ?g {graph ?g {?s ?p ?o}} group by ?g"))
       bindings = res.results.bindings
       graphs   = bindings.map(_.rowMap("g"))
     } yield graphs
@@ -393,14 +393,15 @@ case class TriplestoreServiceLive(
     query: SparqlQuery,
     acceptMimeType: String = mimeTypeApplicationSparqlResultsJson,
   ) = {
-    // in case of a gravsearch query, a longer timeout is set
-    val timeout =
-      if (query.isGravsearch) triplestoreConfig.gravsearchTimeout.toSeconds.toInt.toString
-      else triplestoreConfig.queryTimeout.toSeconds.toInt.toString
+    val timeout: Duration = query.timeout match {
+      case SparqlTimeout.Standard    => triplestoreConfig.queryTimeout
+      case SparqlTimeout.Maintenance => triplestoreConfig.maintenanceTimeout
+      case SparqlTimeout.Gravsearch  => triplestoreConfig.gravsearchTimeout
+    }
 
     val formParams = new util.ArrayList[NameValuePair]()
     formParams.add(new BasicNameValuePair("query", query.sparql))
-    formParams.add(new BasicNameValuePair("timeout", timeout))
+    formParams.add(new BasicNameValuePair("timeout", "${timeout.toSeconds}"))
 
     val request: HttpPost = new HttpPost(paths.query)
     request.setEntity(new UrlEncodedFormEntity(formParams, Consts.UTF_8))
@@ -414,14 +415,15 @@ case class TriplestoreServiceLive(
     for {
       result <- reqTask @@ requestTimer
                   .tagged("type", query.getClass.getSimpleName)
-                  .tagged("isGravsearch", query.isGravsearch.toString)
+                  .tagged("isGravsearch", s"${query == SparqlTimeout.Gravsearch}")
+                  .tagged("isMaintenance", s"${query == SparqlTimeout.Maintenance}")
                   .trackDuration
       _ <- {
              val endTime  = java.lang.System.nanoTime()
              val duration = Duration.fromNanos(endTime - startTime)
              ZIO.when(duration >= trackingThreshold) {
                ZIO.logInfo(
-                 s"Fuseki request took $duration, which is longer than $trackingThreshold, isGravSearch=${query.isGravsearch}\n ${query.sparql}",
+                 s"Fuseki request took $duration, which is longer than $trackingThreshold, timeout=${query.timeout}\n ${query.sparql}",
                )
              }
            }.ignore

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -401,7 +401,7 @@ case class TriplestoreServiceLive(
 
     val formParams = new util.ArrayList[NameValuePair]()
     formParams.add(new BasicNameValuePair("query", query.sparql))
-    formParams.add(new BasicNameValuePair("timeout", "${timeout.toSeconds}"))
+    formParams.add(new BasicNameValuePair("timeout", s"${timeout.toSeconds}"))
 
     val request: HttpPost = new HttpPost(paths.query)
     request.setEntity(new UrlEncodedFormEntity(formParams, Consts.UTF_8))

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
@@ -82,10 +82,8 @@ object TestTripleStore {
 final case class TriplestoreServiceInMemory(datasetRef: Ref[Dataset])(implicit val sf: StringFormatter)
     extends TestTripleStore {
 
-  override def query(query: Select): Task[SparqlSelectResult] = {
-    require(!query.isGravsearch, "`isGravsearch` parameter is not supported by fake implementation yet")
+  override def query(query: Select): Task[SparqlSelectResult] =
     ZIO.scoped(execSelect(query.sparql).map(toSparqlSelectResult))
-  }
 
   private def execSelect(query: String): ZIO[Any & Scope, Throwable, ResultSet] = {
     def executeQuery(qExec: QueryExecution) = ZIO.attempt(qExec.execSelect)


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Replaces `isGravsearch: Boolean` with a `SparqlTimeout` enum. Keeps queries with different timeout separated in our prometheus metrics.

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [x] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
