### PR TITLE
fix: During resource creation verify required cardinalities based on the provided values (DEV-4017) (#3347)"

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -1938,6 +1938,7 @@ object OwlCardinality extends Enumeration {
     def equalsWithoutGuiOrder(that: KnoraCardinalityInfo): Boolean =
       that.cardinality == cardinality
 
+    def isRequired: Boolean = cardinality.isRequired
   }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/model/Cardinality.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/model/Cardinality.scala
@@ -37,6 +37,13 @@ sealed trait Cardinality {
   }
 
   /**
+   * Checks whether for this cardinality a value is required.
+   *
+   * @return `true` if the cardinality is required, `false` otherwise.
+   */
+  def isRequired: Boolean = min > 0
+
+  /**
    * Negated check for [[Cardinality.isIncludedIn(org.knora.webapi.slice.ontology.domain.model.Cardinality)]]
    *
    * @param other The cardinality to be compared against.


### PR DESCRIPTION
This reverts commit ecc5a1ad815440c3549804872dac0860c60d0730.

This was unfortunately merged with https://github.com/dasch-swiss/dsp-api/pull/3354 which should only contain the refactoring but contained a revert of https://github.com/dasch-swiss/dsp-api/pull/3347

Initially I simply wanted to revert the fix before adding a test in order to make sure the test fails. But when opening the PR as refactoring only I then forgot to remove the revert of the fix.



<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
