### PR TITLE
feat: Add 'keepAssets' query param to erase project endpoint

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
@@ -155,6 +155,11 @@ final case class ProjectsEndpoints(
 
     val deleteAdminProjectsByProjectShortcodeErase = baseEndpoints.securedEndpoint.delete
       .in(projectsByShortcode / "erase")
+      .in(
+        query[Boolean]("keepAssets")
+          .default(false)
+          .description("If set to true the assets in ingest will not be removed."),
+      )
       .out(jsonBody[ProjectOperationResponseADM])
       .description(
         """|!ATTENTION! Erase a project with the given shortcode.

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpointsHandler.scala
@@ -139,7 +139,7 @@ final case class ProjectsEndpointsHandler(
   val deleteAdminProjectsByProjectShortcodeEraseHandler =
     SecuredEndpointHandler(
       projectsEndpoints.Secured.deleteAdminProjectsByProjectShortcodeErase,
-      user => (id: Shortcode) => restService.eraseProject(id, user),
+      user => (id: Shortcode, keepAssets: Boolean) => restService.eraseProject(id, user, keepAssets),
     )
 
   val getAdminProjectsExportsHandler =

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectRestService.scala
@@ -129,7 +129,7 @@ final case class ProjectRestService(
       external <- format.toExternal(internal)
     } yield external
 
-  def eraseProject(shortcode: Shortcode, user: User): Task[ProjectOperationResponseADM] =
+  def eraseProject(shortcode: Shortcode, user: User, keepAssets: Boolean): Task[ProjectOperationResponseADM] =
     for {
       _ <- auth.ensureSystemAdmin(user)
       _ <- ZIO.unless(features.allowEraseProjects)(
@@ -142,7 +142,7 @@ final case class ProjectRestService(
                    .findByShortcode(shortcode)
                    .someOrFail(NotFoundException(s"$shortcode not found"))
       _        <- ZIO.logInfo(s"${user.userIri} erases project $shortcode")
-      _        <- projectEraseService.eraseProject(project)
+      _        <- projectEraseService.eraseProject(project, keepAssets)
       external <- format.toExternal(ProjectOperationResponseADM(internal))
     } yield external
 


### PR DESCRIPTION
If true the assets in ingest will be kept.

The motivation for this flag comes from from @jnussbaum who would only want to remove the api data and reuse already ingested assets for test runs [on one of the RDU servers](https://github.com/dasch-swiss/ops-deploy/pull/768/files).
