### PR TITLE
fix: Smaller granularity for Grafana fuseki durations (DEV-3776)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -75,8 +75,8 @@ case class TriplestoreServiceLive(
     Metric.timer(
       "fuseki_request_duration",
       ChronoUnit.MILLIS,
-      // 7 buckets for upper bounds 10ms, 100ms, 1s, 10s, 1.6m, 16.6m, inf
-      Chunk.iterate(10.0, 6)(_ * 10),
+      // 7 buckets for upper bounds: 2 ms, 4 ms, 8 ms, 16 ms, 32 ms, 64 ms, inf
+      Chunk.iterate(2.0, 6)(_ * 2),
     )
 
   private def processError(sparql: String, response: String): IO[TriplestoreException, Nothing] =


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

Right now, they all fall into the same bucket and the graph seems to have no meaning.

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
