### PR TITLE
fix: Erase the project before the import and refresh the ontology cache after import (DEV-4584)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpointsHandler.scala
@@ -161,10 +161,7 @@ final case class ProjectsEndpointsHandler(
     )
 
   val postAdminProjectsByShortcodeImportHandler =
-    SecuredEndpointHandler(
-      projectsEndpoints.Secured.postAdminProjectsByShortcodeImport,
-      user => (id: Shortcode) => restService.importProject(id, user),
-    )
+    SecuredEndpointHandler(projectsEndpoints.Secured.postAdminProjectsByShortcodeImport, restService.importProject)
 
   val postAdminProjectsHandler =
     SecuredEndpointHandler(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectEraseService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectEraseService.scala
@@ -34,6 +34,7 @@ final case class ProjectEraseService(
   private def mkString(values: Seq[StringValue]): String = s"'${values.map(_.value).mkString(",")}'"
 
   def eraseProject(project: KnoraProject, keepAssets: Boolean): Task[Unit] = for {
+    _              <- ZIO.logInfo(s"${logPrefix(project)} Erasing project")
     groupsToDelete <- groupService.findByProject(project)
     _              <- cleanUpUsersAndGroups(project, groupsToDelete)
     _              <- cleanUpPermissions(project)

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectExportService.scala
@@ -33,6 +33,7 @@ import org.knora.webapi.slice.admin.AdminConstants.permissionsDataNamedGraph
 import org.knora.webapi.slice.admin.api.model.ProjectExportInfoResponse
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraAdmin as KA
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
 import org.knora.webapi.store.triplestore.api.TriplestoreService
@@ -71,8 +72,8 @@ trait ProjectExportService {
 
   def listExports(): Task[Chunk[ProjectExportInfo]]
 
-  final def findByProject(project: KnoraProject): Task[Option[ProjectExportInfo]] =
-    listExports().map(_.find(_.projectShortcode == project.shortcode.value))
+  final def findByShortcode(shortcode: Shortcode): Task[Option[ProjectExportInfo]] =
+    listExports().map(_.find(_.projectShortcode == shortcode.value))
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectExportService.scala
@@ -70,6 +70,9 @@ trait ProjectExportService {
   def exportProjectTriples(project: KnoraProject, targetFile: Path): Task[Path]
 
   def listExports(): Task[Chunk[ProjectExportInfo]]
+
+  final def findByProject(project: KnoraProject): Task[Option[ProjectExportInfo]] =
+    listExports().map(_.find(_.projectShortcode == project.shortcode.value))
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectImportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectImportService.scala
@@ -92,12 +92,12 @@ final case class ProjectImportService(
     val trigFile = path / exportStorage.trigFilename(shortcode)
     for {
       trigFileAbsolutePath <- trigFile.toAbsolutePath
-      _                    <- ZIO.logInfo(s"Importing triples for ${shortcode.value} from $trigFileAbsolutePath")
+      _                    <- ZIO.logInfo(s"Importing triples for $shortcode from $trigFileAbsolutePath")
       _ <- ZIO
              .fail(new IllegalStateException(s"trig file does not exist in export ${path.toAbsolutePath}"))
              .whenZIO(Files.notExists(trigFile))
       _ <- importTrigFile(trigFile)
-      _ <- ZIO.logInfo(s"Imported triples for ${shortcode.value}")
+      _ <- ZIO.logInfo(s"Imported triples for $shortcode")
     } yield ()
   }
 


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Bug Description
*Issue*

When importing a project that was previously exported, any data created after the export remains instead of being removed.

*Expected Behavior*

Importing a project should restore the exact state of the export, meaning any data added after the export should be removed.

### Fix Description

Ensure that import exists before importing.
Erase the project before import.
Reload OntologyCache after import.


<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
