### PR TITLE
fix: Fix query tracking tags (== is faulty), set previous bucket sizes (DEV-3776)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -75,8 +75,8 @@ case class TriplestoreServiceLive(
     Metric.timer(
       "fuseki_request_duration",
       ChronoUnit.MILLIS,
-      // 7 buckets for upper bounds: 2 ms, 4 ms, 8 ms, 16 ms, 32 ms, 64 ms, inf
-      Chunk.iterate(2.0, 6)(_ * 2),
+      // 7 buckets for upper bounds: 10 ms, 100 ms, 1s, 10s, 100s, 1000s
+      Chunk.iterate(10.0, 6)(_ * 10),
     )
 
   private def processError(sparql: String, response: String): IO[TriplestoreException, Nothing] =
@@ -403,8 +403,8 @@ case class TriplestoreServiceLive(
     for {
       result <- reqTask @@ requestTimer
                   .tagged("type", query.getClass.getSimpleName)
-                  .tagged("isGravsearch", s"${query == SparqlTimeout.Gravsearch}")
-                  .tagged("isMaintenance", s"${query == SparqlTimeout.Maintenance}")
+                  .tagged("isGravsearch", s"${query.timeout == SparqlTimeout.Gravsearch}")
+                  .tagged("isMaintenance", s"${query.timeout == SparqlTimeout.Maintenance}")
                   .trackDuration
       _ <- {
              val endTime  = java.lang.System.nanoTime()


### PR DESCRIPTION
## Pull Request Checklist

Checked that the labels are now differentiated locally. The problem was == is really lax and just compares the object ids (or something). Cats' `===` would work, but then an `Eq` has to be derived and imported. The problem was `.timeout` wasn't added, so it was compared against an entirely different set of objects.

Second, now that the Grafana dashboard calculates the heatmaps correctly and bucket differences are pristine, I'm restoring the wide bucket range.

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
