### PR TITLE
feat: Allow hard-deleting soft-deleted values (DEV-4701)

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/integration/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -151,6 +151,14 @@ object ValuesEraseSpec extends E2EZSpec {
 
       testCase(lastVersionHasLink = false) && testCase(lastVersionHasLink = true)
     },
+    test("erasing a soft-deleted value") {
+      for {
+        res1 <- TestHelper.createResource
+        val0 <- TestHelper.createIntegerValue(res1)
+        val1 <- TestHelper.deleteIntegerValue(val0, res1)
+        _    <- TestHelper.eraseIntegerValue(val1, res1)
+      } yield assertCompletes
+    },
   ).provideSome[env](TestHelper.layer, ValueRepo.layer)
 }
 
@@ -317,7 +325,7 @@ final case class TestHelper(
       deleted <- valueRepo.findById(value.iri).someOrFail(IllegalStateException("Deleted value not found"))
     } yield deleted
 
-  def eraseIntegerValue(value: ActiveValue, resource: ActiveResource): ZIO[Any, Throwable, Unit] =
+  def eraseIntegerValue(value: ValueModel, resource: ActiveResource): ZIO[Any, Throwable, Unit] =
     val erase = EraseValueV2(
       resource.iri,
       resource.resourceClassIri,
@@ -536,7 +544,7 @@ object TestHelper {
   ): ZIO[TestHelper, Throwable, ActiveValue] =
     ZIO.serviceWithZIO[TestHelper](_.updateIntegerValue(value, resource, newValue))
 
-  def eraseIntegerValue(value: ActiveValue, resource: ActiveResource): ZIO[TestHelper, Throwable, Unit] =
+  def eraseIntegerValue(value: ValueModel, resource: ActiveResource): ZIO[TestHelper, Throwable, Unit] =
     ZIO.serviceWithZIO[TestHelper](_.eraseIntegerValue(value, resource))
 
   def eraseIntegerValueHistory(value: ActiveValue, resource: ActiveResource): ZIO[TestHelper, Throwable, Unit] =

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -1591,11 +1591,6 @@ final case class ValuesResponderV2(
           None
         }
 
-      // Convert the property IRIs to be queried to the API v2 complex schema for Gravsearch.
-      propertyIrisForGravsearchQuery =
-        (Seq(propertyInfo.entityInfoContent.propertyIri) ++ maybeStandoffLinkToPropertyIri)
-          .map(_.toOntologySchema(ApiV2Complex))
-
       searchResponse <- resourcesResponder.getResourcesV2(
                           resourceIris = Seq(resourceIri),
                           targetSchema = ApiV2Complex,
@@ -1764,7 +1759,8 @@ final case class ValuesResponderV2(
 
     sourceResourceInfo.values.get(linkValueProperty).flatMap { (linkValueInfos: Seq[ReadValueV2]) =>
       linkValueInfos.collectFirst {
-        case linkValueInfo: ReadLinkValueV2 if linkValueInfo.valueContent.referredResourceIri == targetResourceIri =>
+        case linkValueInfo: ReadLinkValueV2
+            if linkValueInfo.valueContent.referredResourceIri == targetResourceIri && linkValueInfo.deletionInfo.isEmpty =>
           linkValueInfo
       }
     }


### PR DESCRIPTION
After realizing that `gravsearchV2` produces `ReadResourcesSequenceV2`, I found `getResourcesV2` which also does this, but with the added functionality of also showing deleted values.

It's not possible to query for previousValues in Gravsearch, because it requires having knora-base PREFIX, which is forbidden by Gravsearch.

Unfortunately the existing query cannot be used in all cases, as it starts breaking some integration tests, so instead of updating `def getResourceWithPropertyValues` I used `getResourcesV2` only in one place.