### PR TITLE
fix: Erase a deleted resource

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,6 +9,10 @@ alias ssl := stack-start-latest
 alias stop := stack-stop
 alias ssd := stack-start-dev
 
+# Farmat code
+fmt:
+    ./sbtx fmt
+
 # Start stack
 stack-start:
     @echo "Starting Stack"


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

The issue was caused by resource class validation logic in the eraseResourceV2 method that failed for deleted resources due to an API representation transformation.

The Problem Flow:

1. Resource Created: Original class (e.g., societe-savoie:ItemGroup)

2. Resource Deleted: Still has original class in triplestore, but marked with knora-base:isDeleted=true

3. Resource Retrieved for Erasure: getResourcePreviewV2 calls asDeletedResource() which transforms the class to knora-base:DeletedResource for API responses

4. Validation Failure: The erase operation compared:
   - From triplestore: knora-base:DeletedResource (transformed representation)
   - From client: societe-savoie:ItemGroup (original class in external schema)
   - Expected internal: societe-savoie:ItemGroup (converted to internal schema)
   - Result: knora-base:DeletedResource ≠ societe-savoie:ItemGroup → VALIDATION FAILED

### Solution Implemented
Modified the validation logic to skip resource class validation for deleted resources:
