### PR TITLE
refactor: Make ResourceIri independent from SmartIri

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -17,7 +17,7 @@ import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.messages.util.rdf.RdfModel
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.testservices.RequestsUpdates.addAcceptHeaderRdfXml
 import org.knora.webapi.testservices.RequestsUpdates.addAcceptHeaderTurtle
 import org.knora.webapi.testservices.RequestsUpdates.addSimpleSchemaHeader
@@ -115,14 +115,14 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       s"for the first page of the book '[Das] Narrenschiff (lat.) using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/7bbb8e59b703".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/7bbb8e59b703")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "NarrenschiffFirstPage.jsonld")
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a BCE date property using the complex schema in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithBCEDate.jsonld")
@@ -134,7 +134,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
         s"using the complex schema " +
         s"in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date2".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date2")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithBCEDate2.jsonld")
@@ -142,7 +142,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test(s"for a resource with a list value using the complex schema in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithListValue.jsonld")
@@ -154,7 +154,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
         s"using the simple schema (header) " +
         s"in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value")
       for {
         actual <- TestApiClient
                     .getAsString(uri"/v2/resources/$resourceIri", addSimpleSchemaHeader)
@@ -163,7 +163,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a link using the complex schema in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithLinkComplex.jsonld")
@@ -171,7 +171,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a link using the simple schema (header) in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ")
       for {
         actual <- TestApiClient
                     .getAsString(uri"/v2/resources/$resourceIri", addSimpleSchemaHeader)
@@ -181,7 +181,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a Text language using the complex schema in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithTextLangComplex.jsonld")
@@ -189,7 +189,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a Text language using the simple schema (header) in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage")
       for {
         actual <- TestApiClient
                     .getAsString(uri"/v2/resources/$resourceIri", addSimpleSchemaHeader)
@@ -201,7 +201,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       "for a resource with values of different types using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "Testding.jsonld")
@@ -211,7 +211,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       "for a Thing resource with a link to a ThingPicture resource using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-picture".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-picture")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithPicture.jsonld")
@@ -221,7 +221,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       "for a resource with a link to a resource that the user doesn't have permission to see using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0JhgKcqoRIeRRG6ownArSw".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0JhgKcqoRIeRRG6ownArSw")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithOneHiddenResource.jsonld")
@@ -231,7 +231,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       "for a resource with a link to a resource that is marked as deleted using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithOneDeletedResource.jsonld")

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -35,7 +35,7 @@ import org.knora.webapi.messages.util.rdf.*
 import org.knora.webapi.sharedtestdata.SharedOntologyTestDataADM
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.testservices.RequestsUpdates.addSimpleSchemaQueryParam
 import org.knora.webapi.testservices.RequestsUpdates.addVersionQueryParam
 import org.knora.webapi.testservices.ResponseOps.assert200
@@ -52,8 +52,8 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
   private var aThingLastModificationDate  = Instant.now
   private val hamletResourceIri           = new MutableTestIri
   private val aThingIri                   = "http://rdfh.ch/0001/a-thing"
-  val aThingWithHistoryIri: ResourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri)
-  val reiseInsHeiligeLandIri: ResourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/2a6221216701".toSmartIri)
+  val aThingWithHistoryIri: ResourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
+  val reiseInsHeiligeLandIri: ResourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/2a6221216701")
 
   override val rdfDataObjects: List[RdfDataObject] = List(
     RdfDataObject(

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -24,7 +24,6 @@ import scala.language.implicitConversions
 
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.it.v2.LegalInfoE2ESpec.suite
-import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Complex as KA
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
@@ -322,7 +321,7 @@ object LegalInfoE2ESpec extends E2EZSpec {
   }
 
   private def getResourceFromApi(resourceId: ResourceIri) = for {
-    responseBody <- TestApiClient.getJsonLd(uri"/v2/resources/${resourceId.toComplexSchema}").flatMap(_.assert200)
+    responseBody <- TestApiClient.getJsonLd(uri"/v2/resources/${resourceId.value}").flatMap(_.assert200)
     model        <- ModelOps.fromJsonLd(responseBody).mapError(Exception(_))
   } yield model
 
@@ -334,7 +333,7 @@ object LegalInfoE2ESpec extends E2EZSpec {
 
   private def getValueFromApi(valueId: ValueIri, resourceId: ResourceIri): ZIO[env, Throwable, Model] = for {
     responseBody <-
-      TestApiClient.getJsonLd(uri"/v2/values/${resourceId.toComplexSchema}/${valueId.valueId}").flatMap(_.assert200)
+      TestApiClient.getJsonLd(uri"/v2/values/${resourceId.value}/${valueId.valueId}").flatMap(_.assert200)
     model <- ModelOps.fromJsonLd(responseBody).mapError(Exception(_))
   } yield model
 
@@ -346,7 +345,6 @@ object LegalInfoE2ESpec extends E2EZSpec {
           id   <- root.uri.toRight("No URI found for root resource")
         } yield id,
       )
-      .map(_.toSmartIri)
       .mapBoth(Exception(_), ResourceIri.unsafeFrom)
 
   private def valueId(model: Model): ZIO[IriConverter, Throwable, ValueIri] = {

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -34,7 +34,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.api.PageAndSize
 import org.knora.webapi.slice.api.PagedResponse
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -25,7 +25,6 @@ import scala.language.implicitConversions
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.it.v2.LegalInfoE2ESpec.suite
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Complex as KA
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.admin.domain.model.*
@@ -48,8 +47,6 @@ import org.knora.webapi.testservices.TestDspIngestClient.UploadedFile
 import org.knora.webapi.testservices.TestResourcesApiClient
 
 object LegalInfoE2ESpec extends E2EZSpec {
-
-  private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   override def rdfDataObjects: List[RdfDataObject] = List(anythingRdfData)
 

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -33,8 +33,8 @@ import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.api.PageAndSize
 import org.knora.webapi.slice.api.PagedResponse
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.common.jena.ModelOps.*

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/StandoffEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/StandoffEndpointsE2ESpec.scala
@@ -29,7 +29,7 @@ import org.knora.webapi.messages.util.rdf.JsonLDUtil
 import org.knora.webapi.models.filemodels.FileType
 import org.knora.webapi.models.filemodels.UploadFileRequest
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.testservices.ResponseOps.assert200
 import org.knora.webapi.testservices.TestApiClient
 import org.knora.webapi.testservices.TestDspIngestClient

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ValuesEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ValuesEndpointsE2ESpec.scala
@@ -37,7 +37,7 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.api.v2.values.ReorderValuesRequest
 import org.knora.webapi.slice.api.v2.values.ReorderValuesResponse
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.search.repo.GetResourceWithSpecifiedPropertiesGravsearchQuery
 import org.knora.webapi.testservices.RequestsUpdates.addVersionQueryParam
 import org.knora.webapi.testservices.ResponseOps.assert200
@@ -120,7 +120,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
   private def getResourceWithValues(resourceIri: IRI, propertyIrisForGravsearch: Seq[SmartIri]) = {
     val gravsearchQuery: String =
       GetResourceWithSpecifiedPropertiesGravsearchQuery.build(
-        resourceIri = ResourceIri.unsafeFrom(resourceIri.toSmartIri),
+        resourceIri = ResourceIri.unsafeFrom(resourceIri),
         propertyIris = propertyIrisForGravsearch.map(PropertyIri.unsafeFrom),
       )
     TestApiClient
@@ -641,7 +641,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
       }
     },
     test("get a past version of a value, given its UUID and a timestamp") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
       val valueUuid   = "pLlW4ODASumZfZFbJdpw1g"
       val timestamp   = "20190212T090510Z"
       for {
@@ -3550,7 +3550,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
         assertCompletes
     },
     test("update a TextValue comment containing linebreaks should store linebreaks as Unicode") {
-      val resourceIri     = ResourceIri.unsafeFrom(AThing.iri.toSmartIri)
+      val resourceIri     = ResourceIri.unsafeFrom(AThing.iri)
       val anythingHasText = anythingOntologyIri.makeProperty("hasText").toComplexSchema.toString
       val anythingThing   = anythingOntologyIri.makeClass("Thing").toComplexSchema.toString
 
@@ -3655,7 +3655,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                .flatMap(_.assert200)
 
         // 3. Read the resource and extract the value IRIs in their current order
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3718,7 +3718,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3757,7 +3757,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3794,7 +3794,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3832,7 +3832,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3869,7 +3869,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3930,7 +3930,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                  .flatMap(_.assert200)
 
           // Get the resource to read value IRIs
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4010,7 +4010,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                  .flatMap(_.assert200)
 
           // Get the value IRIs
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4058,7 +4058,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
           // Get the value IRIs
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4152,7 +4152,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
           // Read the value IRIs
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4201,7 +4201,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
           // Get the value IRIs (they belong to hasText, not hasInteger)
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4249,7 +4249,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
           // Get the single value IRI
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -46,6 +46,7 @@ import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.api.v2.ontologies.ReplaceClassCardinalitiesRequestV2
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.domain.LanguageCode.*
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.*
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
@@ -4692,7 +4693,7 @@ object OntologyResponderV2Spec extends E2EZSpec { self =>
                         ),
                       )
         inputResource = CreateResourceV2(
-                          resourceIri = Some(resourceIri.toSmartIri),
+                          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
                           resourceClassIri =
                             "http://0.0.0.0:3333/ontology/0001/freetest/v2#BlueFreeTestClass".toSmartIri,
                           label = "my blue test class thing instance",

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -841,7 +841,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("create a resource with no values") {
         val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -888,7 +888,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("create a resource with no values and custom permissions") {
         val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -1036,7 +1036,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
 
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = inputValues,
@@ -1154,7 +1154,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("not create a resource with missing required values") {
         val resourceIri   = sf.makeRandomResourceIri(incunabulaProject.shortcode)
         val inputResource = CreateResourceV2(
-          Some(resourceIri.toSmartIri),
+          Some(ResourceIri.unsafeFrom(resourceIri)),
           "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           "invalid book",
           Map.empty,
@@ -1194,7 +1194,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          Some(resourceIri.toSmartIri),
+          Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1228,7 +1228,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1252,7 +1252,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1276,7 +1276,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1339,7 +1339,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1364,7 +1364,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1389,7 +1389,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1407,7 +1407,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         val linkedResourceIri = zeitgloeckleinIri
 
         val createResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = Map(
@@ -1434,7 +1434,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
 
         val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values =
@@ -1449,7 +1449,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("not create a resource with invalid custom permissions") {
         val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = Map.empty,
@@ -1475,7 +1475,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = values,
@@ -1489,7 +1489,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("not create a resource that uses a class from another non-shared project") {
         val resourceIri   = sf.makeRandomResourceIri(incunabulaProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -1640,7 +1640,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         val resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
         val createReq   = CreateResourceRequestV2(
           CreateResourceV2(
-            Some(resourceIri.toSmartIri),
+            Some(ResourceIri.unsafeFrom(resourceIri)),
             "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
             "test label",
             Map.empty,
@@ -1715,7 +1715,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       ) {
         val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1730,7 +1730,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       ) {
         val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1745,7 +1745,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       ) {
         val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1772,7 +1772,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1799,7 +1799,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1826,7 +1826,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1857,7 +1857,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = resourceClassIri,
           label = "test thing",
           values = inputValues,
@@ -1939,7 +1939,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceWithLinkIri.smartIri),
+          resourceIri = Some(resourceWithLinkIri),
           resourceClassIri = resourceClassIri.smartIri,
           label = "thing with link",
           values = inputValues,
@@ -2002,7 +2002,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         val resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
         val createReq   = CreateResourceRequestV2(
           CreateResourceV2(
-            Some(resourceIri.toSmartIri),
+            Some(ResourceIri.unsafeFrom(resourceIri)),
             "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
             "test label for resource to be deleted then erased",
             Map.empty,
@@ -2060,7 +2060,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("create a resource with no values but a custom IRI") {
         val resourceIri   = "http://rdfh.ch/0001/55UrkgTKR2SEQgnsLWI9kk"
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "thing with a custom IRI",
           values = Map.empty,
@@ -2109,7 +2109,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "thing with custom value UUID",
           values = inputValues,

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -43,8 +43,8 @@ import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.resources.repo.GetStandoffTagByUUIDQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -43,7 +43,7 @@ import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.resources.repo.GetStandoffTagByUUIDQuery
@@ -874,7 +874,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       },
       test("not create a resource when empty list for required property is provided") {
         val createThis = CreateResourceV2(
-          Some(sf.makeRandomResourceIri(anythingProject.shortcode).toSmartIri),
+          Some(ResourceIri.unsafeFrom(sf.makeRandomResourceIri(anythingProject.shortcode))),
           "http://www.knora.org/ontology/0803/incunabula#book".toSmartIri,
           "test book",
           Map("http://www.knora.org/ontology/0803/incunabula#title".toSmartIri -> Seq.empty),
@@ -1922,7 +1922,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       },
       test("not erase a resource if another resource has a link to it") {
         val resourceWithLinkIri = ResourceIri.unsafeFrom(
-          sf.makeRandomResourceIri(anythingProject.shortcode).toSmartIri,
+          sf.makeRandomResourceIri(anythingProject.shortcode),
         )
         val resourceClassIri =
           ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
@@ -2198,7 +2198,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("delete the newly created value to check the delete value event of resource history") {
-        val resourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri)
+        val resourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
         val valueToDelete =
           ValueIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A".toSmartIri)
         val resourceClassIri =

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -30,8 +30,8 @@ import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.service.ActiveValue
 import org.knora.webapi.slice.resources.repo.service.ResourceModel
 import org.knora.webapi.slice.resources.repo.service.ResourceModel.ActiveResource

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -30,7 +30,7 @@ import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.resources.repo.service.ActiveValue
 import org.knora.webapi.slice.resources.repo.service.ResourceModel
@@ -548,7 +548,7 @@ final case class TestHelper(
     createReq = CreateResourceRequestV2(createRes, rootUser, uuid)
     res      <- resourcesResponderV2.createResource(createReq)
     created  <- resourceRepo
-                 .findActiveById(ResourceIri.unsafeFrom(res.resources.head.resourceIri.toSmartIri))
+                 .findActiveById(ResourceIri.unsafeFrom(res.resources.head.resourceIri))
                  .someOrFail(IllegalStateException("Resource not found"))
   } yield created
 
@@ -562,7 +562,7 @@ final case class TestHelper(
     createReq = CreateResourceRequestV2(createRes, rootUser, uuid)
     resource <- resourcesResponderV2.createResource(createReq).map(_.resources.head)
     created  <- resourceRepo
-                 .findActiveById(ResourceIri.unsafeFrom(resource.resourceIri.toSmartIri))
+                 .findActiveById(ResourceIri.unsafeFrom(resource.resourceIri))
                  .someOrFail(IllegalStateException("Resource not found"))
     values <- ZIO
                 .foreach(resource.values.toList) { (s, vs) =>

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -2966,7 +2966,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     ) {
       val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
       val inputResource = CreateResourceV2(
-        resourceIri = Some(resourceIri.toSmartIri),
+        resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
         resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
         label = "test bildformat",
         values = Map.empty,
@@ -3003,7 +3003,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     ) {
       val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
       val inputResource = CreateResourceV2(
-        resourceIri = Some(resourceIri.toSmartIri),
+        resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
         resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
         label = "test bildformat",
         values = Map.empty,
@@ -3040,7 +3040,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       val resourceIri = sf.makeRandomResourceIri(imagesProject.shortcode)
 
       val inputResource = CreateResourceV2(
-        resourceIri = Some(resourceIri.toSmartIri),
+        resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
         resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
         label = "test bildformat",
         values = Map.empty,

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -34,6 +34,7 @@ import org.knora.webapi.models.filemodels.FileType
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.KnoraIris.*
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.search.repo.GetResourceWithSpecifiedPropertiesGravsearchQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService
@@ -175,7 +176,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
   ): ZIO[SearchResponderV2, Throwable, ReadResourceV2] = {
     val gravsearchQuery: String =
       GetResourceWithSpecifiedPropertiesGravsearchQuery.build(
-        resourceIri = ResourceIri.unsafeFrom(resourceIri.toSmartIri),
+        resourceIri = ResourceIri.unsafeFrom(resourceIri),
         propertyIris = propertyIrisForGravsearch.map(PropertyIri.unsafeFrom),
       )
     for {
@@ -529,7 +530,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("delete an integer value that belongs to a property of another ontology") {
-        val resourceIri      = ResourceIri.unsafeFrom(freetestWithAPropertyFromAnythingOntologyIri.toSmartIri)
+        val resourceIri      = ResourceIri.unsafeFrom(freetestWithAPropertyFromAnythingOntologyIri)
         val propertyIri      = Anything.hasIntegerUsedByOtherOntologies
         val resourceClassIri = ResourceClassIri.unsafeFrom(
           "http://0.0.0.0:3333/ontology/0001/freetest/v2#FreetestWithAPropertyFromAnythingOntology".toSmartIri,
@@ -1131,7 +1132,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           .map(actual => assert(actual)(failsWithA[NotFoundException]))
       },
       test("not delete an integer value if the requesting user does not have DeletePermission on the value") {
-        val resourceIri      = ResourceIri.unsafeFrom(aThingIri.toSmartIri)
+        val resourceIri      = ResourceIri.unsafeFrom(aThingIri)
         val propertyIri      = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri)
         val resourceClassIri = ResourceClassIri.unsafeFrom(Anything.thingClass.smartIri)
         val deleteParams     = DeleteValueV2(
@@ -1147,7 +1148,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           .map(actual => assert(actual)(failsWithA[ForbiddenException]))
       },
       test("delete an integer value") {
-        val resourceIri      = ResourceIri.unsafeFrom(aThingIri.toSmartIri)
+        val resourceIri      = ResourceIri.unsafeFrom(aThingIri)
         val propertyIri      = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri)
         val resourceClassIri = ResourceClassIri.unsafeFrom(Anything.thingClass.smartIri)
         val deleteParams     = DeleteValueV2(
@@ -1171,7 +1172,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("delete an integer value, specifying a custom delete date") {
-        val resourceIri         = ResourceIri.unsafeFrom(aThingIri.toSmartIri)
+        val resourceIri         = ResourceIri.unsafeFrom(aThingIri)
         val propertyIri         = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri)
         val resourceClassIri    = ResourceClassIri.unsafeFrom(Anything.thingClass.smartIri)
         val deleteDate: Instant = Instant.now
@@ -2884,7 +2885,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     },
     test("not delete a standoff link directly") {
       val deleteParams = DeleteValueV2(
-        ResourceIri.unsafeFrom(zeitgloeckleinIri.toSmartIri),
+        ResourceIri.unsafeFrom(zeitgloeckleinIri),
         ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri),
         PropertyIri.unsafeFrom(KA.HasStandoffLinkToValue.toSmartIri),
         standoffLinkValueIri.asValueIri,
@@ -2898,7 +2899,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       val propertyIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book_comment".toSmartIri
 
       val deleteParams = DeleteValueV2(
-        ResourceIri.unsafeFrom(zeitgloeckleinIri.toSmartIri),
+        ResourceIri.unsafeFrom(zeitgloeckleinIri),
         ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri),
         PropertyIri.unsafeFrom(propertyIri),
         ValueIri.unsafeFrom(zeitgloeckleinCommentWithStandoffIri.get.toSmartIri),
@@ -2910,7 +2911,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         maybeResourceLastModDate <- getResourceLastModificationDate(zeitgloeckleinIri, incunabulaMemberUser)
         _                        <- valuesResponder(_.deleteValueV2(deleteParams, incunabulaMemberUser))
         _                        <- checkValueIsDeleted(
-               ResourceIri.unsafeFrom(zeitgloeckleinIri.toSmartIri),
+               ResourceIri.unsafeFrom(zeitgloeckleinIri),
                maybeResourceLastModDate,
                ValueIri.unsafeFrom(zeitgloeckleinCommentWithStandoffIri.get.toSmartIri),
                requestingUser = incunabulaMemberUser,
@@ -2924,7 +2925,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       } yield assertTrue(!resource.values.contains(KA.HasStandoffLinkToValue.toSmartIri))
     },
     test("delete a link between two resources") {
-      val resourceIri          = ResourceIri.unsafeFrom("http://rdfh.ch/0803/cb1a74e3e2f6".toSmartIri)
+      val resourceIri          = ResourceIri.unsafeFrom("http://rdfh.ch/0803/cb1a74e3e2f6")
       val linkValuePropertyIri = PropertyIri.unsafeFrom(KA.HasLinkToValue.toSmartIri)
       val linkValueIRI         = ValueIri.unsafeFrom(linkValueIri.get.toSmartIri)
       val deleteParams         = DeleteValueV2(
@@ -2950,7 +2951,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     test("not delete a value if the property's cardinality doesn't allow it") {
       val propertyIri  = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#title".toSmartIri)
       val deleteParams = DeleteValueV2(
-        ResourceIri.unsafeFrom(zeitgloeckleinIri.toSmartIri),
+        ResourceIri.unsafeFrom(zeitgloeckleinIri),
         ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri),
         propertyIri,
         ValueIri.unsafeFrom("http://rdfh.ch/0803/c5058f3a/values/c3295339".toSmartIri),

--- a/modules/testkit/src/main/scala/org/knora/webapi/models/filemodels/FileModels.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/models/filemodels/FileModels.scala
@@ -8,7 +8,6 @@ package org.knora.webapi.models.filemodels
 import java.time.Instant
 import java.util.UUID
 
-import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceV2
@@ -17,6 +16,7 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
+import org.knora.webapi.slice.common.ResourceIri
 
 sealed abstract case class UploadFileRequest private (
   fileType: FileType,
@@ -157,7 +157,7 @@ sealed abstract case class UploadFileRequest private (
     )
 
     CreateResourceV2(
-      resourceIri = Some(resourceIRIOrDefault.toSmartIri),
+      resourceIri = Some(ResourceIri.unsafeFrom(resourceIRIOrDefault)),
       resourceClassIri = resourceClassIRIOrDefault,
       label = label,
       values = Map(fileValuePropertyIRIOrDefault -> values),

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
@@ -7,14 +7,13 @@ package org.knora.webapi.testservices
 import sttp.client4.*
 import zio.*
 
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.rdf.JsonLDDocument
 import org.knora.webapi.models.filemodels.FileType
 import org.knora.webapi.models.filemodels.UploadFileRequest
 import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.testservices.RequestsUpdates.RequestUpdate
 import org.knora.webapi.testservices.TestDspIngestClient.UploadedFile
 
@@ -70,10 +69,8 @@ object TestResourcesApiClient {
       ),
     )
 
-  def getResource(resourceIri: String)(implicit
-    sf: StringFormatter,
-  ): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
-    ZIO.attempt(ResourceIri.unsafeFrom(sf.toSmartIri(resourceIri))).flatMap(getResource)
+  def getResource(resourceIri: String): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
+    ZIO.attempt(ResourceIri.unsafeFrom(resourceIri)).flatMap(getResource)
 
   def getResource(
     resourceIri: ResourceIri,

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
@@ -69,7 +69,9 @@ object TestResourcesApiClient {
       ),
     )
 
-  def getResource(resourceIri: String): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
+  def getResource(
+    resourceIri: String,
+  ): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
     ZIO.attempt(ResourceIri.unsafeFrom(resourceIri)).flatMap(getResource)
 
   def getResource(

--- a/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
@@ -44,7 +44,7 @@ class MutableTestIri { self =>
   def asProjectIri: ProjectIri                                 = ProjectIri.unsafeFrom(self.get)
   def asUserIri: UserIri                                       = UserIri.unsafeFrom(self.get)
   def asGroupIri: GroupIri                                     = GroupIri.unsafeFrom(self.get)
-  def asResourceIri: ResourceIri = ResourceIri.unsafeFrom(self.get)
+  def asResourceIri: ResourceIri                               = ResourceIri.unsafeFrom(self.get)
   def asValueIri(implicit sf: StringFormatter): ValueIri       = ValueIri.unsafeFrom(self.get.toSmartIri)
 
   override def toString: String = maybeIri match {

--- a/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
@@ -13,6 +13,7 @@ import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 import org.knora.webapi.slice.common.KnoraIris.*
+import org.knora.webapi.slice.common.ResourceIri
 
 /**
  * Holds an optional, mutable IRI for use in tests.
@@ -43,7 +44,7 @@ class MutableTestIri { self =>
   def asProjectIri: ProjectIri                                 = ProjectIri.unsafeFrom(self.get)
   def asUserIri: UserIri                                       = UserIri.unsafeFrom(self.get)
   def asGroupIri: GroupIri                                     = GroupIri.unsafeFrom(self.get)
-  def asResourceIri(implicit sf: StringFormatter): ResourceIri = ResourceIri.unsafeFrom(self.get.toSmartIri)
+  def asResourceIri: ResourceIri = ResourceIri.unsafeFrom(self.get)
   def asValueIri(implicit sf: StringFormatter): ValueIri       = ValueIri.unsafeFrom(self.get.toSmartIri)
 
   override def toString: String = maybeIri match {

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -32,6 +32,7 @@ import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
+import org.knora.webapi.slice.common.ResourceIri
 
 /**
  * An abstract trait for messages that can be sent to `ResourcesResponderV2`.
@@ -548,7 +549,7 @@ case class CreateValueInNewResourceV2(
  * @param creationDate     the optional creation date of the resource.
  */
 case class CreateResourceV2(
-  resourceIri: Option[SmartIri],
+  resourceIri: Option[ResourceIri],
   resourceClassIri: SmartIri,
   label: String,
   values: Map[SmartIri, Seq[CreateValueInNewResourceV2]],

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -47,8 +47,8 @@ import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -47,7 +47,7 @@ import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri

--- a/webapi/src/main/scala/org/knora/webapi/responders/IriService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/IriService.scala
@@ -18,6 +18,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.KnoraIris.KnoraIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.CheckIriExistsQuery
 import org.knora.webapi.slice.ontology.repo.IsClassUsedInDataQuery
@@ -128,9 +129,10 @@ final case class IriService(
     makeUnusedIriRec(attempts = MAX_IRI_ATTEMPTS)
   }
 
-  def checkIriExists(iri: IRI): Task[Boolean]      = triplestore.query(CheckIriExistsQuery.build(iri))
-  def checkIriExists(iri: KnoraIri): Task[Boolean] = checkIriExists(iri.smartIri)
-  def checkIriExists(iri: SmartIri): Task[Boolean] = triplestore.query(CheckIriExistsQuery.build(iri))
+  def checkIriExists(iri: IRI): Task[Boolean]         = triplestore.query(CheckIriExistsQuery.build(iri))
+  def checkIriExists(iri: KnoraIri): Task[Boolean]    = checkIriExists(iri.smartIri)
+  def checkIriExists(iri: SmartIri): Task[Boolean]    = triplestore.query(CheckIriExistsQuery.build(iri))
+  def checkIriExists(iri: StringValue): Task[Boolean] = checkIriExists(iri.value)
 }
 
 object IriService {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -215,8 +215,8 @@ final case class ResourcesResponderV2(
         project <- projectService
                      .findById(resource.projectADM.id)
                      .someOrFail(NotFoundException.notFound(resource.projectADM.id))
-        resourceIri <- iriConverter
-                         .asResourceIri(updateResourceMetadataRequestV2.resourceIri)
+        resourceIri <- ZIO
+                         .fromEither(ResourceIri.from(updateResourceMetadataRequestV2.resourceIri))
                          .mapError(BadRequestException.apply)
         resourceClassIri <- iriConverter
                               .asResourceClassIri(internalResourceClassIri)
@@ -298,7 +298,8 @@ final case class ResourcesResponderV2(
         // Generate SPARQL for marking the resource as deleted.
         requestingUserIri <-
           ZIO.fromEither(UserIri.from(deleteResourceV2.requestingUser.id)).mapError(e => Exception(e)).orDie
-        resourceIri <- iriConverter.asResourceIri(deleteResourceV2.resourceIri).mapError(BadRequestException.apply)
+        resourceIri <-
+          ZIO.fromEither(ResourceIri.from(deleteResourceV2.resourceIri)).mapError(BadRequestException.apply)
         sparqlUpdate = DeleteResourceQuery.build(
                          project = resource.projectADM,
                          resourceIri = resourceIri,
@@ -351,7 +352,9 @@ final case class ResourcesResponderV2(
 
       otherResources <-
         ZIO
-          .foreach(result.results.bindings.map(_.rowMap.get("other")).flatten.toSet)(iriConverter.asResourceIri)
+          .foreach(result.results.bindings.map(_.rowMap.get("other")).flatten.toSet)(s =>
+            ZIO.fromEither(ResourceIri.from(s)),
+          )
           .mapError(DataConversionException.apply)
     } yield otherResources
 
@@ -390,7 +393,7 @@ final case class ResourcesResponderV2(
 
       _ <- ensureNoConflictingChange(resource, deleteResourceV2.maybeLastModificationDate)
 
-      resourceIri <- iriConverter.asResourceIri(deleteResourceV2.resourceIri).mapError(BadRequestException.apply)
+      resourceIri <- ZIO.fromEither(ResourceIri.from(deleteResourceV2.resourceIri)).mapError(BadRequestException.apply)
       _           <- ensureResourceIsNotInUse(resourceIri)
 
       lastModificationDate = resource.lastModificationDate.getOrElse(resource.creationDate)
@@ -454,7 +457,7 @@ final case class ResourcesResponderV2(
 
         _ <- ensureNoConflictingChange(resource, eraseResourceV2.maybeLastModificationDate)
 
-        resourceIri <- iriConverter.asResourceIri(eraseResourceV2.resourceIri).mapError(BadRequestException.apply)
+        resourceIri <- ZIO.fromEither(ResourceIri.from(eraseResourceV2.resourceIri)).mapError(BadRequestException.apply)
         _           <- ensureResourceIsNotInUse(resourceIri)
 
         // Do the update.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -55,7 +55,7 @@ import org.knora.webapi.slice.admin.domain.service.LegalInfoService
 import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
@@ -1206,7 +1206,7 @@ final case class ResourcesResponderV2(
 
     for {
       // Make a Gravsearch query.
-      resIri                         <- ZIO.fromEither(ResourceIri.from(resourceIri.toSmartIri)).mapError(BadRequestException(_))
+      resIri                         <- ZIO.fromEither(ResourceIri.from(resourceIri)).mapError(BadRequestException(_))
       gravsearchQueryForIncomingLinks = GetIncomingImageLinksGravsearchQuery.build(resIri)
 
       // Run the query.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -41,8 +41,8 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.service.IriConverter

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -41,7 +41,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.domain.InternalIri
@@ -526,7 +526,7 @@ final class ValuesResponderV2(
       // Generate a SPARQL update.
       sparqlUpdate <- CreateLinkQuery.build(
                         project = resourceInfo.projectADM,
-                        resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri.toSmartIri),
+                        resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                         linkUpdate = sparqlTemplateLinkUpdate,
                         newValueUUID = newValueUUID,
                         creationDate = creationDate,
@@ -1022,7 +1022,7 @@ final class ValuesResponderV2(
 
         result <- ChangeLinkTargetQuery.build(
                     project = resourceInfo.projectADM,
-                    linkSourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri.toSmartIri),
+                    linkSourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                     linkUpdateForCurrentLink = sparqlTemplateLinkUpdateForCurrentLink,
                     linkUpdateForNewLink = sparqlTemplateLinkUpdateForNewLink,
                     maybeComment = newLinkValue.comment,
@@ -1054,7 +1054,7 @@ final class ValuesResponderV2(
 
         result <- ChangeLinkMetadataQuery.build(
                     project = resourceInfo.projectADM,
-                    linkSourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri.toSmartIri),
+                    linkSourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                     linkUpdate = sparqlTemplateLinkUpdate,
                     maybeComment = newLinkValue.comment,
                   )
@@ -1406,7 +1406,7 @@ final class ValuesResponderV2(
       linkUpdates  <- ZIO.collectAll(linkUpdateTasks)
       sparqlUpdate <- DeleteValueQuery.build(
                         project = resourceInfo.projectADM,
-                        resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri.toSmartIri),
+                        resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                         propertyIri = PropertyIri.unsafeFrom(propertyIri),
                         valueIri = ValueIri.unsafeFrom(currentValue.valueIri.toSmartIri),
                         maybeDeleteComment = deleteComment,
@@ -1529,7 +1529,7 @@ final class ValuesResponderV2(
           Seq(propertyInfo.entityInfoContent.propertyIri) ++ maybeStandoffLinkToPropertyIri,
         )(iri => ZIO.fromEither(PropertyIri.from(iri)).mapError(BadRequestException(_)))
 
-      resIri <- ZIO.fromEither(ResourceIri.from(resourceIri.toSmartIri)).mapError(BadRequestException(_))
+      resIri <- ZIO.fromEither(ResourceIri.from(resourceIri)).mapError(BadRequestException(_))
 
       // Make a Gravsearch query.
       gravsearchQuery =

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -40,6 +40,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraProjectRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.admin.model.*
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
@@ -91,8 +92,10 @@ final case class CreateResourceV2Handler(
       _         <- ensureUserHasPermission(createResourceRequestV2, projectIri)
 
       resourceIri <- iriService.checkOrCreateEntityIri(
-                       createResourceRequestV2.createResource.resourceIri,
-                       stringFormatter.makeRandomResourceIri(shortcode),
+                       createResourceRequestV2.createResource.resourceIri.map(ri =>
+                         stringFormatter.toSmartIri(ri.value),
+                       ),
+                       ResourceIri.makeNew(shortcode).value,
                      )
       taskResult <- IriLocker.runWithIriLock(createResourceRequestV2.apiRequestID, resourceIri)(
                       makeTask(createResourceRequestV2, resourceIri),

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -91,12 +91,11 @@ final case class CreateResourceV2Handler(
       shortcode  = createResourceRequestV2.createResource.projectADM.shortcode
       _         <- ensureUserHasPermission(createResourceRequestV2, projectIri)
 
-      resourceIri <- iriService.checkOrCreateEntityIri(
-                       createResourceRequestV2.createResource.resourceIri.map(ri =>
-                         stringFormatter.toSmartIri(ri.value),
-                       ),
-                       ResourceIri.makeNew(shortcode).value,
-                     )
+      resourceIri <-
+        iriService.checkOrCreateEntityIri(
+          createResourceRequestV2.createResource.resourceIri.map(ri => stringFormatter.toSmartIri(ri.value)),
+          ResourceIri.makeNew(shortcode).value,
+        )
       taskResult <- IriLocker.runWithIriLock(createResourceRequestV2.apiRequestID, resourceIri)(
                       makeTask(createResourceRequestV2, resourceIri),
                     )

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/V3ErrorInfo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/V3ErrorInfo.scala
@@ -12,7 +12,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.api.v3.V3ErrorCode.NotFounds
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 sealed trait V3ErrorInfo {
   def message: String

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -40,6 +40,7 @@ import org.knora.webapi.slice.admin.domain.service.UserService
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.api.v2.mapping.CreateStandoffMappingForm
 import org.knora.webapi.slice.common.KnoraIris.*
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.common.jena.ModelOps.*
@@ -110,14 +111,7 @@ final case class ApiComplexV2JsonLdRequestParser(
       for {
         model             <- ModelOps.fromJsonLd(injectedStr)
         resource          <- ZIO.fromEither(model.singleRootResource)
-        resourceIriOption <-
-          ZIO
-            .foreach(resource.uri)(
-              converter
-                .asSmartIri(_)
-                .mapError(_.getMessage)
-                .flatMap(iri => ZIO.fromEither(KnoraIris.ResourceIri.from(iri))),
-            )
+        resourceIriOption <- ZIO.foreach(resource.uri)(uri => ZIO.fromEither(ResourceIri.from(uri)))
         resourceClassIri <- resourceClassIri(resource)
       } yield RootResource(resource, resourceIriOption, resourceClassIri)
 
@@ -143,7 +137,7 @@ final case class ApiComplexV2JsonLdRequestParser(
              .fail("No updated resource metadata provided")
              .when(label.isEmpty && permissions.isEmpty && newModificationDate.isEmpty)
     } yield UpdateResourceMetadataRequestV2(
-      resourceIri.smartIri.toString,
+      resourceIri.value,
       r.resourceClassSmartIri,
       lastModificationDate,
       label,
@@ -166,7 +160,7 @@ final case class ApiComplexV2JsonLdRequestParser(
       deleteDate           <- r.deleteDateOption
       lastModificationDate <- r.lastModificationDateOption
     } yield DeleteOrEraseResourceRequestV2(
-      resourceIri.smartIri.toString,
+      resourceIri.value,
       r.resourceClassSmartIri,
       deleteComment,
       deleteDate,
@@ -314,7 +308,7 @@ final case class ApiComplexV2JsonLdRequestParser(
       attachedToUser <- attachedToUser(r.resource, requestingUser, project.id)
       values         <- extractValues(r.resource, project.shortcode)
       createResource  = CreateResourceV2(
-                         r.resourceIri.map(_.smartIri),
+                         r.resourceIri,
                          r.resourceClassSmartIri,
                          label,
                          values,
@@ -468,7 +462,7 @@ final case class ApiComplexV2JsonLdRequestParser(
                          case (Some(valueContentV2), _) =>
                            ZIO.succeed(
                              UpdateValueContentV2(
-                               resourceIri.smartIri.toString,
+                               resourceIri.value,
                                r.resourceClassSmartIri,
                                v.propertySmartIri,
                                valueIri.smartIri.toString,
@@ -481,7 +475,7 @@ final case class ApiComplexV2JsonLdRequestParser(
                          case (_, Some(permissions)) =>
                            ZIO.succeed(
                              UpdateValuePermissionsV2(
-                               resourceIri.smartIri.toString,
+                               resourceIri.value,
                                r.resourceClassSmartIri,
                                v.propertySmartIri,
                                valueIri.smartIri.toString,
@@ -509,7 +503,7 @@ final case class ApiComplexV2JsonLdRequestParser(
         valuePermissions  <- v.hasPermissionsOption
         valueContent      <- getValueContent(v, resourceIri.shortcode)
       } yield CreateValueV2(
-        resourceIri.smartIri.toString,
+        resourceIri.value,
         r.resourceClassSmartIri,
         v.propertyIri.smartIri,
         valueContent,

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -112,7 +112,7 @@ final case class ApiComplexV2JsonLdRequestParser(
         model             <- ModelOps.fromJsonLd(injectedStr)
         resource          <- ZIO.fromEither(model.singleRootResource)
         resourceIriOption <- ZIO.foreach(resource.uri)(uri => ZIO.fromEither(ResourceIri.from(uri)))
-        resourceClassIri <- resourceClassIri(resource)
+        resourceClassIri  <- resourceClassIri(resource)
       } yield RootResource(resource, resourceIriOption, resourceClassIri)
 
     private def resourceClassIri(r: Resource): IO[String, ResourceClassIri] = ZIO

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
@@ -12,7 +12,6 @@ import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
-import org.knora.webapi.slice.common.ResourceIri.ResourceId
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.OntologyName
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
@@ -12,12 +12,12 @@ import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.common.ResourceIri.ResourceId
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.OntologyName
 
 object KnoraIris {
 
-  opaque type ResourceId = NonEmptyString
   opaque type ValueId    = NonEmptyString
   opaque type EntityName = NonEmptyString
 
@@ -112,7 +112,7 @@ object KnoraIris {
         // the following three calls are safe because we checked that the
         // shortcode, resourceId and valueId are present in isKnoraValueIri
         val shortcode  = iri.getProjectShortcode.getOrElse(throw Exception())
-        val resourceId = NonEmptyString.unsafeFrom(iri.getResourceID.getOrElse(throw Exception()))
+        val resourceId = ResourceId.unsafeFrom(iri.getResourceID.getOrElse(throw Exception()))
         val valueId    = NonEmptyString.unsafeFrom(iri.getValueID.getOrElse(throw Exception()))
         Right(ValueIri(iri, shortcode, resourceId, valueId))
       else Left(s"<$iri> is not a Knora value IRI")

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
@@ -7,8 +7,6 @@ package org.knora.webapi.slice.common
 
 import eu.timepit.refined.types.string.NonEmptyString
 
-import java.net.URI
-
 import org.knora.webapi.OntologySchema
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
@@ -105,9 +103,6 @@ object KnoraIris {
     def from(iri: SmartIri): Either[String, ResourceClassIri] = Right(ResourceClassIri(iri))
   }
 
-  // `ValueIri` and `ResourceIri` have no different internal representation.
-  // Thus, we only provide functions which create these from a `SmartIri`.
-  // The `fromApiV2Complex` is not required as these Iris are not part of the API v2 complex schema.
   object ValueIri {
 
     def unsafeFrom(iri: SmartIri): ValueIri = from(iri).fold(e => throw IllegalArgumentException(e), identity)
@@ -121,26 +116,6 @@ object KnoraIris {
         val valueId    = NonEmptyString.unsafeFrom(iri.getValueID.getOrElse(throw Exception()))
         Right(ValueIri(iri, shortcode, resourceId, valueId))
       else Left(s"<$iri> is not a Knora value IRI")
-  }
-
-  final case class ResourceIri private (smartIri: SmartIri, shortcode: Shortcode, resourceId: ResourceId)
-      extends KnoraIri {
-    override def equals(other: Any): Boolean = super.equals(other)
-    override def hashCode(): Int             = super.hashCode()
-    val latestArkUrl: URI                    = URI.create(smartIri.fromResourceIriToArkUrl(None))
-  }
-  object ResourceIri {
-
-    def unsafeFrom(iri: SmartIri): ResourceIri = from(iri).fold(e => throw IllegalArgumentException(e), identity)
-
-    def from(iri: SmartIri): Either[String, ResourceIri] =
-      if iri.isKnoraResourceIri then
-        // the following two calls are safe because we checked that the
-        // shortcode and resourceId are present in isKnoraResourceIri
-        val shortcode  = iri.getProjectShortcode.getOrElse(throw Exception())
-        val resourceId = NonEmptyString.unsafeFrom(iri.getResourceID.getOrElse(throw Exception()))
-        Right(ResourceIri(iri, shortcode, resourceId))
-      else Left(s"<$iri> is not a Knora resource IRI")
   }
 
   final case class OntologyIri private (smartIri: SmartIri) extends KnoraIri { self =>

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -5,26 +5,29 @@
 
 package org.knora.webapi.slice.common
 
-import eu.timepit.refined.types.string.NonEmptyString
-
 import java.util.UUID
 import scala.util.matching.Regex
 
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
-import org.knora.webapi.slice.common.ResourceIri.ResourceId
 import org.knora.webapi.slice.common.Value.StringValue
+
+final case class ResourceId private (override val value: String) extends StringValue
+
+object ResourceId extends StringValueCompanion[ResourceId] {
+  private val ResourceIdRegex: Regex = """^[A-Za-z0-9_-]+$""".r
+
+  def from(value: String): Either[String, ResourceId] = value match {
+    case ResourceIdRegex() => Right(ResourceId(value))
+    case _                 => Left(s"<$value> is not a valid resource ID")
+  }
+}
 
 final case class ResourceIri private (override val value: String, shortcode: Shortcode, resourceId: ResourceId)
     extends StringValue
 
 object ResourceIri extends StringValueCompanion[ResourceIri] {
-
-  opaque type ResourceId = NonEmptyString
-  object ResourceId {
-    def unsafeFrom(value: String): ResourceId = NonEmptyString.unsafeFrom(value)
-  }
 
   private val ResourceIriRegex: Regex =
     """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r
@@ -36,7 +39,7 @@ object ResourceIri extends StringValueCompanion[ResourceIri] {
 
   def from(value: String): Either[String, ResourceIri] = value match {
     case ResourceIriRegex(sc, id) =>
-      Shortcode.from(sc).map(shortcode => ResourceIri(value, shortcode, NonEmptyString.unsafeFrom(id)))
+      Shortcode.from(sc).map(shortcode => ResourceIri(value, shortcode, ResourceId.unsafeFrom(id)))
     case _ => Left(s"<$value> is not a Knora resource IRI")
   }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -22,6 +22,9 @@ final case class ResourceIri private (override val value: String, shortcode: Sho
 object ResourceIri extends StringValueCompanion[ResourceIri] {
 
   opaque type ResourceId = NonEmptyString
+  object ResourceId {
+    def unsafeFrom(value: String): ResourceId = NonEmptyString.unsafeFrom(value)
+  }
 
   private val ResourceIriRegex: Regex =
     """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import eu.timepit.refined.types.string.NonEmptyString
+
+import java.util.UUID
+import scala.util.matching.Regex
+
+import dsp.valueobjects.UuidUtil
+import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.common.ResourceIri.ResourceId
+import org.knora.webapi.slice.common.Value.StringValue
+
+final case class ResourceIri private (override val value: String, shortcode: Shortcode, resourceId: ResourceId)
+    extends StringValue
+
+object ResourceIri extends StringValueCompanion[ResourceIri] {
+
+  opaque type ResourceId = NonEmptyString
+
+  private val ResourceIriRegex: Regex =
+    """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r
+
+  def makeNew(shortcode: Shortcode): ResourceIri = {
+    val id = UuidUtil.base64Encode(UUID.randomUUID)
+    unsafeFrom(s"http://rdfh.ch/$shortcode/$id")
+  }
+
+  def from(value: String): Either[String, ResourceIri] = value match {
+    case ResourceIriRegex(sc, id) =>
+      Shortcode.from(sc).map(shortcode => ResourceIri(value, shortcode, NonEmptyString.unsafeFrom(id)))
+    case _ => Left(s"<$value> is not a Knora resource IRI")
+  }
+
+  def from(iri: SmartIri): Either[String, ResourceIri] = from(iri.toString)
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -39,7 +39,11 @@ object ResourceIri extends StringValueCompanion[ResourceIri] {
 
   def from(value: String): Either[String, ResourceIri] = value match {
     case ResourceIriRegex(sc, id) =>
-      Shortcode.from(sc).map(shortcode => ResourceIri(value, shortcode, ResourceId.unsafeFrom(id)))
+      // unsafe is safe here since the regex already ensures
+      // the constraints for both code and id
+      val shortcode  = Shortcode.unsafeFrom(sc)
+      val resourceId = ResourceId.unsafeFrom(id)
+      Right(ResourceIri(value, shortcode, resourceId))
     case _ => Left(s"<$value> is not a Knora resource IRI")
   }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/service/IriConverter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/service/IriConverter.scala
@@ -16,7 +16,6 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri
 
@@ -48,9 +47,6 @@ final case class IriConverter(sf: StringFormatter) {
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.fromApiV2Complex(sIri)))
   def asPropertyIri(iri: String): IO[String, PropertyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.from(sIri)))
-
-  def asResourceIri(iri: String): IO[String, ResourceIri] =
-    ZIO.fromEither(ResourceIri.from(iri))
 
   def asOntologyIriApiV2Complex(iri: String): IO[String, OntologyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(OntologyIri.fromApiV2Complex(sIri)))

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/service/IriConverter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/service/IriConverter.scala
@@ -16,7 +16,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri
 
@@ -50,7 +50,7 @@ final case class IriConverter(sf: StringFormatter) {
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.from(sIri)))
 
   def asResourceIri(iri: String): IO[String, ResourceIri] =
-    asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(ResourceIri.from(sIri)))
+    ZIO.fromEither(ResourceIri.from(iri))
 
   def asOntologyIriApiV2Complex(iri: String): IO[String, OntologyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(OntologyIri.fromApiV2Complex(sIri)))

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
@@ -17,7 +17,7 @@ import java.time.Instant
 
 import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
@@ -17,8 +17,8 @@ import java.time.Instant
 
 import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
@@ -22,7 +22,7 @@ import dsp.errors.SparqlGenerationException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
@@ -22,8 +22,8 @@ import dsp.errors.SparqlGenerationException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
@@ -20,8 +20,8 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
@@ -20,7 +20,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
@@ -24,7 +24,7 @@ import java.util.UUID
 import dsp.errors.SparqlGenerationException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
@@ -24,8 +24,8 @@ import java.util.UUID
 import dsp.errors.SparqlGenerationException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuery.scala
@@ -17,7 +17,7 @@ import java.time.Instant
 
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuery.scala
@@ -17,8 +17,8 @@ import java.time.Instant
 
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 
 object DeleteResourceQuery extends QueryBuilderHelper {

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
@@ -21,9 +21,9 @@ import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
@@ -21,7 +21,7 @@ import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuery.scala
@@ -12,8 +12,8 @@ import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
 
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
 
 object EraseResourceQuery extends QueryBuilderHelper {

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuery.scala
@@ -12,7 +12,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
 
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
@@ -38,7 +38,7 @@ import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.domain.InternalIri
@@ -191,7 +191,7 @@ final case class ResourcesRepoLive(triplestore: TriplestoreService)(implicit val
     .asScala
     .map { stmt =>
       val p = PropertyIri.unsafeFrom(stmt.getPredicate.toString.toSmartIri)
-      val v = ResourceIri.unsafeFrom(stmt.getObject.toString.toSmartIri)
+      val v = ResourceIri.unsafeFrom(stmt.getObject.toString)
       (p, v)
     }
     .toList
@@ -236,7 +236,7 @@ final case class ResourcesRepoLive(triplestore: TriplestoreService)(implicit val
     val isDeleted              = row.getRequired("isDeleted", s => Right(s.toBoolean))
     val label                  = row.getRequired("label")
     val resourceClassIri       = row.getRequired("clazz", s => ResourceClassIri.from(s.toSmartIri))
-    val hasStandoffLinkTo      = row.get("hasStandoffLinkTo", s => ResourceIri.from(s.toSmartIri))
+    val hasStandoffLinkTo      = row.get("hasStandoffLinkTo", s => ResourceIri.from(s))
     val hasStandoffLinkToValue = row.get("hasStandoffLinkToValue", s => ValueIri.from(s.toSmartIri))
     val attachedToUser         = row.getRequired("attachedToUser", UserIri.from)
     val creationDate           = row.getRequired("creationDate", s => Try(Instant.parse(s)).toEither.left.map(_.getMessage))

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
@@ -38,9 +38,9 @@ import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.FileValueTypeSpecificInfo

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ValueContentValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ValueContentValidator.scala
@@ -13,7 +13,7 @@ import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceReq
 import org.knora.webapi.messages.v2.responder.valuemessages.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.service.LegalInfoService
-import org.knora.webapi.slice.common.service.IriConverter
+import org.knora.webapi.slice.common.ResourceIri
 
 /**
  * A service that validates values in requests that create resources with values or create/update values.
@@ -23,7 +23,6 @@ import org.knora.webapi.slice.common.service.IriConverter
  * - Ensuring that file values have valid legal information
  */
 final case class ValueContentValidator(
-  private val iriConverter: IriConverter,
   private val legalInfoService: LegalInfoService,
 ) {
 
@@ -42,7 +41,7 @@ final case class ValueContentValidator(
     extractShortcode(resourceIri).flatMap(validateValueContent(vc, _))
 
   private def extractShortcode(resourceIri: IRI): IO[String, Shortcode] =
-    iriConverter.asResourceIri(resourceIri).map(_.shortcode)
+    ZIO.fromEither(ResourceIri.from(resourceIri)).map(_.shortcode)
 
   private def validateValueContent(vc: ValueContentV2, inProject: Shortcode): IO[String, Unit] =
     ensureNoCrossProjectLink(vc, inProject) *> ensureValidLegalInfo(vc, inProject)

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuery.scala
@@ -5,8 +5,8 @@
 
 package org.knora.webapi.slice.search.repo
 
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 
 object GetIncomingImageLinksGravsearchQuery extends QueryBuilderHelper {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuery.scala
@@ -5,7 +5,7 @@
 
 package org.knora.webapi.slice.search.repo
 
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 
 object GetIncomingImageLinksGravsearchQuery extends QueryBuilderHelper {

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuery.scala
@@ -6,7 +6,7 @@
 package org.knora.webapi.slice.search.repo
 
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 
 object GetResourceWithSpecifiedPropertiesGravsearchQuery extends QueryBuilderHelper {

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuery.scala
@@ -6,8 +6,8 @@
 package org.knora.webapi.slice.search.repo
 
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 
 object GetResourceWithSpecifiedPropertiesGravsearchQuery extends QueryBuilderHelper {
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/api/v3/NotFoundSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/api/v3/NotFoundSpec.scala
@@ -4,20 +4,17 @@
  */
 
 package org.knora.webapi.slice.api.v3
-import zio.*
 import zio.json.*
 import zio.test.*
 
-import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.slice.common.service.IriConverter
+import org.knora.webapi.slice.common.ResourceIri
 
 object NotFoundSpec extends ZIOSpecDefault {
   override val spec = suite("NotFoundSpec")(
     test("NotFound.from(ResourceIri) should create a NotFound instance with the correct message and error details") {
-      for {
-        resourceIri <- ZIO.serviceWithZIO[IriConverter](_.asResourceIri("http://rdfh.ch/0001/abcd1234"))
-        actual       = NotFound.from(resourceIri)
-      } yield assertTrue(
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/abcd1234")
+      val actual      = NotFound.from(resourceIri)
+      assertTrue(
         actual.toJsonPretty == """{
                                  |  "message" : "The resource with IRI 'http://rdfh.ch/0001/abcd1234' was not found.",
                                  |  "errors" : [
@@ -32,5 +29,5 @@ object NotFoundSpec extends ZIOSpecDefault {
                                  |}""".stripMargin,
       )
     },
-  ).provide(IriConverter.layer, StringFormatter.test)
+  )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
@@ -11,7 +11,6 @@ import zio.test.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.KnoraIrisSpec.test
 import org.knora.webapi.slice.common.service.IriConverter
@@ -126,39 +125,8 @@ object KnoraIrisSpec extends ZIOSpecDefault {
     ),
   )
 
-  private val resourceIriSuite = suite("ResourceIri")(
-    suite("from")(
-      test("should return a ResourceIri") {
-        val validIris = Seq(resourceIri)
-        check(Gen.fromIterable(validIris)) { iri =>
-          for {
-            sIri  <- converter(_.asSmartIri(iri))
-            actual = ResourceIri.from(sIri)
-          } yield assertTrue(actual.map(_.smartIri) == Right(sIri))
-        }
-      },
-      test("should fail for an invalid ResourceIri") {
-        val invalidIris = Seq(
-          "http://example.com/ontology#Foo",
-          internalResourceClassIri,
-          apiV2ComplexResourceClassIri,
-          internalPropertyIri,
-          apiV2ComplexPropertyIri,
-          valueIri,
-        )
-        check(Gen.fromIterable(invalidIris)) { iri =>
-          for {
-            sIri  <- converter(_.asSmartIri(iri))
-            actual = ResourceIri.from(sIri)
-          } yield assertTrue(actual == Left(s"<${sIri.toIri}> is not a Knora resource IRI"))
-        }
-      },
-    ),
-  )
-
   val spec = suite("KnoraIris")(
     resourceClassIriSuite,
-    resourceIriSuite,
     propertyIriSuite,
     valueIriSuite,
   ).provide(IriConverter.layer, StringFormatter.test)

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
@@ -11,7 +11,7 @@ import zio.test.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.KnoraIrisSpec.test
 import org.knora.webapi.slice.common.service.IriConverter

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ResourceIriSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ResourceIriSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import zio.test.*
+
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+
+object ResourceIriSpec extends ZIOSpecDefault {
+
+  private val validResourceIri = "http://rdfh.ch/080C/Ef9heHjPWDS7dMR_gGax2Q"
+
+  val spec = suite("ResourceIri")(
+    suite("from")(
+      test("should return a ResourceIri for a valid IRI") {
+        val actual = ResourceIri.from(validResourceIri)
+        assertTrue(
+          actual.isRight,
+          actual.toOption.get.value == validResourceIri,
+          actual.toOption.get.shortcode == Shortcode.unsafeFrom("080C"),
+        )
+      },
+      test("should fail for an invalid ResourceIri") {
+        val invalidIris = Seq(
+          "http://example.com/ontology#Foo",
+          "http://www.knora.org/ontology/0001/anything#Thing",
+          "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing",
+          "http://www.knora.org/ontology/0001/anything#hasListItem",
+          "http://0.0.0.0:3333/ontology/0001/anything/v2#hasListItem",
+          "http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A",
+        )
+        check(Gen.fromIterable(invalidIris)) { iri =>
+          val actual = ResourceIri.from(iri)
+          assertTrue(actual == Left(s"<$iri> is not a Knora resource IRI"))
+        }
+      },
+    ),
+    suite("makeNew")(
+      test("should create a valid ResourceIri") {
+        val shortcode   = Shortcode.unsafeFrom("0001")
+        val resourceIri = ResourceIri.makeNew(shortcode)
+        assertTrue(
+          resourceIri.value.startsWith("http://rdfh.ch/0001/"),
+          resourceIri.shortcode == shortcode,
+          ResourceIri.from(resourceIri.value).isRight,
+        )
+      },
+      test("should create unique IRIs") {
+        val shortcode = Shortcode.unsafeFrom("0001")
+        val iri1      = ResourceIri.makeNew(shortcode)
+        val iri2      = ResourceIri.makeNew(shortcode)
+        assertTrue(iri1.value != iri2.value)
+      },
+    ),
+  )
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuerySpec.scala
@@ -16,7 +16,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object ChangeLinkMetadataQuerySpec extends ZIOSpecDefault {
@@ -37,7 +37,7 @@ object ChangeLinkMetadataQuerySpec extends ZIOSpecDefault {
     Set.empty,
     Set.empty,
   )
-  private val testLinkSourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1".toSmartIri)
+  private val testLinkSourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
   private val testLinkTargetIri   = "http://rdfh.ch/0001/thing2"
   private val testNewLinkValueIri = "http://rdfh.ch/0001/thing1/values/newLinkValue"

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuerySpec.scala
@@ -19,7 +19,7 @@ import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object ChangeLinkTargetQuerySpec extends ZIOSpecDefault {
@@ -40,7 +40,7 @@ object ChangeLinkTargetQuerySpec extends ZIOSpecDefault {
     Set.empty,
     Set.empty,
   )
-  private val testLinkSourceIri             = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1".toSmartIri)
+  private val testLinkSourceIri             = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri           = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
   private val testCurrentLinkTargetIri      = "http://rdfh.ch/0001/thing2"
   private val testNewLinkTargetIri          = "http://rdfh.ch/0001/thing3"

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec.scala
@@ -19,7 +19,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.RestrictedView
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
 object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
@@ -41,7 +41,7 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
     Set.empty,
   )
 
-  private val testResourceIri      = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing".toSmartIri)
+  private val testResourceIri      = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
   private val testResourceClassIri =
     ResourceClassIri.unsafeFrom("http://www.knora.org/ontology/0001/anything#Thing".toSmartIri)
   private val testLastModificationDate = LastModificationDate.from(Instant.parse("2023-08-01T10:30:00Z"))

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuerySpec.scala
@@ -18,7 +18,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object CreateLinkQuerySpec extends ZIOSpecDefault {
@@ -40,7 +40,7 @@ object CreateLinkQuerySpec extends ZIOSpecDefault {
     Set.empty,
   )
 
-  private val testResourceIri         = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1".toSmartIri)
+  private val testResourceIri         = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri     = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
   private val testLinkTargetIri       = "http://rdfh.ch/0001/thing2"
   private val testNewLinkValueIri     = "http://rdfh.ch/0001/thing1/values/newLinkValue"

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuerySpec.scala
@@ -15,7 +15,7 @@ import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 object DeleteResourceQuerySpec extends ZIOSpecDefault {
 
@@ -37,7 +37,7 @@ object DeleteResourceQuerySpec extends ZIOSpecDefault {
   )
 
   private val dataNamedGraph = "http://www.knora.org/data/0001/anything"
-  private val resourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri)
+  private val resourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
   private val currentTime    = Instant.parse("2024-01-01T10:00:00Z")
   private val requestingUser = UserIri.unsafeFrom("http://rdfh.ch/users/root")
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuerySpec.scala
@@ -9,8 +9,6 @@ import zio.test.*
 
 import java.time.Instant
 
-import org.knora.webapi.messages.IriConversions.ConvertibleIri
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
@@ -18,8 +16,6 @@ import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.ResourceIri
 
 object DeleteResourceQuerySpec extends ZIOSpecDefault {
-
-  private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   private val testProject = Project(
     ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001"),

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
@@ -19,7 +19,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
@@ -41,7 +41,7 @@ object DeleteValueQuerySpec extends ZIOSpecDefault {
     Set.empty,
     Set.empty,
   )
-  private val testResourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1".toSmartIri)
+  private val testResourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testPropertyIri    = PropertyIri.unsafeFrom("http://www.knora.org/ontology/0001/anything#hasText".toSmartIri)
   private val testValueIri       = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/value1".toSmartIri)
   private val testCurrentTime    = Instant.parse("2024-01-15T10:30:00Z")

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
@@ -19,8 +19,8 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object DeleteValueQuerySpec extends ZIOSpecDefault {

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuerySpec.scala
@@ -12,7 +12,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 object EraseResourceQuerySpec extends ZIOSpecDefault {
 
@@ -33,7 +33,7 @@ object EraseResourceQuerySpec extends ZIOSpecDefault {
     Set.empty,
   )
 
-  private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_history".toSmartIri)
+  private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_history")
 
   override def spec: Spec[TestEnvironment, Any] = suite("EraseResourceQuery")(
     test("build should produce the expected SPARQL query") {

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuerySpec.scala
@@ -7,16 +7,12 @@ package org.knora.webapi.slice.resources.repo
 
 import zio.test.*
 
-import org.knora.webapi.messages.IriConversions.ConvertibleIri
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.ResourceIri
 
 object EraseResourceQuerySpec extends ZIOSpecDefault {
-
-  private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   private val testProject = Project(
     ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001"),

--- a/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuerySpec.scala
@@ -7,13 +7,9 @@ package org.knora.webapi.slice.search.repo
 
 import zio.test.*
 
-import org.knora.webapi.messages.IriConversions.*
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.ResourceIri
 
 object GetIncomingImageLinksGravsearchQuerySpec extends ZIOSpecDefault {
-
-  implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuerySpec.scala
@@ -9,13 +9,13 @@ import zio.test.*
 
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 object GetIncomingImageLinksGravsearchQuerySpec extends ZIOSpecDefault {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
-  private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing".toSmartIri)
+  private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
 
   override val spec: Spec[Any, Nothing] = suite("GetIncomingImageLinksGravsearchQuery")(
     test("build should produce the expected Gravsearch CONSTRUCT query") {

--- a/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuerySpec.scala
@@ -10,13 +10,13 @@ import zio.test.*
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 object GetResourceWithSpecifiedPropertiesGravsearchQuerySpec extends ZIOSpecDefault {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
-  private val resourceIri  = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing".toSmartIri)
+  private val resourceIri  = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
   private val propertyIris = Seq(
     PropertyIri.unsafeFrom("http://www.knora.org/ontology/knora-base#hasStillImageFileValue".toSmartIri),
     PropertyIri.unsafeFrom("http://www.knora.org/ontology/knora-base#hasStandoffLinkTo".toSmartIri),


### PR DESCRIPTION
ResourceIri no longer extends KnoraIri/SmartIri. Resource IRIs have no ontology schema
variations, so the SmartIri machinery was unnecessary overhead. ResourceIri is now a
simple StringValue with regex validation, following the ProjectIri/UserIri pattern.

- Extract ResourceIri and ResourceId into standalone file with regex-based validation
- Add ResourceIri.makeNew(shortcode) for random IRI generation without StringFormatter
- Change CreateResourceV2.resourceIri type from Option[SmartIri] to Option[ResourceIri]
- Remove IriConverter.asResourceIri
- Remove .toSmartIri calls from all ResourceIri construction sites