### PR TITLE
refactor: Migrate ontology endpoints to tapir pt. 3

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -375,14 +375,8 @@ class OntologyV2R2RSpec extends R2RSpec {
 
     "determine that an ontology can be deleted" in {
       val fooIriEncoded = URLEncoder.encode(fooIri.get, "UTF-8")
-      val responseJsonDoc = UnsafeZioRun.runOrThrow(
-        ZIO.serviceWithZIO[TestClientService](
-          _.getResponseJsonLD(
-            Get(s"$apiBaseUrl/v2/ontologies/candeleteontology/$fooIriEncoded") ~>
-              addCredentials(anythingUserCreds),
-          ),
-        ),
-      )
+      val responseJsonDoc =
+        jsonLdResponse(Get(s"$apiBaseUrl/v2/ontologies/candeleteontology/$fooIriEncoded"), anythingUserCreds)
       assert(responseJsonDoc.body.value(KnoraApiV2Complex.CanDo).asInstanceOf[JsonLDBoolean].value)
     }
 
@@ -2216,15 +2210,9 @@ class OntologyV2R2RSpec extends R2RSpec {
 
     "determine that a class can be deleted" in {
       val classSegment = URLEncoder.encode("http://0.0.0.0:3333/ontology/0001/anything/v2#Nothing", "UTF-8")
-
-      Get(s"/v2/ontologies/candeleteclass/$classSegment") ~> addCredentials(
-        anythingUserCreds,
-      ) ~> ontologiesPath ~> check {
-        val responseStr = responseAs[String]
-        assert(status == StatusCodes.OK, responseStr)
-        val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
-        assert(responseJsonDoc.body.value(KnoraApiV2Complex.CanDo).asInstanceOf[JsonLDBoolean].value)
-      }
+      val responseJsonDoc =
+        jsonLdResponse(Get(s"$apiBaseUrl/v2/ontologies/candeleteclass/$classSegment"), anythingUserCreds)
+      assert(responseJsonDoc.body.value(KnoraApiV2Complex.CanDo).asInstanceOf[JsonLDBoolean].value)
     }
 
     "delete the class anything:Nothing" in {
@@ -3121,42 +3109,22 @@ class OntologyV2R2RSpec extends R2RSpec {
   }
 
   "determine that a class cannot be deleted" in {
-    val thingIri = URLEncoder.encode("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing", "UTF-8")
-
-    Get(s"/v2/ontologies/candeleteclass/$thingIri") ~> addCredentials(
-      anythingUserCreds,
-    ) ~> ontologiesPath ~> check {
-      val responseStr = responseAs[String]
-      assert(status == StatusCodes.OK, responseStr)
-      val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
-      assert(!responseJsonDoc.body.value(KnoraApiV2Complex.CanDo).asInstanceOf[JsonLDBoolean].value)
-    }
+    val thingIri        = URLEncoder.encode("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing", "UTF-8")
+    val responseJsonDoc = jsonLdResponse(Get(s"$apiBaseUrl/v2/ontologies/candeleteclass/$thingIri"), anythingUserCreds)
+    assert(!responseJsonDoc.body.value(KnoraApiV2Complex.CanDo).asInstanceOf[JsonLDBoolean].value)
   }
 
   "determine that a property cannot be deleted" in {
     val propertySegment = URLEncoder.encode("http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger", "UTF-8")
     val responseJsonDoc =
-      UnsafeZioRun.runOrThrow(
-        ZIO.serviceWithZIO[TestClientService](
-          _.getResponseJsonLD(
-            Get(s"$apiBaseUrl/v2/ontologies/candeleteproperty/$propertySegment")
-              ~> addCredentials(anythingUserCreds),
-          ),
-        ),
-      )
+      jsonLdResponse(Get(s"$apiBaseUrl/v2/ontologies/candeleteproperty/$propertySegment"), anythingUserCreds)
     assert(!responseJsonDoc.body.value(KnoraApiV2Complex.CanDo).asInstanceOf[JsonLDBoolean].value)
   }
 
   "determine that an ontology cannot be deleted" in {
     val ontologyIri = URLEncoder.encode("http://0.0.0.0:3333/ontology/0001/anything/v2", "UTF-8")
-    val responseJsonDoc = UnsafeZioRun.runOrThrow(
-      ZIO.serviceWithZIO[TestClientService](
-        _.getResponseJsonLD(
-          Get(s"$apiBaseUrl/v2/ontologies/candeleteontology/$ontologyIri") ~>
-            addCredentials(anythingUserCreds),
-        ),
-      ),
-    )
+    val responseJsonDoc =
+      jsonLdResponse(Get(s"$apiBaseUrl/v2/ontologies/candeleteontology/$ontologyIri"), anythingUserCreds)
     assert(!responseJsonDoc.body.value(KnoraApiV2Complex.CanDo).asInstanceOf[JsonLDBoolean].value)
   }
 

--- a/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -509,25 +509,28 @@ class OntologyV2R2RSpec extends R2RSpec {
 
       // Convert the submitted JSON-LD to an InputOntologyV2, without SPARQL-escaping, so we can compare it to the response.
       val paramsAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(JsonLDUtil.parseJsonLD(params)).unescape
+      val responseJsonDoc = UnsafeZioRun.runOrThrow(
+        ZIO.serviceWithZIO[TestClientService](
+          _.getResponseJsonLD(
+            Put(
+              s"$apiBaseUrl/v2/ontologies/properties",
+              HttpEntity(RdfMediaTypes.`application/ld+json`, params),
+            ) ~> addCredentials(BasicHttpCredentials(anythingUsername, password)),
+          ),
+        ),
+      )
 
-      Put("/v2/ontologies/properties", HttpEntity(RdfMediaTypes.`application/ld+json`, params)) ~> addCredentials(
-        BasicHttpCredentials(anythingUsername, password),
-      ) ~> ontologiesPath ~> check {
-        assert(status == StatusCodes.OK, response.toString)
-        val responseJsonDoc = responseToJsonLDDocument(response)
+      // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
+      val responseAsInput: InputOntologyV2 =
+        InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
+      responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects.toSet should ===(
+        paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects.toSet,
+      )
 
-        // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-        val responseAsInput: InputOntologyV2 =
-          InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
-        responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects.toSet should ===(
-          paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects.toSet,
-        )
-
-        // Check that the ontology's last modification date was updated.
-        val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
-        assert(newAnythingLastModDate.isAfter(anythingLastModDate))
-        anythingLastModDate = newAnythingLastModDate
-      }
+      // Check that the ontology's last modification date was updated.
+      val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
+      assert(newAnythingLastModDate.isAfter(anythingLastModDate))
+      anythingLastModDate = newAnythingLastModDate
     }
 
     "change the rdfs:comment of a property" in {
@@ -566,27 +569,33 @@ class OntologyV2R2RSpec extends R2RSpec {
       // Convert the submitted JSON-LD to an InputOntologyV2, without SPARQL-escaping, so we can compare it to the response.
       val paramsAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(JsonLDUtil.parseJsonLD(params)).unescape
 
-      Put("/v2/ontologies/properties", HttpEntity(RdfMediaTypes.`application/ld+json`, params)) ~> addCredentials(
-        BasicHttpCredentials(anythingUsername, password),
-      ) ~> ontologiesPath ~> check {
-        assert(status == StatusCodes.OK, response.toString)
-        val responseJsonDoc = responseToJsonLDDocument(response)
+      val responseJsonDoc = UnsafeZioRun.runOrThrow(
+        ZIO.serviceWithZIO[TestClientService](
+          _.getResponseJsonLD(
+            Put(
+              s"$apiBaseUrl/v2/ontologies/properties",
+              HttpEntity(RdfMediaTypes.`application/ld+json`, params),
+            ) ~> addCredentials(
+              BasicHttpCredentials(anythingUsername, password),
+            ),
+          ),
+        ),
+      )
 
-        // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-        val responseAsInput: InputOntologyV2 =
-          InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
-        responseAsInput.properties.head._2
-          .predicates(OntologyConstants.Rdfs.Comment.toSmartIri)
-          .objects
-          .toSet should ===(
-          paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects.toSet,
-        )
+      // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
+      val responseAsInput: InputOntologyV2 =
+        InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
+      responseAsInput.properties.head._2
+        .predicates(OntologyConstants.Rdfs.Comment.toSmartIri)
+        .objects
+        .toSet should ===(
+        paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects.toSet,
+      )
 
-        // Check that the ontology's last modification date was updated.
-        val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
-        assert(newAnythingLastModDate.isAfter(anythingLastModDate))
-        anythingLastModDate = newAnythingLastModDate
-      }
+      // Check that the ontology's last modification date was updated.
+      val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
+      assert(newAnythingLastModDate.isAfter(anythingLastModDate))
+      anythingLastModDate = newAnythingLastModDate
     }
 
     "add an rdfs:comment to a link property that has no rdfs:comment" in {
@@ -623,25 +632,29 @@ class OntologyV2R2RSpec extends R2RSpec {
 
       // Convert the submitted JSON-LD to an InputOntologyV2, without SPARQL-escaping, so we can compare it to the response.
       val paramsAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(JsonLDUtil.parseJsonLD(params)).unescape
+      val responseJsonDoc = UnsafeZioRun.runOrThrow(
+        ZIO.serviceWithZIO[TestClientService](
+          _.getResponseJsonLD(
+            Put(
+              s"$apiBaseUrl/v2/ontologies/properties",
+              HttpEntity(RdfMediaTypes.`application/ld+json`, params),
+            ) ~> addCredentials(
+              BasicHttpCredentials(anythingUsername, password),
+            ),
+          ),
+        ),
+      )
+      // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
+      val responseAsInput: InputOntologyV2 =
+        InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
+      responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(
+        paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects,
+      )
 
-      Put("/v2/ontologies/properties", HttpEntity(RdfMediaTypes.`application/ld+json`, params)) ~> addCredentials(
-        BasicHttpCredentials(anythingUsername, password),
-      ) ~> ontologiesPath ~> check {
-        assert(status == StatusCodes.OK, response.toString)
-        val responseJsonDoc = responseToJsonLDDocument(response)
-
-        // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-        val responseAsInput: InputOntologyV2 =
-          InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
-        responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(
-          paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects,
-        )
-
-        // Check that the ontology's last modification date was updated.
-        val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
-        assert(newAnythingLastModDate.isAfter(anythingLastModDate))
-        anythingLastModDate = newAnythingLastModDate
-      }
+      // Check that the ontology's last modification date was updated.
+      val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
+      assert(newAnythingLastModDate.isAfter(anythingLastModDate))
+      anythingLastModDate = newAnythingLastModDate
     }
 
     "delete the rdfs:comment of a property" in {
@@ -1427,62 +1440,66 @@ class OntologyV2R2RSpec extends R2RSpec {
            |  }
            |}""".stripMargin
 
-      Put("/v2/ontologies/properties", HttpEntity(RdfMediaTypes.`application/ld+json`, params)) ~> addCredentials(
-        BasicHttpCredentials(anythingUsername, password),
+      val responseJsonDoc = UnsafeZioRun.runOrThrow(
+        ZIO.serviceWithZIO[TestClientService](
+          _.getResponseJsonLD(
+            Put(
+              s"$apiBaseUrl/v2/ontologies/properties",
+              HttpEntity(RdfMediaTypes.`application/ld+json`, params),
+            ) ~> addCredentials(
+              BasicHttpCredentials(anythingUsername, password),
+            ),
+          ),
+        ),
+      )
+      val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
+      assert(updatedOntologyIri == anythingOntoLocalhostIri)
+      val graph =
+        responseJsonDoc.body.getRequiredArray("@graph").fold(e => throw BadRequestException(e), identity).value
+      val property = graph.head.asInstanceOf[JsonLDObject]
+      val returnedPropertyIri =
+        property.getRequiredString("@id").fold(msg => throw BadRequestException(msg), identity)
+      returnedPropertyIri should equal(hasOtherNothingIri)
+      val returnedLabel = property
+        .getRequiredObject(OntologyConstants.Rdfs.Label)
+        .flatMap(_.getRequiredString("@value"))
+        .fold(msg => throw BadRequestException(msg), identity)
+      returnedLabel should equal(newLabel)
+      val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
+        key = KnoraApiV2Complex.LastModificationDate,
+        expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
+        validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
+      )
+
+      assert(lastModDate.isAfter(fooLastModDate))
+      anythingLastModDate = lastModDate
+
+      // load back the ontology to verify that the updated property still is editable
+      val encodedIri = URLEncoder.encode(s"${SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost}", "UTF-8")
+      Get(
+        s"/v2/ontologies/allentities/$encodedIri",
       ) ~> ontologiesPath ~> check {
-        val responseStr = responseAs[String]
-
+        val responseStr: String = responseAs[String]
         assert(status == StatusCodes.OK, response.toString)
-        val responseJsonDoc    = JsonLDUtil.parseJsonLD(responseStr)
-        val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
-        assert(updatedOntologyIri == anythingOntoLocalhostIri)
-        val graph =
-          responseJsonDoc.body.getRequiredArray("@graph").fold(e => throw BadRequestException(e), identity).value
-        val property = graph.head.asInstanceOf[JsonLDObject]
-        val returnedPropertyIri =
-          property.getRequiredString("@id").fold(msg => throw BadRequestException(msg), identity)
-        returnedPropertyIri should equal(hasOtherNothingIri)
-        val returnedLabel = property
-          .getRequiredObject(OntologyConstants.Rdfs.Label)
-          .flatMap(_.getRequiredString("@value"))
-          .fold(msg => throw BadRequestException(msg), identity)
-        returnedLabel should equal(newLabel)
-        val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
-          key = KnoraApiV2Complex.LastModificationDate,
-          expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
-          validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
-        )
+        val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
 
-        assert(lastModDate.isAfter(fooLastModDate))
-        anythingLastModDate = lastModDate
+        val graph = responseJsonDoc.body
+          .getRequiredArray("@graph")
+          .fold(e => throw BadRequestException(e), identity)
+          .value
+          .map(_.asInstanceOf[JsonLDObject])
+        val nothingValue = graph
+          .filter(
+            _.getRequiredString("@id")
+              .fold(msg => throw BadRequestException(msg), identity) == hasOtherNothingValueIri,
+          )
+          .head
+        val isEditableMaybe =
+          nothingValue
+            .getBoolean(KnoraApiV2Complex.IsEditable)
+            .fold(msg => throw BadRequestException(msg), identity)
 
-        // load back the ontology to verify that the updated property still is editable
-        val encodedIri = URLEncoder.encode(s"${SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost}", "UTF-8")
-        Get(
-          s"/v2/ontologies/allentities/$encodedIri",
-        ) ~> ontologiesPath ~> check {
-          val responseStr: String = responseAs[String]
-          assert(status == StatusCodes.OK, response.toString)
-          val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
-
-          val graph = responseJsonDoc.body
-            .getRequiredArray("@graph")
-            .fold(e => throw BadRequestException(e), identity)
-            .value
-            .map(_.asInstanceOf[JsonLDObject])
-          val nothingValue = graph
-            .filter(
-              _.getRequiredString("@id")
-                .fold(msg => throw BadRequestException(msg), identity) == hasOtherNothingValueIri,
-            )
-            .head
-          val isEditableMaybe =
-            nothingValue
-              .getBoolean(KnoraApiV2Complex.IsEditable)
-              .fold(msg => throw BadRequestException(msg), identity)
-
-          isEditableMaybe should equal(Some(true))
-        }
+        isEditableMaybe should equal(Some(true))
       }
     }
 
@@ -1518,64 +1535,68 @@ class OntologyV2R2RSpec extends R2RSpec {
            |  }
            |}""".stripMargin
 
-      Put("/v2/ontologies/properties", HttpEntity(RdfMediaTypes.`application/ld+json`, params)) ~> addCredentials(
-        BasicHttpCredentials(anythingUsername, password),
-      ) ~> ontologiesPath ~> check {
-        val responseStr = responseAs[String]
+      val responseJsonDoc = UnsafeZioRun.runOrThrow(
+        ZIO.serviceWithZIO[TestClientService](
+          _.getResponseJsonLD(
+            Put(
+              s"$apiBaseUrl/v2/ontologies/properties",
+              HttpEntity(RdfMediaTypes.`application/ld+json`, params),
+            ) ~> addCredentials(
+              BasicHttpCredentials(anythingUsername, password),
+            ),
+          ),
+        ),
+      )
+      val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
+      assert(updatedOntologyIri == anythingOntoLocalhostIri)
+      val graph = responseJsonDoc.body
+        .getRequiredArray("@graph")
+        .fold(e => throw BadRequestException(e), identity)
+        .value
+      val property = graph.head.asInstanceOf[JsonLDObject]
+      val returnedPropertyIri =
+        property.getRequiredString("@id").fold(msg => throw BadRequestException(msg), identity)
+      returnedPropertyIri should equal(hasOtherNothingIri)
+      val returnedComment = property
+        .getRequiredObject(OntologyConstants.Rdfs.Comment)
+        .flatMap(_.getRequiredString("@value"))
+        .fold(msg => throw BadRequestException(msg), identity)
+      returnedComment should equal(newComment)
+      val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
+        key = KnoraApiV2Complex.LastModificationDate,
+        expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
+        validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
+      )
 
+      assert(lastModDate.isAfter(fooLastModDate))
+      anythingLastModDate = lastModDate
+
+      // load back the ontology to verify that the updated property still is editable
+      val encodedIri = URLEncoder.encode(s"${SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost}", "UTF-8")
+      Get(
+        s"/v2/ontologies/allentities/$encodedIri",
+      ) ~> ontologiesPath ~> check {
+        val responseStr: String = responseAs[String]
         assert(status == StatusCodes.OK, response.toString)
-        val responseJsonDoc    = JsonLDUtil.parseJsonLD(responseStr)
-        val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
-        assert(updatedOntologyIri == anythingOntoLocalhostIri)
+        val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
+
         val graph = responseJsonDoc.body
           .getRequiredArray("@graph")
           .fold(e => throw BadRequestException(e), identity)
           .value
-        val property = graph.head.asInstanceOf[JsonLDObject]
-        val returnedPropertyIri =
-          property.getRequiredString("@id").fold(msg => throw BadRequestException(msg), identity)
-        returnedPropertyIri should equal(hasOtherNothingIri)
-        val returnedComment = property
-          .getRequiredObject(OntologyConstants.Rdfs.Comment)
-          .flatMap(_.getRequiredString("@value"))
-          .fold(msg => throw BadRequestException(msg), identity)
-        returnedComment should equal(newComment)
-        val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
-          key = KnoraApiV2Complex.LastModificationDate,
-          expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
-          validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
-        )
+          .map(_.asInstanceOf[JsonLDObject])
+        val nothingValue = graph
+          .filter(
+            _.getRequiredString("@id")
+              .fold(msg => throw BadRequestException(msg), identity) == hasOtherNothingValueIri,
+          )
+          .head
+        val isEditableMaybe =
+          nothingValue
+            .getBoolean(KnoraApiV2Complex.IsEditable)
+            .fold(msg => throw BadRequestException(msg), identity)
 
-        assert(lastModDate.isAfter(fooLastModDate))
-        anythingLastModDate = lastModDate
-
-        // load back the ontology to verify that the updated property still is editable
-        val encodedIri = URLEncoder.encode(s"${SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost}", "UTF-8")
-        Get(
-          s"/v2/ontologies/allentities/$encodedIri",
-        ) ~> ontologiesPath ~> check {
-          val responseStr: String = responseAs[String]
-          assert(status == StatusCodes.OK, response.toString)
-          val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
-
-          val graph = responseJsonDoc.body
-            .getRequiredArray("@graph")
-            .fold(e => throw BadRequestException(e), identity)
-            .value
-            .map(_.asInstanceOf[JsonLDObject])
-          val nothingValue = graph
-            .filter(
-              _.getRequiredString("@id")
-                .fold(msg => throw BadRequestException(msg), identity) == hasOtherNothingValueIri,
-            )
-            .head
-          val isEditableMaybe =
-            nothingValue
-              .getBoolean(KnoraApiV2Complex.IsEditable)
-              .fold(msg => throw BadRequestException(msg), identity)
-
-          isEditableMaybe should equal(Some(true))
-        }
+        isEditableMaybe should equal(Some(true))
       }
     }
 

--- a/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -2846,13 +2846,8 @@ class OntologyV2R2RSpec extends R2RSpec {
     }
 
     // Successfully remove the (unused) text value cardinality from the class.
-    Patch("/v2/ontologies/cardinalities", HttpEntity(RdfMediaTypes.`application/ld+json`, params)) ~> addCredentials(
-      anythingUserCreds,
-    ) ~> ontologiesPath ~> check {
-      val responseStr = responseAs[String]
-      assert(status == StatusCodes.OK, response.toString)
-      val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
-
+    {
+      val responseJsonDoc = patchJsonLd(s"$apiBaseUrl/v2/ontologies/cardinalities", params, anythingUserCreds)
       val responseAsInput: InputOntologyV2 =
         InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
       freetestLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
@@ -3259,6 +3254,9 @@ class OntologyV2R2RSpec extends R2RSpec {
     UnsafeZioRun.runOrThrow(
       ZIO.serviceWithZIO[TestClientService](_.getResponseJsonLD(req ~> addCredentials(credentials))),
     )
+
+  def patchJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): JsonLDDocument =
+    UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TestClientService](_.patchJsonLd(url, jsonLd, credentials)))
 
   def putJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): JsonLDDocument =
     UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TestClientService](_.putJsonLd(url, jsonLd, credentials)))

--- a/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -649,79 +649,81 @@ class OntologyV2R2RSpec extends R2RSpec {
         URLEncoder.encode("http://0.0.0.0:3333/ontology/0001/freetest/v2#hasPropertyWithComment2", "UTF-8")
       val lastModificationDate = URLEncoder.encode(freetestLastModDate.toString, "UTF-8")
 
-      Delete(
-        s"/v2/ontologies/properties/comment/$propertySegment?lastModificationDate=$lastModificationDate",
-      ) ~> addCredentials(BasicHttpCredentials(anythingUsername, password)) ~> ontologiesPath ~> check {
-        val responseStr = responseAs[String]
-        assert(status == StatusCodes.OK, responseStr)
-        val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
-        val newFreetestLastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
-          key = KnoraApiV2Complex.LastModificationDate,
-          expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
-          validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
-        )
+      val responseJsonDoc = UnsafeZioRun.runOrThrow(
+        ZIO.serviceWithZIO[TestClientService](
+          _.getResponseJsonLD(
+            Delete(
+              s"$apiBaseUrl/v2/ontologies/properties/comment/$propertySegment?lastModificationDate=$lastModificationDate",
+            ) ~> addCredentials(BasicHttpCredentials(anythingUsername, password)),
+          ),
+        ),
+      )
+      val newFreetestLastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
+        key = KnoraApiV2Complex.LastModificationDate,
+        expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
+        validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
+      )
 
-        assert(newFreetestLastModDate.isAfter(freetestLastModDate))
-        freetestLastModDate = newFreetestLastModDate
+      assert(newFreetestLastModDate.isAfter(freetestLastModDate))
+      freetestLastModDate = newFreetestLastModDate
 
-        val expectedResponse: String =
-          s"""{
-             |   "knora-api:lastModificationDate": {
-             |       "@value": "$newFreetestLastModDate",
-             |       "@type": "xsd:dateTimeStamp"
-             |   },
-             |   "rdfs:label": "freetest",
-             |   "@graph": [
-             |      {
-             |         "rdfs:label": [
-             |            {
-             |               "@value": "Property mit einem Kommentar 2",
-             |               "@language": "de"
-             |            },
-             |            {
-             |               "@value": "Property with a comment 2",
-             |               "@language": "en"
-             |            }
-             |         ],
-             |         "rdfs:subPropertyOf": {
-             |            "@id": "knora-api:hasValue"
-             |         },
-             |         "@type": "owl:ObjectProperty",
-             |         "knora-api:objectType": {
-             |            "@id": "knora-api:TextValue"
-             |         },
-             |         "salsah-gui:guiElement": {
-             |            "@id": "salsah-gui:SimpleText"
-             |         },
-             |         "@id": "freetest:hasPropertyWithComment2"
-             |      }
-             |   ],
-             |   "knora-api:attachedToProject": {
-             |      "@id": "http://rdfh.ch/projects/0001"
-             |   },
-             |   "@type": "owl:Ontology",
-             |   "@id": "http://0.0.0.0:3333/ontology/0001/freetest/v2",
-             |   "@context": {
-             |      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-             |      "knora-api": "http://api.knora.org/ontology/knora-api/v2#",
-             |      "freetest": "http://0.0.0.0:3333/ontology/0001/freetest/v2#",
-             |      "owl": "http://www.w3.org/2002/07/owl#",
-             |      "salsah-gui": "http://api.knora.org/ontology/salsah-gui/v2#",
-             |      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-             |      "xsd": "http://www.w3.org/2001/XMLSchema#"
-             |   }
-             |}""".stripMargin
+      val expectedResponse: String =
+        s"""{
+           |   "knora-api:lastModificationDate": {
+           |       "@value": "$newFreetestLastModDate",
+           |       "@type": "xsd:dateTimeStamp"
+           |   },
+           |   "rdfs:label": "freetest",
+           |   "@graph": [
+           |      {
+           |         "rdfs:label": [
+           |            {
+           |               "@value": "Property mit einem Kommentar 2",
+           |               "@language": "de"
+           |            },
+           |            {
+           |               "@value": "Property with a comment 2",
+           |               "@language": "en"
+           |            }
+           |         ],
+           |         "rdfs:subPropertyOf": {
+           |            "@id": "knora-api:hasValue"
+           |         },
+           |         "@type": "owl:ObjectProperty",
+           |         "knora-api:objectType": {
+           |            "@id": "knora-api:TextValue"
+           |         },
+           |         "salsah-gui:guiElement": {
+           |            "@id": "salsah-gui:SimpleText"
+           |         },
+           |         "@id": "freetest:hasPropertyWithComment2"
+           |      }
+           |   ],
+           |   "knora-api:attachedToProject": {
+           |      "@id": "http://rdfh.ch/projects/0001"
+           |   },
+           |   "@type": "owl:Ontology",
+           |   "@id": "http://0.0.0.0:3333/ontology/0001/freetest/v2",
+           |   "@context": {
+           |      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+           |      "knora-api": "http://api.knora.org/ontology/knora-api/v2#",
+           |      "freetest": "http://0.0.0.0:3333/ontology/0001/freetest/v2#",
+           |      "owl": "http://www.w3.org/2002/07/owl#",
+           |      "salsah-gui": "http://api.knora.org/ontology/salsah-gui/v2#",
+           |      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+           |      "xsd": "http://www.w3.org/2001/XMLSchema#"
+           |   }
+           |}""".stripMargin
 
-        val expectedResponseToCompare: InputOntologyV2 =
-          InputOntologyV2.fromJsonLD(JsonLDUtil.parseJsonLD(expectedResponse)).unescape
+      val expectedResponseToCompare: InputOntologyV2 =
+        InputOntologyV2.fromJsonLD(JsonLDUtil.parseJsonLD(expectedResponse)).unescape
 
-        val responseFromJsonLD: InputOntologyV2 =
-          InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
+      val responseFromJsonLD: InputOntologyV2 =
+        InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
 
-        responseFromJsonLD.properties.head._2.predicates.toSet should ===(
-          expectedResponseToCompare.properties.head._2.predicates.toSet,
-        )
-      }
+      responseFromJsonLD.properties.head._2.predicates.toSet should ===(
+        expectedResponseToCompare.properties.head._2.predicates.toSet,
+      )
     }
 
     "delete the rdfs:comment of a class" in {
@@ -1581,59 +1583,58 @@ class OntologyV2R2RSpec extends R2RSpec {
       // update label and comment of a property
       val propertyIriEncoded = URLEncoder.encode(hasOtherNothingIri, "UTF-8")
 
-      Delete(
-        s"/v2/ontologies/properties/comment/$propertyIriEncoded?lastModificationDate=$anythingLastModDate",
-      ) ~> addCredentials(
-        BasicHttpCredentials(anythingUsername, password),
-      ) ~> ontologiesPath ~> check {
-        val responseStr = responseAs[String]
+      val responseJsonDoc = UnsafeZioRun.runOrThrow(
+        ZIO.serviceWithZIO[TestClientService](
+          _.getResponseJsonLD(
+            Delete(
+              s"$apiBaseUrl/v2/ontologies/properties/comment/$propertyIriEncoded?lastModificationDate=$anythingLastModDate",
+            ) ~> addCredentials(BasicHttpCredentials(anythingUsername, password)),
+          ),
+        ),
+      )
+      val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
+      assert(updatedOntologyIri == anythingOntoLocalhostIri)
+      val graph = responseJsonDoc.body
+        .getRequiredArray("@graph")
+        .fold(e => throw BadRequestException(e), identity)
+        .value
+      val property = graph.head.asInstanceOf[JsonLDObject]
+      val returnedPropertyIri =
+        property.getRequiredString("@id").fold(msg => throw BadRequestException(msg), identity)
+      returnedPropertyIri should equal(hasOtherNothingIri)
+      assert(property.value.get(OntologyConstants.Rdfs.Comment) == None)
+      val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
+        key = KnoraApiV2Complex.LastModificationDate,
+        expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
+        validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
+      )
 
+      assert(lastModDate.isAfter(fooLastModDate))
+      anythingLastModDate = lastModDate
+
+      // load back the ontology to verify that the updated property still is editable
+      val encodedIri = URLEncoder.encode(s"${SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost}", "UTF-8")
+      Get(
+        s"/v2/ontologies/allentities/$encodedIri",
+      ) ~> ontologiesPath ~> check {
+        val responseStr: String = responseAs[String]
         assert(status == StatusCodes.OK, response.toString)
-        val responseJsonDoc    = JsonLDUtil.parseJsonLD(responseStr)
-        val updatedOntologyIri = responseJsonDoc.body.value("@id").asInstanceOf[JsonLDString].value
-        assert(updatedOntologyIri == anythingOntoLocalhostIri)
+        val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
+
         val graph = responseJsonDoc.body
           .getRequiredArray("@graph")
           .fold(e => throw BadRequestException(e), identity)
           .value
-        val property = graph.head.asInstanceOf[JsonLDObject]
-        val returnedPropertyIri =
-          property.getRequiredString("@id").fold(msg => throw BadRequestException(msg), identity)
-        returnedPropertyIri should equal(hasOtherNothingIri)
-        assert(property.value.get(OntologyConstants.Rdfs.Comment) == None)
-        val lastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
-          key = KnoraApiV2Complex.LastModificationDate,
-          expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
-          validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
-        )
-
-        assert(lastModDate.isAfter(fooLastModDate))
-        anythingLastModDate = lastModDate
-
-        // load back the ontology to verify that the updated property still is editable
-        val encodedIri = URLEncoder.encode(s"${SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost}", "UTF-8")
-        Get(
-          s"/v2/ontologies/allentities/$encodedIri",
-        ) ~> ontologiesPath ~> check {
-          val responseStr: String = responseAs[String]
-          assert(status == StatusCodes.OK, response.toString)
-          val responseJsonDoc = JsonLDUtil.parseJsonLD(responseStr)
-
-          val graph = responseJsonDoc.body
-            .getRequiredArray("@graph")
-            .fold(e => throw BadRequestException(e), identity)
-            .value
-            .map(_.asInstanceOf[JsonLDObject])
-          val nothingValue = graph
-            .filter(
-              _.getRequiredString("@id")
-                .fold(msg => throw BadRequestException(msg), identity) == hasOtherNothingValueIri,
-            )
-            .head
-          val isEditableMaybe =
-            nothingValue.getBoolean(KnoraApiV2Complex.IsEditable).fold(msg => throw BadRequestException(msg), identity)
-          isEditableMaybe should equal(Some(true))
-        }
+          .map(_.asInstanceOf[JsonLDObject])
+        val nothingValue = graph
+          .filter(
+            _.getRequiredString("@id")
+              .fold(msg => throw BadRequestException(msg), identity) == hasOtherNothingValueIri,
+          )
+          .head
+        val isEditableMaybe =
+          nothingValue.getBoolean(KnoraApiV2Complex.IsEditable).fold(msg => throw BadRequestException(msg), identity)
+        isEditableMaybe should equal(Some(true))
       }
     }
 

--- a/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -2231,24 +2231,22 @@ class OntologyV2R2RSpec extends R2RSpec {
       val classSegment         = URLEncoder.encode("http://0.0.0.0:3333/ontology/0001/anything/v2#Nothing", "UTF-8")
       val lastModificationDate = URLEncoder.encode(anythingLastModDate.toString, "UTF-8")
 
-      Delete(s"/v2/ontologies/classes/$classSegment?lastModificationDate=$lastModificationDate") ~> addCredentials(
+      val responseJsonDoc = jsonLdResponse(
+        Delete(s"$apiBaseUrl/v2/ontologies/classes/$classSegment?lastModificationDate=$lastModificationDate"),
         anythingUserCreds,
-      ) ~> ontologiesPath ~> check {
-        assert(status == StatusCodes.OK, response.toString)
-        val responseJsonDoc = responseToJsonLDDocument(response)
-        responseJsonDoc.body.requireStringWithValidation("@id", stringFormatter.toSmartIriWithErr) should ===(
-          "http://0.0.0.0:3333/ontology/0001/anything/v2".toSmartIri,
-        )
+      )
+      responseJsonDoc.body.requireStringWithValidation("@id", stringFormatter.toSmartIriWithErr) should ===(
+        "http://0.0.0.0:3333/ontology/0001/anything/v2".toSmartIri,
+      )
 
-        val newAnythingLastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
-          key = KnoraApiV2Complex.LastModificationDate,
-          expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
-          validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
-        )
+      val newAnythingLastModDate = responseJsonDoc.body.requireDatatypeValueInObject(
+        key = KnoraApiV2Complex.LastModificationDate,
+        expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
+        validationFun = (s, errorFun) => ValuesValidator.xsdDateTimeStampToInstant(s).getOrElse(errorFun),
+      )
 
-        assert(newAnythingLastModDate.isAfter(anythingLastModDate))
-        anythingLastModDate = newAnythingLastModDate
-      }
+      assert(newAnythingLastModDate.isAfter(anythingLastModDate))
+      anythingLastModDate = newAnythingLastModDate
     }
 
     "create a shared ontology and put a property in it" in {

--- a/integration/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -792,10 +792,10 @@ class ResourcesRouteV2E2ESpec extends E2ESpec {
       )
 
       // Request the newly created resource in the simple schema, and check that it matches the ontology.
-      val resourceSimpleGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(resourceIri, "UTF-8")}")
-        .addHeader(SchemaHeader.simple) ~> addCredentials(
-        BasicHttpCredentials(anythingUserEmail, password),
-      )
+      val resourceSimpleGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(resourceIri, "UTF-8")}") ~>
+        SchemaHeader.simple ~>
+        addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+
       val resourceSimpleGetResponse: HttpResponse = singleAwaitingRequest(resourceSimpleGetRequest)
       val resourceSimpleGetResponseAsString       = responseToString(resourceSimpleGetResponse)
 

--- a/integration/src/test/scala/org/knora/webapi/e2e/v2/SchemaHeader.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/v2/SchemaHeader.scala
@@ -10,6 +10,10 @@ import org.apache.pekko.http.scaladsl.model.headers.ModeledCustomHeaderCompanion
 
 import scala.util.Try
 
+import org.knora.webapi.ApiV2Complex
+import org.knora.webapi.ApiV2Schema
+import org.knora.webapi.ApiV2Simple
+
 /**
  * A custom Pekko HTTP header "x-knora-accept-schema", which a client can send to specify which ontology schema
  * should be used in an API response.
@@ -26,6 +30,11 @@ final class SchemaHeader private (token: String) extends ModeledCustomHeader[Sch
 object SchemaHeader extends ModeledCustomHeaderCompanion[SchemaHeader] {
   override val name: String         = "x-knora-accept-schema"
   override def parse(value: String) = Try(new SchemaHeader(value))
+
+  def from(schema: ApiV2Schema): SchemaHeader = schema match {
+    case ApiV2Simple  => simple
+    case ApiV2Complex => complex
+  }
 
   val simple: SchemaHeader  = SchemaHeader("simple")
   val complex: SchemaHeader = SchemaHeader("complex")

--- a/integration/src/test/scala/org/knora/webapi/testservices/TestClientService.scala
+++ b/integration/src/test/scala/org/knora/webapi/testservices/TestClientService.scala
@@ -7,6 +7,8 @@ package org.knora.webapi.testservices
 
 import org.apache.pekko
 import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.HttpEntity
+import org.apache.pekko.http.scaladsl.model.headers.HttpCredentials
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3
 import sttp.client3.*
@@ -22,6 +24,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 import dsp.errors.AssertionException
+import org.knora.webapi.RdfMediaTypes
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.messages.util.rdf.JsonLDDocument
@@ -124,6 +127,9 @@ final case class TestClientService(
       body <- getResponseString(request)
       json <- ZIO.succeed(JsonLDUtil.parseJsonLD(body))
     } yield json
+
+  def postJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): Task[JsonLDDocument] =
+    getResponseJsonLD(Post(url, HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLd)) ~> addCredentials(credentials))
 }
 
 object TestClientService {

--- a/integration/src/test/scala/org/knora/webapi/testservices/TestClientService.scala
+++ b/integration/src/test/scala/org/knora/webapi/testservices/TestClientService.scala
@@ -128,10 +128,18 @@ final case class TestClientService(
       json <- ZIO.succeed(JsonLDUtil.parseJsonLD(body))
     } yield json
 
+  def getJsonLd(url: String, credentials: HttpCredentials): Task[JsonLDDocument] =
+    getResponseJsonLD(Get(url) ~> addCredentials(credentials))
+
+  def getJsonLd(url: String): Task[JsonLDDocument] = getResponseJsonLD(Get(url))
+
   def patchJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): Task[JsonLDDocument] =
     getResponseJsonLD(
       Patch(url, HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLd)) ~> addCredentials(credentials),
     )
+
+  def deleteJsonLd(url: String, credentials: HttpCredentials): Task[JsonLDDocument] =
+    getResponseJsonLD(Delete(url) ~> addCredentials(credentials))
 
   def putJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): Task[JsonLDDocument] =
     getResponseJsonLD(Put(url, HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLd)) ~> addCredentials(credentials))

--- a/integration/src/test/scala/org/knora/webapi/testservices/TestClientService.scala
+++ b/integration/src/test/scala/org/knora/webapi/testservices/TestClientService.scala
@@ -128,6 +128,9 @@ final case class TestClientService(
       json <- ZIO.succeed(JsonLDUtil.parseJsonLD(body))
     } yield json
 
+  def putJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): Task[JsonLDDocument] =
+    getResponseJsonLD(Put(url, HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLd)) ~> addCredentials(credentials))
+
   def postJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): Task[JsonLDDocument] =
     getResponseJsonLD(Post(url, HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLd)) ~> addCredentials(credentials))
 }

--- a/integration/src/test/scala/org/knora/webapi/testservices/TestClientService.scala
+++ b/integration/src/test/scala/org/knora/webapi/testservices/TestClientService.scala
@@ -128,6 +128,11 @@ final case class TestClientService(
       json <- ZIO.succeed(JsonLDUtil.parseJsonLD(body))
     } yield json
 
+  def patchJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): Task[JsonLDDocument] =
+    getResponseJsonLD(
+      Patch(url, HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLd)) ~> addCredentials(credentials),
+    )
+
   def putJsonLd(url: String, jsonLd: String, credentials: HttpCredentials): Task[JsonLDDocument] =
     getResponseJsonLD(Put(url, HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLd)) ~> addCredentials(credentials))
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -183,17 +183,6 @@ case class DeleteClassRequestV2(
 ) extends OntologiesResponderRequestV2
 
 /**
- * Asks whether a class can be deleted. A successful response will be a [[CanDoResponseV2]].
- *
- * @param classIri       the IRI of the class to be deleted.
- * @param requestingUser the user making the request.
- */
-case class CanDeleteClassRequestV2(
-  classIri: SmartIri,
-  requestingUser: User,
-) extends OntologiesResponderRequestV2
-
-/**
  * Requests that the `salsah-gui:guiElement` and `salsah-gui:guiAttribute` of a property are changed.
  *
  * @param propertyIri          the IRI of the property to be changed.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1756,7 +1756,7 @@ final case class OntologyResponderV2(
    * @param changePropertyGuiElementRequest the request to change the property's GUI element and GUI attribute.
    * @return a [[ReadOntologyV2]] containing the modified property definition.
    */
-  private def changePropertyGuiElement(
+  def changePropertyGuiElement(
     changePropertyGuiElementRequest: ChangePropertyGuiElementRequest,
   ): Task[ReadOntologyV2] = {
     def makeTaskFuture(internalPropertyIri: SmartIri, internalOntologyIri: SmartIri): Task[ReadOntologyV2] = for {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1846,7 +1846,7 @@ final case class OntologyResponderV2(
    * @param changePropertyLabelsOrCommentsRequest the request to change the property's labels or comments.
    * @return a [[ReadOntologyV2]] containing the modified property definition.
    */
-  private def changePropertyLabelsOrComments(
+  def changePropertyLabelsOrComments(
     changePropertyLabelsOrCommentsRequest: ChangePropertyLabelsOrCommentsRequestV2,
   ): Task[ReadOntologyV2] = {
     def makeTaskFuture(internalPropertyIri: SmartIri, internalOntologyIri: SmartIri): Task[ReadOntologyV2] =

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1217,7 +1217,7 @@ final case class OntologyResponderV2(
    * @param deleteCardinalitiesFromClassRequest the request to remove cardinalities.
    * @return a [[ReadOntologyV2]] in the internal schema, containing the new class definition.
    */
-  private def deleteCardinalitiesFromClass(
+  def deleteCardinalitiesFromClass(
     deleteCardinalitiesFromClassRequest: DeleteCardinalitiesFromClassRequestV2,
   ): Task[ReadOntologyV2] =
     for {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1183,7 +1183,7 @@ final case class OntologyResponderV2(
    * @param canDeleteCardinalitiesFromClassRequest the request to remove cardinalities.
    * @return a [[CanDoResponseV2]] indicating whether a class's cardinalities can be deleted.
    */
-  private def canDeleteCardinalitiesFromClass(
+  def canDeleteCardinalitiesFromClass(
     canDeleteCardinalitiesFromClassRequest: CanDeleteCardinalitiesFromClassRequestV2,
   ): Task[CanDoResponseV2] =
     for {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -374,6 +374,13 @@ final case class OntologyResponderV2(
    * @param requestingUser the user making the request.
    * @return a [[ReadOntologyV2]].
    */
+  def getPropertiesFromOntologyV2(
+    propertyIris: Set[PropertyIri],
+    allLanguages: Boolean,
+    requestingUser: User,
+  ): Task[ReadOntologyV2] =
+    getPropertyDefinitionsFromOntologyV2(propertyIris.map(_.smartIri), allLanguages, requestingUser)
+
   private def getPropertyDefinitionsFromOntologyV2(
     propertyIris: Set[SmartIri],
     allLanguages: Boolean,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -729,7 +729,7 @@ final case class OntologyResponderV2(
    * @param changeGuiOrderRequest the request message.
    * @return the updated class definition.
    */
-  private def changeGuiOrder(changeGuiOrderRequest: ChangeGuiOrderRequestV2): Task[ReadOntologyV2] = {
+  def changeGuiOrder(changeGuiOrderRequest: ChangeGuiOrderRequestV2): Task[ReadOntologyV2] = {
     def makeTaskFuture(internalClassIri: SmartIri, internalOntologyIri: SmartIri): Task[ReadOntologyV2] =
       for {
         cacheData                           <- ontologyCache.getCacheData

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -61,8 +61,7 @@ final case class OntologiesRouteV2()(
       deleteClassComment() ~
       addCardinalities() ~
       canReplaceCardinalities ~
-      replaceCardinalities() ~
-      canDeleteCardinalitiesFromClass
+      replaceCardinalities()
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -258,21 +257,6 @@ final case class OntologiesRouteV2()(
             user         <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
             apiRequestId <- RouteUtilZ.randomUuid()
             msg <- requestParser(_.replaceClassCardinalitiesRequestV2(reqBody, apiRequestId, user))
-                     .mapError(BadRequestException.apply)
-          } yield msg
-          RouteUtilV2.runRdfRouteZ(messageTask, requestContext)
-        }
-      }
-    }
-
-  private def canDeleteCardinalitiesFromClass: Route =
-    path(ontologiesBasePath / "candeletecardinalities") {
-      post {
-        entity(as[String]) { jsonRequest => requestContext =>
-          val messageTask = for {
-            requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-            apiRequestId   <- RouteUtilZ.randomUuid()
-            msg <- requestParser(_.canDeleteCardinalitiesFromClassRequestV2(jsonRequest, apiRequestId, requestingUser))
                      .mapError(BadRequestException.apply)
           } yield msg
           RouteUtilV2.runRdfRouteZ(messageTask, requestContext)

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -60,8 +60,7 @@ final case class OntologiesRouteV2()(
       updateClass() ~
       deleteClassComment() ~
       addCardinalities() ~
-      canReplaceCardinalities ~
-      replaceCardinalities()
+      canReplaceCardinalities
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -246,21 +245,6 @@ final case class OntologiesRouteV2()(
             ZIO.serviceWithZIO[RestCardinalityService](_.canChangeCardinality(classIri, user, property, newCardinality))
         } yield canChange
         completeResponse(response, requestContext)
-      }
-    }
-
-  private def replaceCardinalities(): Route =
-    path(ontologiesBasePath / "cardinalities") {
-      put {
-        entity(as[String]) { reqBody => requestContext =>
-          val messageTask = for {
-            user         <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-            apiRequestId <- RouteUtilZ.randomUuid()
-            msg <- requestParser(_.replaceClassCardinalitiesRequestV2(reqBody, apiRequestId, user))
-                     .mapError(BadRequestException.apply)
-          } yield msg
-          RouteUtilV2.runRdfRouteZ(messageTask, requestContext)
-        }
       }
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -72,8 +72,7 @@ final case class OntologiesRouteV2()(
       deleteOntologyComment() ~
       createProperty() ~
       updatePropertyLabelsOrComments() ~
-      deletePropertyComment() ~
-      updatePropertyGuiElement()
+      deletePropertyComment()
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -464,19 +463,4 @@ final case class OntologiesRouteV2()(
       }
     }
 
-  private def updatePropertyGuiElement(): Route =
-    path(ontologiesBasePath / "properties" / "guielement") {
-      put {
-        // Change the salsah-gui:guiElement and/or salsah-gui:guiAttribute of a property.
-        entity(as[String]) { jsonRequest => requestContext =>
-          val requestTask = for {
-            requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-            apiRequestId   <- RouteUtilZ.randomUuid()
-            msg <- requestParser(_.changePropertyGuiElementRequest(jsonRequest, apiRequestId, requestingUser))
-                     .mapError(BadRequestException.apply)
-          } yield msg
-          RouteUtilV2.runRdfRouteZ(requestTask, requestContext)
-        }
-      }
-    }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -70,8 +70,7 @@ final case class OntologiesRouteV2()(
       canDeleteClass ~
       deleteClass() ~
       deleteOntologyComment() ~
-      createProperty() ~
-      updatePropertyLabelsOrComments()
+      createProperty()
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -423,23 +422,6 @@ final case class OntologiesRouteV2()(
             apiRequestId   <- RouteUtilZ.randomUuid()
             requestMessage <- requestParser(_.createPropertyRequestV2(jsonRequest, apiRequestId, requestingUser))
                                 .mapError(BadRequestException.apply)
-          } yield requestMessage
-          RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)
-        }
-      }
-    }
-
-  private def updatePropertyLabelsOrComments(): Route =
-    path(ontologiesBasePath / "properties") {
-      put {
-        // Change the labels or comments of a property.
-        entity(as[String]) { jsonRequest => requestContext =>
-          val requestMessageTask = for {
-            requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-            apiRequestId   <- RouteUtilZ.randomUuid()
-            requestMessage <-
-              requestParser(_.changePropertyLabelsOrCommentsRequestV2(jsonRequest, apiRequestId, requestingUser))
-                .mapError(BadRequestException.apply)
           } yield requestMessage
           RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)
         }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -69,8 +69,7 @@ final case class OntologiesRouteV2()(
       getClasses ~
       canDeleteClass ~
       deleteClass() ~
-      deleteOntologyComment() ~
-      createProperty()
+      deleteOntologyComment()
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -410,21 +409,6 @@ final case class OntologiesRouteV2()(
           requestingUser       <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
         } yield DeleteOntologyCommentRequestV2(ontologyIri, lastModificationDate, apiRequestId, requestingUser)
         RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)
-      }
-    }
-
-  private def createProperty(): Route =
-    path(ontologiesBasePath / "properties") {
-      post {
-        entity(as[String]) { jsonRequest => requestContext =>
-          val requestMessageTask = for {
-            requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-            apiRequestId   <- RouteUtilZ.randomUuid()
-            requestMessage <- requestParser(_.createPropertyRequestV2(jsonRequest, apiRequestId, requestingUser))
-                                .mapError(BadRequestException.apply)
-          } yield requestMessage
-          RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)
-        }
       }
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -71,8 +71,7 @@ final case class OntologiesRouteV2()(
       deleteClass() ~
       deleteOntologyComment() ~
       createProperty() ~
-      updatePropertyLabelsOrComments() ~
-      deletePropertyComment()
+      updatePropertyLabelsOrComments()
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -446,21 +445,4 @@ final case class OntologiesRouteV2()(
         }
       }
     }
-
-  // delete the comment of a property definition
-  private def deletePropertyComment(): Route =
-    path(ontologiesBasePath / "properties" / "comment" / Segment) { (propertyIriStr: IRI) =>
-      delete { requestContext =>
-        val requestTask = for {
-          propertyIri <- RouteUtilZ
-                           .toSmartIri(propertyIriStr, s"Invalid property IRI: $propertyIriStr")
-                           .flatMap(RouteUtilZ.ensureApiV2ComplexSchema)
-          lastModificationDate <- getLastModificationDate(requestContext)
-          apiRequestId         <- RouteUtilZ.randomUuid()
-          requestingUser       <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-        } yield DeletePropertyCommentRequestV2(propertyIri, lastModificationDate, apiRequestId, requestingUser)
-        RouteUtilV2.runRdfRouteZ(requestTask, requestContext)
-      }
-    }
-
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -62,8 +62,7 @@ final case class OntologiesRouteV2()(
       addCardinalities() ~
       canReplaceCardinalities ~
       replaceCardinalities() ~
-      canDeleteCardinalitiesFromClass ~
-      deleteCardinalitiesFromClass()
+      canDeleteCardinalitiesFromClass
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -277,23 +276,6 @@ final case class OntologiesRouteV2()(
                      .mapError(BadRequestException.apply)
           } yield msg
           RouteUtilV2.runRdfRouteZ(messageTask, requestContext)
-        }
-      }
-    }
-
-  // delete a single cardinality from the specified class if the property is
-  // not used in resources.
-  private def deleteCardinalitiesFromClass(): Route =
-    path(ontologiesBasePath / "cardinalities") {
-      patch {
-        entity(as[String]) { jsonRequest => requestContext =>
-          val requestMessageTask = for {
-            requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-            apiRequestId   <- RouteUtilZ.randomUuid()
-            msg <- requestParser(_.deleteCardinalitiesFromClassRequestV2(jsonRequest, apiRequestId, requestingUser))
-                     .mapError(BadRequestException.apply)
-          } yield msg
-          RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)
         }
       }
     }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -68,8 +68,7 @@ final case class OntologiesRouteV2()(
       changeGuiOrder() ~
       getClasses ~
       canDeleteClass ~
-      deleteClass() ~
-      deleteOntologyComment()
+      deleteClass()
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -399,16 +398,4 @@ final case class OntologiesRouteV2()(
       )
       .flatMap(it => ZIO.fromOption(it).orElseFail(BadRequestException(s"Invalid timestamp: $it")))
 
-  private def deleteOntologyComment(): Route =
-    path(ontologiesBasePath / "comment" / Segment) { (ontologyIriStr: IRI) =>
-      delete { requestContext =>
-        val requestMessageTask = for {
-          ontologyIri          <- RouteUtilZ.externalApiV2ComplexOntologyIri(ontologyIriStr)
-          lastModificationDate <- getLastModificationDate(requestContext)
-          apiRequestId         <- RouteUtilZ.randomUuid()
-          requestingUser       <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-        } yield DeleteOntologyCommentRequestV2(ontologyIri, lastModificationDate, apiRequestId, requestingUser)
-        RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)
-      }
-    }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -63,8 +63,7 @@ final case class OntologiesRouteV2()(
       canReplaceCardinalities ~
       replaceCardinalities() ~
       canDeleteCardinalitiesFromClass ~
-      deleteCardinalitiesFromClass() ~
-      changeGuiOrder()
+      deleteCardinalitiesFromClass()
 
   private def dereferenceOntologyIri(): Route = path("ontology" / Segments) { (_: List[String]) =>
     get { requestContext =>
@@ -292,21 +291,6 @@ final case class OntologiesRouteV2()(
             requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
             apiRequestId   <- RouteUtilZ.randomUuid()
             msg <- requestParser(_.deleteCardinalitiesFromClassRequestV2(jsonRequest, apiRequestId, requestingUser))
-                     .mapError(BadRequestException.apply)
-          } yield msg
-          RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)
-        }
-      }
-    }
-
-  private def changeGuiOrder(): Route =
-    path(ontologiesBasePath / "guiorder") {
-      put {
-        entity(as[String]) { jsonRequest => requestContext =>
-          val requestMessageTask = for {
-            requestingUser <- ZIO.serviceWithZIO[Authenticator](_.getUserADM(requestContext))
-            apiRequestId   <- RouteUtilZ.randomUuid()
-            msg <- requestParser(_.changeGuiOrderRequestV2(jsonRequest, apiRequestId, requestingUser))
                      .mapError(BadRequestException.apply)
           } yield msg
           RouteUtilV2.runRdfRouteZ(requestMessageTask, requestContext)

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -38,6 +38,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val putOntologiesGuiorder = baseEndpoints.withUserEndpoint.put
+    .in(base / "guiorder")
+    .in(stringJsonBody)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val getOntologiesClassesIris = baseEndpoints.withUserEndpoint.get
     .in(base / "classes" / paths)
     .in(allLanguages)
@@ -135,6 +142,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      putOntologiesGuiorder,
       getOntologiesClassesIris,
       getOntologiesCandeleteclass,
       deleteOntologiesClasses,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -38,7 +38,14 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
-  val getOntologyCandeleteclass = baseEndpoints.withUserEndpoint.get
+  val getOntologiesClassesIris = baseEndpoints.withUserEndpoint.get
+    .in(base / "classes" / paths)
+    .in(allLanguages)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
+  val getOntologiesCandeleteclass = baseEndpoints.withUserEndpoint.get
     .in(base / "candeleteclass" / resourceClassIriPath)
     .in(ApiV2.Inputs.formatOptions)
     .out(stringBody)
@@ -128,7 +135,8 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
-      getOntologyCandeleteclass,
+      getOntologiesClassesIris,
+      getOntologiesCandeleteclass,
       deleteOntologiesClasses,
       deleteOntologiesComment,
       postOntologiesProperties,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -37,6 +37,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val putOntologiesPropertiesGuielement = baseEndpoints.withUserEndpoint.put
+    .in(base / "properties" / "guielement")
+    .in(stringJsonBody)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val getOntologiesProperties = baseEndpoints.withUserEndpoint.get
     .in(base / "properties" / paths)
     .in(allLanguages)
@@ -79,6 +86,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      putOntologiesPropertiesGuielement,
       getOntologiesProperties,
       deleteOntologiesProperty,
       postOntologies,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -37,6 +37,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val putOntologiesProperties = baseEndpoints.withUserEndpoint.put
+    .in(base / "properties")
+    .in(stringJsonBody)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val deletePropertiesComment = baseEndpoints.withUserEndpoint.delete
     .in(base / "properties" / "comment" / propertyIriPath)
     .in(lastModificationDate)
@@ -93,6 +100,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      putOntologiesProperties,
       deletePropertiesComment,
       putOntologiesPropertiesGuielement,
       getOntologiesProperties,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -38,6 +38,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val patchOntologiesCardinalities = baseEndpoints.withUserEndpoint.patch
+    .in(base / "cardinalities")
+    .in(stringJsonBody)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val putOntologiesGuiorder = baseEndpoints.withUserEndpoint.put
     .in(base / "guiorder")
     .in(stringJsonBody)
@@ -142,6 +149,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      patchOntologiesCardinalities,
       putOntologiesGuiorder,
       getOntologiesClassesIris,
       getOntologiesCandeleteclass,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -38,6 +38,12 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val getOntologyCandeleteclass = baseEndpoints.withUserEndpoint.get
+    .in(base / "candeleteclass" / resourceClassIriPath)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val deleteOntologiesClasses = baseEndpoints.withUserEndpoint.delete
     .in(base / "classes" / resourceClassIriPath)
     .in(lastModificationDate)
@@ -122,6 +128,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      getOntologyCandeleteclass,
       deleteOntologiesClasses,
       deleteOntologiesComment,
       postOntologiesProperties,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -37,6 +37,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val deletePropertiesComment = baseEndpoints.withUserEndpoint.delete
+    .in(base / "properties" / "comment" / propertyIriPath)
+    .in(lastModificationDate)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val putOntologiesPropertiesGuielement = baseEndpoints.withUserEndpoint.put
     .in(base / "properties" / "guielement")
     .in(stringJsonBody)
@@ -86,6 +93,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      deletePropertiesComment,
       putOntologiesPropertiesGuielement,
       getOntologiesProperties,
       deleteOntologiesProperty,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -38,6 +38,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val postOntologiesCandeletecardinalities = baseEndpoints.withUserEndpoint.post
+    .in(base / "candeletecardinalities")
+    .in(stringJsonBody)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val patchOntologiesCardinalities = baseEndpoints.withUserEndpoint.patch
     .in(base / "cardinalities")
     .in(stringJsonBody)
@@ -149,6 +156,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      postOntologiesCandeletecardinalities,
       patchOntologiesCardinalities,
       putOntologiesGuiorder,
       getOntologiesClassesIris,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -38,6 +38,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val putOntologiesCardinalities = baseEndpoints.withUserEndpoint.put
+    .in(base / "cardinalities")
+    .in(stringJsonBody)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val postOntologiesCandeletecardinalities = baseEndpoints.withUserEndpoint.post
     .in(base / "candeletecardinalities")
     .in(stringJsonBody)
@@ -156,6 +163,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      putOntologiesCardinalities,
       postOntologiesCandeletecardinalities,
       patchOntologiesCardinalities,
       putOntologiesGuiorder,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -37,6 +37,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val deleteOntologiesComment = baseEndpoints.withUserEndpoint.delete
+    .in(base / "comment" / ontologyIriPath)
+    .in(lastModificationDate)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val postOntologiesProperties = baseEndpoints.withUserEndpoint.post
     .in(base / "properties")
     .in(stringJsonBody)
@@ -107,6 +114,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      deleteOntologiesComment,
       postOntologiesProperties,
       putOntologiesProperties,
       deletePropertiesComment,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -37,6 +37,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
+  val postOntologiesProperties = baseEndpoints.withUserEndpoint.post
+    .in(base / "properties")
+    .in(stringJsonBody)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
   val putOntologiesProperties = baseEndpoints.withUserEndpoint.put
     .in(base / "properties")
     .in(stringJsonBody)
@@ -100,6 +107,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      postOntologiesProperties,
       putOntologiesProperties,
       deletePropertiesComment,
       putOntologiesPropertiesGuielement,
@@ -108,9 +116,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
       postOntologies,
       getOntologiesCandeleteontology,
       deleteOntologies,
-    ).map(
-      _.endpoint.tag("V2 Ontologies"),
-    )
+    ).map(_.endpoint.tag("V2 Ontologies"))
 }
 
 object OntologiesEndpoints {

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -35,8 +35,16 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val ontologyIriPath      = path[IriDto].name("ontologyIri")
   private val propertyIriPath      = path[IriDto].name("propertyIri")
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
+  private val allLanguages         = query[Boolean]("allLanguages").default(false)
 
-  val getOntologyiesCandeleteproperty = baseEndpoints.withUserEndpoint.get
+  val getOntologiesProperties = baseEndpoints.withUserEndpoint.get
+    .in(base / "properties" / paths)
+    .in(allLanguages)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
+
+  val getOntologiesCandeleteproperty = baseEndpoints.withUserEndpoint.get
     .in(base / "candeleteproperty" / propertyIriPath)
     .in(ApiV2.Inputs.formatOptions)
     .out(stringBody)
@@ -70,7 +78,13 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
     .out(header[MediaType](HeaderNames.ContentType))
 
   val endpoints =
-    Seq(deleteOntologiesProperty, postOntologies, getOntologiesCandeleteontology, deleteOntologies).map(
+    Seq(
+      getOntologiesProperties,
+      deleteOntologiesProperty,
+      postOntologies,
+      getOntologiesCandeleteontology,
+      deleteOntologies,
+    ).map(
       _.endpoint.tag("V2 Ontologies"),
     )
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpoints.scala
@@ -34,8 +34,16 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   private val ontologyIriPath      = path[IriDto].name("ontologyIri")
   private val propertyIriPath      = path[IriDto].name("propertyIri")
+  private val resourceClassIriPath = path[IriDto].name("resourceClassIri")
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
   private val allLanguages         = query[Boolean]("allLanguages").default(false)
+
+  val deleteOntologiesClasses = baseEndpoints.withUserEndpoint.delete
+    .in(base / "classes" / resourceClassIriPath)
+    .in(lastModificationDate)
+    .in(ApiV2.Inputs.formatOptions)
+    .out(stringBody)
+    .out(header[MediaType](HeaderNames.ContentType))
 
   val deleteOntologiesComment = baseEndpoints.withUserEndpoint.delete
     .in(base / "comment" / ontologyIriPath)
@@ -114,6 +122,7 @@ final case class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
 
   val endpoints =
     Seq(
+      deleteOntologiesClasses,
       deleteOntologiesComment,
       postOntologiesProperties,
       putOntologiesProperties,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.postOntologiesCandeletecardinalities, restService.canDeleteCardinalitiesFromClass),
     SecuredEndpointHandler(endpoints.patchOntologiesCardinalities, restService.deleteCardinalitiesFromClass),
     SecuredEndpointHandler(endpoints.putOntologiesGuiorder, restService.changeGuiOrder),
     SecuredEndpointHandler(endpoints.getOntologiesClassesIris, restService.getClasses),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.putOntologiesProperties, restService.changePropertyLabelsOrComments),
     SecuredEndpointHandler(endpoints.deletePropertiesComment, restService.deletePropertyComment),
     SecuredEndpointHandler(endpoints.putOntologiesPropertiesGuielement, restService.changePropertyGuiElement),
     SecuredEndpointHandler(endpoints.getOntologiesProperties, restService.getProperties),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,7 +17,8 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
-    SecuredEndpointHandler(endpoints.getOntologyiesCandeleteproperty, restService.canDeleteProperty),
+    SecuredEndpointHandler(endpoints.getOntologiesProperties, restService.getProperties),
+    SecuredEndpointHandler(endpoints.getOntologiesCandeleteproperty, restService.canDeleteProperty),
     SecuredEndpointHandler(endpoints.deleteOntologiesProperty, restService.deleteProperty),
     SecuredEndpointHandler(endpoints.postOntologies, restService.createOntology),
     SecuredEndpointHandler(endpoints.getOntologiesCandeleteontology, restService.canDeleteOntology),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.putOntologiesGuiorder, restService.changeGuiOrder),
     SecuredEndpointHandler(endpoints.getOntologiesClassesIris, restService.getClasses),
     SecuredEndpointHandler(endpoints.getOntologiesCandeleteclass, restService.canDeleteClass),
     SecuredEndpointHandler(endpoints.deleteOntologiesClasses, restService.deleteClass),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.deleteOntologiesComment, restService.deleteOntologyComment),
     SecuredEndpointHandler(endpoints.postOntologiesProperties, restService.createProperty),
     SecuredEndpointHandler(endpoints.putOntologiesProperties, restService.changePropertyLabelsOrComments),
     SecuredEndpointHandler(endpoints.deletePropertiesComment, restService.deletePropertyComment),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.getOntologyCandeleteclass, restService.canDeleteClass),
     SecuredEndpointHandler(endpoints.deleteOntologiesClasses, restService.deleteClass),
     SecuredEndpointHandler(endpoints.deleteOntologiesComment, restService.deleteOntologyComment),
     SecuredEndpointHandler(endpoints.postOntologiesProperties, restService.createProperty),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.putOntologiesCardinalities, restService.replaceCardinalities),
     SecuredEndpointHandler(endpoints.postOntologiesCandeletecardinalities, restService.canDeleteCardinalitiesFromClass),
     SecuredEndpointHandler(endpoints.patchOntologiesCardinalities, restService.deleteCardinalitiesFromClass),
     SecuredEndpointHandler(endpoints.putOntologiesGuiorder, restService.changeGuiOrder),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.deletePropertiesComment, restService.deletePropertyComment),
     SecuredEndpointHandler(endpoints.putOntologiesPropertiesGuielement, restService.changePropertyGuiElement),
     SecuredEndpointHandler(endpoints.getOntologiesProperties, restService.getProperties),
     SecuredEndpointHandler(endpoints.getOntologiesCandeleteproperty, restService.canDeleteProperty),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,7 +17,8 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
-    SecuredEndpointHandler(endpoints.getOntologyCandeleteclass, restService.canDeleteClass),
+    SecuredEndpointHandler(endpoints.getOntologiesClassesIris, restService.getClasses),
+    SecuredEndpointHandler(endpoints.getOntologiesCandeleteclass, restService.canDeleteClass),
     SecuredEndpointHandler(endpoints.deleteOntologiesClasses, restService.deleteClass),
     SecuredEndpointHandler(endpoints.deleteOntologiesComment, restService.deleteOntologyComment),
     SecuredEndpointHandler(endpoints.postOntologiesProperties, restService.createProperty),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.postOntologiesProperties, restService.createProperty),
     SecuredEndpointHandler(endpoints.putOntologiesProperties, restService.changePropertyLabelsOrComments),
     SecuredEndpointHandler(endpoints.deletePropertiesComment, restService.deletePropertyComment),
     SecuredEndpointHandler(endpoints.putOntologiesPropertiesGuielement, restService.changePropertyGuiElement),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.deleteOntologiesClasses, restService.deleteClass),
     SecuredEndpointHandler(endpoints.deleteOntologiesComment, restService.deleteOntologyComment),
     SecuredEndpointHandler(endpoints.postOntologiesProperties, restService.createProperty),
     SecuredEndpointHandler(endpoints.putOntologiesProperties, restService.changePropertyLabelsOrComments),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.putOntologiesPropertiesGuielement, restService.changePropertyGuiElement),
     SecuredEndpointHandler(endpoints.getOntologiesProperties, restService.getProperties),
     SecuredEndpointHandler(endpoints.getOntologiesCandeleteproperty, restService.canDeleteProperty),
     SecuredEndpointHandler(endpoints.deleteOntologiesProperty, restService.deleteProperty),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologiesEndpointsHandler.scala
@@ -17,6 +17,7 @@ final class OntologiesEndpointsHandler(
 ) {
 
   val allHandlers = Seq(
+    SecuredEndpointHandler(endpoints.patchOntologiesCardinalities, restService.deleteCardinalitiesFromClass),
     SecuredEndpointHandler(endpoints.putOntologiesGuiorder, restService.changeGuiOrder),
     SecuredEndpointHandler(endpoints.getOntologiesClassesIris, restService.getClasses),
     SecuredEndpointHandler(endpoints.getOntologiesCandeleteclass, restService.canDeleteClass),

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologyApiModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/OntologyApiModule.scala
@@ -15,12 +15,13 @@ import org.knora.webapi.slice.common.api.KnoraResponseRenderer
 import org.knora.webapi.slice.common.api.TapirToPekkoInterpreter
 import org.knora.webapi.slice.ontology.api.service.OntologiesRestService
 import org.knora.webapi.slice.ontology.domain.service.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 
 object OntologyApiModule
     extends URModule[
-      AuthorizationRestService & BaseEndpoints & HandlerMapper & IriConverter & KnoraResponseRenderer & OntologyRepo &
-        OntologyResponderV2 & TapirToPekkoInterpreter,
+      AuthorizationRestService & BaseEndpoints & HandlerMapper & IriConverter & KnoraResponseRenderer &
+        OntologyCacheHelpers & OntologyRepo & OntologyResponderV2 & TapirToPekkoInterpreter,
       OntologiesApiRoutes & OntologiesEndpoints & OntologyV2RequestParser,
     ] { self =>
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -34,6 +34,14 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def changeGuiOrder(user: User)(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] =
+    for {
+      uuid      <- Random.nextUUID()
+      updateReq <- requestParser.changeGuiOrderRequestV2(jsonLd, uuid, user).mapError(BadRequestException.apply)
+      result    <- ontologyResponder.changeGuiOrder(updateReq)
+      response  <- renderer.render(result, formatOptions)
+    } yield response
+
   def getClasses(user: User)(
     classIris: List[String],
     allLanguages: Boolean,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -34,6 +34,16 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def canDeleteCardinalitiesFromClass(
+    user: User,
+  )(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] = for {
+    uuid <- Random.nextUUID()
+    updateReq <-
+      requestParser.canDeleteCardinalitiesFromClassRequestV2(jsonLd, uuid, user).mapError(BadRequestException.apply)
+    result   <- ontologyResponder.canDeleteCardinalitiesFromClass(updateReq)
+    response <- renderer.render(result, formatOptions)
+  } yield response
+
   def deleteCardinalitiesFromClass(
     user: User,
   )(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] = for {

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -34,6 +34,16 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def deleteCardinalitiesFromClass(
+    user: User,
+  )(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] = for {
+    uuid <- Random.nextUUID()
+    updateReq <-
+      requestParser.deleteCardinalitiesFromClassRequestV2(jsonLd, uuid, user).mapError(BadRequestException.apply)
+    result   <- ontologyResponder.deleteCardinalitiesFromClass(updateReq)
+    response <- renderer.render(result, formatOptions)
+  } yield response
+
   def changeGuiOrder(user: User)(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] =
     for {
       uuid      <- Random.nextUUID()

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -32,6 +32,20 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def deleteOntologyComment(user: User)(
+    ontologyIri: IriDto,
+    lastModificationDate: LastModificationDate,
+    formatOptions: FormatOptions,
+  ): Task[(RenderedResponse, MediaType)] = for {
+    uuid <- Random.nextUUID()
+    ontologyIri <- iriConverter
+                     .asOntologyIriApiV2Complex(ontologyIri.value)
+                     .mapError(BadRequestException.apply)
+                     .filterOrFail(_.isExternal)(BadRequestException("Only external ontologies can have comments"))
+    result   <- ontologyResponder.deleteOntologyComment(ontologyIri, lastModificationDate.value, uuid, user)
+    response <- renderer.render(result, formatOptions)
+  } yield response
+
   def createProperty(user: User)(
     jsonLd: String,
     formatOptions: FormatOptions,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -32,6 +32,18 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def changePropertyLabelsOrComments(user: User)(
+    jsonLd: String,
+    formatOptions: FormatOptions,
+  ): Task[(RenderedResponse, MediaType)] = for {
+    uuid <- Random.nextUUID()
+    updateReq <- requestParser
+                   .changePropertyLabelsOrCommentsRequestV2(jsonLd, uuid, user)
+                   .mapError(BadRequestException.apply)
+    result   <- ontologyResponder.changePropertyLabelsOrComments(updateReq)
+    response <- renderer.render(result, formatOptions)
+  } yield response
+
   def deletePropertyComment(user: User)(
     propertyIri: IriDto,
     lastModificationDate: LastModificationDate,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -32,6 +32,17 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def deletePropertyComment(user: User)(
+    propertyIri: IriDto,
+    lastModificationDate: LastModificationDate,
+    formatOptions: FormatOptions,
+  ): Task[(RenderedResponse, MediaType)] = for {
+    propertyIri <- iriConverter.asPropertyIri(propertyIri.value).mapError(BadRequestException.apply)
+    uuid        <- Random.nextUUID()
+    result      <- ontologyResponder.deletePropertyComment(propertyIri, lastModificationDate.value, uuid, user)
+    response    <- renderer.render(result, formatOptions)
+  } yield response
+
   def changePropertyGuiElement(
     user: User,
   )(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] = for {

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -32,6 +32,15 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def changePropertyGuiElement(
+    user: User,
+  )(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] = for {
+    uuid      <- Random.nextUUID()
+    updateReq <- requestParser.changePropertyGuiElementRequest(jsonLd, uuid, user).mapError(BadRequestException.apply)
+    result    <- ontologyResponder.changePropertyGuiElement(updateReq)
+    response  <- renderer.render(result, formatOptions)
+  } yield response
+
   def getProperties(user: User)(
     propertyIris: List[String],
     allLanguages: Boolean,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -32,6 +32,15 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def canDeleteClass(user: User)(
+    resourceClassIri: IriDto,
+    formatOptions: FormatOptions,
+  ): Task[(RenderedResponse, MediaType)] = for {
+    classIri <- iriConverter.asResourceClassIriApiV2Complex(resourceClassIri.value).mapError(BadRequestException.apply)
+    result   <- ontologyResponder.canDeleteClass(classIri, user)
+    response <- renderer.render(result, formatOptions)
+  } yield response
+
   def deleteClass(user: User)(
     resourceClassIri: IriDto,
     lastModificationDate: LastModificationDate,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -34,6 +34,16 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def replaceCardinalities(
+    user: User,
+  )(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] = for {
+    uuid <- Random.nextUUID()
+    updateReq <-
+      requestParser.replaceClassCardinalitiesRequestV2(jsonLd, uuid, user).mapError(BadRequestException.apply)
+    result   <- ontologyResponder.replaceClassCardinalities(updateReq)
+    response <- renderer.render(result, formatOptions)
+  } yield response
+
   def canDeleteCardinalitiesFromClass(
     user: User,
   )(jsonLd: String, formatOptions: FormatOptions): Task[(RenderedResponse, MediaType)] = for {

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/api/service/OntologiesRestService.scala
@@ -32,6 +32,16 @@ final case class OntologiesRestService(
   private val renderer: KnoraResponseRenderer,
 ) {
 
+  def createProperty(user: User)(
+    jsonLd: String,
+    formatOptions: FormatOptions,
+  ): Task[(RenderedResponse, MediaType)] = for {
+    uuid      <- Random.nextUUID()
+    createReq <- requestParser.createPropertyRequestV2(jsonLd, uuid, user).mapError(BadRequestException.apply)
+    result    <- ontologyResponder.createProperty(createReq)
+    response  <- renderer.render(result, formatOptions)
+  } yield response
+
   def changePropertyLabelsOrComments(user: User)(
     jsonLd: String,
     formatOptions: FormatOptions,

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/IriConverter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/IriConverter.scala
@@ -44,6 +44,8 @@ final case class IriConverter(sf: StringFormatter) {
   def asPropertyIri(iri: String): IO[String, PropertyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.from(sIri)))
 
+  def asOntologyIriApiV2Complex(iri: String): IO[String, OntologyIri] =
+    asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(OntologyIri.fromApiV2Complex(sIri)))
   def asOntologyIri(iri: String): IO[String, OntologyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(OntologyIri.from(sIri)))
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyCacheHelpers.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyCacheHelpers.scala
@@ -18,10 +18,18 @@ import org.knora.webapi.responders.v2.ontology.OntologyHelpers
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
+import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.*
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 
 final case class OntologyCacheHelpers(ontologyCache: OntologyCache, ontologyRepo: OntologyRepo) {
+
+  def getClasses(
+    classIris: Seq[ResourceClassIri],
+    allLanguages: Boolean,
+    requestingUser: User,
+  ): Task[ReadOntologyV2] =
+    getClassDefinitionsFromOntologyV2(classIris.map(_.smartIri).toSet, allLanguages, requestingUser)
 
   /**
    * Requests information about OWL classes in a single ontology.

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyCacheHelpers.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyCacheHelpers.scala
@@ -17,10 +17,11 @@ import org.knora.webapi.messages.v2.responder.ontologymessages.*
 import org.knora.webapi.responders.v2.ontology.OntologyHelpers
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.*
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 
-final case class OntologyCacheHelpers(ontologyCache: OntologyCache) {
+final case class OntologyCacheHelpers(ontologyCache: OntologyCache, ontologyRepo: OntologyRepo) {
 
   /**
    * Requests information about OWL classes in a single ontology.
@@ -319,24 +320,29 @@ final case class OntologyCacheHelpers(ontologyCache: OntologyCache) {
   /**
    * Checks whether the requesting user has permission to update an ontology.
    *
-   * @param internalOntologyIri the internal IRI of the ontology.
+   * @param ontologyIri the internal IRI of the ontology.
    * @param requestingUser      the user making the request.
    * @return `true` if the user has permission to update the ontology
    */
-  def canUserUpdateOntology(internalOntologyIri: SmartIri, requestingUser: User): Task[Boolean] =
-    for {
-      cacheData <- ontologyCache.getCacheData
+  def canUserUpdateOntology(ontologyIri: OntologyIri, requestingUser: User): Task[Boolean] = for {
+    ontology <- ontologyRepo
+                  .findById(ontologyIri)
+                  .someOrFail(NotFoundException(s"Ontology ${ontologyIri.toComplexSchema} not found"))
+    projectIri <- ZIO
+                    .fromOption(ontology.projectIri)
+                    .orElseFail(NotFoundException(s"Project IRI not found for ontology ${ontologyIri.toComplexSchema}"))
+    canUpdate = requestingUser.permissions.isProjectAdmin(projectIri) || requestingUser.permissions.isSystemAdmin
+  } yield canUpdate
 
-      projectIri =
-        cacheData.ontologies
-          .getOrElse(
-            internalOntologyIri,
-            throw NotFoundException(s"Ontology ${internalOntologyIri.toOntologySchema(ApiV2Complex)} not found"),
-          )
-          .ontologyMetadata
-          .projectIri
-          .get
-    } yield requestingUser.permissions.isProjectAdmin(projectIri.toString) || requestingUser.permissions.isSystemAdmin
+  /**
+   * Checks whether the requesting user has permission to update an ontology.
+   *
+   * @param ontologyIri the internal IRI of the ontology.
+   * @param requestingUser      the user making the request.
+   * @return `true` if the user has permission to update the ontology
+   */
+  def canUserUpdateOntology(ontologyIri: SmartIri, requestingUser: User): Task[Boolean] =
+    canUserUpdateOntology(OntologyIri.unsafeFrom(ontologyIri), requestingUser)
 }
 
 object OntologyCacheHelpers {

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyRepo.scala
@@ -16,6 +16,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
+import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.repo.service.Repository
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
 
@@ -32,6 +33,7 @@ trait OntologyRepo extends Repository[ReadOntologyV2, InternalIri] {
 
   def findByProject(projectId: ProjectIri): Task[List[ReadOntologyV2]]
 
+  final def findClassBy(classIri: ResourceClassIri): Task[Option[ReadClassInfoV2]] = findClassBy(classIri.toInternalIri)
   def findClassBy(classIri: InternalIri): Task[Option[ReadClassInfoV2]]
 
   def findDirectSuperClassesBy(classIri: InternalIri): Task[List[ReadClassInfoV2]]


### PR DESCRIPTION
- **Migrate GET /v2/ontologies/properties/:propertyIris**
- **simplify**
- **Migrate PUT /v2/ontologies/properties/guielement**
- **Migrate DELETE /v2/ontologies/properties/comment/:propertyIri?lastModificationDate=...**
- **Migrate PUT /v2/ontologies/properties**
- **Migrate POST /v2/ontologies/properties**
- **Migrate DELETE /v2/ontologies/comment/:ontologyIri**
- **Migrate DELETE /v2/ontologies/classes/:resourceClassIri**
- **Migrate GET /v2/ontologies/candeleteclass/:resourceClassIri**
- **Migrate GET /v2/ontologies/classes/:resourceClassIris**

<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
