### PR TITLE
chore: Add IRI to error message when a Group IRI is invalid.

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/KnoraGroup.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/KnoraGroup.scala
@@ -105,7 +105,7 @@ object GroupIri extends StringValueCompanion[GroupIri] {
   def from(value: String): Either[String, GroupIri] = value match {
     case _ if value.isEmpty          => Left("Group IRI cannot be empty.")
     case _ if isGroupIriValid(value) => Right(GroupIri(value))
-    case _                           => Left("Group IRI is invalid.")
+    case v                           => Left(s"Group IRI is invalid: $v")
   }
 
   /**

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/GroupIriSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/GroupIriSpec.scala
@@ -37,7 +37,7 @@ object GroupIriSpec extends ZIOSpecDefault {
           "http://rdfh.ch/groups/jDEEitJESRi3pDaDjjQ1WQ",
         ),
       )
-      check(invalidIris)(i => assertTrue(GroupIri.from(i) == Left(s"Group IRI is invalid.")))
+      check(invalidIris)(i => assertTrue(GroupIri.from(i) == Left(s"Group IRI is invalid: $i")))
     },
   )
 }


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

When a group IRI is invalid, include in the error message the IRI. This will help debugging an issue that today proved hard to investigate because the error message doesn't provide any information.

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
