### PR TITLE
fix: Do not remove values from other `kb:Resource`s when erasing another `kb:Resource`

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -2245,11 +2245,6 @@ class ResourcesResponderV2Spec extends CoreSpec with ImplicitSender { self =>
         val query = sparql.admin.txt.checkIriExists(erasedIriToCheck.toString)
         UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TriplestoreService](_.query(Ask(query)))) should be(false)
       }
-
-      // Check that the deleted link value that pointed to the resource has also been erased.
-      val query =
-        sparql.v2.txt.isEntityUsed(resourceIriToErase.get.toSmartIri.toInternalIri, ignoreKnoraConstraints = true)
-      UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TriplestoreService](_.query(Ask(query)))) should be(false)
     }
   }
   "When given a custom IRI" should {

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResource.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/eraseResource.scala.txt
@@ -25,8 +25,6 @@ DELETE {
         <@resourceIri> ?resourcePred ?resourceObj .
         ?value ?valuePred ?valueObj .
         ?standoff ?standoffPred ?standoffObj .
-        ?otherResource ?otherResourceProp ?otherResourceCurrentLinkValue .
-        ?otherResourceLinkValue ?otherResourceLinkValuePred ?otherResourceLinkValueObj .
     }
 } WHERE {
     BIND(IRI("@dataNamedGraph") AS ?dataNamedGraph)
@@ -55,14 +53,5 @@ DELETE {
             knora-base:previousValue* ?textValue .
         ?textValue knora-base:valueHasStandoff ?standoff .
         ?standoff ?standoffPred ?standoffObj .
-    } UNION {
-        @* Collect all statements about marked-as-deleted link values that point to the resource. *@
-
-        ?otherResourceCurrentLinkValue rdf:object <@resourceIri> ;
-            a knora-base:LinkValue ;
-            knora-base:isDeleted true ;
-            knora-base:previousValue* ?otherResourceLinkValue .
-        ?otherResourceLinkValue ?otherResourceLinkValuePred ?otherResourceLinkValueObj .
-        ?otherResource ?otherResourceProp ?otherResourceCurrentLinkValue .
     }
 }


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

Before erasing a `kb:Resource` we make sure that no other non-deleted Resource is referencing the one to be deleted with any non-deleted `kb:Value`.

In turn this means we are accepting deleted or previous versions of `kb:Values` may reference an IRI which does not exist anymore, aka. is a dangling reference.

The past practice of erasing `LinkValues` from other resources is not only dangerous and incomplete (as it does not take into account Standoff) - it also created an accidential complexity which is hard to understand. Hence this is removed.