### PR TITLE
refactor: Introduce Core and BaseModule (DEV-4686)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/ProjectEraseIT.scala
+++ b/integration/src/test/scala/org/knora/webapi/ProjectEraseIT.scala
@@ -52,8 +52,8 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupService
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.admin.domain.service.KnoraUserService
 import org.knora.webapi.slice.admin.domain.service.ProjectService
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTestLive.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTestLive.scala
@@ -31,6 +31,7 @@ import org.knora.webapi.slice.admin.api.service.UserRestService
 import org.knora.webapi.slice.admin.domain.service.*
 import org.knora.webapi.slice.admin.domain.service.ProjectExportStorageService
 import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
+import org.knora.webapi.slice.common.BaseModule
 import org.knora.webapi.slice.common.api.*
 import org.knora.webapi.slice.common.repo.service.PredicateObjectMapper
 import org.knora.webapi.slice.infrastructure.CacheManager
@@ -63,8 +64,6 @@ import org.knora.webapi.store.iiif.IIIFRequestMessageHandler
 import org.knora.webapi.store.iiif.IIIFRequestMessageHandlerLive
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.store.iiif.impl.SipiServiceLive
-import org.knora.webapi.store.triplestore.api.TriplestoreService
-import org.knora.webapi.store.triplestore.impl.TriplestoreServiceLive
 import org.knora.webapi.store.triplestore.upgrade.RepositoryUpdater
 import org.knora.webapi.testcontainers.DspIngestTestContainer
 import org.knora.webapi.testcontainers.FusekiTestContainer
@@ -98,6 +97,7 @@ object LayersTestLive { self =>
       AuthenticationApiModule.layer,
       AuthorizationRestService.layer,
       BaseEndpoints.layer,
+      BaseModule.layer,
       CardinalityHandler.layer,
       CoreModule.layer,
       ConstructResponseUtilV2.layer,
@@ -141,11 +141,9 @@ object LayersTestLive { self =>
       StandoffResponderV2.layer,
       StandoffTagUtilV2Live.layer,
       State.layer,
-      StringFormatter.live,
       TapirToPekkoInterpreter.layer,
       TestClientService.layer,
       TestDspIngestClient.layer,
-      TriplestoreServiceLive.layer,
       ValuesResponderV2.layer,
     )
 }

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTestLive.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTestLive.scala
@@ -48,7 +48,6 @@ import org.knora.webapi.slice.ontology.domain.service.OntologyService
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resourceinfo.ResourceInfoLayers
 import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.api.ResourcesApiModule
 import org.knora.webapi.slice.resources.repo.service.ResourcesRepo
 import org.knora.webapi.slice.resources.repo.service.ResourcesRepoLive
@@ -107,7 +106,6 @@ object LayersTestLive { self =>
       HttpServer.layer,
       IIIFRequestMessageHandlerLive.layer,
       InfrastructureModule.layer,
-      IriConverter.layer,
       IriService.layer,
       KnoraResponseRenderer.layer,
       ListsApiModule.layer,

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTestLive.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTestLive.scala
@@ -18,8 +18,6 @@ import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.admin.*
 import org.knora.webapi.responders.v2.*
 import org.knora.webapi.responders.v2.ontology.CardinalityHandler
-import org.knora.webapi.responders.v2.ontology.OntologyCacheHelpers
-import org.knora.webapi.responders.v2.ontology.OntologyTriplestoreHelpers
 import org.knora.webapi.routing.*
 import org.knora.webapi.slice.admin.AdminModule
 import org.knora.webapi.slice.admin.api.*
@@ -116,9 +114,7 @@ object LayersTestLive { self =>
       MessageRelayActorRef.layer,
       MessageRelayLive.layer,
       OntologyApiModule.layer,
-      OntologyCacheHelpers.layer,
       OntologyResponderV2.layer,
-      OntologyTriplestoreHelpers.layer,
       PermissionUtilADMLive.layer,
       PermissionsResponder.layer,
       PredicateObjectMapper.layer,

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTestLive.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTestLive.scala
@@ -39,17 +39,13 @@ import org.knora.webapi.slice.infrastructure.api.ManagementEndpoints
 import org.knora.webapi.slice.infrastructure.api.ManagementRoutes
 import org.knora.webapi.slice.lists.api.ListsApiModule
 import org.knora.webapi.slice.lists.domain.ListsService
+import org.knora.webapi.slice.ontology.CoreModule
 import org.knora.webapi.slice.ontology.api.OntologyApiModule
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityServiceLive
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
-import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.domain.service.OntologyService
-import org.knora.webapi.slice.ontology.domain.service.OntologyServiceLive
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
-import org.knora.webapi.slice.ontology.repo.service.OntologyCacheLive
-import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
-import org.knora.webapi.slice.ontology.repo.service.PredicateRepositoryLive
 import org.knora.webapi.slice.resourceinfo.ResourceInfoLayers
 import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
@@ -104,7 +100,7 @@ object LayersTestLive { self =>
       AuthorizationRestService.layer,
       BaseEndpoints.layer,
       CardinalityHandler.layer,
-      CardinalityService.layer,
+      CoreModule.layer,
       ConstructResponseUtilV2.layer,
       DspIngestClientLive.layer,
       HandlerMapper.layer,
@@ -123,15 +119,11 @@ object LayersTestLive { self =>
       MessageRelayLive.layer,
       OntologyApiModule.layer,
       OntologyCacheHelpers.layer,
-      OntologyCacheLive.layer,
-      OntologyRepoLive.layer,
       OntologyResponderV2.layer,
-      OntologyServiceLive.layer,
       OntologyTriplestoreHelpers.layer,
       PermissionUtilADMLive.layer,
       PermissionsResponder.layer,
       PredicateObjectMapper.layer,
-      PredicateRepositoryLive.layer,
       ProjectExportServiceLive.layer,
       ProjectExportStorageServiceLive.layer,
       ProjectImportService.layer,

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTestMock.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTestMock.scala
@@ -9,8 +9,6 @@ import org.apache.pekko
 import org.apache.pekko.actor.ActorSystem
 import zio.*
 
-import org.knora.webapi.config.AppConfig
-import org.knora.webapi.config.AppConfig.AppConfigurations
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.*
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
@@ -32,6 +30,7 @@ import org.knora.webapi.slice.admin.api.service.UserRestService
 import org.knora.webapi.slice.admin.domain.service.*
 import org.knora.webapi.slice.admin.domain.service.ProjectExportStorageService
 import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
+import org.knora.webapi.slice.common.BaseModule
 import org.knora.webapi.slice.common.api.*
 import org.knora.webapi.slice.common.repo.service.PredicateObjectMapper
 import org.knora.webapi.slice.infrastructure.CacheManager
@@ -65,7 +64,6 @@ import org.knora.webapi.store.iiif.IIIFRequestMessageHandlerLive
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.store.iiif.impl.SipiServiceMock
 import org.knora.webapi.store.triplestore.api.TriplestoreService
-import org.knora.webapi.store.triplestore.impl.TriplestoreServiceLive
 import org.knora.webapi.store.triplestore.upgrade.RepositoryUpdater
 import org.knora.webapi.testcontainers.FusekiTestContainer
 import org.knora.webapi.testservices.TestClientService
@@ -106,6 +104,7 @@ object LayersTestMock { self =>
       AuthenticationApiModule.layer,
       AuthorizationRestService.layer,
       BaseEndpoints.layer,
+      BaseModule.layer,
       CardinalityHandler.layer,
       CoreModule.layer,
       ConstructResponseUtilV2.layer,
@@ -149,11 +148,9 @@ object LayersTestMock { self =>
       StandoffResponderV2.layer,
       StandoffTagUtilV2Live.layer,
       State.layer,
-      StringFormatter.live,
       TapirToPekkoInterpreter.layer,
       TestClientService.layer,
       TestDspIngestClient.layer,
-      TriplestoreServiceLive.layer,
       ValuesResponderV2.layer,
     )
   }

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTestMock.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTestMock.scala
@@ -40,17 +40,13 @@ import org.knora.webapi.slice.infrastructure.api.ManagementEndpoints
 import org.knora.webapi.slice.infrastructure.api.ManagementRoutes
 import org.knora.webapi.slice.lists.api.ListsApiModule
 import org.knora.webapi.slice.lists.domain.ListsService
+import org.knora.webapi.slice.ontology.CoreModule
 import org.knora.webapi.slice.ontology.api.OntologyApiModule
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityServiceLive
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
-import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.domain.service.OntologyService
-import org.knora.webapi.slice.ontology.domain.service.OntologyServiceLive
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
-import org.knora.webapi.slice.ontology.repo.service.OntologyCacheLive
-import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
-import org.knora.webapi.slice.ontology.repo.service.PredicateRepositoryLive
 import org.knora.webapi.slice.resourceinfo.ResourceInfoLayers
 import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
@@ -112,7 +108,7 @@ object LayersTestMock { self =>
       AuthorizationRestService.layer,
       BaseEndpoints.layer,
       CardinalityHandler.layer,
-      CardinalityService.layer,
+      CoreModule.layer,
       ConstructResponseUtilV2.layer,
       DspIngestClientLive.layer,
       HandlerMapper.layer,
@@ -131,15 +127,11 @@ object LayersTestMock { self =>
       MessageRelayLive.layer,
       OntologyApiModule.layer,
       OntologyCacheHelpers.layer,
-      OntologyCacheLive.layer,
-      OntologyRepoLive.layer,
       OntologyResponderV2.layer,
-      OntologyServiceLive.layer,
       OntologyTriplestoreHelpers.layer,
       PermissionUtilADMLive.layer,
       PermissionsResponder.layer,
       PredicateObjectMapper.layer,
-      PredicateRepositoryLive.layer,
       ProjectExportServiceLive.layer,
       ProjectExportStorageServiceLive.layer,
       ProjectImportService.layer,

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTestMock.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTestMock.scala
@@ -49,7 +49,6 @@ import org.knora.webapi.slice.ontology.domain.service.OntologyService
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resourceinfo.ResourceInfoLayers
 import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.api.ResourcesApiModule
 import org.knora.webapi.slice.resources.repo.service.ResourcesRepo
 import org.knora.webapi.slice.resources.repo.service.ResourcesRepoLive
@@ -115,7 +114,6 @@ object LayersTestMock { self =>
       HttpServer.layer,
       IIIFRequestMessageHandlerLive.layer,
       InfrastructureModule.layer,
-      IriConverter.layer,
       IriService.layer,
       KnoraResponseRenderer.layer,
       ListsApiModule.layer,

--- a/integration/src/test/scala/org/knora/webapi/core/LayersTestMock.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTestMock.scala
@@ -17,8 +17,6 @@ import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.admin.*
 import org.knora.webapi.responders.v2.*
 import org.knora.webapi.responders.v2.ontology.CardinalityHandler
-import org.knora.webapi.responders.v2.ontology.OntologyCacheHelpers
-import org.knora.webapi.responders.v2.ontology.OntologyTriplestoreHelpers
 import org.knora.webapi.routing.*
 import org.knora.webapi.slice.admin.AdminModule
 import org.knora.webapi.slice.admin.api.*
@@ -45,6 +43,7 @@ import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityServiceLive
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.OntologyService
+import org.knora.webapi.slice.ontology.domain.service.OntologyTriplestoreHelpers
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resourceinfo.ResourceInfoLayers
 import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
@@ -123,9 +122,7 @@ object LayersTestMock { self =>
       MessageRelayActorRef.layer,
       MessageRelayLive.layer,
       OntologyApiModule.layer,
-      OntologyCacheHelpers.layer,
       OntologyResponderV2.layer,
-      OntologyTriplestoreHelpers.layer,
       PermissionUtilADMLive.layer,
       PermissionsResponder.layer,
       PredicateObjectMapper.layer,

--- a/integration/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -44,8 +44,7 @@ import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.common.jena.ModelOps.*
 import org.knora.webapi.slice.common.jena.ResourceOps.*
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 object LegalInfoE2ESpec extends E2EZSpec {
 
   private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance

--- a/integration/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
@@ -26,7 +26,7 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.anonymousUser
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.User
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.util.ZioScalaTestUtil.assertFailsWithA
 
 class SearchResponderV2Spec extends CoreSpec {

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -23,8 +23,6 @@ import org.knora.webapi.responders.admin.*
 import org.knora.webapi.responders.admin.ListsResponder
 import org.knora.webapi.responders.v2.*
 import org.knora.webapi.responders.v2.ontology.CardinalityHandler
-import org.knora.webapi.responders.v2.ontology.OntologyCacheHelpers
-import org.knora.webapi.responders.v2.ontology.OntologyTriplestoreHelpers
 import org.knora.webapi.routing.*
 import org.knora.webapi.slice.admin.AdminModule
 import org.knora.webapi.slice.admin.api.*
@@ -97,11 +95,9 @@ object LayersLive {
     ListsResponder &
     ListsService &
     MessageRelay &
-    OntologyCacheHelpers &
     OntologyInferencer &
     OntologyApiModule.Provided &
     OntologyResponderV2 &
-    OntologyTriplestoreHelpers &
     PermissionRestService &
     PermissionUtilADM &
     PermissionsResponder &
@@ -159,9 +155,7 @@ object LayersLive {
       ManagementRoutes.layer,
       MessageRelayLive.layer,
       OntologyApiModule.layer,
-      OntologyCacheHelpers.layer,
       OntologyResponderV2.layer,
-      OntologyTriplestoreHelpers.layer,
       PermissionUtilADMLive.layer,
       PermissionsResponder.layer,
       PekkoActorSystem.layer,

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -11,9 +11,7 @@ import zio.ULayer
 import zio.ZLayer
 
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.config.AppConfig.AppConfigurations
 import org.knora.webapi.config.InstrumentationServerConfig
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.*
 import org.knora.webapi.messages.util.search.QueryTraverser
 import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
@@ -37,6 +35,7 @@ import org.knora.webapi.slice.admin.api.service.ProjectRestService
 import org.knora.webapi.slice.admin.api.service.UserRestService
 import org.knora.webapi.slice.admin.domain.service.*
 import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
+import org.knora.webapi.slice.common.BaseModule
 import org.knora.webapi.slice.common.api.*
 import org.knora.webapi.slice.common.repo.service.PredicateObjectMapper
 import org.knora.webapi.slice.infrastructure.InfrastructureModule
@@ -65,8 +64,6 @@ import org.knora.webapi.store.iiif.IIIFRequestMessageHandler
 import org.knora.webapi.store.iiif.IIIFRequestMessageHandlerLive
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.store.iiif.impl.SipiServiceLive
-import org.knora.webapi.store.triplestore.api.TriplestoreService
-import org.knora.webapi.store.triplestore.impl.TriplestoreServiceLive
 import org.knora.webapi.store.triplestore.upgrade.RepositoryUpdater
 
 object LayersLive {
@@ -82,10 +79,11 @@ object LayersLive {
     ApiComplexV2JsonLdRequestParser &
     ApiRoutes &
     ApiV2Endpoints &
-    AppConfigurations &
+    AppConfig.AppConfigurations &
     AssetPermissionsResponder &
     AuthorizationRestService &
     AuthenticationApiModule.Provided &
+    BaseModule.Provided &
     CardinalityHandler &
     CoreModule.Provided &
     ConstructResponseUtilV2 &
@@ -124,8 +122,6 @@ object LayersLive {
     StandoffResponderV2 &
     StandoffTagUtilV2 &
     State &
-    StringFormatter &
-    TriplestoreService &
     UserRestService &
     ValuesResponderV2
     // format: on
@@ -145,6 +141,7 @@ object LayersLive {
       AuthenticationApiModule.layer,
       AuthorizationRestService.layer,
       BaseEndpoints.layer,
+      BaseModule.layer,
       CardinalityHandler.layer,
       ConstructResponseUtilV2.layer,
       CoreModule.layer,
@@ -189,9 +186,7 @@ object LayersLive {
       StandoffResponderV2.layer,
       StandoffTagUtilV2Live.layer,
       State.layer,
-      StringFormatter.live,
       TapirToPekkoInterpreter.layer,
-      TriplestoreServiceLive.layer,
       ValuesResponderV2.layer,
       // ZLayer.Debug.mermaid,
     )

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -44,16 +44,13 @@ import org.knora.webapi.slice.infrastructure.api.ManagementEndpoints
 import org.knora.webapi.slice.infrastructure.api.ManagementRoutes
 import org.knora.webapi.slice.lists.api.ListsApiModule
 import org.knora.webapi.slice.lists.domain.ListsService
+import org.knora.webapi.slice.ontology.CoreModule
 import org.knora.webapi.slice.ontology.api.OntologyApiModule
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityServiceLive
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
-import org.knora.webapi.slice.ontology.domain.service.OntologyServiceLive
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
-import org.knora.webapi.slice.ontology.repo.service.OntologyCacheLive
-import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
-import org.knora.webapi.slice.ontology.repo.service.PredicateRepositoryLive
 import org.knora.webapi.slice.resourceinfo.ResourceInfoLayers
 import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.api.ResourcesApiModule
@@ -91,6 +88,7 @@ object LayersLive {
     AuthorizationRestService &
     AuthenticationApiModule.Provided &
     CardinalityHandler &
+    CoreModule.Provided &
     ConstructResponseUtilV2 &
     DefaultObjectAccessPermissionService &
     GroupRestService &
@@ -103,7 +101,6 @@ object LayersLive {
     ListsResponder &
     ListsService &
     MessageRelay &
-    OntologyCache &
     OntologyCacheHelpers &
     OntologyInferencer &
     OntologyApiModule.Provided &
@@ -151,8 +148,8 @@ object LayersLive {
       AuthorizationRestService.layer,
       BaseEndpoints.layer,
       CardinalityHandler.layer,
-      CardinalityService.layer,
       ConstructResponseUtilV2.layer,
+      CoreModule.layer,
       DspIngestClientLive.layer,
       HandlerMapper.layer,
       HttpServer.layer,
@@ -169,16 +166,12 @@ object LayersLive {
       MessageRelayLive.layer,
       OntologyApiModule.layer,
       OntologyCacheHelpers.layer,
-      OntologyCacheLive.layer,
-      OntologyRepoLive.layer,
       OntologyResponderV2.layer,
-      OntologyServiceLive.layer,
       OntologyTriplestoreHelpers.layer,
       PermissionUtilADMLive.layer,
       PermissionsResponder.layer,
       PekkoActorSystem.layer,
       PredicateObjectMapper.layer,
-      PredicateRepositoryLive.layer,
       ProjectExportServiceLive.layer,
       ProjectExportStorageServiceLive.layer,
       ProjectImportService.layer,

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -52,7 +52,6 @@ import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resourceinfo.ResourceInfoLayers
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.api.ResourcesApiModule
 import org.knora.webapi.slice.resources.repo.service.ResourcesRepoLive
 import org.knora.webapi.slice.search.api.SearchApiRoutes
@@ -96,7 +95,6 @@ object LayersLive {
     IIIFRequestMessageHandler &
     InfrastructureModule.Provided &
     InstrumentationServerConfig &
-    IriConverter &
     ListsApiModule.Provided &
     ListsResponder &
     ListsService &
@@ -155,7 +153,6 @@ object LayersLive {
       HttpServer.layer,
       IIIFRequestMessageHandlerLive.layer,
       InfrastructureModule.layer,
-      IriConverter.layer,
       IriService.layer,
       KnoraResponseRenderer.layer,
       ListsApiModule.layer,

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/JsonLDUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/JsonLDUtil.scala
@@ -35,7 +35,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.routing.RouteUtilZ
 import org.knora.webapi.slice.common.Value.StringValue
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.util.WithAsIs
 
 /*

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/ConstructTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/ConstructTransformer.scala
@@ -9,8 +9,7 @@ import zio.*
 
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.util.search.*
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 final case class ConstructTransformer(
   sparqlTransformerLive: OntologyInferencer,
   iriConverter: IriConverter,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -51,8 +51,8 @@ import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ResourceOps
 import org.knora.webapi.slice.common.jena.ResourceOps.*
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.api.SipiService

--- a/webapi/src/main/scala/org/knora/webapi/responders/IriService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/IriService.scala
@@ -18,7 +18,7 @@ import org.knora.webapi.messages.twirl.queries.sparql
 import org.knora.webapi.slice.admin.domain.model.GroupIri
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.UserIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -49,8 +49,8 @@ import org.knora.webapi.slice.admin.repo.service.DefaultObjectAccessPermissionRe
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -32,9 +32,7 @@ import org.knora.webapi.responders.IriLocker
 import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.Responder
 import org.knora.webapi.responders.v2.ontology.CardinalityHandler
-import org.knora.webapi.responders.v2.ontology.OntologyCacheHelpers
 import org.knora.webapi.responders.v2.ontology.OntologyHelpers
-import org.knora.webapi.responders.v2.ontology.OntologyTriplestoreHelpers
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
@@ -42,7 +40,9 @@ import org.knora.webapi.slice.ontology.domain.model.Cardinality
 import org.knora.webapi.slice.ontology.domain.model.OntologyName
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanSetCardinalityCheckResult
+import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
+import org.knora.webapi.slice.ontology.domain.service.OntologyTriplestoreHelpers
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache.ONTOLOGY_CACHE_LOCK_IRI
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
@@ -1521,7 +1521,8 @@ final case class OntologyResponderV2(
   /**
    * Checks whether an ontology can be deleted.
    *
-   * @param canDeleteOntologyRequest the request message.
+   * @param ontologyIri the ontology to delete.
+   * @param requestingUser the user making the request.
    * @return a [[CanDoResponseV2]] indicating whether an ontology can be deleted.
    */
   private def canDeleteOntology(ontologyIri: OntologyIri, requestingUser: User): Task[CanDoResponseV2] = for {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -52,8 +52,8 @@ import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV
 import org.knora.webapi.messages.v2.responder.resourcemessages.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2Module.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2Module.scala
@@ -19,8 +19,8 @@ import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInf
 import org.knora.webapi.messages.util.search.gravsearch.types.*
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.slice.admin.domain.service.ProjectService
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 
 object SearchResponderV2Module {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -49,8 +49,8 @@ import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.AtLeastOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ontology/CardinalityHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ontology/CardinalityHandler.scala
@@ -18,6 +18,8 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.twirl.queries.sparql
 import org.knora.webapi.messages.v2.responder.CanDoResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.*
+import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
+import org.knora.webapi.slice.ontology.domain.service.OntologyTriplestoreHelpers
 import org.knora.webapi.slice.ontology.repo.model.OntologyCacheData
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri

--- a/webapi/src/main/scala/org/knora/webapi/routing/ApiRoutes.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/ApiRoutes.scala
@@ -32,8 +32,8 @@ import org.knora.webapi.slice.infrastructure.api.ManagementRoutes
 import org.knora.webapi.slice.lists.api.ListsApiV2Routes
 import org.knora.webapi.slice.ontology.api.OntologyV2RequestParser
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resourceinfo.api.ResourceInfoRoutes
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.api.ResourcesApiRoutes
 import org.knora.webapi.slice.search.api.SearchApiRoutes
 import org.knora.webapi.slice.security.Authenticator as WebApiAuthenticator

--- a/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV2.scala
@@ -23,7 +23,7 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.util.rdf.RdfFormat
 import org.knora.webapi.messages.v2.responder.KnoraResponseV2
 import org.knora.webapi.slice.common.api.ApiV2
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 
 import ApiV2.Headers.xKnoraAcceptMarkup
 import ApiV2.Headers.xKnoraAcceptProject

--- a/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilZ.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilZ.scala
@@ -17,8 +17,7 @@ import org.knora.webapi.IRI
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 object RouteUtilZ { self =>
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -31,7 +31,7 @@ import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.ontology.api.OntologyV2RequestParser
 import org.knora.webapi.slice.ontology.api.service.RestCardinalityService
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.security.Authenticator
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/StandoffRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/StandoffRouteV2.scala
@@ -23,7 +23,7 @@ import org.knora.webapi.messages.v2.responder.standoffmessages.CreateMappingRequ
 import org.knora.webapi.routing.RouteUtilV2
 import org.knora.webapi.routing.RouteUtilZ
 import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.security.Authenticator
 
 import pekko.actor.ActorSystem

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/AdminModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/AdminModule.scala
@@ -15,9 +15,9 @@ import org.knora.webapi.slice.admin.domain.service.DspIngestClient
 import org.knora.webapi.slice.admin.repo.AdminRepoModule
 import org.knora.webapi.slice.common.repo.service.PredicateObjectMapper
 import org.knora.webapi.slice.infrastructure.CacheManager
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 
 object AdminModule

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/AdminDomainModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/AdminDomainModule.scala
@@ -20,9 +20,9 @@ import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.admin.domain.service.maintenance.MaintenanceService
 import org.knora.webapi.slice.admin.repo.AdminRepoModule
 import org.knora.webapi.slice.infrastructure.CacheManager
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 
 object AdminDomainModule

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -46,7 +46,7 @@ import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.common.jena.ModelOps.*
 import org.knora.webapi.slice.common.jena.ResourceOps.*
 import org.knora.webapi.slice.common.jena.StatementOps.*
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.store.iiif.api.SipiService
 
 final case class ApiComplexV2JsonLdRequestParser(

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/BaseModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/BaseModule.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.common
 import zio.URLayer
 import zio.ZLayer

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/BaseModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/BaseModule.scala
@@ -1,0 +1,16 @@
+package org.knora.webapi.slice.common
+import zio.URLayer
+import zio.ZLayer
+
+import org.knora.webapi.config.AppConfig
+import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.URModule
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+import org.knora.webapi.store.triplestore.impl.TriplestoreServiceLive
+
+object BaseModule extends URModule[AppConfig.AppConfigurations, StringFormatter & TriplestoreService] { self =>
+
+  override val layer: URLayer[self.Dependencies, self.Provided] =
+    StringFormatter.live >+> TriplestoreServiceLive.layer
+
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/repo/service/PredicateObjectMapper.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/repo/service/PredicateObjectMapper.scala
@@ -11,7 +11,7 @@ import dsp.errors.InconsistentRepositoryDataException
 import org.knora.webapi.IRI
 import org.knora.webapi.messages.store.triplestoremessages.LiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.SparqlExtendedConstructResponse.ConstructPredicateObjects
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 
 /**
  * The [[PredicateObjectMapper]] is a service which provides methods to extract values from a [[ConstructPredicateObjects]].

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/CoreModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/CoreModule.scala
@@ -7,13 +7,17 @@ package org.knora.webapi.slice.ontology
 import zio.URLayer
 import zio.ZLayer
 
+import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.URModule
+import org.knora.webapi.slice.common.BaseModule
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.domain.service.OntologyService
 import org.knora.webapi.slice.ontology.domain.service.OntologyServiceLive
+import org.knora.webapi.slice.ontology.domain.service.OntologyTriplestoreHelpers
 import org.knora.webapi.slice.ontology.domain.service.PredicateRepository
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.ontology.repo.service.OntologyCacheLive
@@ -23,17 +27,20 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService
 
 object CoreModule
     extends URModule[
-      StringFormatter & TriplestoreService,
-      CardinalityService & IriConverter & OntologyCache & OntologyRepo & OntologyService,
+      AppConfig.AppConfigurations & BaseModule.Provided,
+      CardinalityService & IriConverter & OntologyCache & OntologyCacheHelpers & OntologyRepo & OntologyService &
+        OntologyTriplestoreHelpers,
     ] {
   self =>
 
   val layer: URLayer[self.Dependencies, self.Provided] = ZLayer.makeSome[self.Dependencies, self.Provided](
-    IriConverter.layer,
-    OntologyCacheLive.layer,
-    OntologyServiceLive.layer,
-    OntologyRepoLive.layer,
-    PredicateRepositoryLive.layer,
     CardinalityService.layer,
+    IriConverter.layer,
+    OntologyCacheHelpers.layer,
+    OntologyCacheLive.layer,
+    OntologyRepoLive.layer,
+    OntologyServiceLive.layer,
+    OntologyTriplestoreHelpers.layer,
+    PredicateRepositoryLive.layer,
   )
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/CoreModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/CoreModule.scala
@@ -10,6 +10,7 @@ import zio.ZLayer
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.URModule
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.domain.service.OntologyService
 import org.knora.webapi.slice.ontology.domain.service.OntologyServiceLive
@@ -18,17 +19,17 @@ import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.ontology.repo.service.OntologyCacheLive
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
 import org.knora.webapi.slice.ontology.repo.service.PredicateRepositoryLive
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 
 object CoreModule
     extends URModule[
-      IriConverter & StringFormatter & TriplestoreService,
-      CardinalityService & OntologyCache & OntologyRepo & OntologyService,
+      StringFormatter & TriplestoreService,
+      CardinalityService & IriConverter & OntologyCache & OntologyRepo & OntologyService,
     ] {
   self =>
 
   val layer: URLayer[self.Dependencies, self.Provided] = ZLayer.makeSome[self.Dependencies, self.Provided](
+    IriConverter.layer,
     OntologyCacheLive.layer,
     OntologyServiceLive.layer,
     OntologyRepoLive.layer,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/CoreModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/CoreModule.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.ontology
+import zio.URLayer
+import zio.ZLayer
+
+import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.URModule
+import org.knora.webapi.slice.ontology.domain.service.CardinalityService
+import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
+import org.knora.webapi.slice.ontology.domain.service.OntologyService
+import org.knora.webapi.slice.ontology.domain.service.OntologyServiceLive
+import org.knora.webapi.slice.ontology.domain.service.PredicateRepository
+import org.knora.webapi.slice.ontology.repo.service.OntologyCache
+import org.knora.webapi.slice.ontology.repo.service.OntologyCacheLive
+import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
+import org.knora.webapi.slice.ontology.repo.service.PredicateRepositoryLive
+import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+
+object CoreModule
+    extends URModule[
+      IriConverter & StringFormatter & TriplestoreService,
+      CardinalityService & OntologyCache & OntologyRepo & OntologyService,
+    ] {
+  self =>
+
+  val layer: URLayer[self.Dependencies, self.Provided] = ZLayer.makeSome[self.Dependencies, self.Provided](
+    OntologyCacheLive.layer,
+    OntologyServiceLive.layer,
+    OntologyRepoLive.layer,
+    PredicateRepositoryLive.layer,
+    CardinalityService.layer,
+  )
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologyApiModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologyApiModule.scala
@@ -7,8 +7,7 @@ package org.knora.webapi.slice.ontology.api
 import zio.*
 
 import org.knora.webapi.slice.URModule
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 object OntologyApiModule extends URModule[IriConverter, OntologyV2RequestParser] { self =>
 
   val layer: URLayer[self.Dependencies, self.Provided] =

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologyV2RequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologyV2RequestParser.scala
@@ -59,8 +59,7 @@ import org.knora.webapi.slice.common.jena.ModelOps.*
 import org.knora.webapi.slice.common.jena.ResourceOps.*
 import org.knora.webapi.slice.common.jena.StatementOps.*
 import org.knora.webapi.slice.ontology.domain.model.Cardinality
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 final case class OntologyV2RequestParser(iriConverter: IriConverter) {
 
   private final case class OntologyMetadata(

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/RestCardinalityServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/RestCardinalityServiceLive.scala
@@ -28,10 +28,9 @@ import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanReplaceCardinalityCheckResult
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanReplaceCardinalityCheckResult.CanReplaceCardinalityCheckResult
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanSetCardinalityCheckResult
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
 trait RestCardinalityService {
 
   def canChangeCardinality(

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/CardinalityService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/CardinalityService.scala
@@ -297,9 +297,5 @@ final case class CardinalityServiceLive(
 }
 
 object CardinalityService {
-  val layer: ZLayer[
-    StringFormatter & TriplestoreService & PredicateRepository & OntologyRepo & IriConverter,
-    Nothing,
-    CardinalityServiceLive,
-  ] = ZLayer.fromFunction(CardinalityServiceLive.apply _)
+  val layer = ZLayer.derive[CardinalityServiceLive]
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/CardinalityService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/CardinalityService.scala
@@ -21,7 +21,6 @@ import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResu
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanSetCardinalityCheckResult.SubclassCheckFailure
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanSetCardinalityCheckResult.SuperClassCheckFailure
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 import org.knora.webapi.util.EitherUtil.joinOnLeft

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/IriConverter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/IriConverter.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.knora.webapi.slice.resourceinfo.domain
+package org.knora.webapi.slice.ontology.domain.service
 
 import zio.IO
 import zio.Task
@@ -15,6 +15,7 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.resourceinfo.domain.InternalIri
 
 final case class IriConverter(sf: StringFormatter) {
   def asSmartIri(iri: String): Task[SmartIri]              = ZIO.attempt(sf.toSmartIri(iri, requireInternal = false))
@@ -44,5 +45,5 @@ final case class IriConverter(sf: StringFormatter) {
 }
 
 object IriConverter {
-  val layer: ZLayer[StringFormatter, Nothing, IriConverter] = ZLayer.derive[IriConverter]
+  val layer = ZLayer.derive[IriConverter]
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyCacheHelpers.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyCacheHelpers.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.knora.webapi.responders.v2.ontology
+package org.knora.webapi.slice.ontology.domain.service
 
 import zio.*
 
@@ -14,6 +14,7 @@ import org.knora.webapi.*
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.util.ErrorHandlingMap
 import org.knora.webapi.messages.v2.responder.ontologymessages.*
+import org.knora.webapi.responders.v2.ontology.OntologyHelpers
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.*
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
@@ -337,4 +338,6 @@ final case class OntologyCacheHelpers(ontologyCache: OntologyCache) {
     } yield requestingUser.permissions.isProjectAdmin(projectIri.toString) || requestingUser.permissions.isSystemAdmin
 }
 
-object OntologyCacheHelpers { val layer = ZLayer.derive[OntologyCacheHelpers] }
+object OntologyCacheHelpers {
+  val layer = ZLayer.derive[OntologyCacheHelpers]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyTriplestoreHelpers.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyTriplestoreHelpers.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.knora.webapi.responders.v2.ontology
+package org.knora.webapi.slice.ontology.domain.service
 
 import zio.*
 
@@ -18,7 +18,6 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.twirl.queries.sparql
 import org.knora.webapi.messages.v2.responder.ontologymessages.*
-import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 
@@ -71,4 +70,6 @@ final case class OntologyTriplestoreHelpers(
   }
 }
 
-object OntologyTriplestoreHelpers { val layer = ZLayer.derive[OntologyTriplestoreHelpers] }
+object OntologyTriplestoreHelpers {
+  val layer = ZLayer.derive[OntologyTriplestoreHelpers]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/OntologyRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/OntologyRepoLive.scala
@@ -21,11 +21,10 @@ import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.*
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.repo.model.OntologyCacheData
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
 final case class OntologyRepoLive(private val converter: IriConverter, private val ontologyCache: OntologyCache)
     extends OntologyRepo {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resourceinfo/ResourceInfoLayers.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resourceinfo/ResourceInfoLayers.scala
@@ -10,10 +10,10 @@ import zio.ZLayer
 import org.knora.webapi.slice.common.api.BaseEndpoints
 import org.knora.webapi.slice.common.api.HandlerMapper
 import org.knora.webapi.slice.common.api.TapirToPekkoInterpreter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resourceinfo.api.ResourceInfoEndpoints
 import org.knora.webapi.slice.resourceinfo.api.ResourceInfoRoutes
 import org.knora.webapi.slice.resourceinfo.api.service.RestResourceInfoService
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resourceinfo.repo.ResourceInfoRepoLive
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resourceinfo/api/service/RestResourceInfoService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resourceinfo/api/service/RestResourceInfoService.scala
@@ -12,10 +12,10 @@ import java.time.Instant
 import dsp.errors.BadRequestException
 import org.knora.webapi.IRI
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resourceinfo.api.model.ListResponseDto
 import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.*
 import org.knora.webapi.slice.resourceinfo.api.model.ResourceInfoDto
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resourceinfo.domain.ResourceInfoRepo
 
 final case class RestResourceInfoService(repo: ResourceInfoRepo, iriConverter: IriConverter) {

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/api/ResourcesApiModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/api/ResourcesApiModule.scala
@@ -18,7 +18,7 @@ import org.knora.webapi.slice.common.api.BaseEndpoints
 import org.knora.webapi.slice.common.api.HandlerMapper
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer
 import org.knora.webapi.slice.common.api.TapirToPekkoInterpreter
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resources.api.service.ResourcesRestService
 import org.knora.webapi.slice.resources.api.service.ValuesRestService
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/api/service/ResourcesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/api/service/ResourcesRestService.scala
@@ -16,7 +16,7 @@ import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.FormatOptions
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.RenderedResponse
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resources.api.model.GraphDirection
 import org.knora.webapi.slice.resources.api.model.IriDto
 import org.knora.webapi.slice.resources.api.model.VersionDate

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/api/SearchEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/api/SearchEndpoints.scala
@@ -27,7 +27,7 @@ import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.api.*
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.FormatOptions
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.RenderedResponse
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.search.api.SearchEndpointsInputs.InputIri
 import org.knora.webapi.slice.search.api.SearchEndpointsInputs.Offset
 

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/JsonLDObjectSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/rdf/JsonLDObjectSpec.scala
@@ -16,8 +16,7 @@ import dsp.errors.BadRequestException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 object JsonLDObjectSpec extends ZIOSpecDefault {
 
   override def spec: Spec[TestEnvironment & Scope, Any] =

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/ConstructTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/ConstructTransformerSpec.scala
@@ -14,9 +14,8 @@ import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.search.*
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyCacheFake
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
 object ConstructTransformerSpec extends ZIOSpecDefault {
 
   private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/api/service/AuthorizationRestServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/api/service/AuthorizationRestServiceSpec.scala
@@ -28,9 +28,9 @@ import org.knora.webapi.slice.admin.repo.service.KnoraGroupRepoInMemory
 import org.knora.webapi.slice.admin.repo.service.KnoraUserRepoLive
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.infrastructure.CacheManager
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoInMemory
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.impl.TriplestoreServiceLive
 
 object AuthorizationRestServiceSpec extends ZIOSpecDefault {

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/api/service/MaintenanceServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/api/service/MaintenanceServiceSpec.scala
@@ -20,8 +20,8 @@ import org.knora.webapi.slice.admin.domain.repo.KnoraProjectRepoInMemory
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.admin.domain.service.maintenance.MaintenanceService
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoInMemory
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TestTripleStore
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/GroupServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/GroupServiceSpec.scala
@@ -27,9 +27,9 @@ import org.knora.webapi.slice.admin.domain.repo.KnoraProjectRepoInMemory
 import org.knora.webapi.slice.admin.repo.service.KnoraGroupRepoInMemory
 import org.knora.webapi.slice.admin.repo.service.KnoraUserRepoLive
 import org.knora.webapi.slice.infrastructure.CacheManager
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyCacheLive
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory
 
 object GroupServiceSpec extends ZIOSpecDefault {

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LegalInfoServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LegalInfoServiceSpec.scala
@@ -19,8 +19,8 @@ import org.knora.webapi.slice.admin.domain.model.License
 import org.knora.webapi.slice.admin.domain.model.LicenseIri
 import org.knora.webapi.slice.admin.domain.repo.KnoraProjectRepoInMemory
 import org.knora.webapi.slice.admin.repo.LicenseRepo
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoInMemory
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory
 
 object LegalInfoServiceSpec extends ZIOSpecDefault {

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
@@ -53,8 +53,8 @@ import org.knora.webapi.slice.admin.domain.service.*
 import org.knora.webapi.slice.admin.repo.service.*
 import org.knora.webapi.slice.common.JsonLdTestUtil.JsonLdTransformations
 import org.knora.webapi.slice.common.KnoraIris.*
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoInMemory
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.api.SipiService

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
@@ -14,8 +14,7 @@ import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.KnoraIrisSpec.test
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 object KnoraIrisSpec extends ZIOSpecDefault {
 
   private val converter = ZIO.serviceWithZIO[IriConverter]

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/api/OntologyV2RequestParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/api/OntologyV2RequestParserSpec.scala
@@ -34,8 +34,7 @@ import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.jena.DatasetOps.*
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 object OntologyV2RequestParserSpec extends ZIOSpecDefault {
   private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/api/service/RestCardinalityServiceLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/api/service/RestCardinalityServiceLiveSpec.scala
@@ -23,10 +23,10 @@ import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.*
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanReplaceCardinalityCheckResult.IsInUseCheckFailure
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyCacheFake
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resourceinfo.domain.IriTestConstants
 import org.knora.webapi.util.JsonHelper.StringToJson
 import org.knora.webapi.util.JsonHelper.renderResponseJson

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/CardinalityServiceLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/domain/CardinalityServiceLiveSpec.scala
@@ -20,12 +20,12 @@ import org.knora.webapi.slice.ontology.domain.model.Cardinality.*
 import org.knora.webapi.slice.ontology.domain.model.CardinalitySpec.Generator.cardinalitiesGen
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.ChangeCardinalityCheckResult.CanSetCardinalityCheckResult.*
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.model.OntologyCacheData
 import org.knora.webapi.slice.ontology.repo.service.OntologyCacheFake
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
 import org.knora.webapi.slice.ontology.repo.service.PredicateRepositoryLive
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resourceinfo.domain.IriTestConstants.*
 import org.knora.webapi.store.triplestore.TestDatasetBuilder.*
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/OntologyCacheFakeSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/OntologyCacheFakeSpec.scala
@@ -10,11 +10,10 @@ import zio.test.*
 import zio.test.ZIOSpecDefault
 
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.ontology.repo.service.OntologyCacheFake
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
 object OntologyCacheFakeSpec extends ZIOSpecDefault {
   val spec: Spec[Any, Throwable] = suite("OntologyCacheFake")(
     suite("with empty cache")(test("should return empty") {

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/service/OntologyRepoLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/service/OntologyRepoLiveSpec.scala
@@ -16,9 +16,9 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.ontology.domain.OntologyCacheDataBuilder
 import org.knora.webapi.slice.ontology.domain.ReadClassInfoV2Builder
 import org.knora.webapi.slice.ontology.domain.ReadOntologyV2Builder
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resourceinfo.domain.IriTestConstants.Anything
 import org.knora.webapi.slice.resourceinfo.domain.IriTestConstants.Biblio
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/resourceinfo/api/IriConverterLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resourceinfo/api/IriConverterLiveSpec.scala
@@ -9,9 +9,8 @@ import zio.ZIO
 import zio.test.*
 
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
-
 object IriConverterLiveSpec extends ZIOSpecDefault {
 
   private val iriConverter    = ZIO.serviceWithZIO[IriConverter]

--- a/webapi/src/test/scala/org/knora/webapi/slice/resourceinfo/api/LiveRestResourceInfoServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resourceinfo/api/LiveRestResourceInfoServiceSpec.scala
@@ -17,6 +17,7 @@ import dsp.errors.BadRequestException
 import org.knora.webapi.IRI
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.resourceinfo.api.model.ListResponseDto
 import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.Asc
 import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.CreationDate
@@ -26,7 +27,6 @@ import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.Order
 import org.knora.webapi.slice.resourceinfo.api.model.QueryParams.OrderBy
 import org.knora.webapi.slice.resourceinfo.api.model.ResourceInfoDto
 import org.knora.webapi.slice.resourceinfo.api.service.RestResourceInfoService
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.slice.resourceinfo.domain.ResourceInfo
 import org.knora.webapi.slice.resourceinfo.repo.ResourceInfoRepoFake
 import org.knora.webapi.slice.resourceinfo.repo.ResourceInfoRepoFake.knownProjectIRI

--- a/webapi/src/test/scala/org/knora/webapi/slice/security/AuthenticatorLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/security/AuthenticatorLiveSpec.scala
@@ -46,9 +46,9 @@ import org.knora.webapi.slice.infrastructure.InvalidTokenCache
 import org.knora.webapi.slice.infrastructure.JwtService
 import org.knora.webapi.slice.infrastructure.JwtServiceLive
 import org.knora.webapi.slice.infrastructure.Scope as AuthScope
+import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyCacheFake
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
-import org.knora.webapi.slice.resourceinfo.domain.IriConverter
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory
 
 object AuthenticatorLiveSpec extends ZIOSpecDefault {


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description
- **refactor: Introduce CoreModule and BaseModule**
- **refactor: Move components into CoreModule and BaseModule**
- **refactor: Move`IriConverter` to `org.knora.webapi.slice.ontology.domain.service.IriConverter`**


I have been experience [Class too big compile errors again](https://github.com/zio/zio/issues/8855). 
In order to reduce the class size I am continuing to move services into modules.
This is the first step and introduces the CoreModule and BaseModule.

I am currently playing on the idea of merging the values/resources/resourceinfo and ontology slices into a core slice.
Hence the name `CoreModule` rather than `OntologyModule`. 
In this core slice we could modularize even further. 
Using a single core module would make it easier to move the responders into the core module and then refactor it further, wdyt?
<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
