### PR TITLE
chore: Remove unused imports from TWIRL templates and silence false positives

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,6 +149,7 @@ val customScalacOptions = Seq(
   "-unchecked",
   "-deprecation",
   "-Yresolve-term-conflict:package",
+  "-Wconf:src=target/.*:s", // silence TWIRL templates unused imports warnings
   "-Wunused:imports",
   "-Wunused:privates",
   "-Wunused:locals",

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/gravsearch/getIncomingImageLinks.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/gravsearch/getIncomingImageLinks.scala.txt
@@ -4,7 +4,6 @@
  *@
 
 @import org.knora.webapi._
-@import org.knora.webapi.messages.SmartIri
 
 @*
  * Constructs a Gravsearch query that returns all the knora-api:StillImageRepresentation resources

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/changeParentNode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/changeParentNode.scala.txt
@@ -4,7 +4,6 @@
  *@
 
 @import org.knora.webapi.IRI
-@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 
 @**
  * Changes the parent node of an existing node.

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListNodeExistsByName.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/checkListNodeExistsByName.scala.txt
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  *@
 
-@import org.knora.webapi.IRI
-
 @**
  * Checks if a list node exists.
  *

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/deleteNode.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/deleteNode.scala.txt
@@ -4,7 +4,6 @@
  *@
 
 @import org.knora.webapi.IRI
-@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 
 @**
  * Delete a node (root or child). If a child node is deleted, remove it from the list of its parent's sublist nodes.

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/deletePermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/deletePermission.scala.txt
@@ -4,7 +4,6 @@
  *@
 
 @import org.knora.webapi.IRI
-@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 
 @**
  * Delete an existing permission.

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getFileValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getFileValue.scala.txt
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  *@
 
-@import org.knora.webapi.IRI
-
 @**
  * Given a knora:base:internalFilename, retrieves the file value and information
  * attached to it using SPARQL w/o inference.

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectOfEntity.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/getProjectOfEntity.scala.txt
@@ -4,7 +4,6 @@
  *@
 
 @import org.knora.webapi.IRI
-@import org.knora.webapi.messages.util.KnoraSystemInstances
 
 @**
  * Gets the project an entity (resource or value) is attached to.

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateNodePosition.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updateNodePosition.scala.txt
@@ -4,7 +4,6 @@
  *@
 
 @import org.knora.webapi.IRI
-@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 
 @**
  * Updates an existing node's position.

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updatePermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/updatePermission.scala.txt
@@ -4,7 +4,6 @@
  *@
 
 @import org.knora.webapi.IRI
-@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 
 @**
  * Updates an existing permission's properties.

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changePropertyGuiElement.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changePropertyGuiElement.scala.txt
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *@
 
-@import dsp.errors.SparqlGenerationException
 @import org.knora.webapi.messages.SmartIri
-@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 @import java.time.Instant
 
 @*

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createProperty.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/createProperty.scala.txt
@@ -6,7 +6,6 @@
 @import org.knora.webapi._
 @import org.knora.webapi.messages.SmartIri
 @import org.knora.webapi.messages.v2.responder.ontologymessages._
-@import org.knora.webapi.messages.StringFormatter
 @import org.knora.webapi.messages.store.triplestoremessages._
 @import java.time.Instant
 

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteClass.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteClass.scala.txt
@@ -5,7 +5,6 @@
 
 @import org.knora.webapi._
 @import org.knora.webapi.messages.SmartIri
-@import org.knora.webapi.messages.v2.responder.ontologymessages._
 @import java.time.Instant
 
 @*

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteProperty.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteProperty.scala.txt
@@ -5,7 +5,6 @@
 
 @import org.knora.webapi._
 @import org.knora.webapi.messages.SmartIri
-@import org.knora.webapi.messages.v2.responder.ontologymessages._
 @import java.time.Instant
 
 @*

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteValue.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/deleteValue.scala.txt
@@ -4,8 +4,6 @@
  *@
 
 @import java.time.Instant
-@import java.util.UUID
-@import dsp.valueobjects.UuidUtil
 @import org.knora.webapi._
 @import dsp.errors.SparqlGenerationException
 @import org.knora.webapi.messages.SmartIri

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResource.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResource.scala.txt
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  *@
 
-@import java.time.Instant
 @import org.knora.webapi._
 
 @**

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getAllOntologyMetadata.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getAllOntologyMetadata.scala.txt
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  *@
 
-@import org.knora.webapi.IRI
-
 @*
  * Gets the predicates and objects of an ontology IRI.
  *@

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getAllResourcesInProjectPrequery.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getAllResourcesInProjectPrequery.scala.txt
@@ -4,7 +4,6 @@
  *@
 
 @import org.knora.webapi._
-@import org.knora.webapi.messages.SmartIri
 
 @*
  * Constructs a prequery that gets all resources from the specified project

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcePropertiesAndValues.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/getResourcePropertiesAndValues.scala.txt
@@ -7,7 +7,6 @@
 @import java.util.UUID
 @import dsp.valueobjects.UuidUtil
 @import org.knora.webapi.IRI
-@import dsp.errors.SparqlGenerationException
 @import org.knora.webapi.messages.SmartIri
 
 @*

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/isEntityUsed.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/isEntityUsed.scala.txt
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  *@
 
-@import org.knora.webapi.messages.SmartIri
-
 @*
  * Checks whether an entity is used (i.e. is the object of any statements).
  *


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

I've got annoyed by warns thrown by the complier therefore removed unused TWIRL imports.
Additionally silenced the false positive warnings coming from these templates which are not supported in Scala version we are using, but are again supported in Scala 3.5.0: https://github.com/scala/scala3/pull/18783

### PR Type

- [x] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
