### PR TITLE
fix: Make data of our PagedResponses required in OpenAPI yaml

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsLegalInfoEndpoints.scala
@@ -23,6 +23,9 @@ final case class LicenseDto(id: String, uri: String, labelEn: String)
 object LicenseDto {
   given JsonCodec[LicenseDto] = DeriveJsonCodec.gen[LicenseDto]
   given Ordering[LicenseDto]  = Ordering.by(_.labelEn)
+  given Schema[PagedResponse[LicenseDto]] = Schema
+    .derived[PagedResponse[LicenseDto]]
+    .modify(_.data)(_.copy(isOptional = false))
 
   def from(license: License): LicenseDto = LicenseDto(license.id.value, license.uri.toString, license.labelEn)
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/Pagination.scala
@@ -6,6 +6,7 @@
 package org.knora.webapi.slice.admin.api.model
 
 import sttp.tapir.EndpointInput
+import sttp.tapir.Schema
 import sttp.tapir.Validator
 import sttp.tapir.query
 import zio.json.DeriveJsonCodec
@@ -14,6 +15,7 @@ import zio.json.JsonCodec
 final case class Pagination(pageSize: Int, totalItems: Int, totalPages: Int, currentPage: Int)
 object Pagination {
   given JsonCodec[Pagination] = DeriveJsonCodec.gen[Pagination]
+  given Schema[Pagination]    = Schema.derived[Pagination]
 
   def from(totalItems: Int, pageAndSize: PageAndSize): Pagination =
     val totalPages = Math.ceil(totalItems.toDouble / pageAndSize.size).toInt

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -12,6 +12,7 @@ import zio.json.JsonCodec
 import zio.prelude.Validation
 
 import java.net.URI
+
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.admin.api.Codecs.ZioJsonCodec
 import org.knora.webapi.slice.admin.api.model.PagedResponse

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -12,9 +12,9 @@ import zio.json.JsonCodec
 import zio.prelude.Validation
 
 import java.net.URI
-
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.admin.api.Codecs.ZioJsonCodec
+import org.knora.webapi.slice.admin.api.model.PagedResponse
 import org.knora.webapi.slice.admin.domain.model.LicenseIri.AI_GENERATED
 import org.knora.webapi.slice.admin.domain.model.LicenseIri.CC_BY_4_0
 import org.knora.webapi.slice.admin.domain.model.LicenseIri.CC_BY_NC_4_0
@@ -33,7 +33,10 @@ final case class CopyrightHolder private (override val value: String) extends St
 object CopyrightHolder extends StringValueCompanion[CopyrightHolder] {
   given JsonCodec[CopyrightHolder] = ZioJsonCodec.stringCodec(CopyrightHolder.from)
   given Schema[CopyrightHolder]    = Schema.string
-  given Ordering[CopyrightHolder]  = Ordering.by(_.value)
+  given Schema[PagedResponse[CopyrightHolder]] =
+    Schema.derived[PagedResponse[CopyrightHolder]].modify(_.data)(_.copy(isOptional = false))
+
+  given Ordering[CopyrightHolder] = Ordering.by(_.value)
   def from(str: String): Either[String, CopyrightHolder] =
     fromValidations(
       "Copyright Holder",
@@ -46,6 +49,8 @@ final case class Authorship private (override val value: String) extends StringV
 object Authorship extends StringValueCompanion[Authorship] {
   given JsonCodec[Authorship] = ZioJsonCodec.stringCodec(Authorship.from)
   given Schema[Authorship]    = Schema.string
+  given Schema[PagedResponse[Authorship]] =
+    Schema.derived[PagedResponse[Authorship]].modify(_.data)(_.copy(isOptional = false))
   def from(str: String): Either[String, Authorship] =
     fromValidations("Authorship", Authorship.apply, List(nonEmpty, noLineBreaks, maxLength(1_000)))(str)
 }
@@ -53,7 +58,9 @@ object Authorship extends StringValueCompanion[Authorship] {
 final case class LicenseIri private (override val value: String) extends StringValue
 object LicenseIri extends StringValueCompanion[LicenseIri] {
   given JsonCodec[LicenseIri] = ZioJsonCodec.stringCodec(LicenseIri.from)
-  given Schema[LicenseIri]    = Schema.string
+  given Schema[PagedResponse[LicenseIri]] =
+    Schema.derived[PagedResponse[LicenseIri]].modify(_.data)(_.copy(isOptional = false))
+  given Schema[LicenseIri] = Schema.string
 
   /**
    * Explanation of the IRI regex:
@@ -101,6 +108,7 @@ object LicenseIri extends StringValueCompanion[LicenseIri] {
 
 final case class License private (id: LicenseIri, uri: URI, labelEn: String)
 object License {
+
   val BUILT_IN: Chunk[License] = Chunk(
     License(CC_BY_4_0, URI.create("https://creativecommons.org/licenses/by/4.0/"), "CC BY 4.0"),
     License(CC_BY_SA_4_0, URI.create("https://creativecommons.org/licenses/by-sa/4.0/"), "CC BY-SA 4.0"),


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

Due to a bug in the yaml generator I am unable to provide the schema on the generic PagedResponse directly and hence we have to add it to each Value used in PagedResponse.

The bug we are affected by is https://github.com/softwaremill/tapir/issues/3922

<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
