### PR TITLE
fix: Fix double encoding of comments when creating a resource (DEV-5356)

### DIFF
--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
@@ -15,6 +15,7 @@ import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.testservices.RequestsUpdates.RequestUpdate
 import org.knora.webapi.testservices.TestDspIngestClient.UploadedFile
 
 final case class TestResourcesApiClient(private val apiClient: TestApiClient) {
@@ -44,8 +45,8 @@ final case class TestResourcesApiClient(private val apiClient: TestApiClient) {
     apiClient.postJsonLd(uri"/v2/resources", jsonLd, user)
   }
 
-  def getResource(resourceIri: ResourceIri): Task[Response[Either[String, JsonLDDocument]]] =
-    apiClient.getJsonLdDocument(uri"/v2/resources/$resourceIri", None, r => r)
+  def getResource(resourceIri: ResourceIri, user: Option[User], update: RequestUpdate[JsonLDDocument]) =
+    apiClient.getJsonLdDocument(uri"/v2/resources/$resourceIri", user, update)
 }
 
 object TestResourcesApiClient {
@@ -77,7 +78,13 @@ object TestResourcesApiClient {
   def getResource(
     resourceIri: ResourceIri,
   ): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
-    ZIO.serviceWithZIO[TestResourcesApiClient](_.getResource(resourceIri))
+    ZIO.serviceWithZIO[TestResourcesApiClient](_.getResource(resourceIri, None, identity))
+
+  def getResource(
+    resourceIri: ResourceIri,
+    user: User,
+  ): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
+    ZIO.serviceWithZIO[TestResourcesApiClient](_.getResource(resourceIri, Some(user), identity))
 
   val layer = ZLayer.derive[TestResourcesApiClient]
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -61,8 +61,7 @@ import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.util.WithAsIs
 
-private def objectCommentOption(r: Resource): Either[String, Option[String]] =
-  r.objectStringOption(ValueHasComment, str => Iri.toSparqlEncodedString(str).toRight(s"Invalid comment: $str"))
+private def objectCommentOption(r: Resource): Either[String, Option[String]] = r.objectStringOption(ValueHasComment)
 
 /**
  * Represents a successful response to a create value Request.


### PR DESCRIPTION

### Description

Fixes bug when creating a resource with a comment where the resulting comment would contain encoded line breaks due to double encoding.

Added test for resource creation and value update to check encoding is correct.

<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
