### PR TITLE
test: Remove CreatePropertyRequestV2 from OntologyResponderSpecV2

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -1938,7 +1938,6 @@ object OwlCardinality extends Enumeration {
     def equalsWithoutGuiOrder(that: KnoraCardinalityInfo): Boolean =
       that.cardinality == cardinality
 
-    def isRequired: Boolean = cardinality.isRequired
   }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -43,6 +43,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
+import org.knora.webapi.slice.ontology.domain.model.Cardinality.AtLeastOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
@@ -340,21 +341,25 @@ final case class CreateResourceV2Handler(
            }
 
       // Check that no required values are missing.
-      requiredProps = knoraPropertyCardinalities.filter { case (_, cardinality) =>
-                        cardinality.isRequired
-                      }.keySet -- resourceClassInfo.linkProperties
-      propsWithoutValues =
-        internalCreateResource.values.collect { case (key, values) if values.nonEmpty => key }.toSet
-      missingProps = requiredProps -- propsWithoutValues
-      _ <- ZIO.fail {
-             val externalResourceClassIri =
-               s"<${internalCreateResource.resourceClassIri.toOntologySchema(ApiV2Complex)}>"
-             val externalMissingPropIris =
-               missingProps.map(iri => s"<${iri.toOntologySchema(ApiV2Complex)}>").mkString(", ")
-             val msg =
-               s"${resourceIDForErrorMsg}Values were not submitted for the following property or properties, which are required by resource class $externalResourceClassIri: $externalMissingPropIris"
-             OntologyConstraintException(msg)
-           }.when(missingProps.nonEmpty)
+
+      requiredProps: Set[SmartIri] = knoraPropertyCardinalities.filter { case (_, cardinalityInfo) =>
+                                       cardinalityInfo.cardinality == ExactlyOne || cardinalityInfo.cardinality == AtLeastOne
+                                     }.keySet -- resourceClassInfo.linkProperties
+
+      internalPropertyIris: Set[SmartIri] = internalCreateResource.values.keySet
+
+      _ <- ZIO.when(!requiredProps.subsetOf(internalPropertyIris)) {
+             val missingProps =
+               (requiredProps -- internalPropertyIris)
+                 .map(iri => s"<${iri.toOntologySchema(ApiV2Complex)}>")
+                 .mkString(", ")
+             ZIO.fail(
+               OntologyConstraintException(
+                 s"${resourceIDForErrorMsg}Values were not submitted for the following property or properties, which are required by resource class <${internalCreateResource.resourceClassIri
+                     .toOntologySchema(ApiV2Complex)}>: $missingProps",
+               ),
+             )
+           }
 
       // Check that each submitted value is consistent with the knora-base:objectClassConstraint of the property that is supposed to
       // point to it.

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/model/Cardinality.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/model/Cardinality.scala
@@ -37,13 +37,6 @@ sealed trait Cardinality {
   }
 
   /**
-   * Checks whether for this cardinality a value is required.
-   *
-   * @return `true` if the cardinality is required, `false` otherwise.
-   */
-  def isRequired: Boolean = min > 0
-
-  /**
    * Negated check for [[Cardinality.isIncludedIn(org.knora.webapi.slice.ontology.domain.model.Cardinality)]]
    *
    * @param other The cardinality to be compared against.


### PR DESCRIPTION
- **Remove `appActor ! CreatePropertyRequestV2` and replace with method call on responder in `OntologyResponderSpecV2`**

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
