### PR TITLE
fix: Fix double encoding of comments when creating a resource (DEV-5356)

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ValuesRouteV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ValuesRouteV2E2ESpec.scala
@@ -45,7 +45,6 @@ import org.knora.webapi.messages.util.rdf.*
 import org.knora.webapi.routing.UnsafeZioRun
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
-import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceIri
 import org.knora.webapi.testservices.ResponseOps.assert200
 import org.knora.webapi.testservices.TestApiClient
@@ -4777,16 +4776,15 @@ class ValuesRouteV2E2ESpec extends E2ESpec {
     }
 
     "update a TextValue comment containing linebreaks should store linebreaks as Unicode" in {
-      val resourceIri      = ResourceIri.unsafeFrom(AThing.iri.toSmartIri)
-      val anythingOntology = OntologyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2".toSmartIri)
-      val anythinghasText  = anythingOntology.makeProperty("hasText").toString
-      val anythingThing    = anythingOntology.makeClass("Thing").toString
+      val resourceIri     = ResourceIri.unsafeFrom(AThing.iri.toSmartIri)
+      val anythingHasText = anythingOntologyIri.makeProperty("hasText").toString
+      val anythingThing   = anythingOntologyIri.makeClass("Thing").toString
 
       def valueJsonLd(props: (String, Json.Str)*) =
         Json.Obj(
           "@id"   -> Json.Str(resourceIri.toString),
           "@type" -> Json.Str(anythingThing),
-          anythinghasText -> Json.Obj(
+          anythingHasText -> Json.Obj(
             Seq("@type" -> Json.Str(KA.TextValue), KA.ValueAsString -> Json.Str("Not important")) ++ props: _*,
           ),
         )
@@ -4804,7 +4802,7 @@ class ValuesRouteV2E2ESpec extends E2ESpec {
                               )
           _        <- TestApiClient.putJsonLd(uri"/v2/values", updateValueJsonLd.toString, anythingUser1).flatMap(_.assert200)
           resource <- TestResourcesApiClient.getResource(resourceIri, anythingUser1).flatMap(_.assert200)
-          savedComment <- ZIO.fromEither(resource.body.getRequiredArray(anythinghasText).map {
+          savedComment <- ZIO.fromEither(resource.body.getRequiredArray(anythingHasText).map {
                             _.value.collect { case obj: JsonLDObject => obj }
                               .map(_.getRequiredString(KA.ValueHasComment))
                               .collect { case Right(c) => c }

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ValuesRouteV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ValuesRouteV2E2ESpec.scala
@@ -4777,8 +4777,8 @@ class ValuesRouteV2E2ESpec extends E2ESpec {
 
     "update a TextValue comment containing linebreaks should store linebreaks as Unicode" in {
       val resourceIri     = ResourceIri.unsafeFrom(AThing.iri.toSmartIri)
-      val anythingHasText = anythingOntologyIri.makeProperty("hasText").toString
-      val anythingThing   = anythingOntologyIri.makeClass("Thing").toString
+      val anythingHasText = anythingOntologyIri.makeProperty("hasText").toComplexSchema.toString
+      val anythingThing   = anythingOntologyIri.makeClass("Thing").toComplexSchema.toString
 
       def valueJsonLd(props: (String, Json.Str)*) =
         Json.Obj(

--- a/modules/testkit/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -554,9 +554,7 @@ object SharedTestDataADM {
 
   /**
    * *********************************
-   */
-  /** Anything Admin Data            * */
-  /**
+   * Anything Admin Data             *
    * *********************************
    */
   val anythingProjectIri: ProjectIri = ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001")

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
@@ -15,6 +15,7 @@ import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.testservices.RequestsUpdates.RequestUpdate
 import org.knora.webapi.testservices.TestDspIngestClient.UploadedFile
 
 final case class TestResourcesApiClient(private val apiClient: TestApiClient) {
@@ -44,8 +45,8 @@ final case class TestResourcesApiClient(private val apiClient: TestApiClient) {
     apiClient.postJsonLd(uri"/v2/resources", jsonLd, user)
   }
 
-  def getResource(resourceIri: ResourceIri): Task[Response[Either[String, JsonLDDocument]]] =
-    apiClient.getJsonLdDocument(uri"/v2/resources/$resourceIri", None, r => r)
+  def getResource(resourceIri: ResourceIri, user: Option[User], update: RequestUpdate[JsonLDDocument]) =
+    apiClient.getJsonLdDocument(uri"/v2/resources/$resourceIri", user, update)
 }
 
 object TestResourcesApiClient {
@@ -77,7 +78,13 @@ object TestResourcesApiClient {
   def getResource(
     resourceIri: ResourceIri,
   ): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
-    ZIO.serviceWithZIO[TestResourcesApiClient](_.getResource(resourceIri))
+    ZIO.serviceWithZIO[TestResourcesApiClient](_.getResource(resourceIri, None, identity))
+
+  def getResource(
+    resourceIri: ResourceIri,
+    user: User,
+  ): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
+    ZIO.serviceWithZIO[TestResourcesApiClient](_.getResource(resourceIri, Some(user), identity))
 
   val layer = ZLayer.derive[TestResourcesApiClient]
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -61,8 +61,7 @@ import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.util.WithAsIs
 
-private def objectCommentOption(r: Resource): Either[String, Option[String]] =
-  r.objectStringOption(ValueHasComment, str => Iri.toSparqlEncodedString(str).toRight(s"Invalid comment: $str"))
+private def objectCommentOption(r: Resource): Either[String, Option[String]] = r.objectStringOption(ValueHasComment)
 
 /**
  * Represents a successful response to a create value Request.


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

Adds tests to ensure create resource and update value with comments with line breaks are working correctly.

Removes double encoding of comment.

Related to https://github.com/dasch-swiss/dsp-api/pull/3737
<!-- Please add a short description of the changes -->

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
