### PR TITLE
feat: Add more support for JSON-LD on ontology endpoints

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -723,35 +723,6 @@ case class ChangeGuiOrderRequestV2(
   requestingUser: User,
 ) extends OntologiesResponderRequestV2
 
-object ChangeGuiOrderRequestV2 {
-
-  def fromJsonLd(
-    jsonLDDocument: JsonLDDocument,
-    apiRequestID: UUID,
-    requestingUser: User,
-  ): ChangeGuiOrderRequestV2 = {
-    // Get the class definition and the ontology's last modification date from the JSON-LD.
-
-    val inputOntologiesV2    = InputOntologyV2.fromJsonLD(jsonLDDocument)
-    val classUpdateInfo      = OntologyUpdateHelper.getClassDef(inputOntologiesV2)
-    val classInfoContent     = classUpdateInfo.classInfoContent
-    val lastModificationDate = classUpdateInfo.lastModificationDate
-
-    // The request must provide cardinalities.
-
-    if (classInfoContent.directCardinalities.isEmpty) {
-      throw BadRequestException("No cardinalities specified")
-    }
-
-    ChangeGuiOrderRequestV2(
-      classInfoContent = classInfoContent,
-      lastModificationDate = lastModificationDate,
-      apiRequestID = apiRequestID,
-      requestingUser = requestingUser,
-    )
-  }
-}
-
 /**
  * Requests a change in the metadata of an ontology. A successful response will be a [[ReadOntologyMetadataV2]].
  *

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -324,13 +324,12 @@ final case class OntologiesRouteV2()(
   private def changeGuiOrder(): Route =
     path(ontologiesBasePath / "guiorder") {
       put {
-        // Change a class's cardinalities.
         entity(as[String]) { jsonRequest => requestContext =>
           val requestMessageTask = for {
             requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-            requestDoc     <- RouteUtilV2.parseJsonLd(jsonRequest)
             apiRequestId   <- RouteUtilZ.randomUuid()
-            msg            <- ZIO.attempt(ChangeGuiOrderRequestV2.fromJsonLd(requestDoc, apiRequestId, requestingUser))
+            msg <- requestParser(_.changeGuiOrderRequestV2(jsonRequest, apiRequestId, requestingUser))
+                     .mapError(BadRequestException.apply)
           } yield msg
           RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)
         }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologyV2RequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologyV2RequestParser.scala
@@ -28,6 +28,7 @@ import org.knora.webapi.messages.v2.responder.ontologymessages.AddCardinalitiesT
 import org.knora.webapi.messages.v2.responder.ontologymessages.CanDeleteCardinalitiesFromClassRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ChangeClassLabelsOrCommentsRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ChangeClassLabelsOrCommentsRequestV2.LabelOrComment
+import org.knora.webapi.messages.v2.responder.ontologymessages.ChangeGuiOrderRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ChangeOntologyMetadataRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ClassInfoContentV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.CreateClassRequestV2
@@ -303,6 +304,19 @@ final case class OntologyV2RequestParser(iriConverter: IriConverter) {
     requestingUser: User,
   ): IO[String, DeleteCardinalitiesFromClassRequestV2] =
     constructClassRelatedRequest(jsonLd, apiRequestId, requestingUser, DeleteCardinalitiesFromClassRequestV2.apply)
+
+  def changeGuiOrderRequestV2(
+    jsonLd: String,
+    apiRequestId: UUID,
+    requestingUser: User,
+  ): IO[String, ChangeGuiOrderRequestV2] =
+    constructClassRelatedRequest(
+      jsonLd,
+      apiRequestId,
+      requestingUser,
+      ChangeGuiOrderRequestV2.apply,
+      (_, classInfo) => ZIO.fail("No cardinalities specified").when(classInfo.directCardinalities.isEmpty).unit,
+    )
 
   private def constructClassRelatedRequest[A](
     jsonLd: String,


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

Added JSON-LD support for:

* `PUT   v2/ontologies/classes` // change labels or comments of a class
* `POST  v2/ontologies/cardinalities` // add cardinalities to a class
* `PUT   v2/ontologies/cardinalities` // replace cardinalities of a class
* `PATCH v2/ontologies/cardinalities` // delete cardinalities of a class
* `PUT   v2/ontologies/candeletecardinalities` // check if cardinalities of a class can be deleted
* `PUT   v2/ontologies/guiorder` // change gui order

<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
