### PR TITLE
fix: Allow to delete or erase a kb:Resource only if no other non-deleted kb:Resource in the same project points to it

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1257,6 +1257,7 @@ final case class OntologyResponderV2(
            .someOrFail(BadRequestException(s"Class $classIri does not exist"))
     userCanUpdateOntology <- ontologyCacheHelpers.canUserUpdateOntology(classIri.ontologyIri, requestingUser)
     classIsUsed           <- iriService.isEntityUsed(classIri.toInternalSchema)
+    _                     <- ZIO.logInfo(s"class ${classIri.toInternalSchema.toIri}, user $userCanUpdateOntology, classIsUsed $classIsUsed")
   } yield CanDoResponseV2.of(userCanUpdateOntology && !classIsUsed)
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1257,7 +1257,6 @@ final case class OntologyResponderV2(
            .someOrFail(BadRequestException(s"Class $classIri does not exist"))
     userCanUpdateOntology <- ontologyCacheHelpers.canUserUpdateOntology(classIri.ontologyIri, requestingUser)
     classIsUsed           <- iriService.isEntityUsed(classIri.toInternalSchema)
-    _                     <- ZIO.logInfo(s"class ${classIri.toInternalSchema.toIri}, user $userCanUpdateOntology, classIsUsed $classIsUsed")
   } yield CanDoResponseV2.of(userCanUpdateOntology && !classIsUsed)
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -384,6 +384,9 @@ final case class ResourcesResponderV2(
                          requestingUser = deleteResourceV2.requestingUser.id,
                        )
         // Do the update.
+        _ <- ZIO.logInfo(
+               s"User ${deleteResourceV2.requestingUser.id} is deleting resource ${deleteResourceV2.resourceIri}",
+             )
         _ <- triplestore.query(Update(sparqlUpdate))
 
         // Verify that the resource was deleted correctly.
@@ -503,6 +506,9 @@ final case class ResourcesResponderV2(
         dataNamedGraph = ProjectService.projectDataNamedGraphV2(resource.projectADM).value
 
         // Do the update.
+        _ <- ZIO.logInfo(
+               s"User ${eraseResourceV2.requestingUser.id} is erasing resource ${eraseResourceV2.resourceIri}",
+             )
         _ <- triplestore.query(Update(sparql.v2.txt.eraseResource(dataNamedGraph, eraseResourceV2.resourceIri)))
 
         _ <- // Verify that the resource was erased correctly.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -416,7 +416,7 @@ final case class ResourcesResponderV2(
    *
    * @param resourceIri the IRI of the Resource to check.
    *
-   * @return `true` if the entity is used.
+   * @return The list of resources that are pointing to the resource to check.
    */
   private def isResourceInUse(resourceIri: ResourceIri): Task[Set[ResourceIri]] =
     for {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
@@ -113,13 +113,14 @@ final case class KnoraProjectService(knoraProjectRepo: KnoraProjectRepo, ontolog
       } yield updated
     }
 
-  def getNamedGraphsForProject(project: KnoraProject): Task[List[InternalIri]] = {
-    val projectGraph = ProjectService.projectDataNamedGraphV2(project)
-    ontologyRepo
-      .findByProject(project.id)
-      .map(_.map(_.ontologyMetadata.ontologyIri.toInternalIri))
-      .map(_ :+ projectGraph)
-  }
+  def getNamedGraphsForProject(project: KnoraProject): Task[List[InternalIri]] =
+    getOntologyGraphsForProject(project).map(_ :+ getDataGraphForProject(project))
+
+  def getDataGraphForProject(project: KnoraProject): InternalIri =
+    ProjectService.projectDataNamedGraphV2(project)
+
+  def getOntologyGraphsForProject(project: KnoraProject): Task[List[InternalIri]] =
+    ontologyRepo.findByProject(project.id).map(_.map(_.ontologyMetadata.ontologyIri.toInternalIri))
 
   def addCopyrightHolders(project: ProjectIri, addThese: Set[CopyrightHolder]): Task[KnoraProject] =
     withProjectFromDb(project) { project =>

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/repo/rdf/Vocabulary.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/repo/rdf/Vocabulary.scala
@@ -74,6 +74,8 @@ object Vocabulary {
 
     val NS: Namespace = new SimpleNamespace("knora-base", kb)
 
+    val Resource: Iri = iri(kb + "Resource")
+
     val linkValue: Iri = iri(kb + "LinkValue")
 
     val isDeleted: Iri         = iri(kb + "isDeleted")

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/IriConverter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/IriConverter.scala
@@ -16,6 +16,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.KnoraIris.ResourceIri
 import org.knora.webapi.slice.resourceinfo.domain.InternalIri
 
 final case class IriConverter(sf: StringFormatter) {
@@ -43,6 +44,9 @@ final case class IriConverter(sf: StringFormatter) {
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.fromApiV2Complex(sIri)))
   def asPropertyIri(iri: String): IO[String, PropertyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.from(sIri)))
+
+  def asResourceIri(iri: String): IO[String, ResourceIri] =
+    asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(ResourceIri.from(sIri)))
 
   def asOntologyIriApiV2Complex(iri: String): IO[String, OntologyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(OntologyIri.fromApiV2Complex(sIri)))


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

- **fix: Allow to delete or erase a Resource only if no other non-delete Resource in the same project points to it // removes checking refs from Values**

I have been looking into Johannes Nussbaum's problem ([RDU-74](https://linear.app/dasch/issue/RDU-74/0806-webern-remove-class-publishing-house-from-data-model-on-prod)) together with Nora Ammann .

Essentially he wants to erase a resource but api prevents this.
```
{
    "message": "Resource http://rdfh.ch/0806/_o3Ck2WsT-2qiJFmKTEqfQ cannot be erased, because it is referred to by another resource"
}
```


The error message of this response is misleading. Basically the check of "is referred to by another resource" is currently broken, in the sense that it also detects properties coming from deleted or previous versions of `knora-base:Value`s pointing to a` knora-base:Resource`. It is not checking for other `knora-base:Resource`s.

Analysis shows that it is a StandoffLinkTag of a previous version of a non deleted link pointing to the resource is pointing to the resource to be deleted. 

After discussion with Nora we came to the conclusion that the check before delete/erase should only ensure that there are no direct "links" between non-deleted `knora-base:Resource`s in the same project.

The new query looks like this:
```sparql
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>

SELECT DISTINCT ?otherResource
WHERE { 
    GRAPH <data-graph-of-resource-to-be-deleted> {
        ?otherResource ?directLink <resource-to-be-deleted> ;
            knora-base:isDeleted false ;
            a ?otherResourceClass .
    }
    ?otherResourceClass rdfs:subClassOf* knora-base:Resource . 
}
```

Only if the result set is empty a `knora-base:Resource` may be deleted or removed.

