### PR TITLE
test(dsp-api): Reuse test layers across all e2e and it tests

### DIFF
--- a/modules/testkit/src/main/scala/E2EZSpec.scala
+++ b/modules/testkit/src/main/scala/E2EZSpec.scala
@@ -6,7 +6,6 @@
 package org.knora.webapi
 
 import zio.*
-import zio.http.*
 import zio.test.*
 import zio.test.Assertion.*
 
@@ -14,34 +13,34 @@ import scala.reflect.ClassTag
 
 import org.knora.webapi.core.Db
 import org.knora.webapi.core.LayersTest
-import org.knora.webapi.core.TestStartupUtils
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.infrastructure.CacheManager
+import org.knora.webapi.util.Logger
 
-abstract class E2EZSpec extends ZIOSpecDefault with TestStartupUtils {
+abstract class E2EZSpec extends ZIOSpec[LayersTest.Environment] {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
   // test data
   val rootUser: User = SharedTestDataADM.rootUser
 
-  private val testLayers = org.knora.webapi.util.Logger.testSafe() >>> LayersTest.layer
+  override val bootstrap: ULayer[LayersTest.Environment] = Logger.text >>> LayersTest.layer
 
-  def rdfDataObjects: List[RdfDataObject] = List.empty[RdfDataObject]
+  def rdfDataObjects: List[RdfDataObject] = List.empty
 
-  type env = LayersTest.Environment with Client with Scope
+  type env = LayersTest.Environment with Scope
 
-  private def prepare = Db.initWithTestData(rdfDataObjects)
+  private def prepare = Db.initWithTestData(rdfDataObjects) *> ZIO.serviceWithZIO[CacheManager](_.clearAll())
 
   def e2eSpec: Spec[env, Any]
 
-  final override def spec = (
-    e2eSpec
+  final override def spec: Spec[env, Any] =
+    e2eSpec.provideSomeAuto(Scope.default)
       @@ TestAspect.beforeAll(prepare)
       @@ TestAspect.sequential
-  ).provideShared(testLayers, Client.default, Scope.default)
-    @@ TestAspect.withLiveEnvironment
+      @@ TestAspect.withLiveEnvironment
 }
 
 object E2EZSpec {

--- a/webapi/src/main/scala/org/knora/webapi/util/Logger.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/Logger.scala
@@ -53,7 +53,5 @@ object Logger {
 
   def json(): ULayer[Unit] = Runtime.removeDefaultLoggers >>> jsonLogger >+> Slf4jBridge.initialize
 
-  def text(): ULayer[Unit] = Runtime.removeDefaultLoggers >>> textLogger >+> Slf4jBridge.initialize
-
-  def testSafe(): ULayer[Unit] = Runtime.removeDefaultLoggers >>> textLogger
+  val text: ULayer[Unit] = Runtime.removeDefaultLoggers >>> textLogger >+> Slf4jBridge.initialize
 }


### PR DESCRIPTION
This should speed up the tests as the testcontainers do not have to be spun up foreach testsuite, the prepare takes care that the right data is loaded and the caches are refreshed for each suite.
