### PR TITLE
test: Fix testcontainer startup

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/config/AppConfigForTestContainersZSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/config/AppConfigForTestContainersZSpec.scala
@@ -32,7 +32,7 @@ object AppConfigForTestContainersZSpec extends ZIOSpecDefault {
     AppConfigForTestContainers.testcontainers,
     DspIngestTestContainer.layer,
     FusekiTestContainer.layer,
-    SharedVolumes.Images.layer,
+    SharedVolumes.layer,
     SipiTestContainer.layer,
   )
 }

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
@@ -91,8 +91,7 @@ object LayersTest {
     LayersLive.DspEnvironmentLive & FusekiTestContainer & TestClientService
 
   type DefaultTestEnvironmentWithSipi =
-    DefaultTestEnvironmentWithoutSipi & SipiTestContainer & DspIngestTestContainer & SharedVolumes.Images &
-      SharedVolumes.Temp
+    DefaultTestEnvironmentWithoutSipi & SipiTestContainer & DspIngestTestContainer & SharedVolumes.Volumes
 
   type CommonR0 =
     pekko.actor.ActorSystem & AppConfigurationsTest & JwtConfig & WhichSipiService

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
@@ -240,8 +240,8 @@ object LayersTest {
 
   private val fusekiAndSipiTestcontainers =
     ZLayer.make[
-      AppConfigurations & DspIngestTestContainer & FusekiTestContainer & SharedVolumes.Temp & SharedVolumes.Images &
-        SipiTestContainer & WhichSipiService,
+      AppConfigurations & DspIngestTestContainer & FusekiTestContainer & SharedVolumes.Volumes & SipiTestContainer &
+        WhichSipiService,
     ](
       AppConfigForTestContainers.testcontainers,
       DspIngestTestContainer.layer,

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
@@ -91,7 +91,8 @@ object LayersTest {
     LayersLive.DspEnvironmentLive & FusekiTestContainer & TestClientService
 
   type DefaultTestEnvironmentWithSipi =
-    DefaultTestEnvironmentWithoutSipi & SipiTestContainer & DspIngestTestContainer & SharedVolumes.Images
+    DefaultTestEnvironmentWithoutSipi & SipiTestContainer & DspIngestTestContainer & SharedVolumes.Images &
+      SharedVolumes.Temp
 
   type CommonR0 =
     pekko.actor.ActorSystem & AppConfigurationsTest & JwtConfig & WhichSipiService
@@ -239,14 +240,14 @@ object LayersTest {
 
   private val fusekiAndSipiTestcontainers =
     ZLayer.make[
-      AppConfigurations & DspIngestTestContainer & FusekiTestContainer & SharedVolumes.Images & SipiTestContainer &
-        WhichSipiService,
+      AppConfigurations & DspIngestTestContainer & FusekiTestContainer & SharedVolumes.Temp & SharedVolumes.Images &
+        SipiTestContainer & WhichSipiService,
     ](
       AppConfigForTestContainers.testcontainers,
       DspIngestTestContainer.layer,
       FusekiTestContainer.layer,
       SipiTestContainer.layer,
-      SharedVolumes.Images.layer,
+      SharedVolumes.layer,
       WhichSipiService.live,
     )
 

--- a/integration/src/test/scala/org/knora/webapi/testcontainers/DspIngestTestContainer.scala
+++ b/integration/src/test/scala/org/knora/webapi/testcontainers/DspIngestTestContainer.scala
@@ -18,9 +18,9 @@ final class DspIngestTestContainer extends GenericContainer[DspIngestTestContain
 object DspIngestTestContainer {
 
   private val assetDir = "/opt/images"
-  private val tempDir  = "/opt/temp"
+  private val tmpDir   = "/opt/tmp"
 
-  def make(imagesVolume: SharedVolumes.Images): DspIngestTestContainer = {
+  def make(imagesVolume: SharedVolumes.Images, tmpVolume: SharedVolumes.Temp): DspIngestTestContainer = {
     val port = 3340
     new DspIngestTestContainer()
       .withExposedPorts(port)
@@ -29,20 +29,19 @@ object DspIngestTestContainer {
       .withEnv("JWT_AUDIENCE", s"http://localhost:$port")
       .withEnv("JWT_ISSUER", "0.0.0.0:3333")
       .withEnv("STORAGE_ASSET_DIR", assetDir)
-      .withEnv("STORAGE_TEMP_DIR", tempDir)
+      .withEnv("STORAGE_TEMP_DIR", tmpDir)
       .withEnv("JWT_SECRET", "UP 4888, nice 4-8-4 steam engine")
       .withEnv("SIPI_USE_LOCAL_DEV", "false")
       .withEnv("JWT_DISABLE_AUTH", "true")
       .withEnv("DB_JDBC_URL", "jdbc:sqlite:/tmp/ingest.sqlite")
       .withFileSystemBind(imagesVolume.hostPath, assetDir, BindMode.READ_WRITE)
+      .withFileSystemBind(tmpVolume.hostPath, tmpDir, BindMode.READ_WRITE)
   }
 
-  private val initDspIngest = ZLayer.fromZIO(
-    ZIO.serviceWithZIO[DspIngestTestContainer] { it =>
-      ZIO.attemptBlocking(it.execInContainer("mkdir", s"$tempDir")).orDie
-    },
-  )
-
-  val layer: URLayer[SharedVolumes.Images, DspIngestTestContainer] =
-    ZLayer.scoped(ZIO.serviceWithZIO[SharedVolumes.Images](make(_).toZio)) >+> initDspIngest
+  val layer: URLayer[SharedVolumes.Images & SharedVolumes.Temp, DspIngestTestContainer] =
+    ZLayer.scoped(for {
+      imagesVolume <- ZIO.service[SharedVolumes.Images]
+      tmpVolume    <- ZIO.service[SharedVolumes.Temp]
+      container    <- make(imagesVolume, tmpVolume).toZio
+    } yield container)
 }

--- a/integration/src/test/scala/org/knora/webapi/testcontainers/DspIngestTestContainer.scala
+++ b/integration/src/test/scala/org/knora/webapi/testcontainers/DspIngestTestContainer.scala
@@ -18,9 +18,9 @@ final class DspIngestTestContainer extends GenericContainer[DspIngestTestContain
 object DspIngestTestContainer {
 
   private val assetDir = "/opt/images"
-  private val tmpDir   = "/opt/tmp"
+  private val tempDir  = "/opt/temp"
 
-  def make(imagesVolume: SharedVolumes.Images, tmpVolume: SharedVolumes.Temp): DspIngestTestContainer = {
+  def make(imagesVolume: SharedVolumes.Images, tempVolume: SharedVolumes.Temp): DspIngestTestContainer = {
     val port = 3340
     new DspIngestTestContainer()
       .withExposedPorts(port)
@@ -29,16 +29,16 @@ object DspIngestTestContainer {
       .withEnv("JWT_AUDIENCE", s"http://localhost:$port")
       .withEnv("JWT_ISSUER", "0.0.0.0:3333")
       .withEnv("STORAGE_ASSET_DIR", assetDir)
-      .withEnv("STORAGE_TEMP_DIR", tmpDir)
+      .withEnv("STORAGE_TEMP_DIR", tempDir)
       .withEnv("JWT_SECRET", "UP 4888, nice 4-8-4 steam engine")
       .withEnv("SIPI_USE_LOCAL_DEV", "false")
       .withEnv("JWT_DISABLE_AUTH", "true")
       .withEnv("DB_JDBC_URL", "jdbc:sqlite:/tmp/ingest.sqlite")
       .withFileSystemBind(imagesVolume.hostPath, assetDir, BindMode.READ_WRITE)
-      .withFileSystemBind(tmpVolume.hostPath, tmpDir, BindMode.READ_WRITE)
+      .withFileSystemBind(tempVolume.hostPath, tempDir, BindMode.READ_WRITE)
   }
 
-  val layer: URLayer[SharedVolumes.Images & SharedVolumes.Temp, DspIngestTestContainer] =
+  val layer: URLayer[SharedVolumes.Volumes, DspIngestTestContainer] =
     ZLayer.scoped(for {
       imagesVolume <- ZIO.service[SharedVolumes.Images]
       tmpVolume    <- ZIO.service[SharedVolumes.Temp]

--- a/integration/src/test/scala/org/knora/webapi/testcontainers/SharedVolumes.scala
+++ b/integration/src/test/scala/org/knora/webapi/testcontainers/SharedVolumes.scala
@@ -20,6 +20,8 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 
 object SharedVolumes {
 
+  type Volumes = Images & Temp
+
   final case class Images private (hostPath: String) extends AnyVal
 
   object Images {

--- a/integration/src/test/scala/org/knora/webapi/testcontainers/SharedVolumes.scala
+++ b/integration/src/test/scala/org/knora/webapi/testcontainers/SharedVolumes.scala
@@ -60,4 +60,11 @@ object SharedVolumes {
           Files.copy(source, targetDir / filename, StandardCopyOption.REPLACE_EXISTING)
       }
   }
+
+  final case class Temp private (hostPath: String) extends AnyVal
+  object Temp {
+    val layer: ULayer[Temp] = ZLayer.succeed(Temp(System.getProperty("java.io.tmpdir")))
+  }
+
+  val layer: ULayer[Images & Temp] = Images.layer ++ Temp.layer
 }


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->
Currently tests fails also on other PRs. I checked and it seems like the testcontainer for dsp-ingest failed to startup sometimes due to a race condition of how the temp directory was created inside. The temp dir is now mounted as a regular volume which fixes the problem.

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [x] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
