### PR TITLE
fix: Respond with internal error instead of bad credentials when triplestore is down during authentication (DEV-4019)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/security/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/security/Authenticator.scala
@@ -226,13 +226,13 @@ final case class AuthenticatorLive(
   } yield user
 
   private def getUserByIri(iri: UserIri): IO[AuthenticatorError, User] =
-    userService.findUserByIri(iri).some.orElseFail(UserNotFound).tap(ensureActiveUser).logError
+    userService.findUserByIri(iri).orDie.someOrFail(UserNotFound).tap(ensureActiveUser)
 
   private def getUserByEmail(email: Email): IO[AuthenticatorError, User] =
-    userService.findUserByEmail(email).some.orElseFail(UserNotFound).tap(ensureActiveUser)
+    userService.findUserByEmail(email).orDie.someOrFail(UserNotFound).tap(ensureActiveUser)
 
   private def getUserByUsername(username: Username): IO[AuthenticatorError, User] =
-    userService.findUserByUsername(username).some.orElseFail(UserNotFound).tap(ensureActiveUser)
+    userService.findUserByUsername(username).orDie.someOrFail(UserNotFound).tap(ensureActiveUser)
 
   private def ensureActiveUser(user: User): IO[AuthenticatorError, Unit] = for {
     _ <- ZIO.fail(UserNotActive).when(!user.isActive)

--- a/webapi/src/main/scala/org/knora/webapi/slice/security/api/AuthenticationEndpointsV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/security/api/AuthenticationEndpointsV2Handler.scala
@@ -10,6 +10,7 @@ import zio.ZLayer
 
 import java.time.Instant
 
+import dsp.errors.AuthenticationException
 import dsp.errors.BadCredentialsException
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.slice.admin.domain.model.Username
@@ -27,7 +28,6 @@ import org.knora.webapi.slice.security.api.AuthenticationEndpointsV2.LoginPayloa
 import org.knora.webapi.slice.security.api.AuthenticationEndpointsV2.LoginPayload.UsernamePassword
 import org.knora.webapi.slice.security.api.AuthenticationEndpointsV2.LogoutResponse
 import org.knora.webapi.slice.security.api.AuthenticationEndpointsV2.TokenResponse
-import dsp.errors.AuthenticationException
 
 case class AuthenticationEndpointsV2Handler(
   appConfig: AppConfig,

--- a/webapi/src/main/scala/org/knora/webapi/slice/security/api/AuthenticationEndpointsV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/security/api/AuthenticationEndpointsV2Handler.scala
@@ -27,6 +27,7 @@ import org.knora.webapi.slice.security.api.AuthenticationEndpointsV2.LoginPayloa
 import org.knora.webapi.slice.security.api.AuthenticationEndpointsV2.LoginPayload.UsernamePassword
 import org.knora.webapi.slice.security.api.AuthenticationEndpointsV2.LogoutResponse
 import org.knora.webapi.slice.security.api.AuthenticationEndpointsV2.TokenResponse
+import dsp.errors.AuthenticationException
 
 case class AuthenticationEndpointsV2Handler(
   appConfig: AppConfig,
@@ -51,6 +52,8 @@ case class AuthenticationEndpointsV2Handler(
         }).mapBoth(
           _ => BadCredentialsException(BAD_CRED_NOT_VALID),
           (_, token) => setCookieAndResponse(token),
+        ).catchAllDefect(e =>
+          ZIO.fail(AuthenticationException("An internal error happened during authentication", Some(e))),
         )
       },
     )


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

Issue Number: DEV-4019

This PR fixxes the problem that when Fuseki is down and a client tries to authenticate, the API will return a `Bad Credentials` instead of `Internal Server Error` (breaking DSP-TOOLS' retry strategy).  
The cause is that the authenticator treats errors in finding the user the same as not finding them, which is a wrong assumption.  
This PR addresses this by using `die` for the actual errors and the `fail` channel for the not-found case. Alternatively, one could solve this with Optional/Either in the error channel. I'm open for discussion.

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
