### PR TITLE
docs: Clarify legal information cardinalities per file value

### DIFF
--- a/docs/01-introduction/legal-info.md
+++ b/docs/01-introduction/legal-info.md
@@ -3,6 +3,11 @@
 Each file representation in the project data may have legal metadata associated with it.
 This metadata is stored in the [FileValue](../02-dsp-ontologies/knora-base.md#filevalue) that represents the file.
 
+For each file value, the legal information consists of:
+- **Exactly one copyright holder** (mandatory when legal information is required)
+- **Exactly one license** (mandatory when legal information is required)  
+- **One or more authorship attributions** (mandatory when legal information is required)
+
 !!! warning "Legal Information Will Become Mandatory"
 
     Currently, the legal information on the FileValue is optional. This will change in the future when License, Authorship, and Copyright Holder will become mandatory.
@@ -11,6 +16,7 @@ This metadata is stored in the [FileValue](../02-dsp-ontologies/knora-base.md#fi
 
 The copyright holder of the file.
 A copyright holder is a person or organization that holds the copyright to a file.
+Each file value has exactly one copyright holder (currently zero or one).
 
 Each project [references an allowed list of copyright holders](../03-endpoints/api-admin/index.md#get-adminprojectsshortcodeprojectshortcodelegal-infocopyright-holders) that can be used.  
 System project administrators can [add new copyright holders](../03-endpoints/api-admin/index.md#post-adminprojectsshortcodeprojectshortcodelegal-infocopyright-holders) to the list.
@@ -19,10 +25,12 @@ System project administrators can [add new copyright holders](../03-endpoints/ap
 
 The authorship of the file.
 This can be a person or an organization who was involved in creating the asset, also known as moral rights to the asset.
+Each file value can have one or more authorship attributions (currently zero or more).
 
 ## License
 
 The license under which the file is published.
+Each file value has exactly one license (currently zero or one).
 A license has the following properties:
 
 - `uri` - this is a URI that identifies the license.

--- a/docs/01-introduction/legal-info.md
+++ b/docs/01-introduction/legal-info.md
@@ -4,6 +4,7 @@ Each file representation in the project data may have legal metadata associated 
 This metadata is stored in the [FileValue](../02-dsp-ontologies/knora-base.md#filevalue) that represents the file.
 
 For each file value, the legal information consists of:
+
 - **Exactly one copyright holder** (mandatory when legal information is required)
 - **Exactly one license** (mandatory when legal information is required)  
 - **One or more authorship attributions** (mandatory when legal information is required)


### PR DESCRIPTION
## Summary
- Clarify cardinalities of legal information per file value in documentation
- Add explicit statements about exactly one copyright holder, exactly one license, and one or more authorship attributions
- Include current state notation to maintain technical accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)