### PR TITLE
refactor: Split ResourcesEndpointsE2ESpec, extract GET /v2/resources tests

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -10,6 +10,7 @@ import sttp.client4.UriContext
 import sttp.model.MediaType
 import zio.ZIO
 import zio.test.assertTrue
+
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.e2e.InstanceChecker
 import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.aThingWithHistoryIri

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -5,10 +5,7 @@
 
 package org.knora.webapi.e2e.v2
 
-import sttp.client4.Request
 import sttp.client4.UriContext
-import sttp.model.MediaType
-import zio.ZIO
 import zio.test.TestResult
 import zio.test.assertTrue
 
@@ -53,195 +50,225 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
   private val bookSimpleResourceClassIri =
     ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri)
 
-  private enum TestMediaType(val mediaType: MediaType, val readRdf: String => RdfModel) { self =>
-    override def toString: String = self.mediaType.toString()
-
-    case JsonLd extends TestMediaType(MediaType.unsafeApply("application", "ld+json"), RdfModel.fromJsonLD)
-    case RdfXml extends TestMediaType(MediaType.unsafeApply("application", "rdf+xml"), RdfModel.fromRdfXml)
-    case Turtle extends TestMediaType(MediaType.unsafeApply("text", "turtle"), RdfModel.fromTurtle)
-  }
-
-  private enum TestSchema(val f: Request[Either[String, String]] => Request[Either[String, String]]) {
-    case Simple      extends TestSchema(r => r.header("X-Knora-Accept-Schema", "simple"))
-    case SimpleQuery extends TestSchema(r => r.copy(uri = r.uri.addParam("schema", "simple")))
-    case Complex     extends TestSchema(r => r)
-  }
-
-  private final case class TestCase(
-    description: String,
-    resourceIri: ResourceIri,
-    filename: String,
-    mediaType: TestMediaType = TestMediaType.JsonLd,
-    resourceClassIri: Option[ResourceClassIri] = None,
-    schema: TestSchema = TestSchema.Complex,
-    version: Option[String] = None,
-  ) { self =>
-
-    private def readRdf(str: String): RdfModel = mediaType.readRdf(str)
-
-    private val updateRequest: (r: Request[Either[String, String]]) => Request[Either[String, String]] = r => {
-      def versionUpdate = (r: Request[Either[String, String]]) =>
-        version match {
-          case None    => r
-          case Some(v) => r.copy(uri = r.uri.addParam("version", v))
-        }
-      versionUpdate.andThen(schema.f)(r).header("Accept", mediaType.toString())
-    }
-
-    def check: ZIO[TestApiClient & TestDataFileUtil, Throwable, TestResult] = for {
-      actual <- TestApiClient
-                  .getAsString(uri"/v2/resources/${self.resourceIri}", self.updateRequest)
-                  .flatMap(_.assert200)
-      expected <- TestDataFileUtil.readTestData("resourcesR2RV2", self.filename)
-      _ <- (self.resourceClassIri, self.mediaType) match {
-             case (Some(iri), TestMediaType.JsonLd) => instanceChecker.check(actual, iri.smartIri)
-             case _                                 => ZIO.unit
-           }
-    } yield assertTrue(self.readRdf(actual) == self.readRdf(expected))
-  }
-
-  private val readResourcesSuite = suite("GET /v2/resources") {
-    Seq(
-      TestCase(
-        "the book 'Reise ins Heilige Land'",
-        reiseInsHeiligeLandIri,
-        "BookReiseInsHeiligeLand.jsonld",
-        resourceClassIri = Some(bookResourceClassIri),
-      ),
-      TestCase(
-        "the book 'Reise ins Heilige Land'",
-        reiseInsHeiligeLandIri,
-        "BookReiseInsHeiligeLand.ttl",
-        mediaType = TestMediaType.Turtle,
-      ),
-      TestCase(
-        "the book 'Reise ins Heilige Land'",
-        reiseInsHeiligeLandIri,
-        "BookReiseInsHeiligeLand.rdf",
-        mediaType = TestMediaType.RdfXml,
-      ),
-      TestCase(
-        "the book 'Reise ins Heilige Land'",
-        reiseInsHeiligeLandIri,
-        "BookReiseInsHeiligeLandSimple.jsonld",
-        schema = TestSchema.SimpleQuery,
-        resourceClassIri = Some(bookSimpleResourceClassIri),
-      ),
-      TestCase(
-        "the book 'Reise ins Heilige Land'",
-        reiseInsHeiligeLandIri,
-        "BookReiseInsHeiligeLandSimple.jsonld",
-        schema = TestSchema.Simple,
-        resourceClassIri = Some(bookSimpleResourceClassIri),
-      ),
-      TestCase(
-        "the book 'Reise ins Heilige Land'",
-        reiseInsHeiligeLandIri,
-        "BookReiseInsHeiligeLandSimple.rdf",
-        schema = TestSchema.Simple,
-        mediaType = TestMediaType.RdfXml,
-      ),
-      TestCase(
-        "the first page of the book '[Das] Narrenschiff (lat.)'",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0803/7bbb8e59b703".toSmartIri),
-        "NarrenschiffFirstPage.jsonld",
-      ),
-      TestCase(
-        "a resource with a BCE date property",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date".toSmartIri),
-        "ThingWithBCEDate.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "a resource with a date property that represents a period going from BCE to CE",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date2".toSmartIri),
-        "ThingWithBCEDate2.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "a resource with a list value",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri),
-        "ThingWithListValue.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "a resource with a list value",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri),
-        "ThingWithListValueSimple.jsonld",
-        schema = TestSchema.Simple,
-      ),
-      TestCase(
-        "a resource with a link ",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri),
-        "ThingWithLinkComplex.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "a resource with a link",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri),
-        "ThingWithLinkSimple.jsonld",
-        schema = TestSchema.Simple,
-        resourceClassIri = Some(thingSimpleResourceClassIri),
-      ),
-      TestCase(
-        "a resource with a Text language",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri),
-        "ThingWithTextLangComplex.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "a resource with a Text language",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri),
-        "ThingWithTextLangSimple.jsonld",
-        schema = TestSchema.Simple,
-        resourceClassIri = Some(thingSimpleResourceClassIri),
-      ),
-      TestCase(
-        "a resource with values of different types",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw".toSmartIri),
-        "Testding.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "a Thing resource with a link to a ThingPicture resource",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-picture".toSmartIri),
-        "ThingWithPicture.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "a resource with a link to a resource that the user doesn't have permission to see",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/0JhgKcqoRIeRRG6ownArSw".toSmartIri),
-        "ThingWithOneHiddenResource.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "a resource with a link to a resource that is marked as deleted",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A".toSmartIri),
-        "ThingWithOneDeletedResource.jsonld",
-        resourceClassIri = Some(thingResourceClassIri),
-      ),
-      TestCase(
-        "for a past version of a resource, using a URL-encoded xsd:dateTimeStamp",
-        aThingWithHistoryIri,
-        "ThingWithVersionHistory.jsonld",
-        version = Some("2019-02-12T08:05:10.351Z"),
-      ),
-      TestCase(
-        "for a past version of a resource, using a Knora ARK timestamp",
-        aThingWithHistoryIri,
-        "ThingWithVersionHistory.jsonld",
-        version = Some("20190212T080510351Z"),
-      ),
-    ).map { t =>
-      test(
-        s"perform a resource request for ${t.description} ${t.resourceIri} " +
-          s"using the ${t.schema} schema " +
-          s"in ${t.mediaType}",
-      )(t.check)
-    }.toList
-  }
+  private val getV2ResourcesSuite = suite("GET /v2/resources")(
+    test("for the book 'Reise ins Heilige Land' using the complex schema in JSON-LD") {
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$reiseInsHeiligeLandIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "BookReiseInsHeiligeLand.jsonld")
+        _        <- instanceChecker.check(actual, bookResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test("for the book 'Reise ins Heilige Land' using the complex schema in Turtle") {
+      for {
+        actual <- TestApiClient
+                    .getAsString(uri"/v2/resources/$reiseInsHeiligeLandIri", _.header("Accept", "text/turtle"))
+                    .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "BookReiseInsHeiligeLand.ttl")
+      } yield assertTrue(RdfModel.fromTurtle(actual) == RdfModel.fromTurtle(expected))
+    },
+    test("for the book 'Reise ins Heilige Land' using the complex schema in RDF/XML") {
+      for {
+        actual <- TestApiClient
+                    .getAsString(uri"/v2/resources/$reiseInsHeiligeLandIri", _.header("Accept", "application/rdf+xml"))
+                    .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "BookReiseInsHeiligeLand.rdf")
+      } yield assertTrue(RdfModel.fromRdfXml(actual) == RdfModel.fromRdfXml(expected))
+    },
+    test("for the book 'Reise ins Heilige Land' using the simple schema (query) in JSON-LD") {
+      for {
+        actual <- TestApiClient
+                    .getAsString(
+                      uri"/v2/resources/$reiseInsHeiligeLandIri",
+                      r => r.copy(uri = r.uri.addParam("schema", "simple")),
+                    )
+                    .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "BookReiseInsHeiligeLandSimple.jsonld")
+        _        <- instanceChecker.check(actual, bookSimpleResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      "for the book 'Reise ins Heilige Land' using the simple schema (header) in JSON-LD",
+    ) {
+      for {
+        actual <-
+          TestApiClient
+            .getAsString(uri"/v2/resources/$reiseInsHeiligeLandIri", _.header("X-Knora-Accept-Schema", "simple"))
+            .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "BookReiseInsHeiligeLandSimple.jsonld")
+        _        <- instanceChecker.check(actual, bookSimpleResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      s"for the book 'Reise ins Heilige Land' using the simple schema (header) in RDF/XML",
+    ) {
+      for {
+        actual <-
+          TestApiClient
+            .getAsString(
+              uri"/v2/resources/$reiseInsHeiligeLandIri",
+              _.header("X-Knora-Accept-Schema", "simple").header("Accept", "application/rdf+xml"),
+            )
+            .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "BookReiseInsHeiligeLandSimple.rdf")
+      } yield assertTrue(RdfModel.fromRdfXml(actual) == RdfModel.fromRdfXml(expected))
+    },
+    test(
+      s"for the first page of the book '[Das] Narrenschiff (lat.) using the complex schema in JSON-LD",
+    ) {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/7bbb8e59b703".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "NarrenschiffFirstPage.jsonld")
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test("for a resource with a BCE date property using the complex schema in JSON-LD") {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithBCEDate.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      "for a resource with a date property that represents a period going from BCE to CE" +
+        s"using the complex schema " +
+        s"in JSON-LD",
+    ) {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date2".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithBCEDate2.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(s"for a resource with a list value using the complex schema in JSON-LD") {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithListValue.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      s"for a resource with a list value " +
+        s"using the simple schema (header) " +
+        s"in JSON-LD",
+    ) {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri)
+      for {
+        actual <- TestApiClient
+                    .getAsString(uri"/v2/resources/$resourceIri", _.header("X-Knora-Accept-Schema", "simple"))
+                    .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithListValueSimple.jsonld")
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test("for a resource with a link using the complex schema in JSON-LD") {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithLinkComplex.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test("for a resource with a link using the simple schema (header) in JSON-LD") {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri)
+      for {
+        actual <- TestApiClient
+                    .getAsString(uri"/v2/resources/$resourceIri", _.header("X-Knora-Accept-Schema", "simple"))
+                    .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithLinkSimple.jsonld")
+        _        <- instanceChecker.check(actual, thingSimpleResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test("for a resource with a Text language using the complex schema in JSON-LD") {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithTextLangComplex.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test("for a resource with a Text language using the simple schema (header) in JSON-LD") {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri)
+      for {
+        actual <- TestApiClient
+                    .getAsString(uri"/v2/resources/$resourceIri", _.header("X-Knora-Accept-Schema", "simple"))
+                    .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithTextLangSimple.jsonld")
+        _        <- instanceChecker.check(actual, thingSimpleResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      "for a resource with values of different types using the complex schema in JSON-LD",
+    ) {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "Testding.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      "for a Thing resource with a link to a ThingPicture resource using the complex schema in JSON-LD",
+    ) {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-picture".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithPicture.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      "for a resource with a link to a resource that the user doesn't have permission to see using the complex schema in JSON-LD",
+    ) {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0JhgKcqoRIeRRG6ownArSw".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithOneHiddenResource.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      "for a resource with a link to a resource that is marked as deleted using the complex schema in JSON-LD",
+    ) {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A".toSmartIri)
+      for {
+        actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithOneDeletedResource.jsonld")
+        _        <- instanceChecker.check(actual, thingResourceClassIri.smartIri)
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      "for for a past version of a resource, using a URL-encoded xsd:dateTimeStampusing the complex schema in JSON-LD",
+    ) {
+      val version = "2019-02-12T08:05:10.351Z"
+      for {
+        actual <- TestApiClient
+                    .getAsString(
+                      uri"/v2/resources/$aThingWithHistoryIri",
+                      r => r.copy(uri = r.uri.addParam("version", version)),
+                    )
+                    .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithVersionHistory.jsonld")
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+    test(
+      s"for for a past version of a resource, using a Knora ARK timestamp using the complex schema in JSON-LD",
+    ) {
+      val version = "20190212T080510351Z"
+      for {
+        actual <- TestApiClient
+                    .getAsString(
+                      uri"/v2/resources/$aThingWithHistoryIri",
+                      r => r.copy(uri = r.uri.addParam("version", version)),
+                    )
+                    .flatMap(_.assert200)
+        expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithVersionHistory.jsonld")
+      } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
+    },
+  )
 
   override val e2eSpec = suite("ResourcesEndpointsGetResourcesE2ESpec")(
-    readResourcesSuite,
+    getV2ResourcesSuite,
   )
 }

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -10,7 +10,6 @@ import sttp.client4.UriContext
 import sttp.model.MediaType
 import zio.ZIO
 import zio.test.assertTrue
-
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.e2e.InstanceChecker
 import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.reiseInsHeiligeLandIri
@@ -51,32 +50,39 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
   private val bookSimpleResourceClassIri =
     ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri)
 
-  enum TestMediaType(val mediaType: MediaType, val readRdf: String => RdfModel) {
+  private enum TestMediaType(val mediaType: MediaType, val readRdf: String => RdfModel) {
     case JsonLd extends TestMediaType(MediaType.unsafeApply("application", "ld+json"), RdfModel.fromJsonLD)
     case RdfXml extends TestMediaType(MediaType.unsafeApply("application", "rdf+xml"), RdfModel.fromRdfXml)
     case Turtle extends TestMediaType(MediaType.unsafeApply("text", "turtle"), RdfModel.fromTurtle)
   }
 
-  enum TestSchema(val f: Request[Either[String, String]] => Request[Either[String, String]]) {
+  private enum TestSchema(val f: Request[Either[String, String]] => Request[Either[String, String]]) {
     case Simple      extends TestSchema(r => r.header("X-Knora-Accept-Schema", "simple"))
     case SimpleQuery extends TestSchema(r => r.copy(uri = r.uri.addParam("schema", "simple")))
     case Complex     extends TestSchema(r => r)
   }
 
-  final case class TestCase(
+  private final case class TestCase(
     description: String,
     resourceIri: ResourceIri,
     filename: String,
     mediaType: TestMediaType = TestMediaType.JsonLd,
     resourceClassIri: Option[ResourceClassIri] = None,
     schema: TestSchema = TestSchema.Complex,
+    version: Option[String] = None,
   ) {
     def readRdf(str: String): RdfModel = mediaType.readRdf(str)
-    def updateRequest(r: Request[Either[String, String]]): Request[Either[String, String]] =
-      schema.f(r).header("Accept", mediaType.mediaType.toString())
+    def updateRequest(r: Request[Either[String, String]]): Request[Either[String, String]] = {
+      def versionUpdate = (r: Request[Either[String, String]]) =>
+        version match {
+          case None    => r
+          case Some(v) => r.copy(uri = r.uri.addParam("version", v))
+        }
+      versionUpdate.andThen(schema.f)(r).header("Accept", mediaType.mediaType.toString())
+    }
   }
 
-  def check(test: TestCase) = for {
+  private def check(test: TestCase) = for {
     actual   <- TestApiClient.getAsString(uri"/v2/resources/${test.resourceIri}", test.updateRequest).flatMap(_.assert200)
     expected <- TestDataFileUtil.readTestData("resourcesR2RV2", test.filename)
     _ <- (test.resourceClassIri, test.mediaType) match {
@@ -86,7 +92,6 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
   } yield assertTrue(test.readRdf(actual) == test.readRdf(expected))
 
   private val readResourcesSuite = suite("GET /v2/resources") {
-
     Seq(
       TestCase(
         "the book 'Reise ins Heilige Land'",
@@ -205,6 +210,18 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
         ResourceIri.unsafeFrom("http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A".toSmartIri),
         "ThingWithOneDeletedResource.jsonld",
         resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "for a past version of a resource, using a URL-encoded xsd:dateTimeStamp",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri),
+        "ThingWithVersionHistory.jsonld",
+        version = Some("2019-02-12T08:05:10.351Z"),
+      ),
+      TestCase(
+        "for a past version of a resource, using a Knora ARK timestamp",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri),
+        "ThingWithVersionHistory.jsonld",
+        version = Some("20190212T080510351Z"),
       ),
     ).map { t =>
       test(

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -12,6 +12,7 @@ import zio.ZIO
 import zio.test.assertTrue
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.e2e.InstanceChecker
+import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.aThingWithHistoryIri
 import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.reiseInsHeiligeLandIri
 import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.suite
 import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.test
@@ -213,13 +214,13 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       ),
       TestCase(
         "for a past version of a resource, using a URL-encoded xsd:dateTimeStamp",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri),
+        aThingWithHistoryIri,
         "ThingWithVersionHistory.jsonld",
         version = Some("2019-02-12T08:05:10.351Z"),
       ),
       TestCase(
         "for a past version of a resource, using a Knora ARK timestamp",
-        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri),
+        aThingWithHistoryIri,
         "ThingWithVersionHistory.jsonld",
         version = Some("20190212T080510351Z"),
       ),

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -78,7 +78,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
 
     private def readRdf(str: String): RdfModel = mediaType.readRdf(str)
 
-    private def updateRequest(r: Request[Either[String, String]]): Request[Either[String, String]] = {
+    private val updateRequest: (r: Request[Either[String, String]]) => Request[Either[String, String]] = r => {
       def versionUpdate = (r: Request[Either[String, String]]) =>
         version match {
           case None    => r
@@ -88,8 +88,9 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     }
 
     def check: ZIO[TestApiClient & TestDataFileUtil, Throwable, TestResult] = for {
-      actual <-
-        TestApiClient.getAsString(uri"/v2/resources/${self.resourceIri}", self.updateRequest).flatMap(_.assert200)
+      actual <- TestApiClient
+                  .getAsString(uri"/v2/resources/${self.resourceIri}", self.updateRequest)
+                  .flatMap(_.assert200)
       expected <- TestDataFileUtil.readTestData("resourcesR2RV2", self.filename)
       _ <- (self.resourceClassIri, self.mediaType) match {
              case (Some(iri), TestMediaType.JsonLd) => instanceChecker.check(actual, iri.smartIri)

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2021 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.e2e.v2
+
+import sttp.client4.Request
+import sttp.client4.UriContext
+import sttp.model.MediaType
+import zio.ZIO
+import zio.test.assertTrue
+
+import org.knora.webapi.E2EZSpec
+import org.knora.webapi.e2e.InstanceChecker
+import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.reiseInsHeiligeLandIri
+import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.suite
+import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.test
+import org.knora.webapi.messages.IriConversions.*
+import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.messages.util.rdf.RdfModel
+import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.testservices.ResponseOps.assert200
+import org.knora.webapi.testservices.TestApiClient
+import org.knora.webapi.util.TestDataFileUtil
+
+object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
+
+  override lazy val rdfDataObjects: List[RdfDataObject] = List(
+    RdfDataObject(
+      path = "test_data/project_data/incunabula-data.ttl",
+      name = "http://www.knora.org/data/0803/incunabula",
+    ),
+    RdfDataObject(path = "test_data/project_data/anything-data.ttl", name = "http://www.knora.org/data/0001/anything"),
+    RdfDataObject(
+      path = "test_data/project_ontologies/anything-onto.ttl",
+      name = "http://www.knora.org/ontology/0001/anything",
+    ),
+  )
+
+  private val instanceChecker: InstanceChecker = InstanceChecker.make
+
+  private val thingResourceClassIri =
+    ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
+  private val thingSimpleResourceClassIri =
+    ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri)
+
+  private val bookResourceClassIri =
+    ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri)
+  private val bookSimpleResourceClassIri =
+    ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri)
+
+  enum TestMediaType(val mediaType: MediaType, val readRdf: String => RdfModel) {
+    case JsonLd extends TestMediaType(MediaType.unsafeApply("application", "ld+json"), RdfModel.fromJsonLD)
+    case RdfXml extends TestMediaType(MediaType.unsafeApply("application", "rdf+xml"), RdfModel.fromRdfXml)
+    case Turtle extends TestMediaType(MediaType.unsafeApply("text", "turtle"), RdfModel.fromTurtle)
+  }
+
+  enum TestSchema(val f: Request[Either[String, String]] => Request[Either[String, String]]) {
+    case Simple      extends TestSchema(r => r.header("X-Knora-Accept-Schema", "simple"))
+    case SimpleQuery extends TestSchema(r => r.copy(uri = r.uri.addParam("schema", "simple")))
+    case Complex     extends TestSchema(r => r)
+  }
+
+  final case class TestCase(
+    description: String,
+    resourceIri: ResourceIri,
+    filename: String,
+    mediaType: TestMediaType = TestMediaType.JsonLd,
+    resourceClassIri: Option[ResourceClassIri] = None,
+    schema: TestSchema = TestSchema.Complex,
+  ) {
+    def readRdf(str: String): RdfModel = mediaType.readRdf(str)
+    def updateRequest(r: Request[Either[String, String]]): Request[Either[String, String]] =
+      schema.f(r).header("Accept", mediaType.mediaType.toString())
+  }
+
+  def check(test: TestCase) = for {
+    actual   <- TestApiClient.getAsString(uri"/v2/resources/${test.resourceIri}", test.updateRequest).flatMap(_.assert200)
+    expected <- TestDataFileUtil.readTestData("resourcesR2RV2", test.filename)
+    _ <- (test.resourceClassIri, test.mediaType) match {
+           case (Some(iri), TestMediaType.JsonLd) => instanceChecker.check(actual, iri.smartIri)
+           case _                                 => ZIO.unit
+         }
+  } yield assertTrue(test.readRdf(actual) == test.readRdf(expected))
+
+  private val readResourcesSuite = suite("GET /v2/resources") {
+
+    Seq(
+      TestCase(
+        "the book 'Reise ins Heilige Land'",
+        reiseInsHeiligeLandIri,
+        "BookReiseInsHeiligeLand.jsonld",
+        resourceClassIri = Some(bookResourceClassIri),
+      ),
+      TestCase(
+        "the book 'Reise ins Heilige Land'",
+        reiseInsHeiligeLandIri,
+        "BookReiseInsHeiligeLand.ttl",
+        mediaType = TestMediaType.Turtle,
+      ),
+      TestCase(
+        "the book 'Reise ins Heilige Land'",
+        reiseInsHeiligeLandIri,
+        "BookReiseInsHeiligeLand.rdf",
+        mediaType = TestMediaType.RdfXml,
+      ),
+      TestCase(
+        "the book 'Reise ins Heilige Land'",
+        reiseInsHeiligeLandIri,
+        "BookReiseInsHeiligeLandSimple.jsonld",
+        schema = TestSchema.SimpleQuery,
+        resourceClassIri = Some(bookSimpleResourceClassIri),
+      ),
+      TestCase(
+        "the book 'Reise ins Heilige Land'",
+        reiseInsHeiligeLandIri,
+        "BookReiseInsHeiligeLandSimple.jsonld",
+        schema = TestSchema.Simple,
+        resourceClassIri = Some(bookSimpleResourceClassIri),
+      ),
+      TestCase(
+        "the book 'Reise ins Heilige Land'",
+        reiseInsHeiligeLandIri,
+        "BookReiseInsHeiligeLandSimple.rdf",
+        schema = TestSchema.Simple,
+        mediaType = TestMediaType.RdfXml,
+      ),
+      TestCase(
+        "the first page of the book '[Das] Narrenschiff (lat.)'",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0803/7bbb8e59b703".toSmartIri),
+        "NarrenschiffFirstPage.jsonld",
+      ),
+      TestCase(
+        "a resource with a BCE date property",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date".toSmartIri),
+        "ThingWithBCEDate.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "a resource with a date property that represents a period going from BCE to CE",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date2".toSmartIri),
+        "ThingWithBCEDate2.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "a resource with a list value",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri),
+        "ThingWithListValue.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "a resource with a list value",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri),
+        "ThingWithListValueSimple.jsonld",
+        schema = TestSchema.Simple,
+      ),
+      TestCase(
+        "a resource with a link ",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri),
+        "ThingWithLinkComplex.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "a resource with a link",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri),
+        "ThingWithLinkSimple.jsonld",
+        schema = TestSchema.Simple,
+        resourceClassIri = Some(thingSimpleResourceClassIri),
+      ),
+      TestCase(
+        "a resource with a Text language",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri),
+        "ThingWithTextLangComplex.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "a resource with a Text language",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri),
+        "ThingWithTextLangSimple.jsonld",
+        schema = TestSchema.Simple,
+        resourceClassIri = Some(thingSimpleResourceClassIri),
+      ),
+      TestCase(
+        "a resource with values of different types",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw".toSmartIri),
+        "Testding.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "a Thing resource with a link to a ThingPicture resource",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-picture".toSmartIri),
+        "ThingWithPicture.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "a resource with a link to a resource that the user doesn't have permission to see",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/0JhgKcqoRIeRRG6ownArSw".toSmartIri),
+        "ThingWithOneHiddenResource.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+      TestCase(
+        "a resource with a link to a resource that is marked as deleted",
+        ResourceIri.unsafeFrom("http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A".toSmartIri),
+        "ThingWithOneDeletedResource.jsonld",
+        resourceClassIri = Some(thingResourceClassIri),
+      ),
+    ).map { t =>
+      test(
+        s"perform a resource request for ${t.description} ${t.resourceIri} " +
+          s"using the ${t.schema} schema " +
+          s"in ${t.mediaType.mediaType}",
+      )(check(t))
+    }.toList
+  }
+
+  override val e2eSpec = suite("ResourcesEndpointsGetResourcesE2ESpec")(
+    readResourcesSuite,
+  )
+}

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -9,7 +9,9 @@ import sttp.client4.Request
 import sttp.client4.UriContext
 import sttp.model.MediaType
 import zio.ZIO
+import zio.test.TestResult
 import zio.test.assertTrue
+
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.e2e.InstanceChecker
 import org.knora.webapi.e2e.v2.ResourcesRouteV2E2ESpec.aThingWithHistoryIri
@@ -24,7 +26,6 @@ import org.knora.webapi.slice.common.KnoraIris.ResourceIri
 import org.knora.webapi.testservices.ResponseOps.assert200
 import org.knora.webapi.testservices.TestApiClient
 import org.knora.webapi.util.TestDataFileUtil
-import zio.test.TestResult
 
 object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
 

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -52,7 +52,9 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
   private val bookSimpleResourceClassIri =
     ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri)
 
-  private enum TestMediaType(val mediaType: MediaType, val readRdf: String => RdfModel) {
+  private enum TestMediaType(val mediaType: MediaType, val readRdf: String => RdfModel) { self =>
+    override def toString: String = self.mediaType.toString()
+
     case JsonLd extends TestMediaType(MediaType.unsafeApply("application", "ld+json"), RdfModel.fromJsonLD)
     case RdfXml extends TestMediaType(MediaType.unsafeApply("application", "rdf+xml"), RdfModel.fromRdfXml)
     case Turtle extends TestMediaType(MediaType.unsafeApply("text", "turtle"), RdfModel.fromTurtle)
@@ -82,7 +84,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
           case None    => r
           case Some(v) => r.copy(uri = r.uri.addParam("version", v))
         }
-      versionUpdate.andThen(schema.f)(r).header("Accept", mediaType.mediaType.toString())
+      versionUpdate.andThen(schema.f)(r).header("Accept", mediaType.toString())
     }
 
     def check: ZIO[TestApiClient & TestDataFileUtil, Throwable, TestResult] = for {
@@ -232,7 +234,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       test(
         s"perform a resource request for ${t.description} ${t.resourceIri} " +
           s"using the ${t.schema} schema " +
-          s"in ${t.mediaType.mediaType}",
+          s"in ${t.mediaType}",
       )(t.check)
     }.toList
   }

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -35,6 +35,7 @@ import org.knora.webapi.messages.util.rdf.*
 import org.knora.webapi.sharedtestdata.SharedOntologyTestDataADM
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
+import org.knora.webapi.slice.common.KnoraIris.ResourceIri
 import org.knora.webapi.testservices.ResponseOps.assert200
 import org.knora.webapi.testservices.ResponseOps.assert400
 import org.knora.webapi.testservices.ResponseOps.assert404
@@ -49,7 +50,7 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
   private val hamletResourceIri          = new MutableTestIri
   private val aThingIri                  = "http://rdfh.ch/0001/a-thing"
   private val aThingWithHistoryIri       = "http://rdfh.ch/0001/thing-with-history"
-  private val reiseInsHeiligeLandIri     = "http://rdfh.ch/0803/2a6221216701"
+  val reiseInsHeiligeLandIri             = ResourceIri.unsafeFrom("http://rdfh.ch/0803/2a6221216701".toSmartIri)
 
   override lazy val rdfDataObjects: List[RdfDataObject] = List(
     RdfDataObject(
@@ -151,34 +152,6 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
        |}""".stripMargin
 
   override val e2eSpec = suite("The resources v2 endpoint")(
-    test("perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in JSON-LD") {
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$reiseInsHeiligeLandIri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("BookReiseInsHeiligeLand.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri)
-      } yield assertCompletes
-    },
-    test("perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in Turtle") {
-      for {
-        // Test correct handling of q values in the Accept header by requesting as string with turtle content type.
-        responseAsString <-
-          TestApiClient
-            .getAsString(uri"/v2/resources/$reiseInsHeiligeLandIri", _.header("Accept", "text/turtle"))
-            .flatMap(_.assert200)
-        expectedAnswerTurtle <- readFile("BookReiseInsHeiligeLand.ttl")
-      } yield assertTrue(RdfModel.fromTurtle(responseAsString) == RdfModel.fromTurtle(expectedAnswerTurtle))
-    },
-    test("perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in RDF/XML") {
-      for {
-        responseAsString <-
-          TestApiClient
-            .getAsString(uri"/v2/resources/$reiseInsHeiligeLandIri", _.header("Accept", "application/rdf+xml"))
-            .flatMap(_.assert200)
-        expectedAnswerRdfXml <- readFile("BookReiseInsHeiligeLand.rdf")
-      } yield assertTrue(RdfModel.fromRdfXml(responseAsString) == RdfModel.fromRdfXml(expectedAnswerRdfXml))
-    },
     test("perform a resource preview request for the book 'Reise ins Heilige Land' using the complex schema") {
       for {
         responseAsString <-
@@ -195,45 +168,6 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
       } yield assertCompletes
     },
     test(
-      "perform a resource request for the book 'Reise ins Heilige Land' using the simple schema (specified by an HTTP header) in JSON-LD",
-    ) {
-      for {
-        responseAsString <-
-          TestApiClient.getJsonLd(uri"/v2/resources/$reiseInsHeiligeLandIri?schema=simple").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("BookReiseInsHeiligeLandSimple.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(
-               responseAsString,
-               "http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri,
-             )
-      } yield assertCompletes
-    },
-    test("perform a resource request for the book 'Reise ins Heilige Land' using the simple schema in Turtle") {
-      for {
-        responseAsString <- TestApiClient
-                              .getAsString(
-                                uri"/v2/resources/$reiseInsHeiligeLandIri",
-                                _.header("X-Knora-Accept-Schema", "simple").header("Accept", "text/turtle"),
-                              )
-                              .flatMap(_.assert200)
-        expectedAnswerTurtle <- readFile("BookReiseInsHeiligeLandSimple.ttl")
-        _                    <- ZIO.attempt(assert(RdfModel.fromTurtle(responseAsString) == RdfModel.fromTurtle(expectedAnswerTurtle)))
-      } yield assertCompletes
-    },
-    test("perform a resource request for the book 'Reise ins Heilige Land' using the simple schema in RDF/XML") {
-      for {
-        responseAsString <- TestApiClient
-                              .getAsString(
-                                uri"/v2/resources/$reiseInsHeiligeLandIri",
-                                _.header("X-Knora-Accept-Schema", "simple").header("Accept", "application/rdf+xml"),
-                              )
-                              .flatMap(_.assert200)
-        expectedAnswerRdfXml <- readFile("BookReiseInsHeiligeLandSimple.rdf")
-        _                    <- ZIO.attempt(assert(RdfModel.fromRdfXml(responseAsString) == RdfModel.fromRdfXml(expectedAnswerRdfXml)))
-      } yield assertCompletes
-    },
-    test(
       "perform a resource preview request for the book 'Reise ins Heilige Land' using the simple schema (specified by an HTTP header)",
     ) {
       for {
@@ -242,157 +176,6 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
         expectedAnswerJSONLD <-
           readFile("BookReiseInsHeiligeLandSimplePreview.jsonld")
         _ <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-      } yield assertCompletes
-    },
-    test(
-      "perform a resource request for the book 'Reise ins Heilige Land' using the simple schema (specified by a URL parameter)",
-    ) {
-      for {
-        responseAsString <-
-          TestApiClient.getJsonLd(uri"/v2/resources/$reiseInsHeiligeLandIri?schema=simple").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("BookReiseInsHeiligeLandSimple.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-      } yield assertCompletes
-    },
-    test(
-      "perform a resource request for the first page of the book '[Das] Narrenschiff (lat.)' using the complex schema",
-    ) {
-      val iri = "http://rdfh.ch/0803/7bbb8e59b703"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("NarrenschiffFirstPage.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a resource with a BCE date property") {
-      val iri = "http://rdfh.ch/0001/thing_with_BCE_date"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithBCEDate.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
-      } yield assertCompletes
-    },
-    test(
-      "perform a full resource request for a resource with a date property that represents a period going from BCE to CE",
-    ) {
-      val iri = "http://rdfh.ch/0001/thing_with_BCE_date2"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithBCEDate2.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a resource with a list value") {
-      val iri = "http://rdfh.ch/0001/thing_with_list_value"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithListValue.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a resource with a list value (in the simple schema)") {
-      val iri = "http://rdfh.ch/0001/thing_with_list_value"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri?schema=simple").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithListValueSimple.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(
-               responseAsString,
-               "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
-             )
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a resource with a link (in the complex schema)") {
-      val iri = "http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithLinkComplex.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a resource with a link (in the simple schema)") {
-      val iri = "http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri?schema=simple").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithLinkSimple.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(
-               responseAsString,
-               "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
-             )
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a resource with a Text language (in the complex schema)") {
-      val iri = "http://rdfh.ch/0001/a-thing-with-text-valuesLanguage"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithTextLangComplex.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a resource with a Text language (in the simple schema)") {
-      val iri = "http://rdfh.ch/0001/a-thing-with-text-valuesLanguage"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri?schema=simple").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithTextLangSimple.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(
-               responseAsString,
-               "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
-             )
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a resource with values of different types") {
-      val iri = "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("Testding.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a Thing resource with a link to a ThingPicture resource") {
-      val iri = "http://rdfh.ch/0001/a-thing-with-picture"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithPicture.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
-      } yield assertCompletes
-    },
-    test("perform a full resource request with a link to a resource that the user doesn't have permission to see") {
-      val iri = "http://rdfh.ch/0001/0JhgKcqoRIeRRG6ownArSw"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithOneHiddenResource.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
-      } yield assertCompletes
-    },
-    test("perform a full resource request with a link to a resource that is marked as deleted") {
-      val iri = "http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A"
-      for {
-        responseAsString     <- TestApiClient.getJsonLd(uri"/v2/resources/$iri").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithOneDeletedResource.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-        // Check that the resource corresponds to the ontology.
-        _ <- instanceChecker.check(responseAsString, "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
       } yield assertCompletes
     },
     test("perform a full resource request for a past version of a resource, using a URL-encoded xsd:dateTimeStamp") {
@@ -441,7 +224,7 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
         entries = jsonLDDocument.body
                     .getRequiredArray("@graph")
                     .fold(e => throw BadRequestException(e), identity)
-        _ <- ZIO.foreach(entries.value) { entry =>
+        _ <- ZIO.foreachDiscard(entries.value) { entry =>
                entry match {
                  case jsonLDObject: JsonLDObject =>
                    for {

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -178,24 +178,6 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
         _ <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
       } yield assertCompletes
     },
-    test("perform a full resource request for a past version of a resource, using a URL-encoded xsd:dateTimeStamp") {
-      val timestamp = "2019-02-12T08:05:10.351Z"
-      for {
-        responseAsString <-
-          TestApiClient.getJsonLd(uri"/v2/resources/$aThingWithHistoryIri?version=$timestamp").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithVersionHistory.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-      } yield assertCompletes
-    },
-    test("perform a full resource request for a past version of a resource, using a Knora ARK timestamp") {
-      val timestamp = "20190212T080510351Z"
-      for {
-        responseAsString <-
-          TestApiClient.getJsonLd(uri"/v2/resources/$aThingWithHistoryIri?version=$timestamp").flatMap(_.assert200)
-        expectedAnswerJSONLD <- readFile("ThingWithVersionHistory.jsonld")
-        _                    <- ZIO.attempt(compareJSONLDForResourcesResponse(expectedAnswerJSONLD, responseAsString))
-      } yield assertCompletes
-    },
     test("return the complete version history of a resource") {
       for {
         responseAsString <-

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -101,10 +101,8 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
        |    }
        |}""".stripMargin
 
-  private val testDataFolder = "resourcesR2RV2"
-
   private def readFile(fileName: String): ZIO[TestDataFileUtil, Nothing, String] =
-    TestDataFileUtil.readTestData(testDataFolder, fileName)
+    TestDataFileUtil.readTestData("resourcesR2RV2", fileName)
 
   private def createResourceReqPayload() =
     createResourceWithCustomIRI("http://rdfh.ch/0001/" + UuidUtil.makeRandomBase64EncodedUuid)

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -101,8 +101,7 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
        |    }
        |}""".stripMargin
 
-  private def readFile(fileName: String): ZIO[TestDataFileUtil, Nothing, String] =
-    TestDataFileUtil.readTestData("resourcesR2RV2", fileName)
+  private def readFile(fileName: String) = TestDataFileUtil.readTestData("resourcesR2RV2", fileName)
 
   private def createResourceReqPayload() =
     createResourceWithCustomIRI("http://rdfh.ch/0001/" + UuidUtil.makeRandomBase64EncodedUuid)

--- a/modules/testkit/src/main/scala/E2ESpec.scala
+++ b/modules/testkit/src/main/scala/E2ESpec.scala
@@ -60,8 +60,7 @@ abstract class E2ESpec
   val log: Logger                                      = Logger(this.getClass)
 
   // needed by some tests
-  val baseApiUrl: String          = appConfig.knoraApi.internalKnoraApiBaseUrl
-  val baseInternalSipiUrl: String = appConfig.sipi.internalBaseUrl
+  val baseApiUrl: String = appConfig.knoraApi.internalKnoraApiBaseUrl
 
   // the default timeout for all tests
   implicit val timeout: FiniteDuration = FiniteDuration(10, SECONDS)

--- a/modules/testkit/src/main/scala/E2ESpec.scala
+++ b/modules/testkit/src/main/scala/E2ESpec.scala
@@ -80,9 +80,6 @@ abstract class E2ESpec
       ZIO.serviceWithZIO[TestClientService](_.singleAwaitingRequest(request, timeout, printFailure)),
     )
 
-  protected def singleAwaitingRequest(request: HttpRequest, duration: zio.Duration): HttpResponse =
-    UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TestClientService](_.singleAwaitingRequest(request, Some(duration))))
-
   protected def getResponseAsString(request: HttpRequest): String =
     UnsafeZioRun.runOrThrow(ZIO.serviceWithZIO[TestClientService](_.getResponseString(request)))
 

--- a/modules/testkit/src/main/scala/E2ESpec.scala
+++ b/modules/testkit/src/main/scala/E2ESpec.scala
@@ -106,12 +106,6 @@ abstract class E2ESpec
     Await.result(responseBodyFuture, FiniteDuration(10L, TimeUnit.SECONDS))
   }
 
-  protected def doGetRequest(urlPath: String): String = {
-    val request                = Get(s"$baseApiUrl$urlPath")
-    val response: HttpResponse = singleAwaitingRequest(request)
-    responseToString(response)
-  }
-
   def readTestData(folder: String, filename: String): String =
     UnsafeZioRun.runOrThrow(TestDataFileUtil.readTestData(folder, filename))
 }


### PR DESCRIPTION


<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description
Move all tests for `GET /v2/resources/:resourceIri` to a dedicated file.
<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
