### PR TITLE
fix: When an EditConflictException is returned it is rendered as 400 Bad Request

### DIFF
--- a/webapi/src/main/scala/dsp/errors/Errors.scala
+++ b/webapi/src/main/scala/dsp/errors/Errors.scala
@@ -164,6 +164,9 @@ object OntologyConstraintException {
  * @param message a description of the error.
  */
 case class EditConflictException(message: String) extends RequestRejectedException(message)
+object EditConflictException {
+  given codec: JsonCodec[EditConflictException] = DeriveJsonCodec.gen[EditConflictException]
+}
 
 /**
  * An exception indicating that the submitted standoff is not valid.

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/api/BaseEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/api/BaseEndpoints.scala
@@ -37,6 +37,9 @@ final case class BaseEndpoints(authenticator: Authenticator)(implicit val r: zio
       // default
       oneOfVariant[NotFoundException](statusCode(StatusCode.NotFound).and(jsonBody[NotFoundException])),
       oneOfVariant[BadRequestException](statusCode(StatusCode.BadRequest).and(jsonBody[BadRequestException])),
+      oneOfVariant[EditConflictException](
+        statusCode(StatusCode.BadRequest).and(jsonBody[EditConflictException]),
+      ),
       oneOfVariant[OntologyConstraintException](
         statusCode(StatusCode.BadRequest).and(jsonBody[OntologyConstraintException]),
       ),


### PR DESCRIPTION

### Description

Before this fix the appropriate mapping was missing in Tapir and a 500 was returned.

<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->


<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
