### PR TITLE
feat: Add experimental resource metadata endpoint

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -199,8 +199,6 @@ final case class ResourcesResponderV2(
       .distinct()
 
     val projectGraph = projectService.getDataGraphForProject(project)
-    val classConstraintPattern =
-      variable(classIriVar).has(PropertyPathBuilder.of(RDFS.SUBCLASSOF).zeroOrMore().build(), KB.Resource)
     val wherePattern =
       variable(resourceIriVar)
         .isA(variable(classIriVar))
@@ -210,30 +208,42 @@ final case class ResourcesResponderV2(
         .and(variable(resourceIriVar).has(KB.lastModificationDate, variable(lastModificationDateVar)).optional())
         .and(variable(resourceIriVar).has(KB.deleteDate, variable(deleteDateVar)).optional())
         .from(Rdf.iri(projectGraph.value))
-        .and(classConstraintPattern)
+
+    val classConstraintPattern =
+      variable(classIriVar).has(PropertyPathBuilder.of(RDFS.SUBCLASSOF).zeroOrMore().build(), KB.Resource)
 
     val query = Queries
       .SELECT(selectPattern)
-      .where(wherePattern.from(Rdf.iri(projectGraph.value)))
+      .where(wherePattern, classConstraintPattern)
       .prefix(prefix(KB.NS), prefix(RDFS.NS))
 
     def throwEx(field: String): Nothing = throw new InconsistentRepositoryDataException(
       s"Resource metadata query for project ${project.shortcode} returned inconsistent data for $field",
     )
     for {
-      rows <- triplestore.select(query).map(_.results.bindings)
-      meta <- ZIO.attempt(rows.map { row =>
-                val resourceIri = row.rowMap.getOrElse(resourceIriVar, throwEx(resourceIriVar))
-                val classIri    = row.rowMap.getOrElse(classIriVar, throwEx(classIriVar))
-                val creatorIri  = row.rowMap.getOrElse(creatorIriVar, throwEx(creatorIriVar))
-                val label       = row.rowMap.getOrElse(labelVar, throwEx(labelVar))
-                val createdAt   = row.rowMap.get(creationDateVar).map(Instant.parse).getOrElse(throwEx(creationDateVar))
-                val deletedAt   = row.rowMap.get(deleteDateVar).map(Instant.parse)
-                val lastModAt   = row.rowMap.get(lastModificationDateVar).map(Instant.parse)
-                val arkUrl      = resourceIri.toSmartIri.fromResourceIriToArkUrl()
-                ResourceMetadataDto(classIri, resourceIri, arkUrl, label, creatorIri, createdAt, lastModAt, deletedAt)
-              })
-    } yield meta.toList
+      _ <- ZIO.logInfo(s"QUERY: \n ${query.getQueryString}")
+      rows <- triplestore
+                .select(query)
+                .map(_.results.bindings)
+                .timed
+                .flatMap((d, s) => ZIO.logInfo(s"Query took ${d.toMillis} ms and returned ${s.size} rows").ignore.as(s))
+      meta <- ZIO
+                .attempt(rows.map { row =>
+                  val resourceIri = row.rowMap.getOrElse(resourceIriVar, throwEx(resourceIriVar))
+                  val classIri    = row.rowMap.getOrElse(classIriVar, throwEx(classIriVar))
+                  val creatorIri  = row.rowMap.getOrElse(creatorIriVar, throwEx(creatorIriVar))
+                  val label       = row.rowMap.getOrElse(labelVar, throwEx(labelVar))
+                  val createdAt   = row.rowMap.get(creationDateVar).map(Instant.parse).getOrElse(throwEx(creationDateVar))
+                  val deletedAt   = row.rowMap.get(deleteDateVar).map(Instant.parse)
+                  val lastModAt   = row.rowMap.get(lastModificationDateVar).map(Instant.parse)
+                  val arkUrl      = resourceIri.toSmartIri.fromResourceIriToArkUrl()
+                  ResourceMetadataDto(classIri, resourceIri, arkUrl, label, creatorIri, createdAt, lastModAt, deletedAt)
+                })
+                .timed
+                .flatMap((d, m) =>
+                  ZIO.logInfo(s"Mapping took ${d.toMillis} ms and returned ${m.size} rows").ignore.as(m.toList),
+                )
+    } yield meta
   }
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -63,6 +63,7 @@ import org.knora.webapi.slice.common.repo.rdf.Vocabulary
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.ontology.domain.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
+import org.knora.webapi.slice.resources.api.ResourceMetadataDto
 import org.knora.webapi.slice.resources.api.model.GraphDirection
 import org.knora.webapi.slice.resources.api.model.VersionDate
 import org.knora.webapi.slice.resources.repo.service.ResourcesRepo
@@ -173,6 +174,67 @@ final case class ResourcesResponderV2(
 
   def createResource(createResource: CreateResourceRequestV2): Task[ReadResourcesSequenceV2] =
     createHandler(createResource)
+
+  def getResourcesMetadata(project: KnoraProject): Task[List[ResourceMetadataDto]] = {
+    val (
+      classIriVar,
+      creationDateVar,
+      creatorIriVar,
+      deleteDateVar,
+      labelVar,
+      lastModificationDateVar,
+      resourceIriVar,
+    ) = ("classIri", "createdAt", "creator", "deletedAt", "label", "modifiedAt", "resourceIri")
+
+    val selectPattern = SparqlBuilder
+      .select(
+        variable(classIriVar),
+        variable(creationDateVar),
+        variable(creatorIriVar),
+        variable(deleteDateVar),
+        variable(labelVar),
+        variable(lastModificationDateVar),
+        variable(resourceIriVar),
+      )
+      .distinct()
+
+    val projectGraph = projectService.getDataGraphForProject(project)
+    val classConstraintPattern =
+      variable(classIriVar).has(PropertyPathBuilder.of(RDFS.SUBCLASSOF).zeroOrMore().build(), KB.Resource)
+    val wherePattern =
+      variable(resourceIriVar)
+        .isA(variable(classIriVar))
+        .andHas(KB.creationDate, variable(creationDateVar))
+        .andHas(KB.attachedToUser, variable(creatorIriVar))
+        .andHas(RDFS.LABEL, variable(labelVar))
+        .and(variable(resourceIriVar).has(KB.lastModificationDate, variable(lastModificationDateVar)).optional())
+        .and(variable(resourceIriVar).has(KB.deleteDate, variable(deleteDateVar)).optional())
+        .from(Rdf.iri(projectGraph.value))
+        .and(classConstraintPattern)
+
+    val query = Queries
+      .SELECT(selectPattern)
+      .where(wherePattern.from(Rdf.iri(projectGraph.value)))
+      .prefix(prefix(KB.NS), prefix(RDFS.NS))
+
+    def throwEx(field: String): Nothing = throw new InconsistentRepositoryDataException(
+      s"Resource metadata query for project ${project.shortcode} returned inconsistent data for $field",
+    )
+    for {
+      rows <- triplestore.select(query).map(_.results.bindings)
+      meta <- ZIO.attempt(rows.map { row =>
+                val resourceIri = row.rowMap.getOrElse(resourceIriVar, throwEx(resourceIriVar))
+                val classIri    = row.rowMap.getOrElse(classIriVar, throwEx(classIriVar))
+                val creatorIri  = row.rowMap.getOrElse(creatorIriVar, throwEx(creatorIriVar))
+                val label       = row.rowMap.getOrElse(labelVar, throwEx(labelVar))
+                val createdAt   = row.rowMap.get(creationDateVar).map(Instant.parse).getOrElse(throwEx(creationDateVar))
+                val deletedAt   = row.rowMap.get(deleteDateVar).map(Instant.parse)
+                val lastModAt   = row.rowMap.get(lastModificationDateVar).map(Instant.parse)
+                val arkUrl      = resourceIri.toSmartIri.fromResourceIriToArkUrl()
+                ResourceMetadataDto(classIri, resourceIri, arkUrl, label, creatorIri, createdAt, lastModAt, deletedAt)
+              })
+    } yield meta.toList
+  }
 
   /**
    * If resource has already been modified, make sure that its lastModificationDate is given in the request body.

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
@@ -7,6 +7,8 @@ package org.knora.webapi.slice.common
 
 import eu.timepit.refined.types.string.NonEmptyString
 
+import java.net.URI
+
 import org.knora.webapi.OntologySchema
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
@@ -120,6 +122,7 @@ object KnoraIris {
       extends KnoraIri {
     override def equals(other: Any): Boolean = super.equals(other)
     override def hashCode(): Int             = super.hashCode()
+    val latestArkUrl: URI                    = URI.create(smartIri.fromResourceIriToArkUrl(None))
   }
   object ResourceIri {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/api/ResourcesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/api/ResourcesEndpoints.scala
@@ -8,21 +8,43 @@ package org.knora.webapi.slice.resources.api
 import sttp.model.HeaderNames
 import sttp.model.MediaType
 import sttp.tapir.*
+import sttp.tapir.json.zio.jsonBody
 import sttp.tapir.model.UsernamePassword
 import sttp.tapir.server.PartialServerEndpoint
 import zio.ZLayer
+import zio.json.DeriveJsonCodec
+import zio.json.JsonCodec
 
+import java.time.Instant
 import scala.concurrent.Future
 
 import dsp.errors.RequestRejectedException
 import org.knora.webapi.config.GraphRoute
+import org.knora.webapi.slice.admin.api.AdminPathVariables
+import org.knora.webapi.slice.admin.api.AdminPathVariables.projectShortcode
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.api.ApiV2
 import org.knora.webapi.slice.common.api.BaseEndpoints
 import org.knora.webapi.slice.resources.api.model.GraphDirection
 import org.knora.webapi.slice.resources.api.model.IriDto
 import org.knora.webapi.slice.resources.api.model.VersionDate
+
+final case class ResourceMetadataDto(
+  resourceClassIri: String,
+  resourceIri: String,
+  arkUrl: String,
+  label: String,
+  resourceCreatorIri: String,
+  resourceCreationDate: Instant,
+  resourceLastModificationDate: Option[Instant],
+  resourceDeletionDate: Option[Instant],
+)
+object ResourceMetadataDto {
+  given JsonCodec[ResourceMetadataDto] = DeriveJsonCodec.gen[ResourceMetadataDto]
+  given Schema[ResourceMetadataDto]    = Schema.derived[ResourceMetadataDto]
+}
 
 final case class ResourcesEndpoints(
   private val baseEndpoints: BaseEndpoints,
@@ -54,6 +76,15 @@ final case class ResourcesEndpoints(
       case (_, Some(v)) => Some(v)
       case _            => None
     }(d => (d, d))
+
+  val getResourcesMetadata = baseEndpoints.securedEndpoint.get
+    .in(base / "projects" / projectShortcode / "metadata" / "resources")
+    .out(jsonBody[List[ResourceMetadataDto]])
+    .description(
+      "<b>This endpoint is currently not stable and may change in the future.</b> " +
+        "Get metadata of all resources in a project. " +
+        "This endpoint is only available for system and project admins.",
+    )
 
   val getResourcesPreview = baseEndpoints.withUserEndpoint.get
     .in("v2" / "resourcespreview" / paths)
@@ -155,7 +186,8 @@ final case class ResourcesEndpoints(
     .out(stringBody)
     .out(header[MediaType](HeaderNames.ContentType))
 
-  val endpoints: Seq[AnyEndpoint] = Seq(
+  val endpoints: Seq[AnyEndpoint] = (Seq(
+    getResourcesMetadata,
     getResourcesIiifManifest,
     getResourcesPreview,
     getResourcesProjectHistoryEvents,
@@ -169,7 +201,7 @@ final case class ResourcesEndpoints(
     postResourcesDelete,
     postResources,
     putResources,
-  ).map(_.endpoint.tag("V2 Resources"))
+  ).map(_.endpoint)).map(_.tag("V2 Resources"))
 }
 
 object ResourcesEndpoints {

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/api/ResourcesEndpointsHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/api/ResourcesEndpointsHandler.scala
@@ -18,6 +18,7 @@ final class ResourcesEndpointsHandler(
 
   val allHandlers =
     Seq(
+      SecuredEndpointHandler(resourcesEndpoints.getResourcesMetadata, resourcesRestService.getResourcesMetadata),
       SecuredEndpointHandler(resourcesEndpoints.getResourcesGraph, resourcesRestService.getResourcesGraph),
       SecuredEndpointHandler(
         resourcesEndpoints.getResourcesIiifManifest,

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/api/model/Models.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/api/model/Models.scala
@@ -5,6 +5,8 @@
 
 package org.knora.webapi.slice.resources.api.model
 
+import zio.json.JsonCodec
+
 import java.time.Instant
 import java.util.UUID
 import scala.util.Try
@@ -13,7 +15,9 @@ import dsp.valueobjects.Iri
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.messages.ValuesValidator
 import org.knora.webapi.slice.admin.api.Codecs.*
+import org.knora.webapi.slice.common.StringValueCompanion
 import org.knora.webapi.slice.common.Value
+import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.WithFrom
 
 final case class ValueUuid private (value: UUID) extends Value[UUID]
@@ -38,10 +42,11 @@ object VersionDate extends WithFrom[String, VersionDate] {
       .toRight(s"Invalid value for instant: $str")
 }
 
-final case class IriDto(value: String)
-object IriDto {
+final case class IriDto(value: String) extends StringValue
+object IriDto extends StringValueCompanion[IriDto] {
 
-  given TapirCodec.StringCodec[IriDto] = TapirCodec.stringCodec(IriDto.from, _.value)
+  given JsonCodec[IriDto]              = ZioJsonCodec.stringCodec(IriDto.from)
+  given TapirCodec.StringCodec[IriDto] = TapirCodec.stringCodec(IriDto.from)
 
   def from(str: String): Either[String, IriDto] =
     if Iri.isIri(str) then Right(IriDto(str)) else Left(s"Invalid IRI: $str")

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/api/service/ResourcesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/api/service/ResourcesRestService.scala
@@ -8,26 +8,37 @@ import sttp.model.MediaType
 import zio.*
 
 import dsp.errors.BadRequestException
+import dsp.errors.ForbiddenException
 import org.knora.webapi.responders.v2.ResourcesResponderV2
 import org.knora.webapi.responders.v2.SearchResponderV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
+import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.FormatOptions
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.RenderedResponse
 import org.knora.webapi.slice.ontology.domain.service.IriConverter
+import org.knora.webapi.slice.resources.api.ResourceMetadataDto
 import org.knora.webapi.slice.resources.api.model.GraphDirection
 import org.knora.webapi.slice.resources.api.model.IriDto
 import org.knora.webapi.slice.resources.api.model.VersionDate
 
 final case class ResourcesRestService(
+  private val auth: AuthorizationRestService,
   private val resourcesService: ResourcesResponderV2,
   private val searchService: SearchResponderV2,
   private val iriConverter: IriConverter,
   private val requestParser: ApiComplexV2JsonLdRequestParser,
   private val renderer: KnoraResponseRenderer,
 ) {
+
+  def getResourcesMetadata(user: User)(shortcode: Shortcode): IO[ForbiddenException, List[ResourceMetadataDto]] =
+    for {
+      prj    <- auth.ensureSystemAdminOrProjectAdminByShortcode(user, shortcode)
+      result <- resourcesService.getResourcesMetadata(prj).orDie
+    } yield result
 
   def getResourcesIiifManifest(user: User)(
     resourceIri: IriDto,


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

This is meant to be an experimental endpoint which is currently returning the metadata information as json.

It logs out the duration of the query, so that we can understand whether or not we need pagination.

Since this is just explorative I have not bothered to add any tests yet.


The produced query looks like this:

```sparql
PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

SELECT DISTINCT ?classIri ?createdAt ?creator ?deletedAt ?label ?modifiedAt ?resourceIri
WHERE { 
  GRAPH <http://www.knora.org/data/0803/incunabula> { 
    ?resourceIri a ?classIri ;
      knora-base:creationDate ?createdAt ;
      knora-base:attachedToUser ?creator ;
      rdfs:label ?label .
    OPTIONAL { ?resourceIri knora-base:lastModificationDate ?modifiedAt . }
    OPTIONAL { ?resourceIri knora-base:deleteDate ?deletedAt . } 
  }
  ?classIri rdfs:subClassOf* knora-base:Resource .
}
```

The endpoint added is `v2/resources/projects/:shortcode/metadata/resources`. This is also not final.
<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
