### PR TITLE
fix: Do not log on error level when invalid credentials are provided (DEV-3975)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/security/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/security/Authenticator.scala
@@ -221,7 +221,7 @@ final case class AuthenticatorLive(
   override def authenticate(jwtToken: String): IO[AuthenticatorError, User] = for {
     _ <- ZIO.fail(BadCredentials).when(invalidTokens.contains(jwtToken))
     userIri <-
-      jwtService.extractUserIriFromToken(jwtToken).some.map(UserIri.from).right.logError.orElseFail(BadCredentials)
+      jwtService.extractUserIriFromToken(jwtToken).logError.some.map(UserIri.from).right.orElseFail(BadCredentials)
     user <- getUserByIri(userIri)
   } yield user
 


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-3975

This was causing many false positive error logs on grafana

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
