### PR TITLE
chore: Use more reasonable log level

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClient.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClient.scala
@@ -79,9 +79,9 @@ final case class DspIngestClientLive(
     for {
       request  <- authenticatedRequest.map(_.get(uri"${projectsPath(shortcode)}/assets/$assetId"))
       response <- request.send(backend)
-      _        <- ZIO.logWarning(s"asset info for $shortcode/$assetId")
-      _        <- ZIO.logWarning(s"Response from ingest: ${response.code}")
-      _        <- ZIO.logWarning(s"Response from ingest body: ${response.body.fold(identity, identity)}")
+      _        <- ZIO.logInfo(s"asset info for $shortcode/$assetId")
+      _        <- ZIO.logDebug(s"Response from ingest: ${response.code}")
+      _        <- ZIO.logDebug(s"Response from ingest body: ${response.body.fold(identity, identity)}")
       result <- ZIO
                   .fromEither(response.body.flatMap(str => str.fromJson[AssetInfoResponse]))
                   .mapError(err => new IOException(s"Error parsing response: $err"))


### PR DESCRIPTION
### Description

Changed log levels for asset information retrieval in `DspIngestClientLive`. Reduced the verbosity of logs by changing:

- The initial asset info log from `WARNING` to `INFO` level
- The response code and response body logs from `WARNING` to `DEBUG` level

This change ensures that normal operation logs don't clutter the warning log stream, while still maintaining appropriate visibility for asset information retrieval operations.