### PR TITLE
feat: Add default CopyrightHolders when creating a new project (DEV-4929)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
@@ -177,6 +177,9 @@ class ProjectsADME2ESpec extends E2ESpec with SprayJsonSupport {
         result.longname.map(_.value) should be(Some("new project with a custom IRI"))
         result.keywords should be(Seq("projectIRI"))
         result.description should be(Seq(StringLiteralV2.from("a project created with a custom IRI", Some("en"))))
+        result.allowedCopyrightHolders.map(_.value) should be(
+          Set("AI-Generated Content - Not Protected by Copyright", "Public Domain - Not Protected by Copyright"),
+        )
       }
 
       "return 'BadRequest' if the supplied project IRI is not unique" in {

--- a/integration/src/test/scala/org/knora/webapi/messages/admin/responder/IntegrationTestAdminJsonProtocol.scala
+++ b/integration/src/test/scala/org/knora/webapi/messages/admin/responder/IntegrationTestAdminJsonProtocol.scala
@@ -194,6 +194,7 @@ object IntegrationTestAdminJsonProtocol extends TriplestoreJsonProtocol {
       "ontologies",
       "status",
       "selfjoin",
+      "allowedCopyrightHolders",
       "enabledLicenses",
     ),
   )

--- a/integration/src/test/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/integration/src/test/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -176,6 +176,7 @@ object SharedTestDataADM {
     ),
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -191,6 +192,7 @@ object SharedTestDataADM {
     ontologies = Seq.empty[IRI],
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -304,6 +306,7 @@ object SharedTestDataADM {
     ontologies = Seq(SharedOntologyTestDataADM.IMAGES_ONTOLOGY_IRI),
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -319,6 +322,7 @@ object SharedTestDataADM {
     ontologies = Seq(SharedOntologyTestDataADM.IMAGES_ONTOLOGY_IRI_LocalHost),
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -483,6 +487,7 @@ object SharedTestDataADM {
     ontologies = Seq(SharedOntologyTestDataADM.INCUNABULA_ONTOLOGY_IRI),
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -519,6 +524,7 @@ object SharedTestDataADM {
     ontologies = Seq(SharedOntologyTestDataADM.INCUNABULA_ONTOLOGY_IRI_LocalHost),
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -632,6 +638,7 @@ object SharedTestDataADM {
     ontologies = Seq(SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI, SharedOntologyTestDataADM.SomethingOntologyIri),
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -649,6 +656,7 @@ object SharedTestDataADM {
     ),
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -687,6 +695,7 @@ object SharedTestDataADM {
     ),
     status = Status.Active,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 
@@ -737,6 +746,7 @@ object SharedTestDataADM {
     ontologies = Seq("http://www.knora.org/ontology/0804/dokubib"),
     status = Status.Inactive,
     selfjoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders = Set.empty,
     enabledLicenses = Set.empty,
   )
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/Examples.scala
@@ -109,6 +109,7 @@ object Examples {
       status = Active,
       ontologies = Seq.empty,
       selfjoin = CannotJoin,
+      allowedCopyrightHolders = Set.empty,
       enabledLicenses = LicenseIri.BUILT_IN,
     )
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
@@ -193,7 +193,12 @@ final case class ProjectsEndpoints(
 
     val postAdminProjects = baseEndpoints.securedEndpoint.post
       .in(projectsBase)
-      .in(jsonBody[ProjectCreateRequest])
+      .in(
+        jsonBody[ProjectCreateRequest].description(
+          "The property `enabledLicenses` is optional and if not provided the DaSCH recommended licensed will be used. " +
+            "The property `allowedCopyrightHolders` is optional and copyright holder for AI generated values and unknown authorship will be added in any case.",
+        ),
+      )
       .out(jsonBody[ProjectOperationResponseADM])
       .description("Creates a new project.")
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
@@ -195,8 +195,8 @@ final case class ProjectsEndpoints(
       .in(projectsBase)
       .in(
         jsonBody[ProjectCreateRequest].description(
-          "The property `enabledLicenses` is optional and if not provided the DaSCH recommended licenses will be used. " +
-            "The property `allowedCopyrightHolders` is optional and copyright holder for AI generated values and unknown authorship will be added in any case.",
+          "The property `enabledLicenses` is optional. If not provided, the DaSCH recommended licenses will be used. " +
+            "The property `allowedCopyrightHolders` is optional. The copyright holder for AI generated values and unknown authorship will be added in any case.",
         ),
       )
       .out(jsonBody[ProjectOperationResponseADM])

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/ProjectsEndpoints.scala
@@ -195,7 +195,7 @@ final case class ProjectsEndpoints(
       .in(projectsBase)
       .in(
         jsonBody[ProjectCreateRequest].description(
-          "The property `enabledLicenses` is optional and if not provided the DaSCH recommended licensed will be used. " +
+          "The property `enabledLicenses` is optional and if not provided the DaSCH recommended licenses will be used. " +
             "The property `allowedCopyrightHolders` is optional and copyright holder for AI generated values and unknown authorship will be added in any case.",
         ),
       )

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/ProjectsEndpointsRequestsAndResponses.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/ProjectsEndpointsRequestsAndResponses.scala
@@ -12,6 +12,7 @@ import zio.json.JsonCodec
 
 import dsp.errors.BadRequestException
 import org.knora.webapi.slice.admin.api.Codecs.ZioJsonCodec.*
+import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.LicenseIri
 import org.knora.webapi.slice.admin.domain.model.RestrictedView
@@ -28,6 +29,7 @@ object ProjectsEndpointsRequestsAndResponses {
     logo: Option[Logo] = None,
     status: Status = Status.Active,
     selfjoin: SelfJoin = SelfJoin.CannotJoin,
+    allowedCopyrightHolders: Option[Set[CopyrightHolder]] = None,
     enabledLicenses: Option[Set[LicenseIri]] = None,
   )
   object ProjectCreateRequest {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/ProjectsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/api/model/ProjectsMessagesADM.scala
@@ -12,6 +12,7 @@ import org.knora.webapi.IRI
 import org.knora.webapi.messages.admin.responder.AdminKnoraResponseADM
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.api.Codecs.ZioJsonCodec.*
+import org.knora.webapi.slice.admin.domain.model.CopyrightHolder
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.LicenseIri
 import org.knora.webapi.slice.admin.domain.model.RestrictedView
@@ -42,6 +43,7 @@ case class Project(
   ontologies: Seq[IRI],
   status: Status,
   selfjoin: SelfJoin,
+  allowedCopyrightHolders: Set[CopyrightHolder],
   enabledLicenses: Set[LicenseIri],
 ) extends Ordered[Project] {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/model/LegalInfoModel.scala
@@ -37,8 +37,13 @@ final case class CopyrightHolder private (override val value: String) extends St
 object CopyrightHolder extends StringValueCompanion[CopyrightHolder] {
   given JsonCodec[CopyrightHolder] = ZioJsonCodec.stringCodec(CopyrightHolder.from)
   given Schema[CopyrightHolder]    = Schema.string
+  given Ordering[CopyrightHolder]  = Ordering.by(_.value)
 
-  given Ordering[CopyrightHolder] = Ordering.by(_.value)
+  val default: Set[CopyrightHolder] =
+    Set("AI-Generated Content - Not Protected by Copyright", "Public Domain - Not Protected by Copyright").map(
+      CopyrightHolder.unsafeFrom,
+    )
+
   def from(str: String): Either[String, CopyrightHolder] =
     fromValidations(
       "Copyright Holder",

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/KnoraProjectService.scala
@@ -67,6 +67,7 @@ final case class KnoraProjectService(
                     }
                   case None => licenseRepo.findRecommendedLicenses().map(_.map(_.id))
                 }
+    copyrightHolders = req.allowedCopyrightHolders.getOrElse(Set.empty) ++ CopyrightHolder.default
     project = KnoraProject(
                 req.id.getOrElse(ProjectIri.makeNew),
                 req.shortname,
@@ -78,7 +79,7 @@ final case class KnoraProjectService(
                 req.status,
                 req.selfjoin,
                 RestrictedView.default,
-                Set.empty,
+                copyrightHolders,
                 licenses.toSet,
               )
     project <- projectRepo.save(project)

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectService.scala
@@ -56,6 +56,7 @@ final case class ProjectService(
         ontologies,
         knoraProject.status,
         knoraProject.selfjoin,
+        knoraProject.allowedCopyrightHolders,
         knoraProject.enabledLicenses,
       ),
     )
@@ -74,7 +75,7 @@ final case class ProjectService(
       status = project.status,
       selfjoin = project.selfjoin,
       restrictedView,
-      Set.empty,
+      project.allowedCopyrightHolders,
       project.enabledLicenses,
     )
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ProjectServiceSpec.scala
@@ -35,6 +35,7 @@ object ProjectServiceSpec extends ZIOSpecDefault {
           ontologies = List.empty,
           status = Status.Active,
           selfjoin = SelfJoin.CanJoin,
+          allowedCopyrightHolders = Set.empty,
           enabledLicenses = Set.empty,
         )
         assertTrue(


### PR DESCRIPTION
### Description

Add default `CopyrightHolder`s for AI and unknown cases.
Allow to provide `allowedCopyrightHolders` when creating a project.
Always add the default `CopyrightHolder`s to the `allowedCopyrightHolders` during project creation.

<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
