### PR TITLE
refactor: Improve ZIO layer creation

### DIFF
--- a/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
+++ b/integration/src/test/scala/org/knora/webapi/core/LayersTest.scala
@@ -8,9 +8,11 @@ package org.knora.webapi.core
 import org.apache.pekko.actor.ActorSystem
 import zio.*
 
+import org.knora.webapi.config.*
 import org.knora.webapi.config.AppConfig.AppConfigurations
 import org.knora.webapi.messages.util.*
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
+import org.knora.webapi.responders.IriService
 import org.knora.webapi.responders.admin.*
 import org.knora.webapi.responders.v2.*
 import org.knora.webapi.responders.v2.ontology.CardinalityHandler
@@ -18,6 +20,7 @@ import org.knora.webapi.routing.*
 import org.knora.webapi.slice.admin.domain.service.*
 import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.api.*
+import org.knora.webapi.slice.common.repo.service.PredicateObjectMapper
 import org.knora.webapi.slice.lists.domain.ListsService
 import org.knora.webapi.slice.resources.repo.service.ResourcesRepo
 import org.knora.webapi.slice.search.api.SearchApiRoutes
@@ -42,11 +45,18 @@ object LayersTest { self =>
    * Provides a layer for integration tests which depend on Fuseki and Sipi as Testcontainers.
    * @return a [[ULayer]] with the [[DefaultTestEnvironmentWithSipi]]
    */
-  val layer: ULayer[self.Environment] =
+  val layer: ULayer[self.Environment] = {
+    // Custom bootstrap for tests that uses TestContainer configs instead of LayersLive.bootstrap
+    val testBootstrap =
+      TestContainerLayers.all >+>
+        LayersLive.intermediateLayers1 >+>
+        LayersLive.intermediateLayers2 >+>
+        LayersLive.intermediateLayers3 >+>
+        LayersLive.remainingLayer
+
     ZLayer.make[self.Environment](
-      TestContainerLayers.all,
+      testBootstrap,
       TestClientsModule.layer,
-      /// common
-      LayersLive.layer,
     )
+  }
 }

--- a/webapi/src/main/scala/org/knora/webapi/Main.scala
+++ b/webapi/src/main/scala/org/knora/webapi/Main.scala
@@ -7,10 +7,10 @@ package org.knora.webapi
 
 import zio.*
 
-import org.knora.webapi.config.AppConfig
 import org.knora.webapi.core.*
+import org.knora.webapi.core.Db.DbInitEnv
 import org.knora.webapi.slice.infrastructure.MetricsServer
-import org.knora.webapi.util.Logger
+import org.knora.webapi.slice.infrastructure.MetricsServer.MetricsServerEnv
 
 object Main extends ZIOApp {
 
@@ -19,18 +19,20 @@ object Main extends ZIOApp {
   /**
    * The `Environment` that we require to exist at startup.
    */
-  override type Environment = AppConfig.AppConfigurations & LayersLive.Environment
+  override type Environment = LayersLive.ApplicationEnvironment
 
   /**
-   * `Bootstrap` will ensure that everything is instantiated when the Runtime is created
-   * and cleaned up when the Runtime is shutdown.
+   * The layers provided to the application.
    */
-  override def bootstrap: ZLayer[Any, Nothing, Environment] =
-    Logger.fromEnv() >>> AppConfig.layer >+> LayersLive.layer
+  override def bootstrap: ZLayer[Any, Nothing, Environment] = LayersLive.bootstrap
 
   /**
    *  Entrypoint of our Application
    */
-  override def run: ZIO[Environment & ZIOAppArgs & Scope, Any, Any] =
-    Db.init *> MetricsServer.make
+  override def run: ZIO[Environment & ZIOAppArgs & Scope, Any, Any] = app
+
+  /**
+   * The application logic.
+   */
+  def app: ZIO[Environment, Throwable, Unit] = Db.init *> MetricsServer.make
 }

--- a/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -188,7 +188,7 @@ final case class OpenTelemetryConfig(
 )
 
 object AppConfig {
-  type AppConfigurations = LayersLive.Config & InstrumentationServerConfig
+  type AppConfigurations = LayersLive.Config & InstrumentationServerConfig & JwtConfig & DspIngestConfig
 
   val parseConfig: UIO[AppConfig] = {
     val descriptor = deriveConfig[AppConfig].mapKey(toKebabCase)

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -17,6 +17,7 @@ import org.knora.webapi.config.KnoraApi
 import org.knora.webapi.config.OpenTelemetryConfig
 import org.knora.webapi.config.Sipi
 import org.knora.webapi.config.Triplestore
+import org.knora.webapi.core.Db.DbInitEnv
 import org.knora.webapi.messages.util.*
 import org.knora.webapi.messages.util.search.QueryTraverser
 import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
@@ -33,15 +34,21 @@ import org.knora.webapi.slice.admin.api.*
 import org.knora.webapi.slice.admin.domain.service.*
 import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.CommonModule
+import org.knora.webapi.slice.common.CommonModule.Provided
 import org.knora.webapi.slice.common.api.*
 import org.knora.webapi.slice.common.repo.service.PredicateObjectMapper
+import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.infrastructure.InfrastructureModule
+import org.knora.webapi.slice.infrastructure.InfrastructureModule.Provided
+import org.knora.webapi.slice.infrastructure.JwtService
+import org.knora.webapi.slice.infrastructure.MetricsServer.MetricsServerEnv
 import org.knora.webapi.slice.infrastructure.OpenTelemetry
 import org.knora.webapi.slice.infrastructure.api.ManagementEndpoints
 import org.knora.webapi.slice.infrastructure.api.ManagementRoutes
 import org.knora.webapi.slice.lists.api.ListsApiModule
 import org.knora.webapi.slice.lists.domain.ListsService
 import org.knora.webapi.slice.ontology.OntologyModule
+import org.knora.webapi.slice.ontology.OntologyModule.Provided
 import org.knora.webapi.slice.ontology.api.OntologyApiModule
 import org.knora.webapi.slice.ontology.domain.service.CardinalityService
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
@@ -58,13 +65,68 @@ import org.knora.webapi.slice.security.api.AuthenticationApiModule
 import org.knora.webapi.slice.shacl.ShaclModule
 import org.knora.webapi.slice.shacl.api.ShaclApiModule
 import org.knora.webapi.slice.shacl.api.ShaclApiRoutes
+import org.knora.webapi.slice.shacl.api.ShaclEndpoints
 import org.knora.webapi.store.iiif.IIIFRequestMessageHandler
 import org.knora.webapi.store.iiif.IIIFRequestMessageHandlerLive
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.store.iiif.impl.SipiServiceLive
 import org.knora.webapi.store.triplestore.upgrade.RepositoryUpdater
+import org.knora.webapi.util.Logger
 
 object LayersLive { self =>
+
+  /*
+   * This layer composition is done really happhazardly.
+   * This can certainly be improved a lot.
+   * However, this brings the layers ependency graph from ~12.7k to ~2.9k nodes.
+   * (By that I'm refering to the text output one gets when enabling `ZLayer.Debug.mermaid`.)
+   * It is unclear how closely this relates to the actual graph construction code,
+   * but I expect it will prevent the `class too big` error that we have seen in the past.
+   * It seems to have little or no impact on compile time.
+   */
+
+  private type ConfigDependencies = Any
+  private type ConfigProvided     = AppConfig.AppConfigurations
+
+  private type IntermediateDependencies1 = AppConfig & Triplestore & Features & DspIngestConfig & JwtConfig
+  private type IntermediateProvided1 = CommonModule.Provided & IriService & OntologyModule.Provided &
+    InfrastructureModule.Provided
+
+  private type IntermediateDependencies3 = IntermediateProvided1 & Features & DspIngestConfig & JwtConfig &
+    DspIngestClient & PredicateObjectMapper & AppConfig
+  private type IntermediateProvided3 = AdminModule.Provided & IntermediateProvided1
+
+  type ApplicationEnvironment = DbInitEnv & MetricsServerEnv
+
+  private val configLayer: ZLayer[self.ConfigDependencies, Nothing, self.ConfigProvided] =
+    Logger.fromEnv() >>> AppConfig.layer
+
+  val intermediateLayers1: ZLayer[self.IntermediateDependencies1, Nothing, self.IntermediateProvided1] =
+    ZLayer.makeSome[self.IntermediateDependencies1, self.IntermediateProvided1](
+      CommonModule.layer,
+      IriService.layer,
+      OntologyModule.layer,
+      InfrastructureModule.layer,
+    )
+
+  val intermediateLayers2
+    : ZLayer[JwtService & DspIngestConfig & IriConverter, Nothing, DspIngestClient & PredicateObjectMapper] =
+    ZLayer.makeSome[JwtService & DspIngestConfig & IriConverter, DspIngestClient & PredicateObjectMapper](
+      DspIngestClientLive.layer,
+      PredicateObjectMapper.layer,
+    )
+
+  val intermediateLayers3
+    : ZLayer[self.IntermediateDependencies3, Nothing, self.IntermediateProvided3 & DspIngestConfig & JwtConfig] =
+    ZLayer.makeSome[self.IntermediateDependencies3, self.IntermediateProvided3 & DspIngestConfig & JwtConfig](
+      AdminModule.layer,
+    )
+
+  private val intermediateLayersAll =
+    configLayer >+> intermediateLayers1 >+> intermediateLayers2 >+> intermediateLayers3
+
+  val bootstrap: ZLayer[Any, Nothing, ApplicationEnvironment] =
+    intermediateLayersAll >+> LayersLive.remainingLayer
 
   /**
    * The `Environment` that we require to exist at startup.
@@ -72,6 +134,7 @@ object LayersLive { self =>
   type Environment =
     // format: off
     ActorSystem &
+    AdminApiEndpoints &
     AdminApiModule.Provided &
     AdminModule.Provided &
     ApiComplexV2JsonLdRequestParser &
@@ -111,6 +174,7 @@ object LayersLive { self =>
     SecurityModule.Provided &
     ShaclApiModule.Provided &
     ShaclModule.Provided &
+    ShaclEndpoints &
     SipiService &
     StandoffResponderV2 &
     StandoffTagUtilV2 &
@@ -118,13 +182,14 @@ object LayersLive { self =>
     ValuesResponderV2
     // format: on
 
-  type Config = AppConfig & DspIngestConfig & Features & GraphRoute & JwtConfig & KnoraApi & OpenTelemetryConfig &
-    Sipi & Triplestore
+  type Config = AppConfig & Features & GraphRoute & KnoraApi & OpenTelemetryConfig & Sipi & Triplestore
 
-  val layer: URLayer[Config, self.Environment] =
-    ZLayer.makeSome[Config, self.Environment](
+  val remainingLayer =
+    ZLayer.makeSome[
+      Config & IntermediateProvided1 & IntermediateProvided3 & DspIngestClient & PredicateObjectMapper,
+      self.Environment,
+    ](
       AdminApiModule.layer,
-      AdminModule.layer,
       ApiComplexV2JsonLdRequestParser.layer,
       ApiRoutes.layer,
       ApiV2Endpoints.layer,
@@ -133,15 +198,10 @@ object LayersLive { self =>
       AuthorizationRestService.layer,
       BaseEndpoints.layer,
       CardinalityHandler.layer,
-      CommonModule.layer,
       ConstructResponseUtilV2.layer,
-      OntologyModule.layer,
-      DspIngestClientLive.layer,
       HandlerMapper.layer,
       HttpServer.layer,
       IIIFRequestMessageHandlerLive.layer,
-      InfrastructureModule.layer,
-      IriService.layer,
       KnoraResponseRenderer.layer,
       ListsApiModule.layer,
       ListsResponder.layer,
@@ -155,7 +215,6 @@ object LayersLive { self =>
       PekkoActorSystem.layer,
       PermissionUtilADMLive.layer,
       PermissionsResponder.layer,
-      PredicateObjectMapper.layer,
       ProjectExportServiceLive.layer,
       ProjectExportStorageServiceLive.layer,
       ProjectImportService.layer,

--- a/webapi/src/main/scala/org/knora/webapi/slice/infrastructure/MetricsServer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/infrastructure/MetricsServer.scala
@@ -36,11 +36,10 @@ object MetricsServer {
       _          <- ZIO.never.as(())
     } yield ()
 
-  val make: ZIO[
-    KnoraApi & State & InstrumentationServerConfig & ApiV2Endpoints & ShaclEndpoints & AdminApiEndpoints,
-    Throwable,
-    Unit,
-  ] =
+  type MetricsServerEnv = KnoraApi & State & InstrumentationServerConfig & ApiV2Endpoints & ShaclEndpoints &
+    AdminApiEndpoints
+
+  val make: ZIO[MetricsServerEnv, Throwable, Unit] =
     for {
       knoraApiConfig    <- ZIO.service[KnoraApi]
       apiV2Endpoints    <- ZIO.service[ApiV2Endpoints]


### PR DESCRIPTION
Restructure layer dependency graph to reduce complexity from ~12.7k to ~2.9k nodes.
This optimization prevents 'class too big' compilation errors while maintaining
functionality. Changes include:

- Break layer composition into intermediate stages in LayersLive
- Simplify test layer bootstrap in LayersTest
- Extract bootstrap logic to separate method in Main
- Update type definitions to reflect new layer structure
