### PR TITLE
fix: Erase value from deleted resource

### DIFF
--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -480,7 +480,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
   private def getResource(resourceIri: IRI): ReadResourceV2 = {
     val response = UnsafeZioRun.runOrThrow(
       ZIO.serviceWithZIO[ResourcesResponderV2](
-        _.getResourcesV2(
+        _.getResourcesWithDeletedResource(
           resourceIris = Seq(resourceIri),
           targetSchema = ApiV2Complex,
           schemaOptions = Set.empty,
@@ -547,7 +547,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq("http://rdfh.ch/0803/c5058f3a"),
             versionDate = None,
             targetSchema = ApiV2Complex,
@@ -568,7 +568,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcePreviewV2(
+          _.getResourcePreviewWithDeletedResource(
             resourceIris = Seq("http://rdfh.ch/0803/c5058f3a"),
             targetSchema = ApiV2Complex,
             requestingUser = incunabulaUserProfile,
@@ -587,7 +587,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq("http://rdfh.ch/0803/2a6221216701"),
             versionDate = None,
             targetSchema = ApiV2Complex,
@@ -608,7 +608,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq("http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/2a6221216701"),
             versionDate = None,
             targetSchema = ApiV2Complex,
@@ -629,7 +629,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcePreviewV2(
+          _.getResourcePreviewWithDeletedResource(
             resourceIris = Seq("http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/2a6221216701"),
             targetSchema = ApiV2Complex,
             requestingUser = incunabulaUserProfile,
@@ -648,7 +648,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq("http://rdfh.ch/0803/2a6221216701", "http://rdfh.ch/0803/c5058f3a"),
             versionDate = None,
             targetSchema = ApiV2Complex,
@@ -669,7 +669,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris =
               Seq("http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/2a6221216701"),
             versionDate = None,
@@ -734,7 +734,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq(resourceIri),
             versionDate = Some(VersionDate.fromInstant(versionDate)),
             targetSchema = ApiV2Complex,
@@ -794,7 +794,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
     "get the latest version of a value, given its UUID" in {
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq("http://rdfh.ch/0001/thing-with-history"),
             valueUuid = Some(UuidUtil.decode("pLlW4ODASumZfZFbJdpw1g")),
             targetSchema = ApiV2Complex,
@@ -813,7 +813,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
     "get a past version of a value, given its UUID and a timestamp" in {
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq("http://rdfh.ch/0001/thing-with-history"),
             valueUuid = Some(UuidUtil.decode("pLlW4ODASumZfZFbJdpw1g")),
             versionDate = Some(VersionDate.fromInstant(Instant.parse("2019-02-12T09:05:10Z"))),
@@ -1844,7 +1844,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val getResponse = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq(createdResourceIri),
             targetSchema = ApiV2Complex,
             schemaOptions = Set.empty,
@@ -1879,7 +1879,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
 
       val response = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq(resourceIri),
             targetSchema = ApiV2Complex,
             schemaOptions = Set.empty,
@@ -2285,7 +2285,7 @@ class ResourcesResponderV2Spec extends E2ESpec with ImplicitSender { self =>
       // Verify the resource is marked as deleted.
       val getDeletedResponse = UnsafeZioRun.runOrThrow(
         ZIO.serviceWithZIO[ResourcesResponderV2](
-          _.getResourcesV2(
+          _.getResourcesWithDeletedResource(
             resourceIris = Seq(createdResourceIri),
             withDeleted = true,
             targetSchema = ApiV2Complex,

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -238,7 +238,7 @@ class ValuesResponderV2Spec extends E2ESpec with ImplicitSender {
   ): Unit = {
     val getResponse = UnsafeZioRun.runOrThrow(
       ZIO.serviceWithZIO[ResourcesResponderV2](
-        _.getResourcesV2(
+        _.getResourcesWithDeletedResource(
           resourceIris = Seq(resourceIri.toString),
           targetSchema = ApiV2Complex,
           schemaOptions = Set.empty,
@@ -346,7 +346,7 @@ class ValuesResponderV2Spec extends E2ESpec with ImplicitSender {
   private def getResourceLastModificationDate(resourceIri: IRI, requestingUser: User): Option[Instant] = {
     val previewResponse = UnsafeZioRun.runOrThrow(
       ZIO.serviceWithZIO[ResourcesResponderV2](
-        _.getResourcePreviewV2(
+        _.getResourcePreviewWithDeletedResource(
           resourceIris = Seq(resourceIri),
           targetSchema = ApiV2Complex,
           requestingUser = requestingUser,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -1191,7 +1191,7 @@ final case class ValuesResponderV2(
     // Get the resource's metadata and relevant property objects, using the adjusted property. Do this as the system user,
     // so we can see objects that the user doesn't have permission to see.
     resourceInfo <- resourcesResponder
-                      .getResourcesV2(
+                      .getResources(
                         resourceIris = Seq(deleteValue.resourceIri.toString),
                         targetSchema = ApiV2Complex,
                         schemaOptions = Set.empty,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -643,7 +643,7 @@ final case class CreateResourceV2Handler(
 
     for {
       // Get information about the existing resources that are targets of links.
-      existingTargets <- getResources.getResourcePreviewV2(
+      existingTargets <- getResources.getResourcePreviewWithDeletedResource(
                            resourceIris = existingTargetIris.toSeq,
                            targetSchema = ApiV2Complex,
                            requestingUser = requestingUser,
@@ -680,7 +680,7 @@ final case class CreateResourceV2Handler(
     }
 
     getResources
-      .getResourcePreviewV2(
+      .getResourcePreviewWithDeletedResource(
         resourceIris = standoffLinkTargetsThatShouldExist.toSeq,
         targetSchema = ApiV2Complex,
         requestingUser = requestingUser,
@@ -821,7 +821,7 @@ final case class CreateResourceV2Handler(
     requestingUser: User,
   ): Task[ReadResourcesSequenceV2] =
     getResources
-      .getResourcesV2(
+      .getResourcesWithDeletedResource(
         resourceIris = Seq(resourceIri),
         requestingUser = requestingUser,
         targetSchema = ApiV2Complex,

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/api/service/ResourcesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/api/service/ResourcesRestService.scala
@@ -42,7 +42,7 @@ final case class ResourcesRestService(
   ): Task[(RenderedResponse, MediaType)] =
     ensureIris(resourceIris) *>
       resourcesService
-        .getResourcePreviewV2(resourceIris, withDeleted = true, formatOptions.schema, user)
+        .getResourcePreviewWithDeletedResource(resourceIris, withDeleted = true, formatOptions.schema, user)
         .flatMap(renderer.render(_, formatOptions))
 
   def getResourcesProjectHistoryEvents(
@@ -94,7 +94,7 @@ final case class ResourcesRestService(
   ): Task[(RenderedResponse, MediaType)] =
     ensureIris(resourceIris) *>
       resourcesService
-        .getResourcesV2(
+        .getResourcesWithDeletedResource(
           resourceIris,
           propertyIri = None,
           valueUuid = None,

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/api/service/ValuesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/api/service/ValuesRestService.scala
@@ -40,7 +40,7 @@ final class ValuesRestService(
     formatOptions: FormatOptions,
   ): Task[(RenderedResponse, MediaType)] =
     render(
-      resourcesService.getResourcesV2(
+      resourcesService.getResourcesWithDeletedResource(
         Seq(resourceIri),
         None,
         Some(valueUuid.value),


### PR DESCRIPTION
# Allow erasing values from deleted resources

This PR refactors the resource retrieval methods in `ResourcesResponderV2` to separate the core functionality from the business rule that replaces deleted resources with `DeletedResource` objects.

Two new methods were introduced:
- `getResourcePreview` - retrieves resources without replacing deleted ones
- `getResources` - retrieves resources without replacing deleted ones

The existing methods now call these new methods and then apply the deletion replacement logic:
- `getResourcePreviewV2` calls `getResourcePreview`
- `getResourcesV2` calls `getResources`

This change allows the `canRemoveValue` method to use `getResources` directly, which enables erasing values from deleted resources. Previously, this wasn't possible because `getResources` would replace deleted resources with `DeletedResource` objects.

A new test case was added to verify that values can be erased from deleted resources.

Additionally, the previously similar problem with `eraseResourceV2`, was now correctly fixed.