### PR TITLE
feat: Add admin api for legal info (DEV-4502)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: daschswiss/dsp-app:v11.25.1
+    image: daschswiss/dsp-app:v11.26.0
     ports:
       - "4200:4200"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: daschswiss/dsp-app:v11.26.0
+    image: daschswiss/dsp-app:v11.25.1
     ports:
       - "4200:4200"
     networks:

--- a/integration/src/test/scala/org/knora/webapi/E2EZSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/E2EZSpec.scala
@@ -50,7 +50,7 @@ abstract class E2EZSpec extends ZIOSpecDefault with TestStartupUtils {
   def sendGetRequestAsRoot(url: String): URIO[env, Response] =
     getRootToken.mapError(Exception(_)).orDie.flatMap(token => sendGetRequest(url, Some(token)))
 
-  def sendGetRequestAsRootDecode[A: JsonDecoder](url: String): ZIO[env, Serializable, A] =
+  def sendGetRequestAsRootDecode[A: JsonDecoder](url: String): ZIO[env, String, A] =
     sendGetRequestAsRoot(url)
       .flatMap(response => response.body.asString.mapBoth(_.getMessage, (response.status, _)))
       .filterOrElseWith { case (status, _) => status.isSuccess } { case (status, body) =>

--- a/integration/src/test/scala/org/knora/webapi/E2EZSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/E2EZSpec.scala
@@ -8,6 +8,7 @@ package org.knora.webapi
 import zio.*
 import zio.http.*
 import zio.json.*
+import zio.json.DecoderOps
 import zio.json.ast.Json
 import zio.json.ast.JsonCursor
 import zio.test.*
@@ -45,6 +46,17 @@ abstract class E2EZSpec extends ZIOSpecDefault with TestStartupUtils {
       @@ TestAspect.sequential
   ).provideShared(testLayers, Client.default, Scope.default)
     @@ TestAspect.withLiveEnvironment
+
+  def sendGetRequestAsRoot(url: String): URIO[env, Response] =
+    getRootToken.mapError(Exception(_)).orDie.flatMap(token => sendGetRequest(url, Some(token)))
+
+  def sendGetRequestAsRootDecode[A: JsonDecoder](url: String): ZIO[env, Serializable, A] =
+    sendGetRequestAsRoot(url)
+      .flatMap(response => response.body.asString.mapBoth(_.getMessage, (response.status, _)))
+      .filterOrElseWith { case (status, _) => status.isSuccess } { case (status, body) =>
+        ZIO.fail(s"Failed request: Status $status, $body")
+      }
+      .flatMap { case (_, body) => ZIO.fromEither(body.fromJson[A]) }
 
   def sendGetRequest(url: String, token: Option[String] = None): URIO[env, Response] =
     for {

--- a/webapi/src/main/resources/knora-ontologies/knora-admin.ttl
+++ b/webapi/src/main/resources/knora-ontologies/knora-admin.ttl
@@ -250,6 +250,15 @@
     knora-base:objectDatatypeConstraint xsd:string .
 
 
+###  http://www.knora.org/ontology/knora-admin#projectPredefinedAuthorship
+
+:projectPredefinedAuthorship
+    rdf:type                            owl:DatatypeProperty ;
+    rdfs:subPropertyOf                  knora-base:objectCannotBeMarkedAsDeleted ;
+    rdfs:comment                        "Available authorships to be used for creating assets"@en ;
+    knora-base:subjectClassConstraint   :knoraProject ;
+    knora-base:objectDatatypeConstraint xsd:string .
+
 ###  http://www.knora.org/ontology/knora-admin#username
 
 :username
@@ -382,7 +391,10 @@
                       owl:cardinality    "1"^^xsd:nonNegativeInteger ],
                     [ rdf:type           owl:Restriction ;
                       owl:onProperty     :hasSelfJoinEnabled ;
-                      owl:cardinality    "1"^^xsd:nonNegativeInteger ] ;
+                      owl:cardinality    "1"^^xsd:nonNegativeInteger ] ,
+                    [ rdf:type           owl:Restriction ;
+                      owl:onProperty     :projectPredefinedAuthorship ;
+                      owl:minCardinality "0"^^xsd:nonNegativeInteger ] ;
     rdfs:comment    "Represents a project that uses Knora."@en .
 
 

--- a/webapi/src/main/resources/knora-ontologies/knora-admin.ttl
+++ b/webapi/src/main/resources/knora-ontologies/knora-admin.ttl
@@ -250,12 +250,12 @@
     knora-base:objectDatatypeConstraint xsd:string .
 
 
-###  http://www.knora.org/ontology/knora-admin#projectPredefinedAuthorship
+###  http://www.knora.org/ontology/knora-admin#hasAllowedCopyrightHolder
 
-:projectPredefinedAuthorship
+:hasAllowedCopyrightHolder
     rdf:type                            owl:DatatypeProperty ;
     rdfs:subPropertyOf                  knora-base:objectCannotBeMarkedAsDeleted ;
-    rdfs:comment                        "Available authorships to be used for creating assets"@en ;
+    rdfs:comment                        "An authorship allowed for creating assets in project data"@en ;
     knora-base:subjectClassConstraint   :knoraProject ;
     knora-base:objectDatatypeConstraint xsd:string .
 
@@ -393,7 +393,7 @@
                       owl:onProperty     :hasSelfJoinEnabled ;
                       owl:cardinality    "1"^^xsd:nonNegativeInteger ] ,
                     [ rdf:type           owl:Restriction ;
-                      owl:onProperty     :projectPredefinedAuthorship ;
+                      owl:onProperty     :hasAllowedCopyrightHolder ;
                       owl:minCardinality "0"^^xsd:nonNegativeInteger ] ;
     rdfs:comment    "Represents a project that uses Knora."@en .
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -468,7 +468,7 @@ object OntologyConstants {
     val ProjectRestrictedViewSize: IRI      = KnoraAdminPrefixExpansion + "projectRestrictedViewSize"
     val ProjectRestrictedViewWatermark: IRI = KnoraAdminPrefixExpansion + "projectRestrictedViewWatermark"
     val HasSelfJoinEnabled: IRI             = KnoraAdminPrefixExpansion + "hasSelfJoinEnabled"
-    val ProjectPredefinedAuthorship: IRI    = KnoraAdminPrefixExpansion + "projectPredefinedAuthorship"
+    val hasPredefinedCopyrightHolder: IRI   = KnoraAdminPrefixExpansion + "hasPredefinedCopyrightHolder"
 
     /* Group */
     val UserGroup: IRI         = KnoraAdminPrefixExpansion + "UserGroup"

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -468,7 +468,7 @@ object OntologyConstants {
     val ProjectRestrictedViewSize: IRI      = KnoraAdminPrefixExpansion + "projectRestrictedViewSize"
     val ProjectRestrictedViewWatermark: IRI = KnoraAdminPrefixExpansion + "projectRestrictedViewWatermark"
     val HasSelfJoinEnabled: IRI             = KnoraAdminPrefixExpansion + "hasSelfJoinEnabled"
-    val hasPredefinedCopyrightHolder: IRI   = KnoraAdminPrefixExpansion + "hasPredefinedCopyrightHolder"
+    val hasAllowedCopyrightHolder: IRI      = KnoraAdminPrefixExpansion + "hasAllowedCopyrightHolder"
 
     /* Group */
     val UserGroup: IRI         = KnoraAdminPrefixExpansion + "UserGroup"

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -468,6 +468,7 @@ object OntologyConstants {
     val ProjectRestrictedViewSize: IRI      = KnoraAdminPrefixExpansion + "projectRestrictedViewSize"
     val ProjectRestrictedViewWatermark: IRI = KnoraAdminPrefixExpansion + "projectRestrictedViewWatermark"
     val HasSelfJoinEnabled: IRI             = KnoraAdminPrefixExpansion + "hasSelfJoinEnabled"
+    val ProjectPredefinedAuthorship: IRI    = KnoraAdminPrefixExpansion + "projectPredefinedAuthorship"
 
     /* Group */
     val UserGroup: IRI         = KnoraAdminPrefixExpansion + "UserGroup"

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -284,7 +284,7 @@ case class PermissionsDataADM(
 
   /* Is the user a member of the ProjectAdmin group */
   def isProjectAdmin(projectIri: IRI): Boolean =
-    groupsPerProject.getOrElse(projectIri, List.empty[IRI]).contains(KnoraGroupRepo.builtIn.ProjectAdmin.id.value)
+    groupsPerProject.getOrElse(projectIri, List.empty).contains(KnoraGroupRepo.builtIn.ProjectAdmin.id.value)
 
   /* Does the user have the 'ProjectAdminAllPermission' permission for the project */
   def hasProjectAdminAllPermissionFor(projectIri: IRI): Boolean =

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiEndpoints.scala
@@ -14,6 +14,7 @@ final case class AdminApiEndpoints(
   maintenanceEndpoints: MaintenanceEndpoints,
   permissionsEndpoints: PermissionsEndpoints,
   projectsEndpoints: ProjectsEndpoints,
+  projectsLegalInfoEndpoint: ProjectsLegalInfoEndpoints,
   storeEndpoints: StoreEndpoints,
   usersEndpoints: UsersEndpoints,
   filesEndpoints: FilesEndpoints,
@@ -24,6 +25,7 @@ final case class AdminApiEndpoints(
       listsEndpoints.endpoints ++
       maintenanceEndpoints.endpoints ++
       permissionsEndpoints.endpoints ++
+      projectsLegalInfoEndpoint.endpoints ++
       projectsEndpoints.endpoints ++
       storeEndpoints.endpoints ++
       usersEndpoints.endpoints ++

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiModule.scala
@@ -18,6 +18,7 @@ import org.knora.webapi.slice.admin.api.service.GroupRestService
 import org.knora.webapi.slice.admin.api.service.MaintenanceRestService
 import org.knora.webapi.slice.admin.api.service.PermissionRestService
 import org.knora.webapi.slice.admin.api.service.ProjectRestService
+import org.knora.webapi.slice.admin.api.service.ProjectsLegalInfoRestService
 import org.knora.webapi.slice.admin.api.service.StoreRestService
 import org.knora.webapi.slice.admin.api.service.UserRestService
 import org.knora.webapi.slice.admin.domain.service.AdministrativePermissionService
@@ -26,6 +27,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupService
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.admin.domain.service.KnoraUserService
 import org.knora.webapi.slice.admin.domain.service.KnoraUserToUserConverter
+import org.knora.webapi.slice.admin.domain.service.LicenseService
 import org.knora.webapi.slice.admin.domain.service.PasswordService
 import org.knora.webapi.slice.admin.domain.service.ProjectEraseService
 import org.knora.webapi.slice.admin.domain.service.ProjectExportService
@@ -55,6 +57,7 @@ object AdminApiModule
       KnoraResponseRenderer &
       KnoraUserService &
       KnoraUserToUserConverter &
+      LicenseService &
       ListsResponder &
       MaintenanceService &
       OntologyCache &
@@ -95,6 +98,9 @@ object AdminApiModule
       PermissionsEndpoints.layer,
       PermissionsEndpointsHandlers.layer,
       PermissionRestService.layer,
+      ProjectsLegalInfoEndpoints.layer,
+      ProjectsLegalInfoEndpointsHandler.layer,
+      ProjectsLegalInfoRestService.layer,
       ProjectRestService.layer,
       ProjectsEndpoints.layer,
       ProjectsEndpointsHandler.layer,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiRoutes.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/AdminApiRoutes.scala
@@ -16,6 +16,7 @@ final case class AdminApiRoutes(
   lists: ListsEndpointsHandlers,
   maintenance: MaintenanceEndpointsHandlers,
   permissions: PermissionsEndpointsHandlers,
+  projectLegalInfo: ProjectsLegalInfoEndpointsHandler,
   project: ProjectsEndpointsHandler,
   storeEndpoints: StoreEndpointsHandler,
   users: UsersEndpointsHandler,
@@ -28,6 +29,7 @@ final case class AdminApiRoutes(
       lists.allHandlers ++
       maintenance.allHandlers ++
       permissions.allHanders ++
+      projectLegalInfo.allHandlers ++
       project.allHanders ++
       storeEndpoints.allHandlers ++
       users.allHanders

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
@@ -40,10 +40,10 @@ object Examples {
 
   object PagedResponse {
     def fromSlice[A: JsonCodec](data: Seq[A]): model.PagedResponse[A] =
-      model.PagedResponse(data, Pagination.from(data.size * 5, PageAndSize(1, data.size)))
+      model.PagedResponse.from(data, data.size * 5, PageAndSize(1, data.size))
 
     def fromTotal[A: JsonCodec](data: Seq[A]): model.PagedResponse[A] =
-      model.PagedResponse(data, Pagination.from(data.size, PageAndSize(1, data.size)))
+      model.PagedResponse.from(data, data.size, PageAndSize(1, data.size))
   }
 
   object ProjectExample {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
@@ -13,6 +13,9 @@ import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.api.Examples.GroupExample.groupName
 import org.knora.webapi.slice.admin.api.GroupsRequests.GroupCreateRequest
 import org.knora.webapi.slice.admin.api.GroupsRequests.GroupUpdateRequest
+import org.knora.webapi.slice.admin.api.model.PageAndSize
+import org.knora.webapi.slice.admin.api.model.PagedResponse
+import org.knora.webapi.slice.admin.api.model.Pagination
 import org.knora.webapi.slice.admin.api.model.Project
 import org.knora.webapi.slice.admin.domain.model.Email
 import org.knora.webapi.slice.admin.domain.model.FamilyName
@@ -33,8 +36,14 @@ import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.admin.domain.model.UserStatus
 import org.knora.webapi.slice.admin.domain.model.Username
+import zio.json.JsonCodec
 
 object Examples {
+
+  object PageResponse {
+    def from[A: JsonCodec](data: Seq[A]): PagedResponse[A] =
+      PagedResponse(data, Pagination.from(data.size * 5, PageAndSize(1, data.size)))
+  }
 
   object ProjectExample {
     val projectIri: ProjectIri = ProjectIri.unsafeFrom("http://rdfh.ch/projects/0042")

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
@@ -5,6 +5,8 @@
 
 package org.knora.webapi.slice.admin.api
 
+import zio.json.JsonCodec
+
 import org.knora.webapi.messages.admin.responder.groupsmessages.GroupGetResponseADM
 import org.knora.webapi.messages.admin.responder.groupsmessages.GroupsGetResponseADM
 import org.knora.webapi.messages.admin.responder.permissionsmessages.PermissionsDataADM
@@ -36,7 +38,6 @@ import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.admin.domain.model.UserStatus
 import org.knora.webapi.slice.admin.domain.model.Username
-import zio.json.JsonCodec
 
 object Examples {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
@@ -15,10 +15,7 @@ import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.api.Examples.GroupExample.groupName
 import org.knora.webapi.slice.admin.api.GroupsRequests.GroupCreateRequest
 import org.knora.webapi.slice.admin.api.GroupsRequests.GroupUpdateRequest
-import org.knora.webapi.slice.admin.api.model.PageAndSize
-import org.knora.webapi.slice.admin.api.model.PagedResponse
-import org.knora.webapi.slice.admin.api.model.Pagination
-import org.knora.webapi.slice.admin.api.model.Project
+import org.knora.webapi.slice.admin.api.model.*
 import org.knora.webapi.slice.admin.domain.model.Email
 import org.knora.webapi.slice.admin.domain.model.FamilyName
 import org.knora.webapi.slice.admin.domain.model.GivenName
@@ -41,9 +38,12 @@ import org.knora.webapi.slice.admin.domain.model.Username
 
 object Examples {
 
-  object PageResponse {
-    def from[A: JsonCodec](data: Seq[A]): PagedResponse[A] =
-      PagedResponse(data, Pagination.from(data.size * 5, PageAndSize(1, data.size)))
+  object PagedResponse {
+    def fromSlice[A: JsonCodec](data: Seq[A]): model.PagedResponse[A] =
+      model.PagedResponse(data, Pagination.from(data.size * 5, PageAndSize(1, data.size)))
+
+    def fromTotal[A: JsonCodec](data: Seq[A]): model.PagedResponse[A] =
+      model.PagedResponse(data, Pagination.from(data.size, PageAndSize(1, data.size)))
   }
 
   object ProjectExample {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -1,0 +1,66 @@
+package org.knora.webapi.slice.admin.api
+import sttp.tapir.*
+import sttp.tapir.generic.auto.*
+import sttp.tapir.json.zio.jsonBody
+import zio.Chunk
+import zio.ZLayer
+import zio.json.DeriveJsonCodec
+import zio.json.JsonCodec
+
+import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortcode
+import org.knora.webapi.slice.admin.domain.model.License
+import org.knora.webapi.slice.common.api.BaseEndpoints
+
+final case class PageInfo(size: Int, `total-elements`: Int, pages: Int, number: Int)
+object PageInfo {
+  given JsonCodec[PageInfo]         = DeriveJsonCodec.gen[PageInfo]
+  def single(seq: Seq[_]): PageInfo = PageInfo(seq.size, seq.size, 1, 1)
+}
+
+final case class PagedResponse[LicenseDto](data: Chunk[LicenseDto], page: PageInfo)
+object PagedResponse {
+  given JsonCodec[PagedResponse[LicenseDto]] = DeriveJsonCodec.gen[PagedResponse[LicenseDto]]
+  def allInOnePage(licenses: Chunk[LicenseDto]): PagedResponse[LicenseDto] =
+    PagedResponse(licenses, PageInfo.single(licenses))
+}
+
+final case class LicenseDto(id: String, url: String, `label-en`: String)
+object LicenseDto {
+  given JsonCodec[LicenseDto]            = DeriveJsonCodec.gen[LicenseDto]
+  def from(license: License): LicenseDto = LicenseDto(license.id.value, license.uri.toString, license.labelEn)
+}
+
+final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
+
+  private final val base = "admin" / "projects" / "shortcode" / projectShortcode / "legal-info"
+
+  val getProjectLicenses = baseEndpoints.securedEndpoint.get
+    .in(base / "licenses")
+    .out(
+      jsonBody[PagedResponse[LicenseDto]].example(
+        PagedResponse.allInOnePage(
+          Chunk(
+            LicenseDto(
+              "http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g",
+              "https://creativecommons.org/licenses/by/4.0/",
+              "CC BY 4.0",
+            ),
+            LicenseDto(
+              "http://rdfh.ch/licenses/iAMRMWz7QCihyjKTToiOxQ",
+              "https://creativecommons.org/licenses/by-sa/4.0/",
+              "CC BY-SA 4.0",
+            ),
+          ),
+        ),
+      ),
+    )
+    .description("Get the allowed licenses of a project. The user must be a system or project admin.")
+
+  val endpoints: Seq[AnyEndpoint] = Seq(
+    getProjectLicenses,
+  ).map(_.endpoint).map(_.tag("Admin Projects (Legal Info)"))
+}
+
+object ProjectsLegalInfoEndpoints {
+  val layer = ZLayer.derive[ProjectsLegalInfoEndpoints]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -47,7 +47,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
     .in(FilterAndOrder.queryParams)
     .out(
       jsonBody[PagedResponse[Authorship]].example(
-        Examples.PageResponse.from(
+        Examples.PagedResponse.fromSlice(
           Chunk(
             Authorship.unsafeFrom("Lotte Reiniger"),
             Authorship.unsafeFrom("Margaret J. Winkler"),
@@ -65,7 +65,10 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
     .in(base / "licenses")
     .in(PageAndSize.queryParams())
     .in(FilterAndOrder.queryParams)
-    .out(jsonBody[PagedResponse[LicenseDto]].example(Examples.PageResponse.from(License.BUILT_IN.map(LicenseDto.from))))
+    .out(
+      jsonBody[PagedResponse[LicenseDto]]
+        .example(Examples.PagedResponse.fromTotal(License.BUILT_IN.map(LicenseDto.from))),
+    )
     .description(
       "Get the allowed licenses for use within this project. " +
         "The user must be project member, project admin or system admin.",
@@ -77,7 +80,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
     .in(FilterAndOrder.queryParams)
     .out(
       jsonBody[PagedResponse[CopyrightHolder]].example(
-        Examples.PageResponse.from(Chunk("DaSch", "University of Zurich").map(CopyrightHolder.unsafeFrom)),
+        Examples.PagedResponse.fromSlice(Chunk("DaSch", "University of Zurich").map(CopyrightHolder.unsafeFrom)),
       ),
     )
     .description(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.admin.api
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
@@ -41,12 +46,12 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
         PagedResponse.allInOnePage(
           Chunk(
             LicenseDto(
-              "http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g",
+              "http://rdfh.ch/licenses/cc-by-4.0",
               "https://creativecommons.org/licenses/by/4.0/",
               "CC BY 4.0",
             ),
             LicenseDto(
-              "http://rdfh.ch/licenses/iAMRMWz7QCihyjKTToiOxQ",
+              "http://rdfh.ch/licenses/cc-by-sa-4.0",
               "https://creativecommons.org/licenses/by-sa/4.0/",
               "CC BY-SA 4.0",
             ),

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -88,6 +88,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
 
   val getProjectAuthorships = baseEndpoints.securedEndpoint.get
     .in(base / "authorships")
+    .in(pageRequestAndSize)
     .out(
       jsonBody[PagedResponse[Authorship]].example(
         PagedResponse.allInOnePage(Chunk(Authorship.unsafeFrom("DaSch"), Authorship.unsafeFrom("University of Zurich"))),

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -29,9 +29,9 @@ object CopyrightHolderAddRequest {
   given JsonCodec[CopyrightHolderAddRequest] = DeriveJsonCodec.gen[CopyrightHolderAddRequest]
 }
 
-final case class CopyrighHolderReplaceRequest(`old-value`: CopyrightHolder, `new-value`: CopyrightHolder)
-object CopyrighHolderReplaceRequest {
-  given JsonCodec[CopyrighHolderReplaceRequest] = DeriveJsonCodec.gen[CopyrighHolderReplaceRequest]
+final case class CopyrightHolderReplaceRequest(`old-value`: CopyrightHolder, `new-value`: CopyrightHolder)
+object CopyrightHolderReplaceRequest {
+  given JsonCodec[CopyrightHolderReplaceRequest] = DeriveJsonCodec.gen[CopyrightHolderReplaceRequest]
 }
 
 final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
@@ -45,8 +45,9 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
       jsonBody[PagedResponse[Authorship]].example(
         Examples.PageResponse.from(
           Chunk(
-            Authorship.unsafeFrom("Theodor W. Adorno"),
-            Authorship.unsafeFrom("Friedrich Nietzsche"),
+            Authorship.unsafeFrom("Lotte Reiniger"),
+            Authorship.unsafeFrom("Margaret J. Winkler"),
+            Authorship.unsafeFrom("Hilma af Klint"),
           ),
         ),
       ),
@@ -106,9 +107,9 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
   val putProjectCopyrightHolders = baseEndpoints.securedEndpoint.put
     .in(base / "copyright-holders")
     .in(
-      jsonBody[CopyrighHolderReplaceRequest]
+      jsonBody[CopyrightHolderReplaceRequest]
         .example(
-          CopyrighHolderReplaceRequest(
+          CopyrightHolderReplaceRequest(
             CopyrightHolder.unsafeFrom("DaSch"),
             CopyrightHolder.unsafeFrom("DaSCH"),
           ),

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -21,7 +21,9 @@ import org.knora.webapi.slice.common.api.BaseEndpoints
 
 final case class LicenseDto(id: String, uri: String, `label-en`: String)
 object LicenseDto {
-  given JsonCodec[LicenseDto]            = DeriveJsonCodec.gen[LicenseDto]
+  given JsonCodec[LicenseDto] = DeriveJsonCodec.gen[LicenseDto]
+  given Ordering[LicenseDto]  = Ordering.by(_.`label-en`)
+
   def from(license: License): LicenseDto = LicenseDto(license.id.value, license.uri.toString, license.labelEn)
 }
 
@@ -62,6 +64,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
   val getProjectLicenses = baseEndpoints.securedEndpoint.get
     .in(base / "licenses")
     .in(PageAndSize.queryParams())
+    .in(FilterAndOrder.queryParams)
     .out(
       jsonBody[PagedResponse[LicenseDto]].example(
         Examples.PageResponse.from(
@@ -88,6 +91,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
   val getProjectCopyrightHolders = baseEndpoints.securedEndpoint.get
     .in(base / "copyright-holders")
     .in(PageAndSize.queryParams())
+    .in(FilterAndOrder.queryParams)
     .out(
       jsonBody[PagedResponse[CopyrightHolder]].example(
         Examples.PageResponse.from(Chunk("DaSch", "University of Zurich").map(CopyrightHolder.unsafeFrom)),

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -41,6 +41,12 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
   val getProjectAuthorships = baseEndpoints.securedEndpoint.get
     .in(base / "authorships")
     .in(pageAndSizeQuery())
+    .in(
+      query[Option[String]]("filter").description(
+        "Filter the authorships by a search term. " +
+          "The search is case-insensitive and resulting authorships contain the search term.",
+      ),
+    )
     .out(
       jsonBody[PagedResponse[Authorship]].example(
         Examples.PageResponse.from(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -13,8 +13,9 @@ import zio.json.DeriveJsonCodec
 import zio.json.JsonCodec
 
 import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortcode
+import org.knora.webapi.slice.admin.api.model.FilterAndOrder
+import org.knora.webapi.slice.admin.api.model.PageAndSize
 import org.knora.webapi.slice.admin.api.model.PagedResponse
-import org.knora.webapi.slice.admin.api.model.pageAndSizeQuery
 import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.common.api.BaseEndpoints
 
@@ -40,13 +41,8 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
 
   val getProjectAuthorships = baseEndpoints.securedEndpoint.get
     .in(base / "authorships")
-    .in(pageAndSizeQuery())
-    .in(
-      query[Option[String]]("filter").description(
-        "Filter the authorships by a search term. " +
-          "The search is case-insensitive and resulting authorships contain the search term.",
-      ),
-    )
+    .in(PageAndSize.queryParams())
+    .in(FilterAndOrder.queryParams)
     .out(
       jsonBody[PagedResponse[Authorship]].example(
         Examples.PageResponse.from(
@@ -65,7 +61,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
 
   val getProjectLicenses = baseEndpoints.securedEndpoint.get
     .in(base / "licenses")
-    .in(pageAndSizeQuery())
+    .in(PageAndSize.queryParams())
     .out(
       jsonBody[PagedResponse[LicenseDto]].example(
         Examples.PageResponse.from(
@@ -91,7 +87,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
 
   val getProjectCopyrightHolders = baseEndpoints.securedEndpoint.get
     .in(base / "copyright-holders")
-    .in(pageAndSizeQuery())
+    .in(PageAndSize.queryParams())
     .out(
       jsonBody[PagedResponse[CopyrightHolder]].example(
         Examples.PageResponse.from(Chunk("DaSch", "University of Zurich").map(CopyrightHolder.unsafeFrom)),

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -65,24 +65,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
     .in(base / "licenses")
     .in(PageAndSize.queryParams())
     .in(FilterAndOrder.queryParams)
-    .out(
-      jsonBody[PagedResponse[LicenseDto]].example(
-        Examples.PageResponse.from(
-          Chunk(
-            LicenseDto(
-              "http://rdfh.ch/licenses/cc-by-4.0",
-              "https://creativecommons.org/licenses/by/4.0/",
-              "CC BY 4.0",
-            ),
-            LicenseDto(
-              "http://rdfh.ch/licenses/cc-by-sa-4.0",
-              "https://creativecommons.org/licenses/by-sa/4.0/",
-              "CC BY-SA 4.0",
-            ),
-          ),
-        ),
-      ),
-    )
+    .out(jsonBody[PagedResponse[LicenseDto]].example(Examples.PageResponse.from(License.BUILT_IN.map(LicenseDto.from))))
     .description(
       "Get the allowed licenses for use within this project. " +
         "The user must be project member, project admin or system admin.",

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -94,7 +94,10 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
       jsonBody[CopyrightHolderAddRequest]
         .example(CopyrightHolderAddRequest(Set("DaSCH", "University of Zurich").map(CopyrightHolder.unsafeFrom))),
     )
-    .description("Add a new predefined authorships to a project. The user must be a system or project admin.")
+    .description(
+      "Add new allowed copyright holders for use within this project. " +
+        "The user must be a system or project admin.",
+    )
 
   val putProjectCopyrightHolders = baseEndpoints.securedEndpoint.put
     .in(base / "copyright-holders")
@@ -108,7 +111,8 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
         ),
     )
     .description(
-      "Update a particular predefined authorships of a project, does not update existing authorships on assets. The user must be a system admin.",
+      "Update a particular allowed copyright holder for use within this project, does not update existing values on assets. " +
+        "The user must be a system admin.",
     )
 
   val endpoints: Seq[AnyEndpoint] = Seq(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -15,8 +15,7 @@ import zio.json.JsonCodec
 import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortcode
 import org.knora.webapi.slice.admin.api.model.PagedResponse
 import org.knora.webapi.slice.admin.api.model.pageAndSizeQuery
-import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
-import org.knora.webapi.slice.admin.domain.model.License
+import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.common.api.BaseEndpoints
 
 final case class LicenseDto(id: String, uri: String, `label-en`: String)
@@ -38,6 +37,24 @@ object CopyrighHolderReplaceRequest {
 final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
 
   private final val base = "admin" / "projects" / "shortcode" / projectShortcode / "legal-info"
+
+  val getProjectAuthorships = baseEndpoints.securedEndpoint.get
+    .in(base / "authorships")
+    .in(pageAndSizeQuery())
+    .out(
+      jsonBody[PagedResponse[Authorship]].example(
+        Examples.PageResponse.from(
+          Chunk(
+            Authorship.unsafeFrom("Theodor W. Adorno"),
+            Authorship.unsafeFrom("Friedrich Nietzsche"),
+          ),
+        ),
+      ),
+    )
+    .description(
+      "Get the allowed authorships for use within this project. " +
+        "The user must be project member, project admin or system admin.",
+    )
 
   val getProjectLicenses = baseEndpoints.securedEndpoint.get
     .in(base / "licenses")
@@ -102,6 +119,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
     )
 
   val endpoints: Seq[AnyEndpoint] = Seq(
+    getProjectAuthorships,
     getProjectLicenses,
     getProjectCopyrightHolders,
     postProjectCopyrightHolders,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -60,7 +60,10 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
         ),
       ),
     )
-    .description("Get the allowed licenses for use within this project. The user must be a system or project admin.")
+    .description(
+      "Get the allowed licenses for use within this project. " +
+        "The user must be project member, project admin or system admin.",
+    )
 
   val getProjectCopyrightHolders = baseEndpoints.securedEndpoint.get
     .in(base / "copyright-holders")
@@ -69,6 +72,10 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
       jsonBody[PagedResponse[CopyrightHolder]].example(
         Examples.PageResponse.from(Chunk("DaSch", "University of Zurich").map(CopyrightHolder.unsafeFrom)),
       ),
+    )
+    .description(
+      "Get the allowed copyright holders for use within this project. " +
+        "The user must be project member, project admin or system admin.",
     )
 
   val postProjectCopyrightHolders = baseEndpoints.securedEndpoint.post

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -29,7 +29,7 @@ object PagedResponse {
     PagedResponse(licenses, PageInfo.single(licenses))
 }
 
-final case class LicenseDto(id: String, url: String, `label-en`: String)
+final case class LicenseDto(id: String, uri: String, `label-en`: String)
 object LicenseDto {
   given JsonCodec[LicenseDto]            = DeriveJsonCodec.gen[LicenseDto]
   def from(license: License): LicenseDto = LicenseDto(license.id.value, license.uri.toString, license.labelEn)

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -13,7 +13,7 @@ import zio.json.DeriveJsonCodec
 import zio.json.JsonCodec
 
 import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortcode
-import org.knora.webapi.slice.admin.domain.model.Authorship
+import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
 import org.knora.webapi.slice.admin.domain.model.License
 import org.knora.webapi.slice.common.api.BaseEndpoints
 
@@ -49,14 +49,14 @@ object LicenseDto {
   def from(license: License): LicenseDto = LicenseDto(license.id.value, license.uri.toString, license.labelEn)
 }
 
-final case class AuthorshipAddRequest(data: Set[Authorship])
-object AuthorshipAddRequest {
-  given JsonCodec[AuthorshipAddRequest] = DeriveJsonCodec.gen[AuthorshipAddRequest]
+final case class CopyrightHolderAddRequest(data: Set[CopyrightHolder])
+object CopyrightHolderAddRequest {
+  given JsonCodec[CopyrightHolderAddRequest] = DeriveJsonCodec.gen[CopyrightHolderAddRequest]
 }
 
-final case class AuthorshipReplaceRequest(`old-value`: Authorship, `new-value`: Authorship)
-object AuthorshipReplaceRequest {
-  given JsonCodec[AuthorshipReplaceRequest] = DeriveJsonCodec.gen[AuthorshipReplaceRequest]
+final case class CopyrighHolderReplaceRequest(`old-value`: CopyrightHolder, `new-value`: CopyrightHolder)
+object CopyrighHolderReplaceRequest {
+  given JsonCodec[CopyrighHolderReplaceRequest] = DeriveJsonCodec.gen[CopyrighHolderReplaceRequest]
 }
 
 final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
@@ -86,29 +86,32 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
     )
     .description("Get the allowed licenses of a project. The user must be a system or project admin.")
 
-  val getProjectAuthorships = baseEndpoints.securedEndpoint.get
-    .in(base / "authorships")
+  val getProjectCopyrightHolders = baseEndpoints.securedEndpoint.get
+    .in(base / "copyright-holders")
     .in(pageRequestAndSize)
     .out(
-      jsonBody[PagedResponse[Authorship]].example(
-        PagedResponse.allInOnePage(Chunk(Authorship.unsafeFrom("DaSch"), Authorship.unsafeFrom("University of Zurich"))),
+      jsonBody[PagedResponse[CopyrightHolder]].example(
+        PagedResponse.allInOnePage(Chunk("DaSch", "University of Zurich").map(CopyrightHolder.unsafeFrom)),
       ),
     )
 
-  val postProjectAuthorships = baseEndpoints.securedEndpoint.post
-    .in(base / "authorships")
+  val postProjectCopyrightHolders = baseEndpoints.securedEndpoint.post
+    .in(base / "copyright-holders")
     .in(
-      jsonBody[AuthorshipAddRequest]
-        .example(AuthorshipAddRequest(Set("DaSch", "University of Zurich").map(Authorship.unsafeFrom))),
+      jsonBody[CopyrightHolderAddRequest]
+        .example(CopyrightHolderAddRequest(Set("DaSCH", "University of Zurich").map(CopyrightHolder.unsafeFrom))),
     )
     .description("Add a new predefined authorships to a project. The user must be a system or project admin.")
 
-  val putProjectAuthorships = baseEndpoints.securedEndpoint.put
-    .in(base / "authorships")
+  val putProjectCopyrightHolders = baseEndpoints.securedEndpoint.put
+    .in(base / "copyright-holders")
     .in(
-      jsonBody[AuthorshipReplaceRequest]
+      jsonBody[CopyrighHolderReplaceRequest]
         .example(
-          AuthorshipReplaceRequest(Authorship.unsafeFrom("Alpert Einstain"), Authorship.unsafeFrom("Albert Einstein")),
+          CopyrighHolderReplaceRequest(
+            CopyrightHolder.unsafeFrom("DaSch"),
+            CopyrightHolder.unsafeFrom("DaSCH"),
+          ),
         ),
     )
     .description(
@@ -117,9 +120,9 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints: Seq[AnyEndpoint] = Seq(
     getProjectLicenses,
-    getProjectAuthorships,
-    postProjectAuthorships,
-    putProjectAuthorships,
+    getProjectCopyrightHolders,
+    postProjectCopyrightHolders,
+    putProjectCopyrightHolders,
   ).map(_.endpoint).map(_.tag("Admin Projects (Legal Info)"))
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -80,7 +80,7 @@ final case class ProjectsLegalInfoEndpoints(baseEndpoints: BaseEndpoints) {
     .in(FilterAndOrder.queryParams)
     .out(
       jsonBody[PagedResponse[CopyrightHolder]].example(
-        Examples.PagedResponse.fromSlice(Chunk("DaSch", "University of Zurich").map(CopyrightHolder.unsafeFrom)),
+        Examples.PagedResponse.fromSlice(Chunk("DaSCH", "University of Zurich").map(CopyrightHolder.unsafeFrom)),
       ),
     )
     .description(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -20,7 +20,29 @@ final class ProjectsLegalInfoEndpointsHandler(
     user => shortcode => restService.findByProjectId(shortcode, user),
   )
 
-  val allHandlers = List(getProjectLicensesHandler).map(mapper.mapSecuredEndpointHandler(_))
+  val postProjectAuthorshipsHandler = SecuredEndpointHandler(
+    endpoints.postProjectAuthorships,
+    user => (shortcode, req) => restService.addPredefinedAuthorships(shortcode, req, user),
+  )
+
+  val getProjectAuthorshipsHandler = SecuredEndpointHandler(
+    endpoints.getProjectAuthorships,
+    user => shortcode => restService.findAuthorshipsByProject(shortcode, user),
+  )
+
+  val putProjectAuthorshipsHandler = SecuredEndpointHandler(
+    endpoints.putProjectAuthorships,
+    user => (shortcode, req) => restService.replacePredefinedAuthorship(shortcode, req, user),
+  )
+
+  val allHandlers = List(
+    getProjectLicensesHandler,
+    getProjectAuthorshipsHandler,
+    postProjectAuthorshipsHandler,
+    putProjectAuthorshipsHandler,
+  ).map(
+    mapper.mapSecuredEndpointHandler(_),
+  )
 }
 
 object ProjectsLegalInfoEndpointsHandler {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -1,0 +1,23 @@
+package org.knora.webapi.slice.admin.api
+import zio.ZLayer
+
+import org.knora.webapi.slice.admin.api.service.ProjectsLegalInfoRestService
+import org.knora.webapi.slice.common.api.HandlerMapper
+import org.knora.webapi.slice.common.api.SecuredEndpointHandler
+
+final class ProjectsLegalInfoEndpointsHandler(
+  endpoints: ProjectsLegalInfoEndpoints,
+  restService: ProjectsLegalInfoRestService,
+  mapper: HandlerMapper,
+) {
+  val getProjectLicensesHandler = SecuredEndpointHandler(
+    endpoints.getProjectLicenses,
+    user => shortcode => restService.findByProjectId(shortcode, user),
+  )
+
+  val allHandlers = List(getProjectLicensesHandler).map(mapper.mapSecuredEndpointHandler(_))
+}
+
+object ProjectsLegalInfoEndpointsHandler {
+  val layer = ZLayer.derive[ProjectsLegalInfoEndpointsHandler]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -15,41 +15,13 @@ final class ProjectsLegalInfoEndpointsHandler(
   restService: ProjectsLegalInfoRestService,
   mapper: HandlerMapper,
 ) {
-
-  val getProjectAuthorshipHandler = SecuredEndpointHandler(
-    endpoints.getProjectAuthorships,
-    user => (shortcode, pageAndSize) => restService.findAuthorships(shortcode, pageAndSize, user),
-  )
-
-  val getProjectLicensesHandler = SecuredEndpointHandler(
-    endpoints.getProjectLicenses,
-    user => (shortcode, pageAndSize) => restService.findLicensesByProject(shortcode, pageAndSize, user),
-  )
-
-  val postProjectCopyrightHoldersHandler = SecuredEndpointHandler(
-    endpoints.postProjectCopyrightHolders,
-    user => (shortcode, req) => restService.addPredefinedAuthorships(shortcode, req, user),
-  )
-
-  val getProjectCopyrightHoldersHandler = SecuredEndpointHandler(
-    endpoints.getProjectCopyrightHolders,
-    user => (shortcode, pageAndSize) => restService.findCopyrightHoldersByProject(shortcode, pageAndSize, user),
-  )
-
-  val putProjectCopyrightHoldersHandler = SecuredEndpointHandler(
-    endpoints.putProjectCopyrightHolders,
-    user => (shortcode, req) => restService.replacePredefinedAuthorship(shortcode, req, user),
-  )
-
   val allHandlers = List(
-    getProjectAuthorshipHandler,
-    getProjectLicensesHandler,
-    getProjectCopyrightHoldersHandler,
-    postProjectCopyrightHoldersHandler,
-    putProjectCopyrightHoldersHandler,
-  ).map(
-    mapper.mapSecuredEndpointHandler(_),
-  )
+    SecuredEndpointHandler(endpoints.getProjectAuthorships, restService.findAuthorships),
+    SecuredEndpointHandler(endpoints.getProjectLicenses, restService.findLicenses),
+    SecuredEndpointHandler(endpoints.getProjectCopyrightHolders, restService.findCopyrightHolders),
+    SecuredEndpointHandler(endpoints.postProjectCopyrightHolders, restService.addCopyrightHolders),
+    SecuredEndpointHandler(endpoints.putProjectCopyrightHolders, restService.replaceCopyrightHolder),
+  ).map(mapper.mapSecuredEndpointHandler)
 }
 
 object ProjectsLegalInfoEndpointsHandler {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -15,6 +15,12 @@ final class ProjectsLegalInfoEndpointsHandler(
   restService: ProjectsLegalInfoRestService,
   mapper: HandlerMapper,
 ) {
+
+  val getProjectAuthorshipHandler = SecuredEndpointHandler(
+    endpoints.getProjectAuthorships,
+    user => (shortcode, pageAndSize) => restService.findAuthorships(shortcode, pageAndSize, user),
+  )
+
   val getProjectLicensesHandler = SecuredEndpointHandler(
     endpoints.getProjectLicenses,
     user => (shortcode, pageAndSize) => restService.findLicensesByProject(shortcode, pageAndSize, user),
@@ -36,6 +42,7 @@ final class ProjectsLegalInfoEndpointsHandler(
   )
 
   val allHandlers = List(
+    getProjectAuthorshipHandler,
     getProjectLicensesHandler,
     getProjectCopyrightHoldersHandler,
     postProjectCopyrightHoldersHandler,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -17,7 +17,7 @@ final class ProjectsLegalInfoEndpointsHandler(
 ) {
   val getProjectLicensesHandler = SecuredEndpointHandler(
     endpoints.getProjectLicenses,
-    user => shortcode => restService.findByProjectId(shortcode, user),
+    user => (shortcode, pageAndSize) => restService.findByProjectId(shortcode, pageAndSize, user),
   )
 
   val postProjectAuthorshipsHandler = SecuredEndpointHandler(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.admin.api
 import zio.ZLayer
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -20,26 +20,26 @@ final class ProjectsLegalInfoEndpointsHandler(
     user => (shortcode, pageAndSize) => restService.findByProjectId(shortcode, pageAndSize, user),
   )
 
-  val postProjectAuthorshipsHandler = SecuredEndpointHandler(
-    endpoints.postProjectAuthorships,
+  val postProjectCopyrightHoldersHandler = SecuredEndpointHandler(
+    endpoints.postProjectCopyrightHolders,
     user => (shortcode, req) => restService.addPredefinedAuthorships(shortcode, req, user),
   )
 
-  val getProjectAuthorshipsHandler = SecuredEndpointHandler(
-    endpoints.getProjectAuthorships,
-    user => (shortcode, pageAndSize) => restService.findAuthorshipsByProject(shortcode, pageAndSize, user),
+  val getProjectCopyrightHoldersHandler = SecuredEndpointHandler(
+    endpoints.getProjectCopyrightHolders,
+    user => (shortcode, pageAndSize) => restService.findCopyrightHoldersByProject(shortcode, pageAndSize, user),
   )
 
-  val putProjectAuthorshipsHandler = SecuredEndpointHandler(
-    endpoints.putProjectAuthorships,
+  val putProjectCopyrightHoldersHandler = SecuredEndpointHandler(
+    endpoints.putProjectCopyrightHolders,
     user => (shortcode, req) => restService.replacePredefinedAuthorship(shortcode, req, user),
   )
 
   val allHandlers = List(
     getProjectLicensesHandler,
-    getProjectAuthorshipsHandler,
-    postProjectAuthorshipsHandler,
-    putProjectAuthorshipsHandler,
+    getProjectCopyrightHoldersHandler,
+    postProjectCopyrightHoldersHandler,
+    putProjectCopyrightHoldersHandler,
   ).map(
     mapper.mapSecuredEndpointHandler(_),
   )

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -17,7 +17,7 @@ final class ProjectsLegalInfoEndpointsHandler(
 ) {
   val getProjectLicensesHandler = SecuredEndpointHandler(
     endpoints.getProjectLicenses,
-    user => (shortcode, pageAndSize) => restService.findByProjectId(shortcode, pageAndSize, user),
+    user => (shortcode, pageAndSize) => restService.findLicensesByProject(shortcode, pageAndSize, user),
   )
 
   val postProjectCopyrightHoldersHandler = SecuredEndpointHandler(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEntpointsHandler.scala
@@ -27,7 +27,7 @@ final class ProjectsLegalInfoEndpointsHandler(
 
   val getProjectAuthorshipsHandler = SecuredEndpointHandler(
     endpoints.getProjectAuthorships,
-    user => shortcode => restService.findAuthorshipsByProject(shortcode, user),
+    user => (shortcode, pageAndSize) => restService.findAuthorshipsByProject(shortcode, pageAndSize, user),
   )
 
   val putProjectAuthorshipsHandler = SecuredEndpointHandler(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/FilterAndOrder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/FilterAndOrder.scala
@@ -22,8 +22,9 @@ object FilterAndOrder {
   private val filterQueryParam =
     query[Option[String]]("filter")
       .description("Filter the results.")
+      .default(None)
   private val orderQueryParam = query[Order]("order")
-    .description("Order the results by ascending (asc) or descending (desc).")
+    .description("Sort the results in ascending (asc) or descending (desc) order.")
     .default(Order.Asc)
 
   val queryParams: EndpointInput[FilterAndOrder] =

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/FilterAndOrder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/FilterAndOrder.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.admin.api.model
+
+import sttp.tapir.*
+
+case class FilterAndOrder(filter: Option[String], order: Order)
+object FilterAndOrder {
+  private val filterQueryParam =
+    query[Option[String]]("filter")
+      .description("Filter the results by a string")
+  private val orderQueryParam = query[Order]("order")
+    .description("Order the results by ascending or descending")
+    .default(Order.Asc)
+
+  val queryParams: EndpointInput[FilterAndOrder] =
+    filterQueryParam.and(orderQueryParam).mapTo[FilterAndOrder]
+}
+
+enum Order(override val toString: String) {
+  case Asc  extends Order("ASC")
+  case Desc extends Order("DESC")
+}
+object Order {
+  given Codec[String, Order, CodecFormat.TextPlain] = Codec.string.mapEither(from)(_.toString)
+
+  def from(str: String): Either[String, Order] =
+    Order.values.find(_.toString.equalsIgnoreCase(str)).toRight("Invalid order")
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/FilterAndOrder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/FilterAndOrder.scala
@@ -7,7 +7,17 @@ package org.knora.webapi.slice.admin.api.model
 
 import sttp.tapir.*
 
-case class FilterAndOrder(filter: Option[String], order: Order)
+import org.knora.webapi.slice.admin.api.model.Order.Asc
+import org.knora.webapi.slice.admin.api.model.Order.Desc
+
+case class FilterAndOrder(filter: Option[String], order: Order) { self =>
+
+  def ordering[A](using o: Ordering[A]): Ordering[A] = self.order match {
+    case Asc  => o
+    case Desc => o.reverse
+  }
+}
+
 object FilterAndOrder {
   private val filterQueryParam =
     query[Option[String]]("filter")

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/FilterAndOrder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/FilterAndOrder.scala
@@ -21,22 +21,29 @@ case class FilterAndOrder(filter: Option[String], order: Order) { self =>
 object FilterAndOrder {
   private val filterQueryParam =
     query[Option[String]]("filter")
-      .description("Filter the results by a string")
+      .description("Filter the results.")
   private val orderQueryParam = query[Order]("order")
-    .description("Order the results by ascending or descending")
+    .description("Order the results by ascending (asc) or descending (desc).")
     .default(Order.Asc)
 
   val queryParams: EndpointInput[FilterAndOrder] =
     filterQueryParam.and(orderQueryParam).mapTo[FilterAndOrder]
 }
 
-enum Order(override val toString: String) {
-  case Asc  extends Order("ASC")
-  case Desc extends Order("DESC")
+enum Order {
+  case Asc  extends Order
+  case Desc extends Order
+
+  def toQueryString: String = this match {
+    case Asc  => "ASC"
+    case Desc => "DESC"
+  }
 }
 object Order {
   given Codec[String, Order, CodecFormat.TextPlain] = Codec.string.mapEither(from)(_.toString)
 
   def from(str: String): Either[String, Order] =
-    Order.values.find(_.toString.equalsIgnoreCase(str)).toRight("Invalid order")
+    Order.values
+      .find(_.toString.equalsIgnoreCase(str))
+      .toRight(s"Invalid order: possible values are '${Order.values.map(_.toString.toLowerCase).mkString(", ")}'")
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
@@ -22,6 +22,9 @@ object Pagination {
 final case class PagedResponse[A](data: Seq[A], pagination: Pagination)
 object PagedResponse {
   given [A: JsonCodec]: JsonCodec[PagedResponse[A]] = DeriveJsonCodec.gen[PagedResponse[A]]
+
+  def from[A: JsonCodec](data: Seq[A], totalItems: Int, pageAndSize: PageAndSize): PagedResponse[A] =
+    PagedResponse(data, Pagination.from(totalItems, pageAndSize))
 }
 
 val defaultPageSize = 25

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
@@ -20,7 +20,7 @@ object Pagination {
     Pagination(pageAndSize.size, totalItems, totalPages, pageAndSize.page)
 }
 
-final case class PagedResponse[A](data: Seq[A], pagination: Pagination)
+final case class PagedResponse[A] private (data: Seq[A], pagination: Pagination)
 object PagedResponse {
   given [A: JsonCodec]: JsonCodec[PagedResponse[A]] = DeriveJsonCodec.gen[PagedResponse[A]]
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
@@ -35,12 +35,12 @@ object PageAndSize {
   val Default: PageAndSize = PageAndSize(1, DefaultPageSize)
 
   private val pageQuery = query[Int]("page")
-    .description("The page number to retrieve.")
+    .description("The number of the desired page to be returned.")
     .default(1)
     .validate(Validator.min(1))
 
   private def sizeQuery(maxSize: Int) = query[Int]("page-size")
-    .description("The number of items to retrieve.")
+    .description("The number of items per page to be returned.")
     .default(DefaultPageSize)
     .validate(Validator.min(1))
     .validate(Validator.max(maxSize))

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.admin.api.model
+
+import sttp.tapir.Validator
+import sttp.tapir.query
+import zio.json.DeriveJsonCodec
+import zio.json.JsonCodec
+
+final case class Pagination(`page-size`: Int, `total-items`: Int, `total-pages`: Int, `current-page`: Int)
+object Pagination {
+  given JsonCodec[Pagination] = DeriveJsonCodec.gen[Pagination]
+
+  def from(totalItems: Int, pageAndSize: PageAndSize): Pagination =
+    val totalPages = Math.ceil(totalItems.toDouble / pageAndSize.size).toInt
+    Pagination(pageAndSize.size, totalItems, totalPages, pageAndSize.page)
+}
+
+final case class PagedResponse[A](data: Seq[A], pagination: Pagination)
+object PagedResponse {
+  given [A: JsonCodec]: JsonCodec[PagedResponse[A]] = DeriveJsonCodec.gen[PagedResponse[A]]
+}
+
+val defaultPageSize = 25
+
+case class PageAndSize(page: Int, size: Int = defaultPageSize)
+
+def pageAndSizeQuery(maxSize: Int = 100) = pageQuery.and(sizeQuery(maxSize)).mapTo[PageAndSize]
+
+private val pageQuery = query[Int]("page")
+  .description("The page number to retrieve.")
+  .default(1)
+  .validate(Validator.min(1))
+
+private def sizeQuery(maxSize: Int) = query[Int]("page-size")
+  .description("The number of items to retrieve.")
+  .default(defaultPageSize)
+  .validate(Validator.min(1))
+  .validate(Validator.max(maxSize))

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
@@ -10,9 +10,13 @@ import sttp.tapir.query
 import zio.json.DeriveJsonCodec
 import zio.json.JsonCodec
 
+import org.knora.webapi.slice.admin.api.model.Pagination.DefaultPageSize
+
 final case class Pagination(`page-size`: Int, `total-items`: Int, `total-pages`: Int, `current-page`: Int)
 object Pagination {
   given JsonCodec[Pagination] = DeriveJsonCodec.gen[Pagination]
+
+  val DefaultPageSize: Int = 25
 
   def from(totalItems: Int, pageAndSize: PageAndSize): Pagination =
     val totalPages = Math.ceil(totalItems.toDouble / pageAndSize.size).toInt
@@ -27,9 +31,10 @@ object PagedResponse {
     PagedResponse(data, Pagination.from(totalItems, pageAndSize))
 }
 
-val defaultPageSize = 25
-
-case class PageAndSize(page: Int, size: Int = defaultPageSize)
+case class PageAndSize(page: Int, size: Int)
+object PageAndSize {
+  val Default = PageAndSize(1, DefaultPageSize)
+}
 
 def pageAndSizeQuery(maxSize: Int = 100) = pageQuery.and(sizeQuery(maxSize)).mapTo[PageAndSize]
 
@@ -40,6 +45,6 @@ private val pageQuery = query[Int]("page")
 
 private def sizeQuery(maxSize: Int) = query[Int]("page-size")
   .description("The number of items to retrieve.")
-  .default(defaultPageSize)
+  .default(Pagination.DefaultPageSize)
   .validate(Validator.min(1))
   .validate(Validator.max(maxSize))

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -1,0 +1,28 @@
+package org.knora.webapi.slice.admin.api.service
+import zio.IO
+import zio.ZIO
+import zio.ZLayer
+
+import dsp.errors.ForbiddenException
+import org.knora.webapi.slice.admin.api.LicenseDto
+import org.knora.webapi.slice.admin.api.PagedResponse
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.admin.domain.service.LicenseService
+import org.knora.webapi.slice.common.api.AuthorizationRestService
+
+final case class ProjectsLegalInfoRestService(
+  private val licenses: LicenseService,
+  private val auth: AuthorizationRestService,
+) {
+  def findByProjectId(shortcode: Shortcode, user: User): IO[ForbiddenException, PagedResponse[LicenseDto]] =
+    for {
+      _      <- auth.ensureSystemAdminOrProjectAdminByShortcode(user, shortcode)
+      result <- licenses.findByProjectShortcode(shortcode)
+      page    = PagedResponse.allInOnePage(result.map(LicenseDto.from))
+    } yield page
+}
+
+object ProjectsLegalInfoRestService {
+  val layer = ZLayer.derive[ProjectsLegalInfoRestService]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -17,6 +17,7 @@ import org.knora.webapi.slice.admin.api.LicenseDto
 import org.knora.webapi.slice.admin.api.model.PageAndSize
 import org.knora.webapi.slice.admin.api.model.PagedResponse
 import org.knora.webapi.slice.admin.api.model.Pagination
+import org.knora.webapi.slice.admin.domain.model.Authorship
 import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
@@ -29,6 +30,12 @@ final case class ProjectsLegalInfoRestService(
   private val projects: KnoraProjectService,
   private val auth: AuthorizationRestService,
 ) {
+
+  def findAuthorships(shortcode: Shortcode, pageAndSize: PageAndSize, user: User): Task[PagedResponse[Authorship]] =
+    for {
+      _          <- auth.ensureProjectMember(user, shortcode)
+      authorships = Seq.empty // TODO: Implement query
+    } yield slice(authorships, pageAndSize)
 
   def findLicensesByProject(
     shortcode: Shortcode,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -11,13 +11,13 @@ import zio.ZLayer
 
 import dsp.errors.ForbiddenException
 import dsp.errors.NotFoundException
-import org.knora.webapi.slice.admin.api.AuthorshipAddRequest
-import org.knora.webapi.slice.admin.api.AuthorshipReplaceRequest
+import org.knora.webapi.slice.admin.api.CopyrighHolderReplaceRequest
+import org.knora.webapi.slice.admin.api.CopyrightHolderAddRequest
 import org.knora.webapi.slice.admin.api.LicenseDto
 import org.knora.webapi.slice.admin.api.PageAndSize
 import org.knora.webapi.slice.admin.api.PageInfo
 import org.knora.webapi.slice.admin.api.PagedResponse
-import org.knora.webapi.slice.admin.domain.model.Authorship
+import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
@@ -44,34 +44,34 @@ final case class ProjectsLegalInfoRestService(
     val slice = all.slice(pageAndSize.size * (pageAndSize.page - 1), pageAndSize.size * pageAndSize.page)
     PagedResponse(slice, PageInfo.from(all.size, pageAndSize))
 
-  def findAuthorshipsByProject(
+  def findCopyrightHoldersByProject(
     shortcode: Shortcode,
     pageAndSize: PageAndSize,
     user: User,
-  ): Task[PagedResponse[Authorship]] =
+  ): Task[PagedResponse[CopyrightHolder]] =
     for {
       project <- auth.ensureSystemAdminOrProjectAdminByShortcode(user, shortcode)
-    } yield slice(project.predefinedAuthorships.toSeq, pageAndSize)
+    } yield slice(project.predefinedCopyrightHolders.toSeq, pageAndSize)
 
   def addPredefinedAuthorships(
     shortcode: Shortcode,
-    req: AuthorshipAddRequest,
+    req: CopyrightHolderAddRequest,
     user: User,
   ): Task[Unit] =
     for {
       project <- auth.ensureSystemAdminOrProjectAdminByShortcode(user, shortcode)
-      _       <- projects.addPredefinedAuthorships(project.id, req.data)
+      _       <- projects.addCopyrightHolders(project.id, req.data)
     } yield ()
 
   def replacePredefinedAuthorship(
     shortcode: Shortcode,
-    req: AuthorshipReplaceRequest,
+    req: CopyrighHolderReplaceRequest,
     user: User,
   ): Task[Unit] =
     for {
       _       <- auth.ensureSystemAdmin(user)
       project <- projects.findByShortcode(shortcode).someOrFail(NotFoundException(s"Project ${shortcode} not found"))
-      _       <- projects.replacePredefinedAuthorship(project.id, req.`old-value`, req.`new-value`)
+      _       <- projects.replaceCopyrightHolser(project.id, req.`old-value`, req.`new-value`)
     } yield ()
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -71,7 +71,7 @@ final case class ProjectsLegalInfoRestService(
     for {
       _       <- auth.ensureSystemAdmin(user)
       project <- projects.findByShortcode(shortcode).someOrFail(NotFoundException(s"Project ${shortcode} not found"))
-      _       <- projects.replaceCopyrightHolser(project.id, req.`old-value`, req.`new-value`)
+      _       <- projects.replaceCopyrightHolder(project.id, req.`old-value`, req.`new-value`)
     } yield ()
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -67,7 +67,7 @@ final case class ProjectsLegalInfoRestService(
          |  ${searchTermQueryString.fold("")(term => s"FILTER(CONTAINS(LCASE(STR(?$authorVar)), ${term.toLowerCase}))")}
          |}""".stripMargin
 
-    val order = filterAndOrder.order.toString
+    val order = filterAndOrder.order.toQueryString
     val authorshipsQuery =
       s"""
          |SELECT DISTINCT ?$authorVar WHERE {
@@ -143,7 +143,7 @@ final case class ProjectsLegalInfoRestService(
   ): Task[Unit] =
     for {
       _       <- auth.ensureSystemAdmin(user)
-      project <- projects.findByShortcode(shortcode).someOrFail(NotFoundException(s"Project ${shortcode} not found"))
+      project <- projects.findByShortcode(shortcode).someOrFail(NotFoundException(s"Project $shortcode not found"))
       _       <- projects.replaceCopyrightHolder(project.id, req.`old-value`, req.`new-value`)
     } yield ()
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -4,12 +4,16 @@
  */
 
 package org.knora.webapi.slice.admin.api.service
+
+import cats.syntax.traverse.*
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import zio.IO
 import zio.Task
 import zio.ZIO
 import zio.ZLayer
 
 import dsp.errors.ForbiddenException
+import dsp.errors.InconsistentRepositoryDataException
 import dsp.errors.NotFoundException
 import org.knora.webapi.slice.admin.api.CopyrightHolderAddRequest
 import org.knora.webapi.slice.admin.api.CopyrightHolderReplaceRequest
@@ -19,23 +23,81 @@ import org.knora.webapi.slice.admin.api.model.PagedResponse
 import org.knora.webapi.slice.admin.api.model.Pagination
 import org.knora.webapi.slice.admin.domain.model.Authorship
 import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.admin.domain.service.LicenseService
+import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.api.AuthorizationRestService
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 
 final case class ProjectsLegalInfoRestService(
   private val licenses: LicenseService,
   private val projects: KnoraProjectService,
   private val auth: AuthorizationRestService,
+  private val triplestore: TriplestoreService,
 ) {
 
-  def findAuthorships(user: User)(shortcode: Shortcode, pageAndSize: PageAndSize): Task[PagedResponse[Authorship]] =
+  def findAuthorships(user: User)(
+    shortcode: Shortcode,
+    pageAndSize: PageAndSize,
+    searchTerm: Option[String],
+  ): Task[PagedResponse[Authorship]] =
     for {
-      _          <- auth.ensureProjectMember(user, shortcode)
-      authorships = Seq.empty // TODO: Implement query
-    } yield slice(authorships, pageAndSize)
+      project         <- auth.ensureProjectMember(user, shortcode)
+      totalAndAuthors <- queryAuthorships(project, pageAndSize, searchTerm)
+      (total, authors) = totalAndAuthors
+    } yield PagedResponse.from(authors, total, pageAndSize)
+
+  private def queryAuthorships(
+    project: KnoraProject,
+    paging: PageAndSize,
+    searchTerm: Option[String],
+  ): Task[(Int, Seq[Authorship])] = {
+    val graph                 = Rdf.iri(ProjectService.projectDataNamedGraphV2(project).value)
+    val searchTermQueryString = searchTerm.map(Rdf.literalOf).map(_.getQueryString)
+    val authorVar             = "author"
+    val graphPattern =
+      s"""GRAPH ${graph.getQueryString} {
+         |  ?fileValue ${Vocabulary.KnoraBase.hasAuthorship.getQueryString} ?$authorVar .
+         |  ${searchTermQueryString.fold("")(term => s"FILTER(CONTAINS(LCASE(STR(?$authorVar)), ${term.toLowerCase}))")}
+         |}""".stripMargin
+
+    val authorshipsQuery =
+      s"""
+         |SELECT DISTINCT ?$authorVar WHERE {
+         |  $graphPattern
+         |} ORDER BY ASC(?$authorVar) LIMIT ${paging.size} OFFSET ${paging.size * (paging.page - 1)}
+         |""".stripMargin
+    val queryAuthorships = for {
+      result <- triplestore.query(Select(authorshipsQuery)).map(_.results.bindings)
+      authors <-
+        ZIO
+          .fromEither(result.flatMap(_.rowMap.get(authorVar)).traverse(Authorship.from))
+          .mapError(e => InconsistentRepositoryDataException(e))
+    } yield authors
+
+    val countVar = "count"
+    val countQuery =
+      s"""
+         |SELECT (COUNT(DISTINCT ?$authorVar) AS ?$countVar) WHERE {
+         |  $graphPattern
+         |}
+         |""".stripMargin
+    val queryCount = triplestore
+      .query(Select(countQuery))
+      .map(_.results.bindings)
+      .flatMap(result => ZIO.attempt(result.head.rowMap(countVar).toInt))
+
+    for {
+      authorsFiber <- queryAuthorships.fork
+      count        <- queryCount
+      authors      <- authorsFiber.join
+    } yield (count, authors)
+  }
 
   def findLicenses(user: User)(
     shortcode: Shortcode,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -5,27 +5,61 @@
 
 package org.knora.webapi.slice.admin.api.service
 import zio.IO
+import zio.Task
 import zio.ZIO
 import zio.ZLayer
 
 import dsp.errors.ForbiddenException
+import dsp.errors.NotFoundException
+import org.knora.webapi.slice.admin.api.AuthorshipAddRequest
+import org.knora.webapi.slice.admin.api.AuthorshipReplaceRequest
 import org.knora.webapi.slice.admin.api.LicenseDto
 import org.knora.webapi.slice.admin.api.PagedResponse
+import org.knora.webapi.slice.admin.domain.model.Authorship
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.admin.domain.service.LicenseService
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 
 final case class ProjectsLegalInfoRestService(
   private val licenses: LicenseService,
+  private val projects: KnoraProjectService,
   private val auth: AuthorizationRestService,
 ) {
+
   def findByProjectId(shortcode: Shortcode, user: User): IO[ForbiddenException, PagedResponse[LicenseDto]] =
     for {
       _      <- auth.ensureSystemAdminOrProjectAdminByShortcode(user, shortcode)
       result <- licenses.findByProjectShortcode(shortcode)
       page    = PagedResponse.allInOnePage(result.map(LicenseDto.from))
     } yield page
+
+  def findAuthorshipsByProject(shortcode: Shortcode, user: User): Task[List[Authorship]] =
+    for {
+      project <- auth.ensureSystemAdminOrProjectAdminByShortcode(user, shortcode)
+    } yield project.predefinedAuthorships.toList
+
+  def addPredefinedAuthorships(
+    shortcode: Shortcode,
+    req: AuthorshipAddRequest,
+    user: User,
+  ): Task[Unit] =
+    for {
+      project <- auth.ensureSystemAdminOrProjectAdminByShortcode(user, shortcode)
+      _       <- projects.addPredefinedAuthorships(project.id, req.data)
+    } yield ()
+
+  def replacePredefinedAuthorship(
+    shortcode: Shortcode,
+    req: AuthorshipReplaceRequest,
+    user: User,
+  ): Task[Unit] =
+    for {
+      _       <- auth.ensureSystemAdmin(user)
+      project <- projects.findByShortcode(shortcode).someOrFail(NotFoundException(s"Project ${shortcode} not found"))
+      _       <- projects.replacePredefinedAuthorship(project.id, req.`old-value`, req.`new-value`)
+    } yield ()
 }
 
 object ProjectsLegalInfoRestService {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -14,9 +14,9 @@ import dsp.errors.NotFoundException
 import org.knora.webapi.slice.admin.api.CopyrighHolderReplaceRequest
 import org.knora.webapi.slice.admin.api.CopyrightHolderAddRequest
 import org.knora.webapi.slice.admin.api.LicenseDto
-import org.knora.webapi.slice.admin.api.PageAndSize
-import org.knora.webapi.slice.admin.api.PageInfo
-import org.knora.webapi.slice.admin.api.PagedResponse
+import org.knora.webapi.slice.admin.api.model.PageAndSize
+import org.knora.webapi.slice.admin.api.model.PagedResponse
+import org.knora.webapi.slice.admin.api.model.Pagination
 import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
@@ -42,7 +42,7 @@ final case class ProjectsLegalInfoRestService(
 
   private def slice[A](all: Seq[A], pageAndSize: PageAndSize): PagedResponse[A] =
     val slice = all.slice(pageAndSize.size * (pageAndSize.page - 1), pageAndSize.size * pageAndSize.page)
-    PagedResponse(slice, PageInfo.from(all.size, pageAndSize))
+    PagedResponse(slice, Pagination.from(all.size, pageAndSize))
 
   def findCopyrightHoldersByProject(
     shortcode: Shortcode,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.admin.api.service
 import zio.IO
 import zio.ZIO

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/service/ProjectsLegalInfoRestService.scala
@@ -129,7 +129,7 @@ final case class ProjectsLegalInfoRestService(
   ): Task[PagedResponse[CopyrightHolder]] =
     for {
       project <- auth.ensureProjectMember(user, shortcode)
-    } yield slice(project.predefinedCopyrightHolders.toSeq, pageAndSize, filterAndOrder)
+    } yield slice(project.allowedCopyrightHolders.toSeq, pageAndSize, filterAndOrder)
 
   def addCopyrightHolders(user: User)(shortcode: Shortcode, req: CopyrightHolderAddRequest): Task[Unit] =
     for {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/AdminDomainModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/AdminDomainModule.scala
@@ -45,6 +45,7 @@ object AdminDomainModule
       KnoraProjectService &
       KnoraUserService &
       KnoraUserToUserConverter &
+      LicenseService &
       MaintenanceService &
       PasswordService &
       ProjectEraseService &
@@ -61,6 +62,7 @@ object AdminDomainModule
       KnoraProjectService.layer,
       KnoraUserService.layer,
       KnoraUserToUserConverter.layer,
+      LicenseService.layer,
       MaintenanceService.layer,
       PasswordService.layer,
       ProjectEraseService.layer,

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/KnoraProject.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/KnoraProject.scala
@@ -34,7 +34,7 @@ case class KnoraProject(
   status: Status,
   selfjoin: SelfJoin,
   restrictedView: RestrictedView,
-  predefinedAuthorships: Set[Authorship],
+  predefinedCopyrightHolders: Set[CopyrightHolder],
 ) extends EntityWithId[ProjectIri]
 
 object KnoraProject {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/KnoraProject.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/KnoraProject.scala
@@ -34,6 +34,7 @@ case class KnoraProject(
   status: Status,
   selfjoin: SelfJoin,
   restrictedView: RestrictedView,
+  predefinedAuthorships: Set[Authorship],
 ) extends EntityWithId[ProjectIri]
 
 object KnoraProject {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/KnoraProject.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/KnoraProject.scala
@@ -34,7 +34,7 @@ case class KnoraProject(
   status: Status,
   selfjoin: SelfJoin,
   restrictedView: RestrictedView,
-  predefinedCopyrightHolders: Set[CopyrightHolder],
+  allowedCopyrightHolders: Set[CopyrightHolder],
 ) extends EntityWithId[ProjectIri]
 
 object KnoraProject {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -43,7 +43,7 @@ object CopyrightHolder extends StringValueCompanion[CopyrightHolder] {
 
 final case class Authorship private (override val value: String) extends StringValue
 object Authorship extends StringValueCompanion[Authorship] {
-  given JsonCodec[LicenseIri] = ZioJsonCodec.stringCodec(LicenseIri.from)
+  given JsonCodec[Authorship] = ZioJsonCodec.stringCodec(Authorship.from)
   def from(str: String): Either[String, Authorship] =
     fromValidations("Authorship", Authorship.apply, List(nonEmpty, noLineBreaks, maxLength(1_000)))(str)
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -109,7 +109,7 @@ object License {
     License(CC_BY_NC_SA_4_0, URI.create("https://creativecommons.org/licenses/by-nc-sa/4.0/"), "CC BY-NC-SA 4.0"),
     License(CC_BY_ND_4_0, URI.create("https://creativecommons.org/licenses/by-nd/4.0/"), "CC BY-ND 4.0"),
     License(CC_BY_NC_ND_4_0, URI.create("https://creativecommons.org/licenses/by-nc-nd/4.0/"), "CC BY-NC-ND 4.0"),
-    License(AI_GENERATED, URI.create("http://example.com/"), "Produced by an AI - Not Protected by Copyright"),
+    License(AI_GENERATED, URI.create("http://example.com/"), "AI-Generated Content - Not Protected by Copyright"),
     License(UNKNOWN, URI.create("http://example.com/"), "Unknown License - Ask Copyright Holder for Permission"),
     License(PUBLIC_DOMAIN, URI.create("http://example.com/"), "Public Domain - Not Protected by Copyright"),
   )

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -7,12 +7,10 @@ package org.knora.webapi.slice.admin.domain.model
 
 import zio.Chunk
 import zio.NonEmptyChunk
-import zio.json.DeriveJsonCodec
 import zio.json.JsonCodec
 import zio.prelude.Validation
 
 import java.net.URI
-import scala.util.Try
 
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.admin.api.Codecs.ZioJsonCodec
@@ -99,10 +97,6 @@ object LicenseIri extends StringValueCompanion[LicenseIri] {
 
 final case class License private (id: LicenseIri, uri: URI, labelEn: String)
 object License {
-  given JsonCodec[URI] =
-    JsonCodec[String].transformOrFail(s => Try(URI.create(s)).toEither.left.map(_.getMessage), _.toString)
-  given JsonCodec[License] = DeriveJsonCodec.gen[License]
-
   val BUILT_IN: Chunk[License] = Chunk(
     License(CC_BY_4_0, URI.create("https://creativecommons.org/licenses/by/4.0/"), "CC BY 4.0"),
     License(CC_BY_SA_4_0, URI.create("https://creativecommons.org/licenses/by-sa/4.0/"), "CC BY-SA 4.0"),

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -109,9 +109,9 @@ object License {
     License(CC_BY_NC_SA_4_0, URI.create("https://creativecommons.org/licenses/by-nc-sa/4.0/"), "CC BY-NC-SA 4.0"),
     License(CC_BY_ND_4_0, URI.create("https://creativecommons.org/licenses/by-nd/4.0/"), "CC BY-ND 4.0"),
     License(CC_BY_NC_ND_4_0, URI.create("https://creativecommons.org/licenses/by-nc-nd/4.0/"), "CC BY-NC-ND 4.0"),
-    License(AI_GENERATED, URI.create("http://example.com/"), "AI-Generated Content - Not Protected by Copyright"),
-    License(UNKNOWN, URI.create("http://example.com/"), "Unknown License - Ask Copyright Holder for Permission"),
-    License(PUBLIC_DOMAIN, URI.create("http://example.com/"), "Public Domain - Not Protected by Copyright"),
+    License(AI_GENERATED, URI.create(AI_GENERATED.value), "AI-Generated Content - Not Protected by Copyright"),
+    License(UNKNOWN, URI.create(UNKNOWN.value), "Unknown License - Ask Copyright Holder for Permission"),
+    License(PUBLIC_DOMAIN, URI.create(PUBLIC_DOMAIN.value), "Public Domain - Not Protected by Copyright"),
   )
 
   def from(id: LicenseIri, uri: URI, labelEn: String): Either[String, License] = {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -33,6 +33,7 @@ import org.knora.webapi.slice.common.Value.StringValue
 final case class CopyrightHolder private (override val value: String) extends StringValue
 object CopyrightHolder extends StringValueCompanion[CopyrightHolder] {
   given JsonCodec[CopyrightHolder] = ZioJsonCodec.stringCodec(CopyrightHolder.from)
+  given Ordering[CopyrightHolder]  = Ordering.by(_.value)
   def from(str: String): Either[String, CopyrightHolder] =
     fromValidations(
       "Copyright Holder",

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectRepo.scala
@@ -47,6 +47,7 @@ object KnoraProjectRepo {
       KnoraProject.Status.Active,
       KnoraProject.SelfJoin.CannotJoin,
       RestrictedView.default,
+      Set.empty,
     )
 
     val SystemProject: KnoraProject = makeBuiltIn(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
@@ -113,11 +113,11 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
       .map(_ :+ projectGraph)
   }
 
-  def addPredefinedAuthorships(project: ProjectIri, addThese: Chunk[Authorship]): Task[KnoraProject] =
+  def addPredefinedAuthorships(project: ProjectIri, addThese: Set[Authorship]): Task[KnoraProject] =
     withProjectFromDb(project) { project =>
       if (addThese.isEmpty) ZIO.succeed(project)
       else {
-        val newAuthors = (project.predefinedAuthorships ++ addThese)
+        val newAuthors = project.predefinedAuthorships ++ addThese
         knoraProjectRepo.save(project.copy(predefinedAuthorships = newAuthors))
       }
     }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
@@ -30,13 +30,14 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
   def findByShortcode(code: Shortcode): Task[Option[KnoraProject]] = knoraProjectRepo.findByShortcode(code)
   def findByShortname(code: Shortname): Task[Option[KnoraProject]] = knoraProjectRepo.findByShortname(code)
   def findAll(): Task[Chunk[KnoraProject]]                         = knoraProjectRepo.findAll()
-  def setProjectRestrictedView(project: KnoraProject, settings: RestrictedView): Task[RestrictedView] = {
-    val newSettings = settings match {
-      case RestrictedView.Watermark(false) => RestrictedView.default
-      case s                               => s
+  def setProjectRestrictedView(project: KnoraProject, settings: RestrictedView): Task[RestrictedView] =
+    withProjectFromDb(project.id) { project =>
+      val newSettings = settings match {
+        case RestrictedView.Watermark(false) => RestrictedView.default
+        case s                               => s
+      }
+      knoraProjectRepo.save(project.copy(restrictedView = newSettings)).as(newSettings)
     }
-    knoraProjectRepo.save(project.copy(restrictedView = newSettings)).as(newSettings)
-  }
 
   def createProject(req: ProjectCreateRequest): Task[KnoraProject] = for {
     _            <- ensureShortcodeIsUnique(req.shortcode)
@@ -58,6 +59,12 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
     project <- knoraProjectRepo.save(project)
   } yield project
 
+  private def withProjectFromDb[A](id: ProjectIri)(task: KnoraProject => Task[A]): Task[A] =
+    knoraProjectRepo
+      .findById(id)
+      .someOrFail(new IllegalArgumentException(s"Project with id: $id not found"))
+      .flatMap(task)
+
   private def toNonEmptyChunk(descriptions: List[Description]) =
     ZIO
       .fail(new IllegalArgumentException("Descriptions may not be empty"))
@@ -71,6 +78,7 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
       .filterOrFail(identity)(
         DuplicateValueException(s"Project with the shortcode: '${shortcode.value}' already exists"),
       )
+
   private def ensureShortnameIsUnique(shortname: Shortname) =
     knoraProjectRepo
       .existsByShortname(shortname)
@@ -82,28 +90,28 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
   def erase(project: KnoraProject): Task[Unit] = knoraProjectRepo.delete(project)
 
   def updateProject(project: KnoraProject, updateReq: ProjectUpdateRequest): Task[KnoraProject] =
-    for {
-      desc <- updateReq.description match {
-                case Some(value) => toNonEmptyChunk(value).map(Some(_))
-                case None        => ZIO.none
-              }
-      _ <- updateReq.shortname match {
-             case Some(value) => ensureShortnameIsUnique(value)
-             case None        => ZIO.unit
-           }
-      updated <- knoraProjectRepo.save(
-                   project.copy(
-                     longname = updateReq.longname.orElse(project.longname),
-                     description = desc.getOrElse(project.description),
-                     keywords = updateReq.keywords.getOrElse(project.keywords),
-                     logo = updateReq.logo.orElse(project.logo),
-                     status = updateReq.status.getOrElse(project.status),
-                     selfjoin = updateReq.selfjoin.getOrElse(project.selfjoin),
-                   ),
-                 )
-    } yield updated
-
-  def save(project: KnoraProject): Task[KnoraProject] = knoraProjectRepo.save(project)
+    withProjectFromDb(project.id) { project =>
+      for {
+        desc <- updateReq.description match {
+                  case Some(value) => toNonEmptyChunk(value).map(Some(_))
+                  case None        => ZIO.none
+                }
+        _ <- updateReq.shortname match {
+               case Some(value) => ensureShortnameIsUnique(value)
+               case None        => ZIO.unit
+             }
+        updated <- knoraProjectRepo.save(
+                     project.copy(
+                       longname = updateReq.longname.orElse(project.longname),
+                       description = desc.getOrElse(project.description),
+                       keywords = updateReq.keywords.getOrElse(project.keywords),
+                       logo = updateReq.logo.orElse(project.logo),
+                       status = updateReq.status.getOrElse(project.status),
+                       selfjoin = updateReq.selfjoin.getOrElse(project.selfjoin),
+                     ),
+                   )
+      } yield updated
+    }
 
   def getNamedGraphsForProject(project: KnoraProject): Task[List[InternalIri]] = {
     val projectGraph = ProjectService.projectDataNamedGraphV2(project)
@@ -122,7 +130,7 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
       }
     }
 
-  def replaceCopyrightHolser(
+  def replaceCopyrightHolder(
     projectIri: ProjectIri,
     oldValue: CopyrightHolder,
     newValue: CopyrightHolder,
@@ -134,12 +142,6 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
         knoraProjectRepo.save(project.copy(predefinedCopyrightHolders = newAuthors))
       }
     }
-
-  private def withProjectFromDb[A](id: ProjectIri)(task: KnoraProject => Task[A]): Task[A] =
-    knoraProjectRepo
-      .findById(id)
-      .someOrFail(new IllegalArgumentException(s"Project with id: $id not found"))
-      .flatMap(task)
 }
 
 object KnoraProjectService {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
@@ -14,7 +14,7 @@ import zio.ZLayer
 import dsp.errors.DuplicateValueException
 import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequestsAndResponses.ProjectCreateRequest
 import org.knora.webapi.slice.admin.api.model.ProjectsEndpointsRequestsAndResponses.ProjectUpdateRequest
-import org.knora.webapi.slice.admin.domain.model.Authorship
+import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Description
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
@@ -113,25 +113,25 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
       .map(_ :+ projectGraph)
   }
 
-  def addPredefinedAuthorships(project: ProjectIri, addThese: Set[Authorship]): Task[KnoraProject] =
+  def addCopyrightHolders(project: ProjectIri, addThese: Set[CopyrightHolder]): Task[KnoraProject] =
     withProjectFromDb(project) { project =>
       if (addThese.isEmpty) ZIO.succeed(project)
       else {
-        val newAuthors = project.predefinedAuthorships ++ addThese
-        knoraProjectRepo.save(project.copy(predefinedAuthorships = newAuthors))
+        val newAuthors = project.predefinedCopyrightHolders ++ addThese
+        knoraProjectRepo.save(project.copy(predefinedCopyrightHolders = newAuthors))
       }
     }
 
-  def replacePredefinedAuthorship(
+  def replaceCopyrightHolser(
     projectIri: ProjectIri,
-    oldValue: Authorship,
-    newValue: Authorship,
+    oldValue: CopyrightHolder,
+    newValue: CopyrightHolder,
   ): Task[KnoraProject] =
     withProjectFromDb(projectIri) { project =>
-      if (!project.predefinedAuthorships.contains(oldValue)) ZIO.succeed(project)
+      if (!project.predefinedCopyrightHolders.contains(oldValue)) ZIO.succeed(project)
       else {
-        val newAuthors = project.predefinedAuthorships - oldValue + newValue
-        knoraProjectRepo.save(project.copy(predefinedAuthorships = newAuthors))
+        val newAuthors = project.predefinedCopyrightHolders - oldValue + newValue
+        knoraProjectRepo.save(project.copy(predefinedCopyrightHolders = newAuthors))
       }
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
@@ -125,8 +125,8 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
     withProjectFromDb(project) { project =>
       if (addThese.isEmpty) ZIO.succeed(project)
       else {
-        val newAuthors = project.predefinedCopyrightHolders ++ addThese
-        knoraProjectRepo.save(project.copy(predefinedCopyrightHolders = newAuthors))
+        val newAuthors = project.allowedCopyrightHolders ++ addThese
+        knoraProjectRepo.save(project.copy(allowedCopyrightHolders = newAuthors))
       }
     }
 
@@ -136,10 +136,10 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
     newValue: CopyrightHolder,
   ): Task[KnoraProject] =
     withProjectFromDb(projectIri) { project =>
-      if (!project.predefinedCopyrightHolders.contains(oldValue)) ZIO.succeed(project)
+      if (!project.allowedCopyrightHolders.contains(oldValue)) ZIO.succeed(project)
       else {
-        val newAuthors = project.predefinedCopyrightHolders - oldValue + newValue
-        knoraProjectRepo.save(project.copy(predefinedCopyrightHolders = newAuthors))
+        val newAuthors = project.allowedCopyrightHolders - oldValue + newValue
+        knoraProjectRepo.save(project.copy(allowedCopyrightHolders = newAuthors))
       }
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/LicenseService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/LicenseService.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.admin.domain.service
+import zio.*
+
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.model.License
+import org.knora.webapi.slice.admin.repo.LicenseRepo
+
+case class LicenseService(repo: LicenseRepo) {
+
+  /**
+   * Currently, the project is not used in the implementation and all allowed licenses are returned.
+   *
+   * @param id the Project for which the licenses are retrieved.
+   * @return Returns the licenses available in the project.
+   */
+  def findByProjectId(id: ProjectIri): UIO[Chunk[License]] =
+    repo.findAll().orDie
+}
+
+object LicenseService {
+  val layer = ZLayer.derive[LicenseService]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/LicenseService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/LicenseService.scala
@@ -6,7 +6,7 @@
 package org.knora.webapi.slice.admin.domain.service
 import zio.*
 
-import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.License
 import org.knora.webapi.slice.admin.repo.LicenseRepo
 
@@ -18,7 +18,7 @@ case class LicenseService(repo: LicenseRepo) {
    * @param id the Project for which the licenses are retrieved.
    * @return Returns the licenses available in the project.
    */
-  def findByProjectId(id: ProjectIri): UIO[Chunk[License]] =
+  def findByProjectShortcode(id: Shortcode): UIO[Chunk[License]] =
     repo.findAll().orDie
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectService.scala
@@ -73,6 +73,7 @@ final case class ProjectService(
       status = project.status,
       selfjoin = project.selfjoin,
       restrictedView,
+      Set.empty,
     )
 
   def setProjectRestrictedView(project: Project, settings: RestrictedView): Task[RestrictedView] =

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/AdminRepoModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/AdminRepoModule.scala
@@ -44,5 +44,6 @@ object AdminRepoModule {
     KnoraUserRepoLive.layer,
     AdministrativePermissionRepoLive.layer,
     DefaultObjectAccessPermissionRepoLive.layer,
+    LicenseRepo.layer,
   )
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/AdminRepoModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/AdminRepoModule.scala
@@ -33,6 +33,7 @@ object AdminRepoModule {
     AdministrativePermissionRepo &
     CacheManager &
     DefaultObjectAccessPermissionRepo &
+    LicenseRepo &
     KnoraGroupRepo &
     KnoraProjectRepo &
     KnoraUserRepo

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/LicenseRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/LicenseRepo.scala
@@ -23,54 +23,54 @@ final case class LicenseRepo(ref: Ref[Chunk[License]]) extends Repository[Licens
 
 object LicenseRepo {
   def layer = ZLayer.fromZIO(Ref.make(AllowedLicenses.all).map(LicenseRepo.apply))
-}
 
-object AllowedLicenses {
-  val all: Chunk[License] = Chunk(
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g"),
-      URI.create("https://creativecommons.org/licenses/by/4.0/"),
-      "CC BY 4.0",
-    ),
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/iAMRMWz7QCihyjKTToiOxQ"),
-      URI.create("https://creativecommons.org/licenses/by-sa/4.0/"),
-      "CC BY-SA 4.0",
-    ),
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/jfTnk7gSTLCfbaG1jw7TxQ"),
-      URI.create("https://creativecommons.org/licenses/by-nc/4.0/"),
-      "CC BY-NC 4.0",
-    ),
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/ImEbZ_1RQXuZ1vBP6h9Y1g"),
-      URI.create("https://creativecommons.org/licenses/by-nc-sa/4.0/"),
-      "CC BY-NC-SA 4.0",
-    ),
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/G4aqIIoZQ_a185x73y8Neg"),
-      URI.create("https://creativecommons.org/licenses/by-nd/4.0/"),
-      "CC BY-ND 4.0",
-    ),
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/wxaLnc8mT4-HqLv06zMDrA"),
-      URI.create("https://creativecommons.org/licenses/by-nc-nd/4.0/"),
-      "CC BY-NC-ND 4.0",
-    ),
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/u27qfxzgSSWxNA_1o9_VQg"),
-      URI.create("http://example.com/"),
-      "Produced by an AI - Not Protected by Copyright",
-    ),
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/B1pkLhbcSCioh_2NothNNQ"),
-      URI.create("http://example.com/"),
-      "Unknown License - Ask Copyright Holder for Permission",
-    ),
-    License.unsafeFrom(
-      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/noWBM260TbS3laZ5yxKZSQ"),
-      URI.create("http://example.com/"),
-      "Public Domain - Not Protected by Copyright",
-    ),
-  )
+  private object AllowedLicenses {
+    val all: Chunk[License] = Chunk(
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g"),
+        URI.create("https://creativecommons.org/licenses/by/4.0/"),
+        "CC BY 4.0",
+      ),
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/iAMRMWz7QCihyjKTToiOxQ"),
+        URI.create("https://creativecommons.org/licenses/by-sa/4.0/"),
+        "CC BY-SA 4.0",
+      ),
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/jfTnk7gSTLCfbaG1jw7TxQ"),
+        URI.create("https://creativecommons.org/licenses/by-nc/4.0/"),
+        "CC BY-NC 4.0",
+      ),
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/ImEbZ_1RQXuZ1vBP6h9Y1g"),
+        URI.create("https://creativecommons.org/licenses/by-nc-sa/4.0/"),
+        "CC BY-NC-SA 4.0",
+      ),
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/G4aqIIoZQ_a185x73y8Neg"),
+        URI.create("https://creativecommons.org/licenses/by-nd/4.0/"),
+        "CC BY-ND 4.0",
+      ),
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/wxaLnc8mT4-HqLv06zMDrA"),
+        URI.create("https://creativecommons.org/licenses/by-nc-nd/4.0/"),
+        "CC BY-NC-ND 4.0",
+      ),
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/u27qfxzgSSWxNA_1o9_VQg"),
+        URI.create("http://example.com/"),
+        "Produced by an AI - Not Protected by Copyright",
+      ),
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/B1pkLhbcSCioh_2NothNNQ"),
+        URI.create("http://example.com/"),
+        "Unknown License - Ask Copyright Holder for Permission",
+      ),
+      License.unsafeFrom(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/noWBM260TbS3laZ5yxKZSQ"),
+        URI.create("http://example.com/"),
+        "Public Domain - Not Protected by Copyright",
+      ),
+    )
+  }
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/LicenseRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/LicenseRepo.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.admin.repo
+
+import zio.Chunk
+import zio.Ref
+import zio.Task
+import zio.ZLayer
+
+import java.net.URI
+
+import org.knora.webapi.slice.admin.domain.model.License
+import org.knora.webapi.slice.admin.domain.model.LicenseIri
+import org.knora.webapi.slice.common.repo.service.Repository
+
+final case class LicenseRepo(ref: Ref[Chunk[License]]) extends Repository[License, LicenseIri] {
+  override def findById(id: LicenseIri): Task[Option[License]] = ref.get.map(_.find(_.id == id))
+  override def findAll(): Task[Chunk[License]]                 = ref.get
+}
+
+object LicenseRepo {
+  def layer = ZLayer.fromZIO(Ref.make(AllowedLicenses.all).map(LicenseRepo.apply))
+}
+
+object AllowedLicenses {
+  val all: Chunk[License] = Chunk(
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g"),
+      URI.create("https://creativecommons.org/licenses/by/4.0/"),
+      "CC BY 4.0",
+    ),
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/iAMRMWz7QCihyjKTToiOxQ"),
+      URI.create("https://creativecommons.org/licenses/by-sa/4.0/"),
+      "CC BY-SA 4.0",
+    ),
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/jfTnk7gSTLCfbaG1jw7TxQ"),
+      URI.create("https://creativecommons.org/licenses/by-nc/4.0/"),
+      "CC BY-NC 4.0",
+    ),
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/ImEbZ_1RQXuZ1vBP6h9Y1g"),
+      URI.create("https://creativecommons.org/licenses/by-nc-sa/4.0/"),
+      "CC BY-NC-SA 4.0",
+    ),
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/G4aqIIoZQ_a185x73y8Neg"),
+      URI.create("https://creativecommons.org/licenses/by-nd/4.0/"),
+      "CC BY-ND 4.0",
+    ),
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/wxaLnc8mT4-HqLv06zMDrA"),
+      URI.create("https://creativecommons.org/licenses/by-nc-nd/4.0/"),
+      "CC BY-NC-ND 4.0",
+    ),
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/u27qfxzgSSWxNA_1o9_VQg"),
+      URI.create("http://example.com/"),
+      "Produced by an AI - Not Protected by Copyright",
+    ),
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/B1pkLhbcSCioh_2NothNNQ"),
+      URI.create("http://example.com/"),
+      "Unknown License - Ask Copyright Holder for Permission",
+    ),
+    License.unsafeFrom(
+      LicenseIri.unsafeFrom("http://rdfh.ch/licenses/noWBM260TbS3laZ5yxKZSQ"),
+      URI.create("http://example.com/"),
+      "Public Domain - Not Protected by Copyright",
+    ),
+  )
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/LicenseRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/LicenseRepo.scala
@@ -10,8 +10,6 @@ import zio.Ref
 import zio.Task
 import zio.ZLayer
 
-import java.net.URI
-
 import org.knora.webapi.slice.admin.domain.model.License
 import org.knora.webapi.slice.admin.domain.model.LicenseIri
 import org.knora.webapi.slice.common.repo.service.Repository
@@ -22,55 +20,5 @@ final case class LicenseRepo(ref: Ref[Chunk[License]]) extends Repository[Licens
 }
 
 object LicenseRepo {
-  def layer = ZLayer.fromZIO(Ref.make(AllowedLicenses.all).map(LicenseRepo.apply))
-
-  private object AllowedLicenses {
-    val all: Chunk[License] = Chunk(
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g"),
-        URI.create("https://creativecommons.org/licenses/by/4.0/"),
-        "CC BY 4.0",
-      ),
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/iAMRMWz7QCihyjKTToiOxQ"),
-        URI.create("https://creativecommons.org/licenses/by-sa/4.0/"),
-        "CC BY-SA 4.0",
-      ),
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/jfTnk7gSTLCfbaG1jw7TxQ"),
-        URI.create("https://creativecommons.org/licenses/by-nc/4.0/"),
-        "CC BY-NC 4.0",
-      ),
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/ImEbZ_1RQXuZ1vBP6h9Y1g"),
-        URI.create("https://creativecommons.org/licenses/by-nc-sa/4.0/"),
-        "CC BY-NC-SA 4.0",
-      ),
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/G4aqIIoZQ_a185x73y8Neg"),
-        URI.create("https://creativecommons.org/licenses/by-nd/4.0/"),
-        "CC BY-ND 4.0",
-      ),
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/wxaLnc8mT4-HqLv06zMDrA"),
-        URI.create("https://creativecommons.org/licenses/by-nc-nd/4.0/"),
-        "CC BY-NC-ND 4.0",
-      ),
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/u27qfxzgSSWxNA_1o9_VQg"),
-        URI.create("http://example.com/"),
-        "Produced by an AI - Not Protected by Copyright",
-      ),
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/B1pkLhbcSCioh_2NothNNQ"),
-        URI.create("http://example.com/"),
-        "Unknown License - Ask Copyright Holder for Permission",
-      ),
-      License.unsafeFrom(
-        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/noWBM260TbS3laZ5yxKZSQ"),
-        URI.create("http://example.com/"),
-        "Public Domain - Not Protected by Copyright",
-      ),
-    )
-  }
+  def layer = ZLayer.fromZIO(Ref.make(License.BUILT_IN).map(LicenseRepo.apply))
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
@@ -102,7 +102,7 @@ object KnoraProjectRepoLive {
         logo        <- resource.getStringLiteral[Logo](ProjectLogo)
         status      <- resource.getBooleanLiteralOrFail[Status](StatusProp)
         selfjoin    <- resource.getBooleanLiteralOrFail[SelfJoin](HasSelfJoinEnabled)
-        predefinedCopyrightHolders <-
+        allowedCopyrightHolders <-
           resource.getStringLiterals(hasAllowedCopyrightHolder)(CopyrightHolder.from).map(_.toSet)
         restrictedView <- getRestrictedView
       } yield KnoraProject(
@@ -116,7 +116,7 @@ object KnoraProjectRepoLive {
         status = status,
         selfjoin = selfjoin,
         restrictedView = restrictedView,
-        predefinedCopyrightHolders = predefinedCopyrightHolders,
+        allowedCopyrightHolders = allowedCopyrightHolders,
       )
     }
 
@@ -141,7 +141,7 @@ object KnoraProjectRepoLive {
         case RestrictedView.Watermark(watermark) =>
           pattern.andHas(Vocabulary.KnoraAdmin.projectRestrictedViewWatermark, watermark)
       }
-      project.predefinedCopyrightHolders.foreach(authorship =>
+      project.allowedCopyrightHolders.foreach(authorship =>
         pattern.andHas(Vocabulary.KnoraAdmin.hasAllowedCopyrightHolder, authorship.value),
       )
       pattern

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLive.scala
@@ -49,7 +49,7 @@ final case class KnoraProjectRepoLive(
       Vocabulary.KnoraAdmin.projectLongname,
       Vocabulary.KnoraAdmin.projectRestrictedViewSize,
       Vocabulary.KnoraAdmin.projectRestrictedViewWatermark,
-      Vocabulary.KnoraAdmin.hasPredefinedCopyrightHolder,
+      Vocabulary.KnoraAdmin.hasAllowedCopyrightHolder,
     ),
   )
 
@@ -103,7 +103,7 @@ object KnoraProjectRepoLive {
         status      <- resource.getBooleanLiteralOrFail[Status](StatusProp)
         selfjoin    <- resource.getBooleanLiteralOrFail[SelfJoin](HasSelfJoinEnabled)
         predefinedCopyrightHolders <-
-          resource.getStringLiterals(hasPredefinedCopyrightHolder)(CopyrightHolder.from).map(_.toSet)
+          resource.getStringLiterals(hasAllowedCopyrightHolder)(CopyrightHolder.from).map(_.toSet)
         restrictedView <- getRestrictedView
       } yield KnoraProject(
         id = ProjectIri.unsafeFrom(iri.value),
@@ -142,7 +142,7 @@ object KnoraProjectRepoLive {
           pattern.andHas(Vocabulary.KnoraAdmin.projectRestrictedViewWatermark, watermark)
       }
       project.predefinedCopyrightHolders.foreach(authorship =>
-        pattern.andHas(Vocabulary.KnoraAdmin.hasPredefinedCopyrightHolder, authorship.value),
+        pattern.andHas(Vocabulary.KnoraAdmin.hasAllowedCopyrightHolder, authorship.value),
       )
       pattern
     }

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ValueTypes.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ValueTypes.scala
@@ -49,6 +49,9 @@ object StringValueCompanion {
   def isUri: String => Validation[String, String] =
     value => Validation.fromTry(Try(URI.create(value))).as(value).mapError(_ => s"is not a valid URI")
 
+  def absoluteUri: URI => Validation[String, URI] =
+    uri => Validation.fromPredicateWith(s"URI must be absolute")(uri)(_.isAbsolute)
+
   def fromValidations[A](
     typ: String,
     make: String => A,

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/api/DocsGenerator.scala
@@ -29,6 +29,7 @@ import org.knora.webapi.slice.admin.api.ListsEndpoints
 import org.knora.webapi.slice.admin.api.MaintenanceEndpoints
 import org.knora.webapi.slice.admin.api.PermissionsEndpoints
 import org.knora.webapi.slice.admin.api.ProjectsEndpoints
+import org.knora.webapi.slice.admin.api.ProjectsLegalInfoEndpoints
 import org.knora.webapi.slice.admin.api.StoreEndpoints
 import org.knora.webapi.slice.admin.api.UsersEndpoints
 import org.knora.webapi.slice.admin.domain.model.Email
@@ -92,6 +93,7 @@ object DocsGenerator extends ZIOAppDefault {
     MaintenanceEndpoints.layer,
     ManagementEndpoints.layer,
     PermissionsEndpoints.layer,
+    ProjectsLegalInfoEndpoints.layer,
     ProjectsEndpoints.layer,
     ResourceInfoEndpoints.layer,
     SearchEndpoints.layer,

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/repo/rdf/Vocabulary.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/repo/rdf/Vocabulary.scala
@@ -58,7 +58,7 @@ object Vocabulary {
     val projectLongname: Iri                = Rdf.iri(ka, "projectLongname")
     val projectShortcode: Iri               = Rdf.iri(ka, "projectShortcode")
     val projectShortname: Iri               = Rdf.iri(ka, "projectShortname")
-    val projectPredefinedAuthorship         = Rdf.iri(ka, "projectPredefinedAuthorship")
+    val hasPredefinedCopyrightHolder        = Rdf.iri(ka, "hasPredefinedCopyrightHolder")
 
     // permission properties
     val AdministrativePermission: Iri      = Rdf.iri(ka, "AdministrativePermission")

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/repo/rdf/Vocabulary.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/repo/rdf/Vocabulary.scala
@@ -58,6 +58,7 @@ object Vocabulary {
     val projectLongname: Iri                = Rdf.iri(ka, "projectLongname")
     val projectShortcode: Iri               = Rdf.iri(ka, "projectShortcode")
     val projectShortname: Iri               = Rdf.iri(ka, "projectShortname")
+    val projectPredefinedAuthorship         = Rdf.iri(ka, "projectPredefinedAuthorship")
 
     // permission properties
     val AdministrativePermission: Iri      = Rdf.iri(ka, "AdministrativePermission")

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/repo/rdf/Vocabulary.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/repo/rdf/Vocabulary.scala
@@ -58,7 +58,7 @@ object Vocabulary {
     val projectLongname: Iri                = Rdf.iri(ka, "projectLongname")
     val projectShortcode: Iri               = Rdf.iri(ka, "projectShortcode")
     val projectShortname: Iri               = Rdf.iri(ka, "projectShortname")
-    val hasPredefinedCopyrightHolder        = Rdf.iri(ka, "hasPredefinedCopyrightHolder")
+    val hasAllowedCopyrightHolder: Iri      = Rdf.iri(ka, "hasAllowedCopyrightHolder")
 
     // permission properties
     val AdministrativePermission: Iri      = Rdf.iri(ka, "AdministrativePermission")

--- a/webapi/src/test/scala/org/knora/webapi/TestDataFactory.scala
+++ b/webapi/src/test/scala/org/knora/webapi/TestDataFactory.scala
@@ -129,5 +129,6 @@ object TestDataFactory {
     Status.Active,
     SelfJoin.CannotJoin,
     RestrictedView.default,
+    Set.empty,
   )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModelSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModelSpec.scala
@@ -7,6 +7,8 @@ package org.knora.webapi.slice.admin.domain.model
 
 import zio.test.*
 
+import java.net.URI
+
 object LegalInfoModelSpec extends ZIOSpecDefault {
 
   private val authorshipSuite = suite("Authorship")(
@@ -43,8 +45,49 @@ object LegalInfoModelSpec extends ZIOSpecDefault {
     },
   )
 
+  private val licenseSuite = suiteAll("License") {
+    val validIri   = LicenseIri.unsafeFrom("http://rdfh.ch/licenses/i6xBpZn4RVOdOIyTezEumw")
+    val validUri   = URI.create("https://creativecommons.org/licenses/by/4.0/")
+    val invalidUri = URI.create("./invalid")
+    val validLabel = "CC BY 4.0"
+
+    test("pass a valid object and successfully create value object") {
+      val actual = License.from(validIri, validUri, validLabel)
+      assertTrue(
+        actual.map(_.id).contains(validIri),
+        actual.map(_.uri).contains(validUri),
+        actual.map(_.labelEn).contains(validLabel),
+      )
+    }
+    test("pass a relative URI and return an error") {
+      val actual = License.from(validIri, invalidUri, validLabel)
+      assertTrue(actual == Left("License: URI must be absolute"))
+    }
+    test("pass an empty label and return an error") {
+      val actual = License.from(validIri, validUri, "")
+      assertTrue(actual == Left("License: Label en cannot be empty"))
+    }
+    test("pass a new line in labelEn and return an error") {
+      val actual = License.from(validIri, validUri, "some\nlabel")
+      assertTrue(actual == Left("License: Label en must not contain line breaks"))
+    }
+    test("pass a too long labelEn and return an error") {
+      val actual = License.from(validIri, validUri, "s" * 256)
+      assertTrue(actual == Left("License: Label en must be maximum 255 characters long"))
+    }
+    test("errors are combined") {
+      val actual = License.from(validIri, invalidUri, "s\n" * 256)
+      assertTrue(
+        actual == Left(
+          "License: URI must be absolute, Label en must be maximum 255 characters long; must not contain line breaks",
+        ),
+      )
+    }
+  }
+
   val spec: Spec[Any, Nothing] = suite("Copyright And Licenses Model")(
     authorshipSuite,
     licenseIriSuite,
+    licenseSuite,
   )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModelSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModelSpec.scala
@@ -46,7 +46,7 @@ object LegalInfoModelSpec extends ZIOSpecDefault {
   )
 
   private val licenseSuite = suiteAll("License") {
-    val validIri   = LicenseIri.unsafeFrom("http://rdfh.ch/licenses/i6xBpZn4RVOdOIyTezEumw")
+    val validIri   = LicenseIri.unsafeFrom("http://rdfh.ch/licenses/cc-by-4.0")
     val validUri   = URI.create("https://creativecommons.org/licenses/by/4.0/")
     val invalidUri = URI.create("./invalid")
     val validLabel = "CC BY 4.0"
@@ -82,6 +82,14 @@ object LegalInfoModelSpec extends ZIOSpecDefault {
           "License: URI must be absolute, Label en must be maximum 255 characters long; must not contain line breaks",
         ),
       )
+    }
+    test("pass in a predefined invalid license") {
+      val actual = License.from(
+        LicenseIri.unsafeFrom("http://rdfh.ch/licenses/cc-by-4.0"),
+        URI.create("http://rdfh.ch/licenses/cc-by-4.0"),
+        "Wrong label",
+      )
+      assertTrue(actual.isLeft)
     }
   }
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModelSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModelSpec.scala
@@ -89,7 +89,11 @@ object LegalInfoModelSpec extends ZIOSpecDefault {
         URI.create("http://rdfh.ch/licenses/cc-by-4.0"),
         "Wrong label",
       )
-      assertTrue(actual.isLeft)
+      assertTrue(
+        actual == Left(
+          "License: Found predefined license expected one of 'License(http://rdfh.ch/licenses/cc-by-4.0,https://creativecommons.org/licenses/by/4.0/,CC BY 4.0)'",
+        ),
+      )
     }
   }
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LicenseServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LicenseServiceSpec.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.admin.domain.service
+
+import zio.ZIO
+import zio.test.*
+
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.repo.LicenseRepo
+
+object LicenseServiceSpec extends ZIOSpecDefault {
+
+  private val service = ZIO.serviceWithZIO[LicenseService]
+
+  def spec = suite("LicenseService")(
+    test("findByProjectId should return all licenses for any ProjectIri") {
+      for {
+        actual <- service(_.findByProjectId(ProjectIri.makeNew))
+      } yield assertTrue(actual.size == 9)
+    },
+  ).provide(LicenseService.layer, LicenseRepo.layer)
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LicenseServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LicenseServiceSpec.scala
@@ -7,8 +7,10 @@ package org.knora.webapi.slice.admin.domain.service
 
 import zio.ZIO
 import zio.test.*
+import zio.test.Assertion.hasSameElements
 
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.admin.domain.model.License
 import org.knora.webapi.slice.admin.repo.LicenseRepo
 
 object LicenseServiceSpec extends ZIOSpecDefault {
@@ -16,10 +18,10 @@ object LicenseServiceSpec extends ZIOSpecDefault {
   private val service = ZIO.serviceWithZIO[LicenseService]
 
   def spec = suite("LicenseService")(
-    test("findByProjectId should return all licenses for any ProjectIri") {
+    test("findByProjectShortcode should return all licenses for project") {
       for {
         actual <- service(_.findByProjectShortcode(Shortcode.unsafeFrom("0001")))
-      } yield assertTrue(actual.size == 9)
+      } yield assert(actual)(hasSameElements(License.BUILT_IN))
     },
   ).provide(LicenseService.layer, LicenseRepo.layer)
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LicenseServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LicenseServiceSpec.scala
@@ -8,7 +8,7 @@ package org.knora.webapi.slice.admin.domain.service
 import zio.ZIO
 import zio.test.*
 
-import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.repo.LicenseRepo
 
 object LicenseServiceSpec extends ZIOSpecDefault {
@@ -18,7 +18,7 @@ object LicenseServiceSpec extends ZIOSpecDefault {
   def spec = suite("LicenseService")(
     test("findByProjectId should return all licenses for any ProjectIri") {
       for {
-        actual <- service(_.findByProjectId(ProjectIri.makeNew))
+        actual <- service(_.findByProjectShortcode(Shortcode.unsafeFrom("0001")))
       } yield assertTrue(actual.size == 9)
     },
   ).provide(LicenseService.layer, LicenseRepo.layer)

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectServiceSpec.scala
@@ -55,7 +55,7 @@ object ProjectServiceSpec extends ZIOSpecDefault {
           status = Status.Active,
           selfjoin = SelfJoin.CanJoin,
           restrictedView = RestrictedView.default,
-          predefinedAuthorships = Set.empty,
+          predefinedCopyrightHolders = Set.empty,
         )
         assertTrue(
           ProjectService

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectServiceSpec.scala
@@ -55,7 +55,7 @@ object ProjectServiceSpec extends ZIOSpecDefault {
           status = Status.Active,
           selfjoin = SelfJoin.CanJoin,
           restrictedView = RestrictedView.default,
-          predefinedCopyrightHolders = Set.empty,
+          allowedCopyrightHolders = Set.empty,
         )
         assertTrue(
           ProjectService

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectServiceSpec.scala
@@ -55,6 +55,7 @@ object ProjectServiceSpec extends ZIOSpecDefault {
           status = Status.Active,
           selfjoin = SelfJoin.CanJoin,
           restrictedView = RestrictedView.default,
+          predefinedAuthorships = Set.empty,
         )
         assertTrue(
           ProjectService

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/LicenseRepositorySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/LicenseRepositorySpec.scala
@@ -21,12 +21,12 @@ object LicenseRepositorySpec extends ZIOSpecDefault {
     },
     test("should find license by id") {
       for {
-        actual <- repo(_.findById(LicenseIri.unsafeFrom("http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g")))
+        actual <- repo(_.findById(LicenseIri.unsafeFrom("http://rdfh.ch/licenses/cc-by-4.0")))
       } yield {
         assertTrue(
           actual.contains(
             License.unsafeFrom(
-              LicenseIri.unsafeFrom("http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g"),
+              LicenseIri.unsafeFrom("http://rdfh.ch/licenses/cc-by-4.0"),
               URI.create("https://creativecommons.org/licenses/by/4.0/"),
               "CC BY 4.0",
             ),

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/LicenseRepositorySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/LicenseRepositorySpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.admin.repo
+
+import zio.*
+import zio.test.*
+
+import java.net.URI
+
+import org.knora.webapi.slice.admin.domain.model.License
+import org.knora.webapi.slice.admin.domain.model.LicenseIri
+
+object LicenseRepositorySpec extends ZIOSpecDefault {
+  private val repo = ZIO.serviceWithZIO[LicenseRepo]
+  val spec = suite("LicenseRepository")(
+    test("findAll returns nine supported license") {
+      repo(_.findAll()).map(actual => assertTrue(actual.size == 9))
+    },
+    test("should find license by id") {
+      for {
+        actual <- repo(_.findById(LicenseIri.unsafeFrom("http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g")))
+      } yield {
+        assertTrue(
+          actual.contains(
+            License.unsafeFrom(
+              LicenseIri.unsafeFrom("http://rdfh.ch/licenses/heUgoYutSxWm2Rc7Gc1J5g"),
+              URI.create("https://creativecommons.org/licenses/by/4.0/"),
+              "CC BY 4.0",
+            ),
+          ),
+        )
+      }
+    },
+    test("should not find license by unknown id") {
+      repo(_.findById(LicenseIri.makeNew)).map(actual => assertTrue(actual.isEmpty))
+    },
+  ).provide(LicenseRepo.layer)
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/LicenseRepositorySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/LicenseRepositorySpec.scala
@@ -16,7 +16,7 @@ import org.knora.webapi.slice.admin.domain.model.LicenseIri
 object LicenseRepositorySpec extends ZIOSpecDefault {
   private val repo = ZIO.serviceWithZIO[LicenseRepo]
   val spec = suite("LicenseRepository")(
-    test("findAll returns nine supported license") {
+    test("findAll returns nine supported licenses") {
       repo(_.findAll()).map(actual => assertTrue(actual.size == 9))
     },
     test("should find license by id") {

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
@@ -17,6 +17,7 @@ import zio.test.check
 
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.AdminConstants
+import org.knora.webapi.slice.admin.domain.model.Authorship
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Description
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Keyword
@@ -45,6 +46,7 @@ object KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
     Status.Active,
     SelfJoin.CannotJoin,
     RestrictedView.default,
+    Set("foo", "bar").map(Authorship.unsafeFrom),
   )
 
   private val someProjectTrig =
@@ -63,7 +65,8 @@ object KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
         |    knora-admin:projectLogo "logo.png" ;
         |    knora-admin:status true ;
         |    knora-admin:hasSelfJoinEnabled false ;
-        |    knora-admin:projectRestrictedViewSize "!128,128" .
+        |    knora-admin:projectRestrictedViewSize "!128,128" ;
+        |    knora-admin:projectPredefinedAuthorship "foo", "bar" .
         |}
         |""".stripMargin
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
@@ -66,7 +66,7 @@ object KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
         |    knora-admin:status true ;
         |    knora-admin:hasSelfJoinEnabled false ;
         |    knora-admin:projectRestrictedViewSize "!128,128" ;
-        |    knora-admin:hasPredefinedCopyrightHolder "foo", "bar" .
+        |    knora-admin:hasAllowedCopyrightHolder "foo", "bar" .
         |}
         |""".stripMargin
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
@@ -17,7 +17,7 @@ import zio.test.check
 
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.AdminConstants
-import org.knora.webapi.slice.admin.domain.model.Authorship
+import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Description
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Keyword
@@ -46,7 +46,7 @@ object KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
     Status.Active,
     SelfJoin.CannotJoin,
     RestrictedView.default,
-    Set("foo", "bar").map(Authorship.unsafeFrom),
+    Set("foo", "bar").map(CopyrightHolder.unsafeFrom),
   )
 
   private val someProjectTrig =
@@ -66,7 +66,7 @@ object KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
         |    knora-admin:status true ;
         |    knora-admin:hasSelfJoinEnabled false ;
         |    knora-admin:projectRestrictedViewSize "!128,128" ;
-        |    knora-admin:projectPredefinedAuthorship "foo", "bar" .
+        |    knora-admin:hasPredefinedCopyrightHolder "foo", "bar" .
         |}
         |""".stripMargin
 


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

- **Add pagination, filter and ordering query params and responses`**
- **Add API on `admin/projects/shortcode/:shortcode/legal-info`**
-- `GET /admin/projects/shortcode/{projectShortcode}/legal-info/authorships` returns authorships used in project data
-- `GET /admin/projects/shortcode/{projectShortcode}/legal-info/licenses` returns licenses allowed in project data
-- `GET /admin/projects/shortcode/{projectShortcode}/legal-info/copyright-holders` returns copyright holders allowed in project data
-- `PUT /admin/projects/shortcode/{projectShortcode}/legal-info/copyright-holders` add allowed copyright holders
-- `POST /admin/projects/shortcode/{projectShortcode}/legal-info/copyright-holders` replace allowed copyright holder
- **Add tests**

### Out of scope

The check if the allowed values for copyright holder and license were provided when creating `FileValue`s  will be done in a [followup pull request](https://github.com/dasch-swiss/dsp-api/pull/3512).
<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
