### PR TITLE
fix: Allow empty strings as results from the database (DEV-4887)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
@@ -226,14 +226,14 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
       }
     }
 
-    "should allow empty Strings a values" in {
+    "should allow empty Strings as values" in {
       val iri          = Rdf.iri("http://example.com/test")
       val emptyString  = ""
       val emptyComment = "emptyComment"
 
       val insertQuery = Queries
         .INSERT_DATA(iri.has(RDFS.COMMENT, emptyString))
-        .into(Rdf.iri("http://example.com/graph"))
+        .into(Rdf.iri("http://example.com/allowemptystringgraph"))
 
       val selectQuery = Queries
         .SELECT(SparqlBuilder.`var`(emptyComment))
@@ -243,12 +243,7 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
         ZIO.logWarning(insertQuery.getQueryString) *>
           ZIO.serviceWithZIO[TriplestoreService](ts => ts.query(Update(insertQuery)) *> ts.query(Select(selectQuery))),
       )
-      actual.results.bindings.headOption match {
-        case Some(row) =>
-          row.rowMap.get(emptyComment) should ===(Some(emptyString))
-        case None =>
-          fail("Expected a result, but got none")
-      }
+      actual.getCol(emptyComment) shouldBe Seq(emptyString)
     }
   }
 }

--- a/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
@@ -221,21 +221,21 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
     }
 
     "should allow empty Strings as values" in {
-      val iri          = Rdf.iri("http://example.com/test")
-      val emptyString  = ""
-      val emptyComment = "emptyComment"
+      val iri         = Rdf.iri("http://example.com/resource-with-comment")
+      val emptyString = ""
+      val commentVar  = "emptyComment"
 
       val insertQuery = Queries
         .INSERT_DATA(iri.has(RDFS.COMMENT, emptyString))
-        .into(Rdf.iri("http://example.com/allowemptystringgraph"))
+        .into(Rdf.iri("allowemptystringgraph"))
 
       val selectQuery = Queries
-        .SELECT(SparqlBuilder.`var`(emptyComment))
-        .where(iri.has(RDFS.COMMENT, SparqlBuilder.`var`(emptyComment)))
+        .SELECT(SparqlBuilder.`var`(commentVar))
+        .where(iri.has(RDFS.COMMENT, SparqlBuilder.`var`(commentVar)))
 
       val actual =
         UnsafeZioRun.runOrThrow(triplestore(t => t.insert(insertQuery) *> t.select(selectQuery)))
-      actual.getCol(emptyComment) shouldBe Seq(emptyString)
+      actual.getCol(commentVar) shouldBe Seq(emptyString)
     }
   }
 }

--- a/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
@@ -24,6 +24,8 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
 class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
 
+  private val triplestore = ZIO.serviceWithZIO[TriplestoreService]
+
   override implicit val timeout: FiniteDuration = 30.seconds
 
   override lazy val rdfDataObjects: List[RdfDataObject] = List(
@@ -141,39 +143,36 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
 
     "reset the data after receiving a 'ResetTriplestoreContent' request" in {
       UnsafeZioRun.runOrThrow(
-        ZIO
-          .serviceWithZIO[TriplestoreService](_.resetTripleStoreContent(rdfDataObjects))
+        triplestore(_.resetTripleStoreContent(rdfDataObjects))
           .timeout(java.time.Duration.ofMinutes(5)),
       )
 
-      val msg = UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TriplestoreService](_.query(Select(countTriplesQuery))))
+      val msg = UnsafeZioRun.runOrThrow(triplestore(_.query(Select(countTriplesQuery))))
       afterLoadCount = msg.getFirstOrThrow("no").toInt
       (afterLoadCount > 0) should ===(true)
     }
 
     "provide data receiving a Named Graph request" in {
-      val actual = UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TriplestoreService](_.query(Select(namedGraphQuery))))
+      val actual = UnsafeZioRun.runOrThrow(triplestore(_.query(Select(namedGraphQuery))))
       actual.nonEmpty should ===(true)
     }
 
     "execute an update" in {
       val countTriplesBefore = UnsafeZioRun.runOrThrow(
-        ZIO
-          .serviceWithZIO[TriplestoreService](_.query(Select(countTriplesQuery)))
+        triplestore(_.query(Select(countTriplesQuery)))
           .map(_.getFirstOrThrow("no").toInt),
       )
       countTriplesBefore should ===(afterLoadCount)
 
-      UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TriplestoreService](_.query(Update(insertQuery))))
+      UnsafeZioRun.runOrThrow(triplestore(_.query(Update(insertQuery))))
 
       val checkInsertActual = UnsafeZioRun.runOrThrow(
-        ZIO.serviceWithZIO[TriplestoreService](_.query(Select(checkInsertQuery))).map(_.size),
+        triplestore(_.query(Select(checkInsertQuery))).map(_.size),
       )
       checkInsertActual should ===(3)
 
       afterChangeCount = UnsafeZioRun.runOrThrow(
-        ZIO
-          .serviceWithZIO[TriplestoreService](_.query(Select(countTriplesQuery)))
+        triplestore(_.query(Select(countTriplesQuery)))
           .map(_.getFirstOrThrow("no").toInt),
       )
       (afterChangeCount - afterLoadCount) should ===(3)
@@ -181,24 +180,21 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
 
     "revert back " in {
       val countTriplesBefore = UnsafeZioRun.runOrThrow(
-        ZIO
-          .serviceWithZIO[TriplestoreService](_.query(Select(countTriplesQuery)))
+        triplestore(_.query(Select(countTriplesQuery)))
           .map(_.getFirstOrThrow("no").toInt),
       )
       countTriplesBefore should ===(afterChangeCount)
 
-      UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TriplestoreService](_.query(Update(revertInsertQuery))))
+      UnsafeZioRun.runOrThrow(triplestore(_.query(Update(revertInsertQuery))))
 
       val countTriplesQueryActual = UnsafeZioRun.runOrThrow(
-        ZIO
-          .serviceWithZIO[TriplestoreService](_.query(Select(countTriplesQuery)))
+        triplestore(_.query(Select(countTriplesQuery)))
           .map(_.getFirstOrThrow("no").toInt),
       )
       countTriplesQueryActual should ===(afterLoadCount)
 
       val checkInsertActual = UnsafeZioRun.runOrThrow(
-        ZIO
-          .serviceWithZIO[TriplestoreService](_.query(Select(checkInsertQuery)))
+        triplestore(_.query(Select(checkInsertQuery)))
           .map(_.size),
       )
       checkInsertActual should ===(0)
@@ -207,8 +203,7 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
     "execute the search with the lucene index for 'knora-base:valueHasString' properties" in {
       within(1000.millis) {
         val actual = UnsafeZioRun.runOrThrow(
-          ZIO
-            .serviceWithZIO[TriplestoreService](_.query(Select(textSearchQueryFusekiValueHasString)))
+          triplestore(_.query(Select(textSearchQueryFusekiValueHasString)))
             .map(_.size),
         )
         actual should ===(4)
@@ -218,8 +213,7 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
     "execute the search with the lucene index for 'rdfs:label' properties" in {
       within(1000.millis) {
         val actual = UnsafeZioRun.runOrThrow(
-          ZIO
-            .serviceWithZIO[TriplestoreService](_.query(Select(textSearchQueryFusekiDRFLabel)))
+          triplestore(_.query(Select(textSearchQueryFusekiDRFLabel)))
             .map(_.size),
         )
         actual should ===(1)
@@ -239,10 +233,8 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
         .SELECT(SparqlBuilder.`var`(emptyComment))
         .where(iri.has(RDFS.COMMENT, SparqlBuilder.`var`(emptyComment)))
 
-      val actual = UnsafeZioRun.runOrThrow(
-        ZIO.logWarning(insertQuery.getQueryString) *>
-          ZIO.serviceWithZIO[TriplestoreService](ts => ts.query(Update(insertQuery)) *> ts.query(Select(selectQuery))),
-      )
+      val actual =
+        UnsafeZioRun.runOrThrow(triplestore(ts => ts.query(Update(insertQuery)) *> ts.query(Select(selectQuery))))
       actual.getCol(emptyComment) shouldBe Seq(emptyString)
     }
   }

--- a/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/store/triplestore/TriplestoreServiceLiveSpec.scala
@@ -234,7 +234,7 @@ class TriplestoreServiceLiveSpec extends CoreSpec with ImplicitSender {
         .where(iri.has(RDFS.COMMENT, SparqlBuilder.`var`(emptyComment)))
 
       val actual =
-        UnsafeZioRun.runOrThrow(triplestore(ts => ts.query(Update(insertQuery)) *> ts.query(Select(selectQuery))))
+        UnsafeZioRun.runOrThrow(triplestore(t => t.insert(insertQuery) *> t.select(selectQuery)))
       actual.getCol(emptyComment) shouldBe Seq(emptyString)
     }
   }

--- a/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/store/triplestoremessages/TriplestoreMessages.scala
@@ -393,7 +393,7 @@ object SparqlResultProtocol extends DefaultJsonProtocol {
   implicit val VariableResultsZioJsonFormat: JsonDecoder[VariableResultsRow] =
     JsonDecoder[Json.Obj].map { obj =>
       val mapToWrap: Map[String, String] = obj.fields.toList.foldMap { case (key, value) =>
-        value.asObject.foldMap(_.get("value").flatMap(_.asString).filter(_.nonEmpty).foldMap(s => Map(key -> s)))
+        value.asObject.foldMap(_.get("value").flatMap(_.asString).foldMap(s => Map(key -> s)))
       }
 
       // Wrapped in an ErrorHandlingMap which gracefully reports errors about accessing missing values.
@@ -402,7 +402,7 @@ object SparqlResultProtocol extends DefaultJsonProtocol {
     }
 
   implicit val SparqlSelectResponseBodyFormatZ: JsonDecoder[SparqlSelectResultBody] =
-    DeriveJsonDecoder.gen[SparqlSelectResultBodyUnchecked].map(_.asChecked)
+    DeriveJsonDecoder.gen[SparqlSelectResultBody]
 
   implicit val headerDecoder: JsonDecoder[SparqlSelectResultHeader] = DeriveJsonDecoder.gen[SparqlSelectResultHeader]
   implicit val responseDecoder: JsonDecoder[SparqlSelectResult]     = DeriveJsonDecoder.gen[SparqlSelectResult]

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/SparqlSelectResult.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/SparqlSelectResult.scala
@@ -70,13 +70,7 @@ case class SparqlSelectResultHeader(vars: Seq[String])
  * @param bindings the bindings of values to the variables used in the SPARQL SELECT statement.
  *                 Empty rows are not allowed.
  */
-case class SparqlSelectResultBody(bindings: Seq[VariableResultsRow]) {
-  require(bindings.forall(_.rowMap.nonEmpty), "Empty rows are not allowed in a SparqlSelectResponseBody")
-}
-
-case class SparqlSelectResultBodyUnchecked(bindings: Seq[VariableResultsRow]) {
-  def asChecked = SparqlSelectResultBody(bindings.filter(_.rowMap.keySet.nonEmpty))
-}
+case class SparqlSelectResultBody(bindings: Seq[VariableResultsRow])
 
 /**
  * Represents a row of results in the result of a SPARQL SELECT query.
@@ -84,11 +78,4 @@ case class SparqlSelectResultBodyUnchecked(bindings: Seq[VariableResultsRow]) {
  * @param rowMap a map of variable names to values in the row. An empty string is not allowed as a variable
  *               name or value.
  */
-case class VariableResultsRow(rowMap: Map[String, String]) {
-  require(
-    rowMap.forall { case (key, value) =>
-      key.nonEmpty && value.nonEmpty
-    },
-    "An empty string is not allowed as a variable name or value in a VariableResultsRow",
-  )
-}
+case class VariableResultsRow(rowMap: Map[String, String])

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/SparqlSelectResult.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/SparqlSelectResult.scala
@@ -68,14 +68,12 @@ case class SparqlSelectResultHeader(vars: Seq[String])
  * Represents the body of the result of a SPARQL SELECT query.
  *
  * @param bindings the bindings of values to the variables used in the SPARQL SELECT statement.
- *                 Empty rows are not allowed.
  */
 case class SparqlSelectResultBody(bindings: Seq[VariableResultsRow])
 
 /**
  * Represents a row of results in the result of a SPARQL SELECT query.
  *
- * @param rowMap a map of variable names to values in the row. An empty string is not allowed as a variable
- *               name or value.
+ * @param rowMap a map of variable names to values in the row.
  */
 case class VariableResultsRow(rowMap: Map[String, String])

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyTriplestoreHelpers.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/domain/service/OntologyTriplestoreHelpers.scala
@@ -66,7 +66,7 @@ final case class OntologyTriplestoreHelpers(
         classIris = ontology.classes.keySet,
         propertyIris = ontology.properties.keySet,
       )
-    triplestore.query(Select(query)).map(_.getColOrThrow("s").toSet)
+    triplestore.query(Select(query)).map(_.getCol("s").toSet)
   }
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -67,6 +67,7 @@ trait TriplestoreService {
    * @return a [[Unit]].
    */
   def query(sparql: Update): Task[Unit]
+  final def insert(q: InsertDataQuery): Task[Unit] = query(Update(q))
 
   /**
    * Given a SPARQL CONSTRUCT query string, runs the query, saving the result in a file.


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description
This PR removes the implicit filtering of empty strings from the result set returned by Fuseki.

The `TripelstoreService`, as the database access layer, should remain neutral regarding the validity of data values. Previously, it allowed writing empty strings to the database but silently excluded them when reading data back. This inconsistency introduced unexpected behavior and, in past cases, caused application failures — including instances where the application was unable to start.

By preserving empty strings in the query results, this change ensures consistent read/write behavior and delegates data validation responsibilities to the appropriate layers of the application.

<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
