### PR TITLE
fix: Dummy filenames may not contain a file extension, remove it only if it exists (DEV-4227)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -2249,9 +2249,9 @@ object StillImageExternalFileValueContentV2 {
     licenseText          <- r.objectStringOption(HasLicenseText, LicenseText.from)
     licenseUri           <- r.objectDataTypeOption(HasLicenseUri, XSD.anyURI.toString, LicenseUri.from)
     fileValue = FileValueV2(
-                  "dummy.foo",
+                  "internalFilename",
                   "internalMimeType",
-                  Some("dummy.foo"),
+                  Some("originalFilename"),
                   Some("originalMimeType"),
                   copyrightAttribution,
                   licenseText,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -712,8 +712,10 @@ object ValueContentV2 {
     ZIO.foreach(filenameMaybe) { filename =>
       for {
         sipiService <- ZIO.service[SipiService]
+        assetIdStr = // remove the file extension if it exists
+          if filename.contains(".") then filename.substring(0, filename.indexOf('.')) else filename
         assetId <- ZIO
-                     .fromEither(AssetId.from(filename.substring(0, filename.indexOf('.'))))
+                     .fromEither(AssetId.from(assetIdStr))
                      .mapError(msg => BadRequestException(s"Invalid value for 'fileValueHasFilename': $msg"))
         meta <- sipiService.getFileMetadataFromDspIngest(shortcode, assetId).mapError {
                   case NotFoundException(_) =>

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -712,10 +712,8 @@ object ValueContentV2 {
     ZIO.foreach(filenameMaybe) { filename =>
       for {
         sipiService <- ZIO.service[SipiService]
-        assetIdStr = // remove the file extension if it exists
-          if filename.contains(".") then filename.substring(0, filename.indexOf('.')) else filename
         assetId <- ZIO
-                     .fromEither(AssetId.from(assetIdStr))
+                     .fromEither(AssetId.fromFilename(filename))
                      .mapError(msg => BadRequestException(s"Invalid value for 'fileValueHasFilename': $msg"))
         meta <- sipiService.getFileMetadataFromDspIngest(shortcode, assetId).mapError {
                   case NotFoundException(_) =>
@@ -2251,9 +2249,9 @@ object StillImageExternalFileValueContentV2 {
     licenseText          <- r.objectStringOption(HasLicenseText, LicenseText.from)
     licenseUri           <- r.objectDataTypeOption(HasLicenseUri, XSD.anyURI.toString, LicenseUri.from)
     fileValue = FileValueV2(
-                  "internalFilename",
+                  "dummy.foo",
                   "internalMimeType",
-                  Some("originalFilename"),
+                  Some("dummy.foo"),
                   Some("originalMimeType"),
                   copyrightAttribution,
                   licenseText,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/MaintenanceRequests.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/MaintenanceRequests.scala
@@ -21,7 +21,14 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 object MaintenanceRequests {
 
   type AssetId = String Refined MatchesRegex["^[a-zA-Z0-9-_]{4,}$"]
-  object AssetId extends RefinedTypeOps[AssetId, String]
+  object AssetId extends RefinedTypeOps[AssetId, String] {
+
+    def fromFilename(filename: String): Either[String, AssetId] = {
+      val withoutFileExtension =
+        if filename.contains(".") then filename.substring(0, filename.indexOf('.')) else filename
+      AssetId.from(withoutFileExtension)
+    }
+  }
 
   final case class Dimensions(width: Int Refined Positive, height: Int Refined Positive)
 


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

Fixes an occurence of a `StringIndexOutOfBoundsException`:
```
{"name":"org.knora.webapi.http.handler.KnoraExceptionHandler$","timestamp":"2024-12-10T16:05:57.392932872Z  ","level":"ERROR","thread":"zio-fiber-1856268975","message":"Unable to run route /v2/resources","cause":"Exception in thread \"zio-fiber-\" java.lang.StringIndexOutOfBoundsException: Range [0, -1) out of bounds for length 0
\tat java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
\tat java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
\tat java.base/jdk.internal.util.Preconditions$4.apply(Unknown Source)
\tat java.base/jdk.internal.util.Preconditions$4.apply(Unknown Source)
\tat java.base/jdk.internal.util.Preconditions.outOfBounds(Unknown Source)
\tat java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Unknown Source)
\tat java.base/jdk.internal.util.Preconditions.checkFromToIndex(Unknown Source)
\tat java.base/java.lang.String.checkBoundsBeginEnd(Unknown Source)
\tat java.base/java.lang.String.substring(Unknown Source)
\tat org.knora.webapi.messages.v2.responder.valuemessages.ValueContentV2$.fileInfoFromExternal$$anonfun$1$$anonfun$1$$anonfun$1(ValueMessagesV2.scala:717)
\tat zio.ZIO$.fromEither$$anonfun$1(ZIO.scala:3680)","logger_name":"org.knora.webapi.http.handler.KnoraExceptionHandler$","org.knora.webapi.http.handler.KnoraExceptionHandler$":"1ms"}
```
<!-- Please add either the issue number or, in case of unscheduled work, a short description of the task at hand -->

Issue Number: DEV-

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [x] fix: represents bug fixes
- [ ] perf: performance improvements
- [ ] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
