### PR TITLE
refactor: Remove user argument from reloading ontology cache

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/core/TestStartupUtils.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/TestStartupUtils.scala
@@ -9,7 +9,6 @@ import com.typesafe.scalalogging.LazyLogging
 import zio.*
 
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
-import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 
@@ -32,7 +31,7 @@ trait TestStartupUtils extends LazyLogging {
       tss <- ZIO.service[TriplestoreService]
       _   <- tss.resetTripleStoreContent(rdfDataObjects).timeout(480.seconds)
       _   <- ZIO.logInfo("... loading test data done.")
-      _   <- ZIO.serviceWithZIO[OntologyCache](_.loadOntologies(KnoraSystemInstances.Users.SystemUser)).orDie
+      _   <- ZIO.serviceWithZIO[OntologyCache](_.loadOntologies()).orDie
     } yield ()
 
 }

--- a/integration/src/test/scala/org/knora/webapi/responders/v2/LoadOntologiesSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/LoadOntologiesSpec.scala
@@ -10,7 +10,6 @@ import zio.ZIO
 
 import org.knora.webapi.CoreSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
-import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.routing.UnsafeZioRun
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
@@ -42,7 +41,7 @@ class LoadOntologiesSpec extends CoreSpec with ImplicitSender {
     )
 
     UnsafeZioRun
-      .run(ZIO.serviceWithZIO[OntologyCache](_.loadOntologies(KnoraSystemInstances.Users.SystemUser)))
+      .run(ZIO.serviceWithZIO[OntologyCache](_.loadOntologies()))
       .toEither
       .map(_ => SuccessResponseV2("OK"))
       .left

--- a/integration/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -24,7 +24,6 @@ import org.knora.webapi.messages.OntologyConstants.Rdfs
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.*
-import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.messages.util.rdf.SparqlSelectResult
 import org.knora.webapi.messages.v2.responder.CanDoResponseV2
 import org.knora.webapi.messages.v2.responder.SuccessResponseV2
@@ -452,9 +451,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
       assert(!cachedMetadataResponse.ontologies.exists(_.ontologyIri == fooIri.get.toSmartIri))
 
       // Reload the ontologies from the triplestore and check again.
-      UnsafeZioRun.runOrThrow(
-        ZIO.serviceWithZIO[OntologyCache](_.loadOntologies(KnoraSystemInstances.Users.SystemUser)),
-      )
+      UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[OntologyCache](_.loadOntologies()))
 
       appActor ! OntologyMetadataGetByProjectRequestV2()
 
@@ -795,7 +792,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
 
       // Reload the ontology cache and see if we get the same result.
       UnsafeZioRun.runOrThrow(
-        ZIO.serviceWithZIO[OntologyCache](_.loadOntologies(KnoraSystemInstances.Users.SystemUser)),
+        ZIO.serviceWithZIO[OntologyCache](_.loadOntologies()),
       )
 
       appActor ! PropertiesGetRequestV2(
@@ -899,7 +896,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
 
       // Reload the ontology cache and see if we get the same result.
       UnsafeZioRun.runOrThrow(
-        ZIO.serviceWithZIO[OntologyCache](_.loadOntologies(KnoraSystemInstances.Users.SystemUser)),
+        ZIO.serviceWithZIO[OntologyCache](_.loadOntologies()),
       )
 
       appActor ! PropertiesGetRequestV2(
@@ -3738,7 +3735,7 @@ class OntologyResponderV2Spec extends CoreSpec with ImplicitSender {
 
       // Reload the ontology cache and see if we get the same result.
       UnsafeZioRun.runOrThrow(
-        ZIO.serviceWithZIO[OntologyCache](_.loadOntologies(KnoraSystemInstances.Users.SystemUser)),
+        ZIO.serviceWithZIO[OntologyCache](_.loadOntologies()),
       )
 
       appActor ! linkPropGetRequest

--- a/webapi/src/main/scala/org/knora/webapi/core/AppServer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/AppServer.scala
@@ -10,7 +10,6 @@ import zio.*
 
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.core.domain.AppState
-import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.store.triplestore.api.TriplestoreService
@@ -66,9 +65,7 @@ final case class AppServer(
   private def populateOntologyCaches(requiresRepository: Boolean): Task[Unit] =
     for {
       _ <- state.set(AppState.LoadingOntologies)
-      _ <- ontologyCache
-             .loadOntologies(KnoraSystemInstances.Users.SystemUser)
-             .when(requiresRepository)
+      _ <- ontologyCache.loadOntologies().when(requiresRepository)
       _ <- state.set(AppState.OntologiesReady)
     } yield ()
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/StoreRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/StoreRestService.scala
@@ -10,7 +10,6 @@ import zio.*
 import dsp.errors.ForbiddenException
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
-import org.knora.webapi.messages.util.KnoraSystemInstances.Users.SystemUser
 import org.knora.webapi.slice.admin.api.MessageResponse
 import org.knora.webapi.slice.infrastructure.CacheManager
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
@@ -42,7 +41,7 @@ final case class StoreRestService(
            }
       _ <- ZIO.logWarning(s"Resetting triplestore content with ${rdfDataObjects.map(_.name).mkString(", ")}")
       _ <- triplestoreService.resetTripleStoreContent(rdfDataObjects, prependDefaults).logError
-      _ <- ontologyCache.loadOntologies(SystemUser).logError
+      _ <- ontologyCache.loadOntologies().logError
       _  = cacheManager.clearAll()
     } yield MessageResponse("success")
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCache.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCache.scala
@@ -21,13 +21,11 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.twirl.queries.sparql
 import org.knora.webapi.messages.util.ErrorHandlingMap
-import org.knora.webapi.messages.util.KnoraSystemInstances
 import org.knora.webapi.messages.util.OntologyUtil
 import org.knora.webapi.messages.v2.responder.ontologymessages.*
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.*
 import org.knora.webapi.responders.v2.ontology.OntologyHelpers
 import org.knora.webapi.responders.v2.ontology.OntologyHelpers.OntologyGraph
-import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectRepo
 import org.knora.webapi.slice.ontology.repo.model.OntologyCacheData
 import org.knora.webapi.store.triplestore.api.TriplestoreService
@@ -419,11 +417,8 @@ trait OntologyCache {
 
   /**
    * Loads and caches all ontology information.
-   *
-   * @param requestingUser the user making the request.
-   * @return [[Unit]]
    */
-  def loadOntologies(requestingUser: User): Task[Unit]
+  def loadOntologies(): Task[Unit]
 
   /**
    * Gets the ontology data from the cache.
@@ -475,12 +470,6 @@ trait OntologyCache {
     updatedClassIri: SmartIri,
   ): Task[OntologyCacheData]
 
-  /**
-   * Loads and caches all ontology information.
-   *
-   * @return [[Unit]]
-   */
-  final def loadOntologies(): Task[Unit] = loadOntologies(KnoraSystemInstances.Users.SystemUser)
 }
 
 final case class OntologyCacheLive(triplestore: TriplestoreService, cacheDataRef: Ref[OntologyCacheData])(implicit
@@ -490,19 +479,9 @@ final case class OntologyCacheLive(triplestore: TriplestoreService, cacheDataRef
 
   /**
    * Loads and caches all ontology information.
-   *
-   * @param requestingUser the user making the request.
-   * @return [[Unit]]
    */
-  override def loadOntologies(requestingUser: User): Task[Unit] =
+  override def loadOntologies(): Task[Unit] =
     for {
-      _ <-
-        ZIO
-          .fail(ForbiddenException(s"Only a system administrator can reload ontologies"))
-          .when(
-            !(requestingUser.id == KnoraSystemInstances.Users.SystemUser.id || requestingUser.permissions.isSystemAdmin),
-          )
-
       // Get all ontology metadata.
       _                           <- ZIO.logInfo(s"Loading ontologies into cache")
       allOntologyMetadataResponse <- triplestore.query(Select(sparql.v2.txt.getAllOntologyMetadata()))

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCacheFake.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCacheFake.scala
@@ -12,7 +12,6 @@ import zio.ZLayer
 
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadOntologyV2
-import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.ontology.repo.model.OntologyCacheData
 
 case class OntologyCacheFake(ref: Ref[OntologyCacheData]) extends OntologyCache {
@@ -23,11 +22,8 @@ case class OntologyCacheFake(ref: Ref[OntologyCacheData]) extends OntologyCache 
 
   /**
    * Loads and caches all ontology information.
-   *
-   * @param requestingUser the user making the request.
-   * @return a [[Unit]].
    */
-  override def loadOntologies(requestingUser: User): Task[Unit] =
+  override def loadOntologies(): Task[Unit] =
     throw new UnsupportedOperationException("Not possible in tests. Provide the respective test data as Ref.")
 
   /**


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests: https://docs.dasch.swiss/latest/developers/contribution/ -->

## Pull Request Checklist

### Task Description/Number

Remove unused parameter and obsolete checks. Reloading ontologies in ontology cache does not require a requesting user.

### PR Type

- [ ] build/chore: maintenance tasks (no production code change)
- [ ] docs: documentation changes (no production code change)
- [ ] feat: represents new features
- [ ] fix: represents bug fixes
- [ ] perf: performance improvements
- [x] refactor: represents production code refactoring
- [ ] test: adding or refactoring tests (no production code change)
- [ ] deprecated: Deprecation warning (ideally referencing a migration guide)

### Basic requirements for bug fixes and features

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes


