### PR TITLE
refactor: Simplify Value create code and use ProjectIri instead of String

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderSpec.scala
@@ -544,7 +544,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getDefaultValuePermissions(
+              _.getPropertyDefaultPermissions(
                 projectIri = SharedTestDataADM.incunabulaProjectIri,
                 resourceClassIri = stringFormatter.toSmartIri(OntologyConstants.KnoraBase.StillImageRepresentation),
                 propertyIri = stringFormatter.toSmartIri(OntologyConstants.KnoraBase.HasStillImageFileValue),
@@ -595,7 +595,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getDefaultValuePermissions(
+              _.getPropertyDefaultPermissions(
                 projectIri = SharedTestDataADM.anythingProjectIri,
                 resourceClassIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#Thing"),
                 propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasInterval"),
@@ -629,7 +629,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getDefaultValuePermissions(
+              _.getPropertyDefaultPermissions(
                 projectIri = SharedTestDataADM.anythingProjectIri,
                 resourceClassIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#Thing"),
                 propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasText"),
@@ -644,7 +644,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getDefaultValuePermissions(
+              _.getPropertyDefaultPermissions(
                 projectIri = SharedTestDataADM.anythingProjectIri,
                 resourceClassIri = stringFormatter.toSmartIri(s"${SharedOntologyTestDataADM.IMAGES_ONTOLOGY_IRI}#bild"),
                 propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasText"),
@@ -662,7 +662,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getDefaultValuePermissions(
+              _.getPropertyDefaultPermissions(
                 projectIri = projectIri,
                 resourceClassIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
                 propertyIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
@@ -677,7 +677,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getDefaultValuePermissions(
+              _.getPropertyDefaultPermissions(
                 projectIri = SharedTestDataADM.imagesProjectIri,
                 resourceClassIri = stringFormatter.toSmartIri(SharedTestDataADM.customResourceIRI),
                 propertyIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
@@ -692,7 +692,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getDefaultValuePermissions(
+              _.getPropertyDefaultPermissions(
                 projectIri = SharedTestDataADM.imagesProjectIri,
                 resourceClassIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
                 propertyIri = stringFormatter.toSmartIri(SharedTestDataADM.customValueIRI),
@@ -707,7 +707,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getDefaultValuePermissions(
+              _.getPropertyDefaultPermissions(
                 projectIri = SharedTestDataADM.imagesProjectIri,
                 resourceClassIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
                 propertyIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),

--- a/integration/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderSpec.scala
@@ -526,7 +526,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       "return the default object access permissions 'string' for the 'knora-base:LinkObj' resource class (system resource class)" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getResourceDefaultPermissions(
+            _.newResourceDefaultObjectAccessPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
               OntologyConstants.KnoraBase.LinkObj.toSmartIri,
               SharedTestDataADM.incunabulaProjectAdminUser,
@@ -541,26 +541,29 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       }
 
       "return the default object access permissions 'string' for the 'knora-base:hasStillImageFileValue' property (system property)" in {
-        UnsafeZioRun
+        val actual = UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getPropertyDefaultPermissions(
-                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
-                resourceClassIri = stringFormatter.toSmartIri(OntologyConstants.KnoraBase.StillImageRepresentation),
-                propertyIri = stringFormatter.toSmartIri(OntologyConstants.KnoraBase.HasStillImageFileValue),
-                targetUser = SharedTestDataADM.incunabulaProjectAdminUser,
+              _.newValueDefaultObjectAccessPermissions(
+                ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
+                stringFormatter.toSmartIri(OntologyConstants.KnoraBase.StillImageRepresentation),
+                stringFormatter.toSmartIri(OntologyConstants.KnoraBase.HasStillImageFileValue),
+                SharedTestDataADM.incunabulaProjectAdminUser,
               ),
             ),
           )
-          .shouldEqual(
+
+        assert(
+          actual == DefaultObjectAccessPermissionsStringResponseADM(
             "M knora-admin:Creator,knora-admin:ProjectMember|V knora-admin:KnownUser,knora-admin:UnknownUser",
-          )
+          ),
+        )
       }
 
       "return the default object access permissions 'string' for the 'incunabula:book' resource class (project resource class)" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getResourceDefaultPermissions(
+            _.newResourceDefaultObjectAccessPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
               SharedOntologyTestDataADM.INCUNABULA_BOOK_RESOURCE_CLASS.toSmartIri,
               SharedTestDataADM.incunabulaProjectAdminUser,
@@ -577,7 +580,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       "return the default object access permissions 'string' for the 'incunabula:page' resource class (project resource class)" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getResourceDefaultPermissions(
+            _.newResourceDefaultObjectAccessPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
               SharedOntologyTestDataADM.INCUNABULA_PAGE_RESOURCE_CLASS.toSmartIri,
               SharedTestDataADM.incunabulaProjectAdminUser,
@@ -592,26 +595,28 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       }
 
       "return the default object access permissions 'string' for the 'anything:hasInterval' property" in {
-        UnsafeZioRun
-          .runOrThrow(
-            permissionsResponder(
-              _.getPropertyDefaultPermissions(
-                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
-                resourceClassIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#Thing"),
-                propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasInterval"),
-                targetUser = SharedTestDataADM.anythingUser2,
-              ),
+        val actual = UnsafeZioRun.runOrThrow(
+          permissionsResponder(
+            _.newValueDefaultObjectAccessPermissions(
+              ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
+              stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#Thing"),
+              stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasInterval"),
+              SharedTestDataADM.anythingUser2,
             ),
-          )
-          .shouldEqual(
+          ),
+        )
+
+        assert(
+          actual == DefaultObjectAccessPermissionsStringResponseADM(
             "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          )
+          ),
+        )
       }
 
       "return the default object access permissions 'string' for the 'anything:Thing' class" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getResourceDefaultPermissions(
+            _.newResourceDefaultObjectAccessPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
               "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri,
               SharedTestDataADM.anythingUser2,
@@ -626,10 +631,10 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       }
 
       "return the default object access permissions 'string' for the 'anything:Thing' class and 'anything:hasText' property" in {
-        UnsafeZioRun
+        val actual = UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getPropertyDefaultPermissions(
+              _.newValueDefaultObjectAccessPermissions(
                 projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
                 resourceClassIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#Thing"),
                 propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasText"),
@@ -637,75 +642,79 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
               ),
             ),
           )
-          .shouldEqual("CR knora-admin:Creator")
+        actual.permissionLiteral shouldEqual "CR knora-admin:Creator"
       }
 
       "return the default object access permissions 'string' for the 'images:Bild' class and 'anything:hasText' property" in {
-        UnsafeZioRun
+        val actual = UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
-              _.getPropertyDefaultPermissions(
-                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
-                resourceClassIri = stringFormatter.toSmartIri(s"${SharedOntologyTestDataADM.IMAGES_ONTOLOGY_IRI}#bild"),
-                propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasText"),
-                targetUser = SharedTestDataADM.anythingUser2,
+              _.newValueDefaultObjectAccessPermissions(
+                ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
+                stringFormatter.toSmartIri(s"${SharedOntologyTestDataADM.IMAGES_ONTOLOGY_IRI}#bild"),
+                stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasText"),
+                SharedTestDataADM.anythingUser2,
               ),
             ),
           )
-          .shouldEqual(
+
+        assert(
+          actual == DefaultObjectAccessPermissionsStringResponseADM(
             "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          )
+          ),
+        )
       }
 
       "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
-        UnsafeZioRun
-          .runOrThrow(
+        val exit = UnsafeZioRun
+          .run(
             permissionsResponder(
-              _.getPropertyDefaultPermissions(
-                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
-                resourceClassIri = stringFormatter.toSmartIri(SharedTestDataADM.customResourceIRI),
-                propertyIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
-                targetUser = SharedTestDataADM.imagesReviewerUser,
+              _.newValueDefaultObjectAccessPermissions(
+                ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
+                stringFormatter.toSmartIri(SharedTestDataADM.customResourceIRI),
+                stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
+                SharedTestDataADM.imagesReviewerUser,
               ),
-            ).flip.map(_.getMessage),
+            ),
           )
-          .shouldEqual(s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}")
+        assertFailsWithA[BadRequestException](
+          exit,
+          s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}",
+        )
       }
 
       "return 'BadRequest' if the supplied property IRI for DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
-        UnsafeZioRun
-          .runOrThrow(
-            permissionsResponder(
-              _.getPropertyDefaultPermissions(
-                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
-                resourceClassIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
-                propertyIri = stringFormatter.toSmartIri(SharedTestDataADM.customValueIRI),
-                targetUser = SharedTestDataADM.imagesReviewerUser,
-              ),
-            ).flip.map(_.getMessage),
-          )
-          .shouldEqual(s"Invalid property IRI: ${SharedTestDataADM.customValueIRI}")
+        val exit = UnsafeZioRun.run(
+          permissionsResponder(
+            _.newValueDefaultObjectAccessPermissions(
+              ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
+              stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
+              stringFormatter.toSmartIri(SharedTestDataADM.customValueIRI),
+              SharedTestDataADM.imagesReviewerUser,
+            ),
+          ),
+        )
+        assertFailsWithA[BadRequestException](exit, s"Invalid property IRI: ${SharedTestDataADM.customValueIRI}")
       }
 
       "return 'BadRequest' if the target user of DefaultObjectAccessPermissionsStringForPropertyGetADM is an Anonymous user" in {
-        UnsafeZioRun
-          .runOrThrow(
-            permissionsResponder(
-              _.getPropertyDefaultPermissions(
-                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
-                resourceClassIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
-                propertyIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
-                targetUser = SharedTestDataADM.anonymousUser,
-              ),
-            ).flip.map(_.getMessage),
-          )
-          .shouldEqual("Anonymous Users are not allowed.")
+        val exit = UnsafeZioRun.run(
+          permissionsResponder(
+            _.newValueDefaultObjectAccessPermissions(
+              ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
+              stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
+              stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
+              SharedTestDataADM.anonymousUser,
+            ),
+          ),
+        )
+        assertFailsWithA[BadRequestException](exit, "Anonymous Users are not allowed.")
       }
 
       "return the default object access permissions 'string' for the 'anything:Thing' resource class for the root user (system admin and not member of project)" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getResourceDefaultPermissions(
+            _.newResourceDefaultObjectAccessPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
               "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri,
               SharedTestDataADM.rootUser,

--- a/integration/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderSpec.scala
@@ -526,7 +526,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       "return the default object access permissions 'string' for the 'knora-base:LinkObj' resource class (system resource class)" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getDefaultResourcePermissions(
+            _.getResourceDefaultPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
               OntologyConstants.KnoraBase.LinkObj.toSmartIri,
               SharedTestDataADM.incunabulaProjectAdminUser,
@@ -560,7 +560,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       "return the default object access permissions 'string' for the 'incunabula:book' resource class (project resource class)" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getDefaultResourcePermissions(
+            _.getResourceDefaultPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
               SharedOntologyTestDataADM.INCUNABULA_BOOK_RESOURCE_CLASS.toSmartIri,
               SharedTestDataADM.incunabulaProjectAdminUser,
@@ -577,7 +577,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       "return the default object access permissions 'string' for the 'incunabula:page' resource class (project resource class)" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getDefaultResourcePermissions(
+            _.getResourceDefaultPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
               SharedOntologyTestDataADM.INCUNABULA_PAGE_RESOURCE_CLASS.toSmartIri,
               SharedTestDataADM.incunabulaProjectAdminUser,
@@ -611,7 +611,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       "return the default object access permissions 'string' for the 'anything:Thing' class" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getDefaultResourcePermissions(
+            _.getResourceDefaultPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
               "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri,
               SharedTestDataADM.anythingUser2,
@@ -705,7 +705,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
       "return the default object access permissions 'string' for the 'anything:Thing' resource class for the root user (system admin and not member of project)" in {
         val actual = UnsafeZioRun.runOrThrow(
           permissionsResponder(
-            _.getDefaultResourcePermissions(
+            _.getResourceDefaultPermissions(
               ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
               "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri,
               SharedTestDataADM.rootUser,

--- a/integration/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderSpec.scala
@@ -545,7 +545,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
           .runOrThrow(
             permissionsResponder(
               _.getPropertyDefaultPermissions(
-                projectIri = SharedTestDataADM.incunabulaProjectIri,
+                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.incunabulaProjectIri),
                 resourceClassIri = stringFormatter.toSmartIri(OntologyConstants.KnoraBase.StillImageRepresentation),
                 propertyIri = stringFormatter.toSmartIri(OntologyConstants.KnoraBase.HasStillImageFileValue),
                 targetUser = SharedTestDataADM.incunabulaProjectAdminUser,
@@ -596,7 +596,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
           .runOrThrow(
             permissionsResponder(
               _.getPropertyDefaultPermissions(
-                projectIri = SharedTestDataADM.anythingProjectIri,
+                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
                 resourceClassIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#Thing"),
                 propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasInterval"),
                 targetUser = SharedTestDataADM.anythingUser2,
@@ -630,7 +630,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
           .runOrThrow(
             permissionsResponder(
               _.getPropertyDefaultPermissions(
-                projectIri = SharedTestDataADM.anythingProjectIri,
+                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
                 resourceClassIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#Thing"),
                 propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasText"),
                 targetUser = SharedTestDataADM.anythingUser1,
@@ -645,7 +645,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
           .runOrThrow(
             permissionsResponder(
               _.getPropertyDefaultPermissions(
-                projectIri = SharedTestDataADM.anythingProjectIri,
+                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.anythingProjectIri),
                 resourceClassIri = stringFormatter.toSmartIri(s"${SharedOntologyTestDataADM.IMAGES_ONTOLOGY_IRI}#bild"),
                 propertyIri = stringFormatter.toSmartIri("http://www.knora.org/ontology/0001/anything#hasText"),
                 targetUser = SharedTestDataADM.anythingUser2,
@@ -657,28 +657,12 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
           )
       }
 
-      "return 'BadRequest' if the supplied project IRI DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
-        val projectIri = ""
-        UnsafeZioRun
-          .runOrThrow(
-            permissionsResponder(
-              _.getPropertyDefaultPermissions(
-                projectIri = projectIri,
-                resourceClassIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
-                propertyIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
-                targetUser = SharedTestDataADM.imagesUser02,
-              ),
-            ).flip.map(_.getMessage),
-          )
-          .shouldEqual(s"Invalid project IRI $projectIri")
-      }
-
       "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
         UnsafeZioRun
           .runOrThrow(
             permissionsResponder(
               _.getPropertyDefaultPermissions(
-                projectIri = SharedTestDataADM.imagesProjectIri,
+                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
                 resourceClassIri = stringFormatter.toSmartIri(SharedTestDataADM.customResourceIRI),
                 propertyIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
                 targetUser = SharedTestDataADM.imagesReviewerUser,
@@ -693,7 +677,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
           .runOrThrow(
             permissionsResponder(
               _.getPropertyDefaultPermissions(
-                projectIri = SharedTestDataADM.imagesProjectIri,
+                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
                 resourceClassIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
                 propertyIri = stringFormatter.toSmartIri(SharedTestDataADM.customValueIRI),
                 targetUser = SharedTestDataADM.imagesReviewerUser,
@@ -708,7 +692,7 @@ class PermissionsResponderSpec extends CoreSpec with ImplicitSender {
           .runOrThrow(
             permissionsResponder(
               _.getPropertyDefaultPermissions(
-                projectIri = SharedTestDataADM.imagesProjectIri,
+                projectIri = ProjectIri.unsafeFrom(SharedTestDataADM.imagesProjectIri),
                 resourceClassIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
                 propertyIri = stringFormatter.toSmartIri(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
                 targetUser = SharedTestDataADM.anonymousUser,

--- a/integration/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -8,7 +8,6 @@ package org.knora.webapi.responders.v2
 import org.apache.pekko.actor.Status.Failure
 import org.apache.pekko.pattern.ask
 import org.apache.pekko.testkit.ImplicitSender
-import org.scalatest.Assertion
 import zio.ZIO
 
 import java.time.Instant

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -1480,15 +1480,16 @@ final case class PermissionsResponder(
    * @param targetUser       the user that is creating the value.
    * @return a permission string.
    */
-  def getPropertiesDefaultPermissions(
+  def newValueDefaultObjectAccessPermissions(
     projectIri: ProjectIri,
     resourceClassIri: SmartIri,
     propertyIris: Set[SmartIri],
     targetUser: User,
-  ): Task[Map[SmartIri, String]] =
+  ): Task[Map[SmartIri, DefaultObjectAccessPermissionsStringResponseADM]] =
     ZIO
       .foreach(propertyIris) { propertyIri =>
-        getPropertyDefaultPermissions(projectIri, resourceClassIri, propertyIri, targetUser).map(propertyIri -> _)
+        newValueDefaultObjectAccessPermissions(projectIri, resourceClassIri, propertyIri, targetUser)
+          .map(propertyIri -> _)
       }
       .map(_.toMap)
 
@@ -1498,15 +1499,15 @@ final case class PermissionsResponder(
    * @param projectIri       the IRI of the project of the containing resource.
    * @param resourceClassIri the internal IRI of the resource class.
    * @param propertyIri      the internal IRI of the property that points to the value.
-   * @param targetUser the user that is creating the value.
+   * @param targetUser       the user that is creating the value.
    * @return a permission string.
    */
-  def getPropertyDefaultPermissions(
+  def newValueDefaultObjectAccessPermissions(
     projectIri: ProjectIri,
     resourceClassIri: SmartIri,
     propertyIri: SmartIri,
     targetUser: User,
-  ): Task[String] =
+  ): Task[DefaultObjectAccessPermissionsStringResponseADM] =
     for {
       _ <- ZIO.unless(resourceClassIri.isKnoraEntityIri) {
              ZIO.fail(BadRequestException(s"Invalid resource class IRI: $resourceClassIri"))
@@ -1524,9 +1525,9 @@ final case class PermissionsResponder(
                       EntityType.Property,
                       targetUser,
                     )
-    } yield permission.permissionLiteral
+    } yield permission
 
-  def getResourceDefaultPermissions(
+  def newResourceDefaultObjectAccessPermissions(
     projectIri: ProjectIri,
     resourceClassIri: SmartIri,
     targetUser: User,

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -1497,6 +1497,27 @@ final case class PermissionsResponder(
     } yield ()
 
   /**
+   * Gets the default permissions for new values.
+   *
+   * @param projectIri       the IRI of the project of the containing resource.
+   * @param resourceClassIri the internal IRI of the resource class.
+   * @param propertyIris     the internal IRIs of the properties that points to the values.
+   * @param targetUser       the user that is creating the value.
+   * @return a permission string.
+   */
+  def getPropertiesDefaultPermissions(
+    projectIri: ProjectIri,
+    resourceClassIri: SmartIri,
+    propertyIris: Set[SmartIri],
+    targetUser: User,
+  ): Task[Map[SmartIri, String]] =
+    ZIO
+      .foreach(propertyIris) { propertyIri =>
+        getDefaultValuePermissions(projectIri.value, resourceClassIri, propertyIri, targetUser).map(propertyIri -> _)
+      }
+      .map(_.toMap)
+
+  /**
    * Gets the default permissions for a new value.
    *
    * @param projectIri       the IRI of the project of the containing resource.

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -10,10 +10,8 @@ import zio.*
 
 import java.util.UUID
 import scala.collection.mutable.ListBuffer
-
 import dsp.errors.*
 import org.knora.webapi.*
-import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
@@ -45,13 +43,12 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
 final case class PermissionsResponder(
-  appConfig: AppConfig,
-  groupService: GroupService,
-  iriService: IriService,
-  knoraProjectService: KnoraProjectService,
-  triplestore: TriplestoreService,
-  auth: AuthorizationRestService,
-  administrativePermissionService: AdministrativePermissionService,
+  private val groupService: GroupService,
+  private val iriService: IriService,
+  private val knoraProjectService: KnoraProjectService,
+  private val triplestore: TriplestoreService,
+  private val auth: AuthorizationRestService,
+  private val administrativePermissionService: AdministrativePermissionService,
 )(implicit val stringFormatter: StringFormatter)
     extends LazyLogging {
 
@@ -61,7 +58,6 @@ final case class PermissionsResponder(
     case Resource
     case Property
   }
-  
 
   def getPermissionsApByProjectIri(projectIRI: IRI): Task[AdministrativePermissionsForProjectGetResponseADM] =
     for {

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -10,6 +10,7 @@ import zio.*
 
 import java.util.UUID
 import scala.collection.mutable.ListBuffer
+
 import dsp.errors.*
 import org.knora.webapi.*
 import org.knora.webapi.messages.OntologyConstants

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -10,7 +10,6 @@ import zio.*
 
 import java.util.UUID
 import scala.collection.mutable.ListBuffer
-
 import dsp.errors.*
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
@@ -1513,7 +1512,7 @@ final case class PermissionsResponder(
   ): Task[Map[SmartIri, String]] =
     ZIO
       .foreach(propertyIris) { propertyIri =>
-        getDefaultValuePermissions(projectIri.value, resourceClassIri, propertyIri, targetUser).map(propertyIri -> _)
+        getPropertyDefaultPermissions(projectIri.value, resourceClassIri, propertyIri, targetUser).map(propertyIri -> _)
       }
       .map(_.toMap)
 
@@ -1526,7 +1525,7 @@ final case class PermissionsResponder(
    * @param targetUser the user that is creating the value.
    * @return a permission string.
    */
-  def getDefaultValuePermissions(
+  def getPropertyDefaultPermissions(
     projectIri: IRI,
     resourceClassIri: SmartIri,
     propertyIri: SmartIri,

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -56,9 +56,12 @@ final case class PermissionsResponder(
     extends LazyLogging {
 
   private val PERMISSIONS_GLOBAL_LOCK_IRI = "http://rdfh.ch/permissions"
-  /* Entity types used to more clearly distinguish what kind of entity is meant */
-  private val ResourceEntityType = "resource"
-  private val PropertyEntityType = "property"
+
+  private enum EntityType {
+    case Resource
+    case Property
+  }
+  
 
   def getPermissionsApByProjectIri(projectIRI: IRI): Task[AdministrativePermissionsForProjectGetResponseADM] =
     for {
@@ -448,7 +451,7 @@ final case class PermissionsResponder(
     projectIri: ProjectIri,
     resourceClassIri: IRI,
     propertyIri: Option[IRI],
-    entityType: IRI,
+    entityType: EntityType,
     targetUser: User,
   ): Task[DefaultObjectAccessPermissionsStringResponseADM] =
     for {
@@ -495,7 +498,7 @@ final case class PermissionsResponder(
       ///////////////////////////////
       /* project resource class / property combination */
       defaultPermissionsOnProjectResourceClassProperty <- {
-        if (entityType == PropertyEntityType && permissionsListBuffer.isEmpty) {
+        if (entityType == EntityType.Property && permissionsListBuffer.isEmpty) {
           defaultObjectAccessPermissionsForResourceClassPropertyGetADM(
             projectIri = projectIri,
             resourceClassIri = resourceClassIri,
@@ -516,7 +519,7 @@ final case class PermissionsResponder(
 
       /* system resource class / property combination */
       defaultPermissionsOnSystemResourceClassProperty <- {
-        if (entityType == PropertyEntityType && permissionsListBuffer.isEmpty) {
+        if (entityType == EntityType.Property && permissionsListBuffer.isEmpty) {
           defaultObjectAccessPermissionsForResourceClassPropertyGetADM(
             projectIri = KnoraProjectRepo.builtIn.SystemProject.id,
             resourceClassIri = resourceClassIri,
@@ -535,7 +538,7 @@ final case class PermissionsResponder(
       ///////////////////////
       /* Get the default object access permissions defined on the resource class for the current project */
       defaultPermissionsOnProjectResourceClass <- {
-        if (entityType == ResourceEntityType && permissionsListBuffer.isEmpty) {
+        if (entityType == EntityType.Resource && permissionsListBuffer.isEmpty) {
           defaultObjectAccessPermissionsForResourceClassGetADM(
             projectIri = projectIri,
             resourceClassIri = resourceClassIri,
@@ -550,7 +553,7 @@ final case class PermissionsResponder(
 
       /* Get the default object access permissions defined on the resource class inside the SystemProject */
       defaultPermissionsOnSystemResourceClass <- {
-        if (entityType == ResourceEntityType && permissionsListBuffer.isEmpty) {
+        if (entityType == EntityType.Resource && permissionsListBuffer.isEmpty) {
           defaultObjectAccessPermissionsForResourceClassGetADM(
             KnoraProjectRepo.builtIn.SystemProject.id,
             resourceClassIri,
@@ -568,7 +571,7 @@ final case class PermissionsResponder(
       ///////////////////////
       /* project property */
       defaultPermissionsOnProjectProperty <- {
-        if (entityType == PropertyEntityType && permissionsListBuffer.isEmpty) {
+        if (entityType == EntityType.Property && permissionsListBuffer.isEmpty) {
           defaultObjectAccessPermissionsForPropertyGetADM(
             projectIri = projectIri,
             propertyIri = propertyIri.getOrElse(throw BadRequestException("PropertyIri needs to be supplied.")),
@@ -583,7 +586,7 @@ final case class PermissionsResponder(
 
       /* system property */
       defaultPermissionsOnSystemProperty <- {
-        if (entityType == PropertyEntityType && permissionsListBuffer.isEmpty) {
+        if (entityType == EntityType.Property && permissionsListBuffer.isEmpty) {
           defaultObjectAccessPermissionsForPropertyGetADM(
             KnoraProjectRepo.builtIn.SystemProject.id,
             propertyIri.getOrElse(throw BadRequestException("PropertyIri needs to be supplied.")),
@@ -1521,7 +1524,7 @@ final case class PermissionsResponder(
                       projectIri,
                       resourceClassIri.toString,
                       Some(propertyIri.toString),
-                      PropertyEntityType,
+                      EntityType.Property,
                       targetUser,
                     )
     } yield permission.permissionLiteral
@@ -1538,7 +1541,7 @@ final case class PermissionsResponder(
         projectIri,
         resourceClassIri.toString,
         None,
-        ResourceEntityType,
+        EntityType.Resource,
         targetUser,
       )
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -264,7 +264,7 @@ final case class ValuesResponderV2Live(
              }
 
         // Get the default permissions for the new value.
-        defaultValuePermissions <- permissionsResponder.getPropertyDefaultPermissions(
+        defaultValuePermissions <- permissionsResponder.newValueDefaultObjectAccessPermissions(
                                      resourceInfo.projectADM.projectIri,
                                      resourceInfo.resourceClassIri,
                                      submittedInternalPropertyIri,
@@ -288,7 +288,7 @@ final case class ValuesResponderV2Live(
                          PermissionUtilADM.comparePermissionsADM(
                            entityProject = resourceInfo.projectADM.id,
                            permissionLiteralA = validatedCustomPermissions,
-                           permissionLiteralB = defaultValuePermissions,
+                           permissionLiteralB = defaultValuePermissions.permissionLiteral,
                            requestingUser = requestingUser,
                          )
 
@@ -304,7 +304,7 @@ final case class ValuesResponderV2Live(
 
             case None =>
               // No. Use the default permissions.
-              ZIO.succeed(defaultValuePermissions)
+              ZIO.succeed(defaultValuePermissions.permissionLiteral)
           }
 
         dataNamedGraph: IRI = ProjectService.projectDataNamedGraphV2(resourceInfo.projectADM).value

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -265,7 +265,7 @@ final case class ValuesResponderV2Live(
 
         // Get the default permissions for the new value.
         defaultValuePermissions <-
-          permissionsResponder.getDefaultValuePermissions(
+          permissionsResponder.getPropertyDefaultPermissions(
             projectIri = resourceInfo.projectADM.id,
             resourceClassIri = resourceInfo.resourceClassIri,
             propertyIri = submittedInternalPropertyIri,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -9,6 +9,7 @@ import zio.*
 
 import java.time.Instant
 import java.util.UUID
+
 import dsp.errors.*
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.*

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -9,7 +9,6 @@ import zio.*
 
 import java.time.Instant
 import java.util.UUID
-
 import dsp.errors.*
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.*
@@ -264,13 +263,12 @@ final case class ValuesResponderV2Live(
              }
 
         // Get the default permissions for the new value.
-        defaultValuePermissions <-
-          permissionsResponder.getPropertyDefaultPermissions(
-            projectIri = resourceInfo.projectADM.id,
-            resourceClassIri = resourceInfo.resourceClassIri,
-            propertyIri = submittedInternalPropertyIri,
-            targetUser = requestingUser,
-          )
+        defaultValuePermissions <- permissionsResponder.getPropertyDefaultPermissions(
+                                     resourceInfo.projectADM.projectIri,
+                                     resourceInfo.resourceClassIri,
+                                     submittedInternalPropertyIri,
+                                     requestingUser,
+                                   )
 
         // Did the user submit permissions for the new value?
         newValuePermissionLiteral <-

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -220,14 +220,14 @@ final case class CreateResourceV2Handler(
                       )
 
       // Get the default permissions of the resource class.
-      defaultResourcePermissions <- permissionsResponder.getResourceDefaultPermissions(
+      defaultResourcePermissions <- permissionsResponder.newResourceDefaultObjectAccessPermissions(
                                       createResourceRequestV2.createResource.projectADM.projectIri,
                                       internalCreateResource.resourceClassIri,
                                       createResourceRequestV2.requestingUser,
                                     )
 
       // Get the default permissions of each property used.
-      defaultPropertyPermissionsMap <- permissionsResponder.getPropertiesDefaultPermissions(
+      defaultPropertyPermissionsMap <- permissionsResponder.newValueDefaultObjectAccessPermissions(
                                          createResourceRequestV2.createResource.projectADM.projectIri,
                                          internalCreateResource.resourceClassIri,
                                          internalCreateResource.values.keySet,
@@ -244,7 +244,7 @@ final case class CreateResourceV2Handler(
           entityInfo = allEntityInfo,
           clientResourceIDs = Map.empty[IRI, String],
           defaultResourcePermissions = defaultResourcePermissions.permissionLiteral,
-          defaultPropertyPermissions = defaultPropertyPermissionsMap,
+          defaultPropertyPermissions = defaultPropertyPermissionsMap.map((k, v) => (k, v.permissionLiteral)),
           creationDate = internalCreateResource.creationDate.getOrElse(Instant.now),
           requestingUser = createResourceRequestV2.requestingUser,
         )


### PR DESCRIPTION
- **extract code to PermissionsResponder. getPropertiesDefaultPermissions to**
- **align method names (getDefaultValuePermissions -> getPropertyDefaultPermissions)**
- **use ProjectIri type for getPropertyDefaultPermissions**
- **use ProjectIri type for getPropertyDefaultPermissions and simplify code**
- **clarify PermissionResponder method naming for new Resource and Value creation**

<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [x] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
