### PR TITLE
feat: Add feature flag to disable lastModificationDate check (DEV-3870)

### DIFF
--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -456,5 +456,8 @@ app {
     features {
         allow-erase-projects = false
         allow-erase-projects = ${?ALLOW_ERASE_PROJECTS}
+
+        disable-last-modification-date-check = false
+        disable-last-modification-date-check = ${DISABLE_LAST_MODIFICATION_DATE_CHECK}
     }
 }

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -458,6 +458,6 @@ app {
         allow-erase-projects = ${?ALLOW_ERASE_PROJECTS}
 
         disable-last-modification-date-check = false
-        disable-last-modification-date-check = ${DISABLE_LAST_MODIFICATION_DATE_CHECK}
+        disable-last-modification-date-check = ${?DISABLE_LAST_MODIFICATION_DATE_CHECK}
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -185,14 +185,19 @@ object AppConfig {
   val parseConfig: UIO[AppConfig] = {
     val descriptor = deriveConfig[AppConfig].mapKey(toKebabCase)
     val source     = TypesafeConfigProvider.fromTypesafeConfig(ConfigFactory.load().getConfig("app").resolve)
-    read(descriptor from source).orDie
+    read(descriptor from source).tap(logFeaturesEnabled).orDie
   }
 
-  val layer: ULayer[AppConfigurations] = {
-    val appConfigLayer = ZLayer.fromZIO(
-      parseConfig.tap(c => ZIO.logInfo("Feature: ALLOW_ERASE_PROJECTS enabled").when(c.features.allowEraseProjects)),
-    )
-    projectAppConfigurations(appConfigLayer).tap(_ => ZIO.logInfo(">>> AppConfig Initialized <<<"))
+  val layer: ULayer[AppConfigurations] =
+    projectAppConfigurations(ZLayer.fromZIO(parseConfig))
+      .tap(_ => ZIO.logInfo(">>> AppConfig Initialized <<<"))
+
+  private def logFeaturesEnabled(c: AppConfig) = {
+    val features = List(
+      "ALLOW_ERASE_PROJECTS"                 -> c.features.allowEraseProjects,
+      "DISABLE_LAST_MODIFICATION_DATE_CHECK" -> c.features.disableLastModificationDateCheck,
+    ).collect { case (feature, enabled) if enabled => feature }
+    ZIO.logInfo(s"Features enabled: ${features.mkString(", ")}").when(features.nonEmpty)
   }
 
   def projectAppConfigurations[R](appConfigLayer: URLayer[R, AppConfig]): URLayer[R, AppConfigurations] =

--- a/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -173,7 +173,10 @@ final case class InstrumentationServerConfig(
   interval: Duration,
 )
 
-final case class Features(allowEraseProjects: Boolean)
+final case class Features(
+  allowEraseProjects: Boolean,
+  disableLastModificationDateCheck: Boolean,
+)
 
 object AppConfig {
   type AppConfigurationsTest = AppConfig & DspIngestConfig & Triplestore & Features & Sipi

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -11,6 +11,7 @@ import zio.ZIO
 
 import java.time.Instant
 import java.util.UUID
+
 import dsp.errors.*
 import dsp.valueobjects.Iri
 import dsp.valueobjects.UuidUtil

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -208,7 +208,7 @@ final case class ResourcesResponderV2(
     ZIO
       .fail(
         EditConflictException(
-          s"Resource $resourceIri has been modified since you last read it.  Its lastModificationDate " +
+          s"Resource $resourceIri has been modified since you last read it. Its lastModificationDate " +
             s"${providedLastModificationDate.map(_.toString).getOrElse("")} must be included in the request body.",
         ),
       )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -217,7 +217,7 @@ final case class ResourcesResponderV2(
       .fail(
         EditConflictException(
           s"Resource $resourceIri has been modified since you last read it. Its lastModificationDate " +
-            s"${providedLastModificationDate.map(_.toString).getOrElse("")} must be included in the request body.",
+            s"${existingLastModificationDate.map(_.toString).getOrElse("")} must be included in the request body.",
         ),
       )
       .when(isConflict && !appConfig.features.disableLastModificationDateCheck)

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -206,7 +206,6 @@ final case class ResourcesResponderV2(
     providedLastModificationDate: Option[Instant],
   ): IO[EditConflictException, Unit] = {
     val existingLastModificationDate = resource.lastModificationDate
-    val resourceIri                  = resource.resourceIri
     val isConflict = (
       for {
         existingDate <- existingLastModificationDate
@@ -216,7 +215,7 @@ final case class ResourcesResponderV2(
     ZIO
       .fail(
         EditConflictException(
-          s"Resource $resourceIri has been modified since you last read it. Its lastModificationDate " +
+          s"Resource ${resource.resourceIri} has been modified since you last read it. Its lastModificationDate " +
             s"${existingLastModificationDate.map(_.toString).getOrElse("")} must be included in the request body.",
         ),
       )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -197,8 +197,7 @@ final case class ResourcesResponderV2(
    * It is a conflict if the resource has been modified since the client last read it.
    * It is also conflict if the resource has a LMD  but it was not provided by the client.
    *
-   * @param resourceIri The resource to be updated.
-   * @param existingLastModificationDate The lastModificationDate of the existing resource.
+   * @param resource The resource to be updated.
    * @param providedLastModificationDate The lastModificationDate provided by the client.
    * @return Fails with an [[EditConflictException]] if there is a conflict.
    */

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -200,13 +200,13 @@ final case class ResourcesResponderV2(
    * @param resourceIri The resource to be updated.
    * @param existingLastModificationDate The lastModificationDate of the existing resource.
    * @param providedLastModificationDate The lastModificationDate provided by the client.
-   * @return
+   * @return Fails with an [[EditConflictException]] if there is a conflict.
    */
   private def checkForConflictingChanges(
     resourceIri: IRI,
     existingLastModificationDate: Option[Instant],
     providedLastModificationDate: Option[Instant],
-  ) = {
+  ): IO[EditConflictException, Unit] = {
     val isConflict = (
       for {
         existingDate <- existingLastModificationDate
@@ -221,6 +221,7 @@ final case class ResourcesResponderV2(
         ),
       )
       .when(isConflict && !appConfig.features.disableLastModificationDateCheck)
+      .unit
   }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -195,7 +195,7 @@ final case class ResourcesResponderV2(
   /**
    * If resource has already been modified, make sure that its lastModificationDate is given in the request body.
    * It is a conflict if the resource has been modified since the client last read it.
-   * It is also conflict if the resource has a LMD  but it was not provided by the client.
+   * It is also conflict if the resource has a lastModificationDate but it was not provided by the client.
    *
    * @param resource The resource to be updated.
    * @param providedLastModificationDate The lastModificationDate provided by the client.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ontology/OntologyTriplestoreHelpers.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ontology/OntologyTriplestoreHelpers.scala
@@ -9,6 +9,7 @@ import zio.*
 
 import java.time.Instant
 import scala.collection.immutable
+
 import dsp.errors.*
 import org.knora.webapi.*
 import org.knora.webapi.config.Features


### PR DESCRIPTION
- **Add feature flag**
- **Integrate feature flag**
- **Introduces `DISABLE_LAST_MODIFICATION_DATE_CHECK` environment variable, set to `true` in order to disable the check for all endpoints**

List of places where the LMD is checked:

In ResourceResponderV2:
* markResourceAsDeletedV2
* eraseResourceV2
* updateResourceMetadataV2

In OntologyResponderV2:
* changeGuiOrder
* changeOntologyMetadata
* deleteCardinalitiesFromClass
* changePropertyLabelsOrComments
* deleteOntologyComment
* changePropertyGuiElement
* addCardinalitiesToClass
* changeClassLabelsOrComments
* createProperty
* createClass
* canDeleteCardinalitiesFromClass
* checkLastModificationDateAndCanCardinalitiesBeSet
* deleteProperty
* deleteClassComment
* deleteOntology
* deletePropertyComment
* deleteClass

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [x] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
