### PR TITLE
fix: Align erasing and deleting Resources, prevent deletion of a resource if it is in use (DEV-4767)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -61,7 +61,6 @@ object ResourcesResponderV2Spec {
 
   private val aThingIri                  = "http://rdfh.ch/0001/a-thing"
   private var aThingLastModificationDate = Instant.now
-  private val aThingCreationDate         = Instant.parse("2016-03-02T15:05:10Z")
 
   private val resourceIriToErase                  = new MutableTestIri
   private val firstValueIriToErase                = new MutableTestIri


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description
Deleting or erasing a resource have different preconditions.
Add check for in use when deleting the resource; the same way when erasing.

<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
