### PR TITLE
feat: Add feature flag for full license check during asset creation

### DIFF
--- a/integration/src/test/resources/application.conf
+++ b/integration/src/test/resources/application.conf
@@ -18,5 +18,6 @@ app {
 
   features {
     allow-erase-projects = true
+    enable-full-license-check = true
   }
 }

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -462,6 +462,9 @@ app {
 
         disable-last-modification-date-check = false
         disable-last-modification-date-check = ${?DISABLE_LAST_MODIFICATION_DATE_CHECK}
+
+        enable-full-license-check = false
+        enable-full-license-check = ${?ENABLE_FULL_LICENSE_CHECK}
     }
 
     open-telemetry-tracer {

--- a/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -179,6 +179,7 @@ final case class Features(
   allowEraseProjects: Boolean,
   disableLastModificationDateCheck: Boolean,
   triggerCompactionAfterProjectErasure: Boolean,
+  enableFullLicenseCheck: Boolean,
 )
 
 final case class OpenTelemetryTracer(

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/AdminModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/AdminModule.scala
@@ -8,6 +8,7 @@ package org.knora.webapi.slice.admin
 import zio.URLayer
 
 import org.knora.webapi.config.AppConfig
+import org.knora.webapi.config.Features
 import org.knora.webapi.responders.IriService
 import org.knora.webapi.slice.URModule
 import org.knora.webapi.slice.admin.domain.AdminDomainModule
@@ -26,6 +27,7 @@ object AdminModule
       AppConfig &
       CacheManager &
       DspIngestClient &
+      Features &
       IriConverter &
       IriService &
       OntologyCache &

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/AdminDomainModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/AdminDomainModule.scala
@@ -9,6 +9,7 @@ import zio.URLayer
 import zio.ZLayer
 
 import org.knora.webapi.config.AppConfig
+import org.knora.webapi.config.Features
 import org.knora.webapi.responders.IriService
 import org.knora.webapi.slice.URModule
 import org.knora.webapi.slice.admin.domain.service.*
@@ -32,6 +33,7 @@ object AdminDomainModule
       AppConfig &
       CacheManager &
       DspIngestClient &
+      Features &
       IriConverter &
       IriService &
       OntologyCache &

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LegalInfoServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LegalInfoServiceSpec.scala
@@ -58,7 +58,7 @@ object LegalInfoServiceSpec extends ZIOSpecDefault {
         prj    <- setupProject
         _      <- service(_.disableLicense(enabledLicense, prj))
         actual <- service(_.findAvailableLicenses(prj.shortcode))
-      } yield assertTrue(actual == License.BUILT_IN)
+      } yield assertTrue(actual == License.BUILT_IN.toSet)
     },
   )
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LegalInfoServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/LegalInfoServiceSpec.scala
@@ -5,8 +5,7 @@
 
 package org.knora.webapi.slice.admin.domain.service
 
-import zio.Exit
-import zio.ZIO
+import zio.*
 import zio.test.*
 import zio.test.Assertion.*
 
@@ -137,5 +136,13 @@ object LegalInfoServiceSpec extends ZIOSpecDefault {
     StringFormatter.test,
     TriplestoreServiceInMemory.emptyLayer,
     CacheManager.layer,
+    ZLayer.succeed(
+      org.knora.webapi.config.Features(
+        allowEraseProjects = false,
+        disableLastModificationDateCheck = false,
+        triggerCompactionAfterProjectErasure = false,
+        enableFullLicenseCheck = true,
+      ),
+    ),
   )
 }


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

The frontend does not yet implement the possibility to enable licenses, so that we have to be able to disable the check for now.

This PR makes it configurable per environment. Per default the license is only checked to be available but does not have to be enabled on the project where the `FileValue` was created.
<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
