### PR TITLE
fix: Fix deadlock when streaming out the shacl validation report

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/shacl/api/ShaclApiService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/shacl/api/ShaclApiService.scala
@@ -16,6 +16,7 @@ import java.io.ByteArrayInputStream
 import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
+
 import org.knora.webapi.slice.shacl.domain.ShaclValidator
 import org.knora.webapi.slice.shacl.domain.ValidationOptions
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/shacl/api/ShaclApiService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/shacl/api/ShaclApiService.scala
@@ -33,7 +33,7 @@ final case class ShaclApiService(validator: ShaclValidator) {
     for {
       report    <- validator.validate(dataStream, shaclStream, options)
       (out, src) = makeOutputStreamAndSource()
-      _ <- ZIO.attempt {
+      _ <- ZIO.attemptBlockingIO {
              try { RDFDataMgr.write(out, report.getModel, RDFFormat.TURTLE) }
              finally { out.close() }
            }.forkDaemon

--- a/webapi/src/main/scala/org/knora/webapi/slice/shacl/api/ShaclApiService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/shacl/api/ShaclApiService.scala
@@ -16,15 +16,17 @@ import java.io.ByteArrayInputStream
 import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
-
 import org.knora.webapi.slice.shacl.domain.ShaclValidator
 import org.knora.webapi.slice.shacl.domain.ValidationOptions
+
+import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 
 final case class ShaclApiService(validator: ShaclValidator) {
 
   def validate(formData: ValidationFormData): Task[Source[ByteString, Any]] = {
-    val dataStream  = ByteArrayInputStream(formData.`data.ttl`.getBytes)
-    val shaclStream = ByteArrayInputStream(formData.`shacl.ttl`.getBytes)
+    val dataStream  = ByteArrayInputStream(formData.`data.ttl`.getBytes(UTF_8))
+    val shaclStream = ByteArrayInputStream(formData.`shacl.ttl`.getBytes(UTF_8))
     val options = ValidationOptions(
       formData.validateShapes.getOrElse(ValidationOptions.default.validateShapes),
       formData.reportDetails.getOrElse(ValidationOptions.default.reportDetails),

--- a/webapi/src/main/scala/org/knora/webapi/slice/shacl/api/ShaclEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/shacl/api/ShaclEndpoints.scala
@@ -14,14 +14,16 @@ import sttp.tapir.Schema.annotations.description
 import sttp.tapir.generic.auto.*
 import zio.ZLayer
 
+import java.io.File
+
 import dsp.errors.RequestRejectedException
 import org.knora.webapi.slice.common.api.BaseEndpoints
 
 case class ValidationFormData(
   @description("The data to be validated.")
-  `data.ttl`: String,
+  `data.ttl`: File,
   @description("The shapes for validation.")
-  `shacl.ttl`: String,
+  `shacl.ttl`: File,
   @description(s"Should shapes also be validated.")
   validateShapes: Option[Boolean],
   @description("Add `sh:details` to the validation report.")

--- a/webapi/src/main/scala/org/knora/webapi/slice/shacl/domain/ShaclValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/shacl/domain/ShaclValidator.scala
@@ -15,6 +15,7 @@ import org.topbraid.shacl.validation.ValidationEngineConfiguration
 import org.topbraid.shacl.validation.ValidationUtil
 import zio.*
 
+import java.io.ByteArrayInputStream
 import java.io.InputStream
 
 final case class ValidationOptions(validateShapes: Boolean, reportDetails: Boolean, addBlankNodes: Boolean)
@@ -23,6 +24,9 @@ object ValidationOptions {
 }
 
 final case class ShaclValidator() { self =>
+
+  def validate(data: String, shapes: String, opts: ValidationOptions): Task[Resource] =
+    validate(new ByteArrayInputStream(data.getBytes), new ByteArrayInputStream(shapes.getBytes), opts)
 
   def validate(data: InputStream, shapes: InputStream, opts: ValidationOptions): Task[Resource] = for {
     dataModel   <- readModel(data)

--- a/webapi/src/test/scala/org/knora/webapi/slice/shacl/api/ShaclApiServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/shacl/api/ShaclApiServiceSpec.scala
@@ -1,0 +1,41 @@
+package org.knora.webapi.slice.shacl.api
+
+import org.apache.pekko.stream.scaladsl.Source
+
+import scala.concurrent.duration.Duration
+import org.apache.pekko.actor.*
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.util.ByteString
+import org.knora.webapi.slice.shacl.domain.ShaclValidator
+import zio.test.*
+import zio.*
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+
+object ShaclApiServiceSpec extends ZIOSpecDefault {
+
+  private val shaclApiService = ZIO.serviceWithZIO[ShaclApiService]
+
+  val spec = suite("ShaclApiService")(
+    test("validate") {
+      val formData = ValidationFormData("", "", None, None, None)
+      for {
+        result <- shaclApiService(_.validate(formData))
+      } yield assertTrue(reportConforms(result))
+    },
+  ).provide(ShaclApiService.layer, ShaclValidator.layer)
+
+  private def reportConforms(result: Source[ByteString, Any]): Boolean = {
+    implicit val system = ActorSystem.create()
+    implicit val ec     = system.dispatcher
+    implicit val mat    = Materializer(system)
+
+    val str: Future[String] = result
+      .runWith(Sink.fold(ByteString.empty)(_ ++ _)) // Accumulate ByteString
+      .map(_.utf8String)
+    val foo = Await.result(str, Duration.fromNanos(5_000_000))
+    foo.contains("sh:conforms  true")
+  }
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/shacl/api/ShaclApiServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/shacl/api/ShaclApiServiceSpec.scala
@@ -1,18 +1,23 @@
+/*
+ * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.shacl.api
 
-import org.apache.pekko.stream.scaladsl.Source
-
-import scala.concurrent.duration.Duration
 import org.apache.pekko.actor.*
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
-import org.knora.webapi.slice.shacl.domain.ShaclValidator
-import zio.test.*
 import zio.*
+import zio.test.*
 
 import scala.concurrent.Await
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+import org.knora.webapi.slice.shacl.domain.ShaclValidator
 
 object ShaclApiServiceSpec extends ZIOSpecDefault {
 
@@ -35,7 +40,7 @@ object ShaclApiServiceSpec extends ZIOSpecDefault {
     val str: Future[String] = result
       .runWith(Sink.fold(ByteString.empty)(_ ++ _)) // Accumulate ByteString
       .map(_.utf8String)
-    val foo = Await.result(str, Duration.fromNanos(5_000_000))
-    foo.contains("sh:conforms  true")
+    val reportStr = Await.result(str, 5.seconds.asScala)
+    reportStr.contains("sh:conforms  true")
   }
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/shacl/api/ShaclApiServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/shacl/api/ShaclApiServiceSpec.scala
@@ -15,8 +15,6 @@ import zio.test.*
 
 import scala.concurrent.Await
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
-
 import org.knora.webapi.slice.shacl.domain.ShaclValidator
 
 object ShaclApiServiceSpec extends ZIOSpecDefault {

--- a/webapi/src/test/scala/org/knora/webapi/slice/shacl/domain/ShaclValidatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/shacl/domain/ShaclValidatorSpec.scala
@@ -13,50 +13,47 @@ import zio.test.Spec
 import zio.test.ZIOSpecDefault
 import zio.test.assertTrue
 
-import java.io.ByteArrayInputStream
-
 object ShaclValidatorSpec extends ZIOSpecDefault {
 
   val shaclValidator = ZIO.serviceWithZIO[ShaclValidator]
 
   private val shapes =
-    new ByteArrayInputStream("""
-                               |@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                               |@prefix schema: <http://schema.org/> .
-                               |@prefix sh: <http://www.w3.org/ns/shacl#> .
-                               |@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-                               |
-                               |schema:PersonShape
-                               |    a sh:NodeShape ;
-                               |    sh:targetClass schema:Person ;
-                               |    sh:property [
-                               |        sh:path schema:givenName ;
-                               |        sh:datatype xsd:string ;
-                               |        sh:name "given name" ;
-                               |    ] .
-                               |""".stripMargin.getBytes)
+    """
+      |@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      |@prefix schema: <http://schema.org/> .
+      |@prefix sh: <http://www.w3.org/ns/shacl#> .
+      |@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+      |
+      |schema:PersonShape
+      |    a sh:NodeShape ;
+      |    sh:targetClass schema:Person ;
+      |    sh:property [
+      |        sh:path schema:givenName ;
+      |        sh:datatype xsd:string ;
+      |    ] .
+      |""".stripMargin
 
   private val invalidData =
-    new ByteArrayInputStream("""
-                               |@prefix ex: <http://example.org/ns#> .
-                               |@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                               |@prefix schema: <http://schema.org/> .
-                               |
-                               |ex:Bob
-                               |    a schema:Person ;
-                               |    schema:givenName 0 .
-                               |""".stripMargin.getBytes)
+    """
+      |@prefix ex: <http://example.org/ns#> .
+      |@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      |@prefix schema: <http://schema.org/> .
+      |
+      |ex:Bob
+      |    a schema:Person ;
+      |    schema:givenName 0 .
+      |""".stripMargin
 
   private val validData =
-    new ByteArrayInputStream("""
-                               |@prefix ex: <http://example.org/ns#> .
-                               |@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                               |@prefix schema: <http://schema.org/> .
-                               |
-                               |ex:Bob
-                               |    a schema:Person ;
-                               |    schema:givenName "valid name" .
-                               |""".stripMargin.getBytes)
+    """
+      |@prefix ex: <http://example.org/ns#> .
+      |@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      |@prefix schema: <http://schema.org/> .
+      |
+      |ex:Bob
+      |    a schema:Person ;
+      |    schema:givenName "valid name" .
+      |""".stripMargin
 
   def spec: Spec[Any, Throwable] =
     suite("ShaclValidator")(


### PR DESCRIPTION
The writing into the output stream must happen on a different thread than the reading from the input stream.

Additionally use a temp File for streaming the turtle from the request in order to reduce memory footprint.

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
