### PR TITLE
feat(sipi): Allow read all images for users with write:project:XXXX scope (DEV-2628)

### DIFF
--- a/integration/src/test/scala/org/knora/sipi/SipiIT.scala
+++ b/integration/src/test/scala/org/knora/sipi/SipiIT.scala
@@ -11,7 +11,9 @@ import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern
-import dsp.valueobjects.UuidUtil
+import pdi.jwt.JwtAlgorithm
+import pdi.jwt.JwtClaim
+import pdi.jwt.JwtZIOJson
 import zio.*
 import zio.http.*
 import zio.json.DecoderOps
@@ -21,13 +23,12 @@ import zio.test.*
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+
+import dsp.valueobjects.UuidUtil
 import org.knora.sipi.MockDspApiServer.verify.*
 import org.knora.webapi.slice.admin.api.model.PermissionCodeAndProjectRestrictedViewSettings
 import org.knora.webapi.testcontainers.SharedVolumes
 import org.knora.webapi.testcontainers.SipiTestContainer
-import pdi.jwt.JwtAlgorithm
-import pdi.jwt.JwtClaim
-import pdi.jwt.JwtZIOJson
 
 object SipiIT extends ZIOSpecDefault {
 

--- a/sipi/scripts/authentication.lua
+++ b/sipi/scripts/authentication.lua
@@ -74,7 +74,7 @@ function _decode_jwt(token_str)
     -- check audience of token
     local audience = decoded_token["aud"]
     local expected_audience = "Sipi"
-    if audience == nil or not table.contains(audience, expected_audience) then
+    if audience == nil or not table_contains(audience, expected_audience) then
         return _send_unauthorized_error("Invalid 'aud' (audience) in token, expected: " .. expected_audience .. ".")
     end
 

--- a/sipi/scripts/file_info.lua
+++ b/sipi/scripts/file_info.lua
@@ -141,7 +141,7 @@ function make_image_file_info(extension)
 end
 
 function make_audio_file_info(extension)
-    if not table.contains(audio_extensions, extension) then
+    if not table_contains(audio_extensions, extension) then
         return nil
     else
         return {
@@ -152,7 +152,7 @@ function make_audio_file_info(extension)
 end
 
 function make_video_file_info(extension)
-    if not table.contains(video_extensions, extension) then
+    if not table_contains(video_extensions, extension) then
         return nil
     else
         return {
@@ -163,7 +163,7 @@ function make_video_file_info(extension)
 end
 
 function make_text_file_info(extension)
-    if not table.contains(text_extensions, extension) then
+    if not table_contains(text_extensions, extension) then
         return nil
     else
         return {
@@ -174,7 +174,7 @@ function make_text_file_info(extension)
 end
 
 function make_document_file_info(extension)
-    if not table.contains(document_extensions, extension) then
+    if not table_contains(document_extensions, extension) then
         return nil
     else
         return {
@@ -185,7 +185,7 @@ function make_document_file_info(extension)
 end
 
 function make_archive_file_info(extension)
-    if not table.contains(archive_extensions, extension) then
+    if not table_contains(archive_extensions, extension) then
         return nil
     else
         return {
@@ -210,17 +210,17 @@ function get_file_info(filename, mimetype)
 
     if extension == nil then
         return nil
-    elseif table.contains(image_mime_types, mimetype) then
+    elseif table_contains(image_mime_types, mimetype) then
         return make_image_file_info(extension)
-    elseif table.contains(audio_mime_types, mimetype) then
+    elseif table_contains(audio_mime_types, mimetype) then
         return make_audio_file_info(extension)
-    elseif table.contains(video_mime_types, mimetype) then
+    elseif table_contains(video_mime_types, mimetype) then
         return make_video_file_info(extension)
-    elseif table.contains(text_mime_types, mimetype) then
+    elseif table_contains(text_mime_types, mimetype) then
         return make_text_file_info(extension)
-    elseif table.contains(document_mime_types, mimetype) then
+    elseif table_contains(document_mime_types, mimetype) then
         return make_document_file_info(extension)
-    elseif table.contains(archive_mime_types, mimetype) then
+    elseif table_contains(archive_mime_types, mimetype) then
         return make_archive_file_info(extension)
     else
 

--- a/sipi/scripts/sipi.init.lua
+++ b/sipi/scripts/sipi.init.lua
@@ -161,8 +161,7 @@ function _is_system_or_project_admin(token, shortcode)
     else
         local write_prj_scope = "write:project:" .. shortcode
         local scopes = str_splitString(token["scope"], " ")
-        log("pre_flight - scopes: " .. tableToString(scopes), server.loglevel.LOG_DEBUG)
-        return table.contains(scopes, "admin") or table.contains(scopes, write_prj_scope)
+        return table_contains(scopes, "admin") or table_contains(scopes, write_prj_scope)
     end
 end
 

--- a/sipi/scripts/sipi.init.lua
+++ b/sipi/scripts/sipi.init.lua
@@ -162,17 +162,8 @@ function _is_system_or_project_admin(token, shortcode)
         local write_prj_scope = "write:project:" .. shortcode
         local scopes = str_splitString(token["scope"], " ")
         log("pre_flight - scopes: " .. tableToString(scopes), server.loglevel.LOG_DEBUG)
-        return _table_contains(scopes, "admin") or _table_contains(scopes, write_prj_scope)
+        return table.contains(scopes, "admin") or table.contains(scopes, write_prj_scope)
     end
-end
-
-function _table_contains(table, what)
-    for _, value in pairs(table) do
-        if value == what then
-            return true
-        end
-    end
-    return false
 end
 
 function _file_not_found_response()

--- a/sipi/scripts/util.lua
+++ b/sipi/scripts/util.lua
@@ -1,19 +1,16 @@
 -- * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
 -- * SPDX-License-Identifier: Apache-2.0
 
---------------------------------------------------------------------------
--- Checks whether a table contains a value.
--- @param table the table to be checked.
--- @param search_value the value to look for.
--- @param a boolean indicating whether the table contains the value.
---------------------------------------------------------------------------
-function table.contains(table, search_value)
+--- Checks whether a table contains a value.
+--- @param table table to be checked.
+--- @param what any value to look for.
+--- @return boolean indicating whether the table contains the value.
+function table_contains(table, what)
   for _, value in pairs(table) do
-    if value == search_value then
+    if value == what then
       return true
     end
   end
-
   return false
 end
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/infrastructure/Scope.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/infrastructure/Scope.scala
@@ -17,6 +17,8 @@ object Scope {
   val admin: Scope = Scope(Set(ScopeValue.Admin))
 
   def from(scopeValues: Seq[ScopeValue]): Scope = scopeValues.foldLeft(Scope.empty)(_ + _)
+  def read(project: Shortcode): Scope           = Scope(Set(ScopeValue.Read(project)))
+  def write(project: Shortcode): Scope          = Scope(Set(ScopeValue.Write(project)))
 }
 
 sealed trait ScopeValue {


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

 Always allow access to resources in sipi if the access token is that of a system admin or project admin for the respective prefix. 
 
 This is necessary for the preview in dsp-app after the upload.
<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [x] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
