### PR TITLE
fix: Ensure that legal info String value objects are rendered as String in OpenApi yml (DEV-4695)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.admin.domain.model
 
+import sttp.tapir.Schema
 import zio.Chunk
 import zio.NonEmptyChunk
 import zio.json.JsonCodec
@@ -31,6 +32,7 @@ import org.knora.webapi.slice.common.Value.StringValue
 final case class CopyrightHolder private (override val value: String) extends StringValue
 object CopyrightHolder extends StringValueCompanion[CopyrightHolder] {
   given JsonCodec[CopyrightHolder] = ZioJsonCodec.stringCodec(CopyrightHolder.from)
+  given Schema[CopyrightHolder]    = Schema.string
   given Ordering[CopyrightHolder]  = Ordering.by(_.value)
   def from(str: String): Either[String, CopyrightHolder] =
     fromValidations(
@@ -43,6 +45,7 @@ object CopyrightHolder extends StringValueCompanion[CopyrightHolder] {
 final case class Authorship private (override val value: String) extends StringValue
 object Authorship extends StringValueCompanion[Authorship] {
   given JsonCodec[Authorship] = ZioJsonCodec.stringCodec(Authorship.from)
+  given Schema[Authorship]    = Schema.string
   def from(str: String): Either[String, Authorship] =
     fromValidations("Authorship", Authorship.apply, List(nonEmpty, noLineBreaks, maxLength(1_000)))(str)
 }
@@ -50,6 +53,7 @@ object Authorship extends StringValueCompanion[Authorship] {
 final case class LicenseIri private (override val value: String) extends StringValue
 object LicenseIri extends StringValueCompanion[LicenseIri] {
   given JsonCodec[LicenseIri] = ZioJsonCodec.stringCodec(LicenseIri.from)
+  given Schema[LicenseIri]    = Schema.string
 
   /**
    * Explanation of the IRI regex:


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
