### PR TITLE
fix: Fix precedence of endpoints so that /v2/resources/info is routed to the ResourceInfoEndpointHandler

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/routing/ApiRoutes.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/ApiRoutes.scala
@@ -79,12 +79,15 @@ final case class ApiRoutes(
               .withAllowedMethods(List(GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS)),
           ) {
             DSPApiDirectives.handleErrors(routeData.appConfig) {
-              OntologiesRouteV2().makeRoute ~
-                ResourcesRouteV2(routeData.appConfig).makeRoute ~
-                StandoffRouteV2().makeRoute ~
-                ValuesRouteV2().makeRoute ~
+              val tapirRoutes =
                 (adminApiRoutes.routes ++ authenticationApiRoutes.routes ++ resourceInfoRoutes.routes ++ searchApiRoutes.routes ++ managementRoutes.routes ++ listsApiV2Routes.routes ++ shaclApiRoutes.routes)
                   .reduce(_ ~ _)
+              val pekkoRoutes =
+                OntologiesRouteV2().makeRoute ~
+                  ResourcesRouteV2(routeData.appConfig).makeRoute ~
+                  StandoffRouteV2().makeRoute ~
+                  ValuesRouteV2().makeRoute
+              tapirRoutes ~ pekkoRoutes
             }
           }
         }


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
