### PR TITLE
docs: Fix docs publish CI failing on main

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,9 +10,18 @@ jobs:
     name: Publish Docs to Github Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Run preparatory steps
+        uses: dasch-swiss/dsp-api/.github/actions/preparation@main
+      - name: Install Just
+        uses: taiki-e/install-action@just
+      - name: Install Python
+        uses: actions/setup-python@v2
         with:
-          fetch-depth: 0
+          python-version: '3.13'
+      - name: Install Graphviz
+        run: sudo apt-get install graphviz
+      - name: Prepare docs
+        run: just docs-build-dependent
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

Docs publish CI failed on main because the OpenAPI docs are not present - as they need to be generated.  
This requires a bit of setup (java, just, ...).

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
