### PR TITLE
fix: Send queries to Fuseki as form data not as URL parameters

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -344,8 +344,8 @@ case class TriplestoreServiceLive(
     }
 
     val params  = Map(("query", query.sparql), ("timeout", timeout.toSeconds.toString))
-    val uri     = targetHostUri.addPath(paths.query).addParams(params)
-    val request = authenticatedRequest.post(uri).header("Accept", acceptMimeType)
+    val uri     = targetHostUri.addPath(paths.query)
+    val request = authenticatedRequest.post(uri).header("Accept", acceptMimeType).body(params)
     trackQueryDuration(query, doHttpRequest(request).map(_.body.merge))
   }
 


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description


This pull request updates how SPARQL queries are sent to the triplestore service in `TriplestoreServiceLive`. The main change is switching back from passing query parameters in the URL to sending them in the request body as form data.
This restores previous behaviour and should resolve the `URI too long` error we were seeing, in case of very long query strings.