### PR TITLE
refactor: Migrate ResourceIri and ValueIri to standalone types (DEV-6231)

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesEndpointsGetResourcesE2ESpec.scala
@@ -17,7 +17,7 @@ import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.messages.util.rdf.RdfModel
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.testservices.RequestsUpdates.addAcceptHeaderRdfXml
 import org.knora.webapi.testservices.RequestsUpdates.addAcceptHeaderTurtle
 import org.knora.webapi.testservices.RequestsUpdates.addSimpleSchemaHeader
@@ -115,14 +115,14 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       s"for the first page of the book '[Das] Narrenschiff (lat.) using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/7bbb8e59b703".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/7bbb8e59b703")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "NarrenschiffFirstPage.jsonld")
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a BCE date property using the complex schema in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithBCEDate.jsonld")
@@ -134,7 +134,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
         s"using the complex schema " +
         s"in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date2".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_BCE_date2")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithBCEDate2.jsonld")
@@ -142,7 +142,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test(s"for a resource with a list value using the complex schema in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithListValue.jsonld")
@@ -154,7 +154,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
         s"using the simple schema (header) " +
         s"in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_list_value")
       for {
         actual <- TestApiClient
                     .getAsString(uri"/v2/resources/$resourceIri", addSimpleSchemaHeader)
@@ -163,7 +163,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a link using the complex schema in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithLinkComplex.jsonld")
@@ -171,7 +171,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a link using the simple schema (header) in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ")
       for {
         actual <- TestApiClient
                     .getAsString(uri"/v2/resources/$resourceIri", addSimpleSchemaHeader)
@@ -181,7 +181,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a Text language using the complex schema in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithTextLangComplex.jsonld")
@@ -189,7 +189,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
       } yield assertTrue(RdfModel.fromJsonLD(actual) == RdfModel.fromJsonLD(expected))
     },
     test("for a resource with a Text language using the simple schema (header) in JSON-LD") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-valuesLanguage")
       for {
         actual <- TestApiClient
                     .getAsString(uri"/v2/resources/$resourceIri", addSimpleSchemaHeader)
@@ -201,7 +201,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       "for a resource with values of different types using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "Testding.jsonld")
@@ -211,7 +211,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       "for a Thing resource with a link to a ThingPicture resource using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-picture".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-picture")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithPicture.jsonld")
@@ -221,7 +221,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       "for a resource with a link to a resource that the user doesn't have permission to see using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0JhgKcqoRIeRRG6ownArSw".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/0JhgKcqoRIeRRG6ownArSw")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithOneHiddenResource.jsonld")
@@ -231,7 +231,7 @@ object ResourcesEndpointsGetResourcesE2ESpec extends E2EZSpec {
     test(
       "for a resource with a link to a resource that is marked as deleted using the complex schema in JSON-LD",
     ) {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/l8f8FVEiSCeq9A1p8gBR-A")
       for {
         actual   <- TestApiClient.getJsonLd(uri"/v2/resources/$resourceIri").flatMap(_.assert200)
         expected <- TestDataFileUtil.readTestData("resourcesR2RV2", "ThingWithOneDeletedResource.jsonld")

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -35,7 +35,7 @@ import org.knora.webapi.messages.util.rdf.*
 import org.knora.webapi.sharedtestdata.SharedOntologyTestDataADM
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.testservices.RequestsUpdates.addSimpleSchemaQueryParam
 import org.knora.webapi.testservices.RequestsUpdates.addVersionQueryParam
 import org.knora.webapi.testservices.ResponseOps.assert200
@@ -52,8 +52,8 @@ object ResourcesRouteV2E2ESpec extends E2EZSpec {
   private var aThingLastModificationDate  = Instant.now
   private val hamletResourceIri           = new MutableTestIri
   private val aThingIri                   = "http://rdfh.ch/0001/a-thing"
-  val aThingWithHistoryIri: ResourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri)
-  val reiseInsHeiligeLandIri: ResourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/2a6221216701".toSmartIri)
+  val aThingWithHistoryIri: ResourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
+  val reiseInsHeiligeLandIri: ResourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/2a6221216701")
 
   override val rdfDataObjects: List[RdfDataObject] = List(
     RdfDataObject(

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -24,7 +24,6 @@ import scala.language.implicitConversions
 
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.it.v2.LegalInfoE2ESpec.suite
-import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Complex as KA
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
@@ -322,7 +321,7 @@ object LegalInfoE2ESpec extends E2EZSpec {
   }
 
   private def getResourceFromApi(resourceId: ResourceIri) = for {
-    responseBody <- TestApiClient.getJsonLd(uri"/v2/resources/${resourceId.toComplexSchema}").flatMap(_.assert200)
+    responseBody <- TestApiClient.getJsonLd(uri"/v2/resources/${resourceId.value}").flatMap(_.assert200)
     model        <- ModelOps.fromJsonLd(responseBody).mapError(Exception(_))
   } yield model
 
@@ -334,7 +333,7 @@ object LegalInfoE2ESpec extends E2EZSpec {
 
   private def getValueFromApi(valueId: ValueIri, resourceId: ResourceIri): ZIO[env, Throwable, Model] = for {
     responseBody <-
-      TestApiClient.getJsonLd(uri"/v2/values/${resourceId.toComplexSchema}/${valueId.valueId}").flatMap(_.assert200)
+      TestApiClient.getJsonLd(uri"/v2/values/${resourceId.value}/${valueId.valueId}").flatMap(_.assert200)
     model <- ModelOps.fromJsonLd(responseBody).mapError(Exception(_))
   } yield model
 
@@ -346,7 +345,6 @@ object LegalInfoE2ESpec extends E2EZSpec {
           id   <- root.uri.toRight("No URI found for root resource")
         } yield id,
       )
-      .map(_.toSmartIri)
       .mapBoth(Exception(_), ResourceIri.unsafeFrom)
 
   private def valueId(model: Model): ZIO[IriConverter, Throwable, ValueIri] = {

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -34,7 +34,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.api.PageAndSize
 import org.knora.webapi.slice.api.PagedResponse
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -32,8 +32,8 @@ import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.api.PageAndSize
 import org.knora.webapi.slice.api.PagedResponse
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.common.jena.ModelOps.*

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -355,8 +355,7 @@ object LegalInfoE2ESpec extends E2EZSpec {
         ZIO
           .fromEither(s.uri.toRight("No URI found for value"))
           .mapError(Exception(_))
-          .flatMap(str => ZIO.serviceWithZIO[IriConverter](_.asSmartIri(str)))
-          .flatMap(iri => ZIO.fromEither(ValueIri.from(iri)).mapError(Exception(_)))
+          .flatMap(str => ZIO.fromEither(ValueIri.from(str)).mapError(Exception(_)))
       case Nil => ZIO.fail(Exception("No value found"))
       case _   => ZIO.fail(Exception("Multiple values found"))
   }

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -32,7 +32,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.api.PageAndSize
 import org.knora.webapi.slice.api.PagedResponse
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -25,7 +25,6 @@ import scala.language.implicitConversions
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.it.v2.LegalInfoE2ESpec.suite
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Complex as KA
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.admin.domain.model.*
@@ -48,8 +47,6 @@ import org.knora.webapi.testservices.TestDspIngestClient.UploadedFile
 import org.knora.webapi.testservices.TestResourcesApiClient
 
 object LegalInfoE2ESpec extends E2EZSpec {
-
-  private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   override def rdfDataObjects: List[RdfDataObject] = List(anythingRdfData)
 

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -33,8 +33,8 @@ import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.api.PageAndSize
 import org.knora.webapi.slice.api.PagedResponse
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.common.jena.ModelOps.*

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/StandoffEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/StandoffEndpointsE2ESpec.scala
@@ -29,7 +29,7 @@ import org.knora.webapi.messages.util.rdf.JsonLDUtil
 import org.knora.webapi.models.filemodels.FileType
 import org.knora.webapi.models.filemodels.UploadFileRequest
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.testservices.ResponseOps.assert200
 import org.knora.webapi.testservices.TestApiClient
 import org.knora.webapi.testservices.TestDspIngestClient

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ValuesEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ValuesEndpointsE2ESpec.scala
@@ -37,7 +37,7 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.api.v2.values.ReorderValuesRequest
 import org.knora.webapi.slice.api.v2.values.ReorderValuesResponse
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.search.repo.GetResourceWithSpecifiedPropertiesGravsearchQuery
 import org.knora.webapi.testservices.RequestsUpdates.addVersionQueryParam
 import org.knora.webapi.testservices.ResponseOps.assert200
@@ -120,7 +120,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
   private def getResourceWithValues(resourceIri: IRI, propertyIrisForGravsearch: Seq[SmartIri]) = {
     val gravsearchQuery: String =
       GetResourceWithSpecifiedPropertiesGravsearchQuery.build(
-        resourceIri = ResourceIri.unsafeFrom(resourceIri.toSmartIri),
+        resourceIri = ResourceIri.unsafeFrom(resourceIri),
         propertyIris = propertyIrisForGravsearch.map(PropertyIri.unsafeFrom),
       )
     TestApiClient
@@ -641,7 +641,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
       }
     },
     test("get a past version of a value, given its UUID and a timestamp") {
-      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri)
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
       val valueUuid   = "pLlW4ODASumZfZFbJdpw1g"
       val timestamp   = "20190212T090510Z"
       for {
@@ -3550,7 +3550,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
         assertCompletes
     },
     test("update a TextValue comment containing linebreaks should store linebreaks as Unicode") {
-      val resourceIri     = ResourceIri.unsafeFrom(AThing.iri.toSmartIri)
+      val resourceIri     = ResourceIri.unsafeFrom(AThing.iri)
       val anythingHasText = anythingOntologyIri.makeProperty("hasText").toComplexSchema.toString
       val anythingThing   = anythingOntologyIri.makeClass("Thing").toComplexSchema.toString
 
@@ -3655,7 +3655,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                .flatMap(_.assert200)
 
         // 3. Read the resource and extract the value IRIs in their current order
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3718,7 +3718,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3757,7 +3757,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3794,7 +3794,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3832,7 +3832,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3869,7 +3869,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                             .flatMap(_.assert200)
         resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
-        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+        resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
         resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
         valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
         valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -3930,7 +3930,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                  .flatMap(_.assert200)
 
           // Get the resource to read value IRIs
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4010,7 +4010,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
                  .flatMap(_.assert200)
 
           // Get the value IRIs
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4058,7 +4058,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
           // Get the value IRIs
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4152,7 +4152,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
           // Read the value IRIs
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4201,7 +4201,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
           // Get the value IRIs (they belong to hasText, not hasInteger)
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
@@ -4249,7 +4249,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resourceIri <- ZIO.fromEither(createResponse.body.getRequiredString(JsonLDKeywords.ID))
 
           // Get the single value IRI
-          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri.toSmartIri))
+          resIri       <- ZIO.attempt(ResourceIri.unsafeFrom(resourceIri))
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/StringFormatterSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/StringFormatterSpec.scala
@@ -17,6 +17,7 @@ import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.routing.UnsafeZioRun
+import org.knora.webapi.slice.common.ResourceIri
 
 /**
  * Tests [[StringFormatter]].
@@ -908,29 +909,29 @@ class StringFormatterSpec extends AnyWordSpec with Matchers {
     }
 
     "generate an ARK URL for a resource IRI without a timestamp" in {
-      val resourceIri: IRI = "http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA"
-      val arkUrl           = resourceIri.toSmartIri.fromResourceIriToArkUrl()
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA")
+      val arkUrl      = stringFormatter.resourceIriToArkUrl(resourceIri)
       assert(arkUrl == "http://0.0.0.0:3336/ark:/72163/1/0001/cmfk1DMHRBiR4=_6HXpEFAn")
     }
 
     "generate an ARK URL for a resource IRI with a timestamp with a fractional part" in {
-      val resourceIri: IRI = "http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA"
-      val timestamp        = Instant.parse("2018-06-04T08:56:22.9876543Z")
-      val arkUrl           = resourceIri.toSmartIri.fromResourceIriToArkUrl(maybeTimestamp = Some(timestamp))
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA")
+      val timestamp   = Instant.parse("2018-06-04T08:56:22.9876543Z")
+      val arkUrl      = stringFormatter.resourceIriToArkUrl(resourceIri, maybeTimestamp = Some(timestamp))
       assert(arkUrl == "http://0.0.0.0:3336/ark:/72163/1/0001/cmfk1DMHRBiR4=_6HXpEFAn.20180604T0856229876543Z")
     }
 
     "generate an ARK URL for a resource IRI with a timestamp with a leading zero" in {
-      val resourceIri: IRI = "http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA"
-      val timestamp        = Instant.parse("2018-06-04T08:56:22.098Z")
-      val arkUrl           = resourceIri.toSmartIri.fromResourceIriToArkUrl(maybeTimestamp = Some(timestamp))
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA")
+      val timestamp   = Instant.parse("2018-06-04T08:56:22.098Z")
+      val arkUrl      = stringFormatter.resourceIriToArkUrl(resourceIri, maybeTimestamp = Some(timestamp))
       assert(arkUrl == "http://0.0.0.0:3336/ark:/72163/1/0001/cmfk1DMHRBiR4=_6HXpEFAn.20180604T085622098Z")
     }
 
     "generate an ARK URL for a resource IRI with a timestamp without a fractional part" in {
-      val resourceIri: IRI = "http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA"
-      val timestamp        = Instant.parse("2018-06-04T08:56:22Z")
-      val arkUrl           = resourceIri.toSmartIri.fromResourceIriToArkUrl(maybeTimestamp = Some(timestamp))
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA")
+      val timestamp   = Instant.parse("2018-06-04T08:56:22Z")
+      val arkUrl      = stringFormatter.resourceIriToArkUrl(resourceIri, maybeTimestamp = Some(timestamp))
       assert(arkUrl == "http://0.0.0.0:3336/ark:/72163/1/0001/cmfk1DMHRBiR4=_6HXpEFAn.20180604T085622Z")
     }
 

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -46,6 +46,7 @@ import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.api.v2.ontologies.ReplaceClassCardinalitiesRequestV2
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.domain.LanguageCode.*
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.*
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
@@ -4692,7 +4693,7 @@ object OntologyResponderV2Spec extends E2EZSpec { self =>
                         ),
                       )
         inputResource = CreateResourceV2(
-                          resourceIri = Some(resourceIri.toSmartIri),
+                          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
                           resourceClassIri =
                             "http://0.0.0.0:3333/ontology/0001/freetest/v2#BlueFreeTestClass".toSmartIri,
                           label = "my blue test class thing instance",

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -4679,7 +4679,7 @@ object OntologyResponderV2Spec extends E2EZSpec { self =>
           self.freetestLastModDate.updateFrom(addCardinalitiesResponse)
 
         // Create a resource of #BlueTestClass using only #hasBlueTestIntProp.
-        resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
+        resourceIri = ResourceIri.makeNew(anythingProject.shortcode).value
         inputValues = Map(
                         "http://0.0.0.0:3333/ontology/0001/freetest/v2#hasBlueTestIntProp".toSmartIri -> Seq(
                           CreateValueInNewResourceV2(

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -1966,7 +1966,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
                      resourceWithLinkIri,
                      ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri),
                      linkValuePropertyIri,
-                     ValueIri.unsafeFrom(linkValue.valueIri.toSmartIri),
+                     ValueIri.unsafeFrom(linkValue.valueIri),
                      valueTypeIri = OntologyConstants.KnoraApiV2Complex.LinkValue.toSmartIri,
                      apiRequestId = randomUUID,
                    ),
@@ -2200,7 +2200,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("delete the newly created value to check the delete value event of resource history") {
         val resourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
         val valueToDelete =
-          ValueIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A".toSmartIri)
+          ValueIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A")
         val resourceClassIri =
           ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
         val propertyIri   = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasText".toSmartIri)

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -841,7 +841,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("create a resource with no values") {
         val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -888,7 +888,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("create a resource with no values and custom permissions") {
         val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -1036,7 +1036,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
 
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = inputValues,
@@ -1154,7 +1154,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("not create a resource with missing required values") {
         val resourceIri   = sf.makeRandomResourceIri(incunabulaProject.shortcode)
         val inputResource = CreateResourceV2(
-          Some(resourceIri.toSmartIri),
+          Some(ResourceIri.unsafeFrom(resourceIri)),
           "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           "invalid book",
           Map.empty,
@@ -1194,7 +1194,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          Some(resourceIri.toSmartIri),
+          Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1228,7 +1228,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1252,7 +1252,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1276,7 +1276,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1339,7 +1339,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1364,7 +1364,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1389,7 +1389,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1407,7 +1407,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         val linkedResourceIri = zeitgloeckleinIri
 
         val createResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = Map(
@@ -1434,7 +1434,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
 
         val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values =
@@ -1449,7 +1449,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("not create a resource with invalid custom permissions") {
         val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = Map.empty,
@@ -1475,7 +1475,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = values,
@@ -1489,7 +1489,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("not create a resource that uses a class from another non-shared project") {
         val resourceIri   = sf.makeRandomResourceIri(incunabulaProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -1640,7 +1640,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         val resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
         val createReq   = CreateResourceRequestV2(
           CreateResourceV2(
-            Some(resourceIri.toSmartIri),
+            Some(ResourceIri.unsafeFrom(resourceIri)),
             "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
             "test label",
             Map.empty,
@@ -1715,7 +1715,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       ) {
         val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1730,7 +1730,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       ) {
         val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1745,7 +1745,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       ) {
         val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1772,7 +1772,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1799,7 +1799,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1826,7 +1826,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1857,7 +1857,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = resourceClassIri,
           label = "test thing",
           values = inputValues,
@@ -1939,7 +1939,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceWithLinkIri.smartIri),
+          resourceIri = Some(resourceWithLinkIri),
           resourceClassIri = resourceClassIri.smartIri,
           label = "thing with link",
           values = inputValues,
@@ -2002,7 +2002,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         val resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
         val createReq   = CreateResourceRequestV2(
           CreateResourceV2(
-            Some(resourceIri.toSmartIri),
+            Some(ResourceIri.unsafeFrom(resourceIri)),
             "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
             "test label for resource to be deleted then erased",
             Map.empty,
@@ -2060,7 +2060,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test("create a resource with no values but a custom IRI") {
         val resourceIri   = "http://rdfh.ch/0001/55UrkgTKR2SEQgnsLWI9kk"
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "thing with a custom IRI",
           values = Map.empty,
@@ -2109,7 +2109,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(resourceIri.toSmartIri),
+          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "thing with custom value UUID",
           values = inputValues,

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -43,8 +43,8 @@ import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.resources.repo.GetStandoffTagByUUIDQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -43,7 +43,7 @@ import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.resources.repo.GetStandoffTagByUUIDQuery
@@ -874,7 +874,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       },
       test("not create a resource when empty list for required property is provided") {
         val createThis = CreateResourceV2(
-          Some(sf.makeRandomResourceIri(anythingProject.shortcode).toSmartIri),
+          Some(ResourceIri.unsafeFrom(sf.makeRandomResourceIri(anythingProject.shortcode))),
           "http://www.knora.org/ontology/0803/incunabula#book".toSmartIri,
           "test book",
           Map("http://www.knora.org/ontology/0803/incunabula#title".toSmartIri -> Seq.empty),
@@ -1922,7 +1922,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       },
       test("not erase a resource if another resource has a link to it") {
         val resourceWithLinkIri = ResourceIri.unsafeFrom(
-          sf.makeRandomResourceIri(anythingProject.shortcode).toSmartIri,
+          sf.makeRandomResourceIri(anythingProject.shortcode),
         )
         val resourceClassIri =
           ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
@@ -2198,7 +2198,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("delete the newly created value to check the delete value event of resource history") {
-        val resourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri)
+        val resourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
         val valueToDelete =
           ValueIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A".toSmartIri)
         val resourceClassIri =

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -43,8 +43,8 @@ import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.resources.repo.GetStandoffTagByUUIDQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService
@@ -839,9 +839,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertTrue(response == GraphTestData.graphWithOneNode)
       },
       test("create a resource with no values") {
-        val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -851,9 +851,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         for {
           response <-
             resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          actualFromResponse <- response.toResource(resourceIri).map(_.toOntologySchema(ApiV2Complex))
+          actualFromResponse <- response.toResource(resourceIri.value).map(_.toOntologySchema(ApiV2Complex))
           _                  <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = actualFromResponse,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,
@@ -861,9 +861,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
                  requestingUser = anythingUser2,
                )
           // Get the resource from the triplestore and check it again.
-          actualFromDb <- getResource(resourceIri)
+          actualFromDb <- getResource(resourceIri.value)
           _            <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = actualFromDb,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,
@@ -874,7 +874,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       },
       test("not create a resource when empty list for required property is provided") {
         val createThis = CreateResourceV2(
-          Some(ResourceIri.unsafeFrom(sf.makeRandomResourceIri(anythingProject.shortcode))),
+          Some(ResourceIri.makeNew(anythingProject.shortcode)),
           "http://www.knora.org/ontology/0803/incunabula#book".toSmartIri,
           "test book",
           Map("http://www.knora.org/ontology/0803/incunabula#title".toSmartIri -> Seq.empty),
@@ -886,9 +886,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("create a resource with no values and custom permissions") {
-        val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -898,9 +898,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
 
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceIri)
+          outputResource <- getResource(resourceIri.value)
           _              <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = outputResource,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,
@@ -910,7 +910,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("create a resource with values") {
-        val resourceIri                                                 = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(anythingProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1036,7 +1036,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
 
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = inputValues,
@@ -1045,9 +1045,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
 
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceIri)
+          outputResource <- getResource(resourceIri.value)
           _              <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = outputResource,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,
@@ -1057,7 +1057,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("create a resource with a still image file value") {
-        val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(anythingProject.shortcode)
         val inputResource = UploadFileRequest
           .make(
             fileType = FileType.StillImageFile(
@@ -1066,12 +1066,12 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
             ),
             internalFilename = "IQUO3t1AABm-FSLC0vNvVpr.jp2",
           )
-          .toMessage(resourceIri = Some(resourceIri))
+          .toMessage(resourceIri = Some(resourceIri.value))
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceIri)
+          outputResource <- getResource(resourceIri.value)
           _              <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = outputResource,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,
@@ -1081,7 +1081,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("create a resource with an external still image file value") {
-        val resourceIri     = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri     = ResourceIri.makeNew(anythingProject.shortcode)
         val imageRequestUrl = IiifImageRequestUrl.unsafeFrom(
           "https://iiif.ub.unibe.ch/image/v2.1/632664f2-20cb-43e4-8584-2fa3988c63a2/full/max/0/default.jpg",
         )
@@ -1090,13 +1090,13 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
             fileType = FileType.StillImageExternalFile(imageRequestUrl),
             internalFilename = "IQUO3t1AABm-TTTTTTTTTTT.jp2",
           )
-          .toMessage(resourceIri = Some(resourceIri))
+          .toMessage(resourceIri = Some(resourceIri.value))
 
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceIri)
+          outputResource <- getResource(resourceIri.value)
           _              <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = outputResource,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,
@@ -1106,19 +1106,19 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("create a resource with document representation") {
-        val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(anythingProject.shortcode)
         val inputResource = UploadFileRequest
           .make(
             fileType = FileType.DocumentFile(),
             internalFilename = "IQUO3t1AABm-FSLC0vNvVpr.pdf",
           )
-          .toMessage(resourceIri = Some(resourceIri))
+          .toMessage(resourceIri = Some(resourceIri.value))
 
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceIri)
+          outputResource <- getResource(resourceIri.value)
           _              <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = outputResource,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,
@@ -1128,21 +1128,21 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("create a resource with archive representation") {
-        val resourceIri: String = sf.makeRandomResourceIri(anythingProject.shortcode)
-        val inputResource       = UploadFileRequest
+        val resourceIri   = ResourceIri.makeNew(anythingProject.shortcode)
+        val inputResource = UploadFileRequest
           .make(
             fileType = FileType.ArchiveFile,
             internalFilename = "IQUO3t1AABm-FSLC0vNvVps.zip",
           )
           .toMessage(
-            resourceIri = Some(resourceIri),
+            resourceIri = Some(resourceIri.value),
             internalMimeType = Some("application/zip"),
           )
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceIri)
+          outputResource <- getResource(resourceIri.value)
           _              <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = outputResource,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,
@@ -1152,9 +1152,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("not create a resource with missing required values") {
-        val resourceIri   = sf.makeRandomResourceIri(incunabulaProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(incunabulaProject.shortcode)
         val inputResource = CreateResourceV2(
-          Some(ResourceIri.unsafeFrom(resourceIri)),
+          Some(resourceIri),
           "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           "invalid book",
           Map.empty,
@@ -1165,7 +1165,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         ).exit.map(actual => assert(actual)(failsWithA[OntologyConstraintException]))
       },
       test("not create a resource with too many values for the cardinality of a property") {
-        val resourceIri                                                 = sf.makeRandomResourceIri(incunabulaProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(incunabulaProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0803/incunabula/v2#title".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1194,7 +1194,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          Some(ResourceIri.unsafeFrom(resourceIri)),
+          Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1206,7 +1206,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         ).exit.map(actual => assert(actual)(failsWithA[OntologyConstraintException]))
       },
       test("not create a resource with a property for which there is no cardinality in the resource class") {
-        val resourceIri                                                 = sf.makeRandomResourceIri(incunabulaProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(incunabulaProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0803/incunabula/v2#title".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1228,7 +1228,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1239,7 +1239,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         ).exit.map(actual => assert(actual)(failsWithA[OntologyConstraintException]))
       },
       test("not create a resource if the user doesn't have permission to create resources in the project") {
-        val resourceIri                                                 = sf.makeRandomResourceIri(incunabulaProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(incunabulaProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0803/incunabula/v2#title".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1252,7 +1252,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
           label = "invalid book",
           values = inputValues,
@@ -1264,7 +1264,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("not create a resource with a link to a nonexistent other resource") {
-        val resourceIri                                                 = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(anythingProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1276,7 +1276,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1287,7 +1287,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("not create a resource with a standoff link to a nonexistent other resource") {
-        val resourceIri                                    = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri                                    = ResourceIri.makeNew(anythingProject.shortcode)
         val standoffWithInvalidLink: Vector[StandoffTagV2] = Vector(
           StandoffTagV2(
             standoffTagClassIri = OntologyConstants.Standoff.StandoffRootTag.toSmartIri,
@@ -1339,7 +1339,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1350,7 +1350,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("not create a resource with a list value referring to a nonexistent list node") {
-        val resourceIri                                                 = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(anythingProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0001/anything/v2#hasListItem".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1364,7 +1364,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1376,7 +1376,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("not create a resource with a value that's the wrong type for the property") {
-        val resourceIri                                                 = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(anythingProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0001/anything/v2#hasListItem".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1389,7 +1389,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = inputValues,
@@ -1402,12 +1402,12 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       },
       test("not create a resource with a link to a resource in a different project") {
         // The new resource should be created in the Anything project 0001
-        val resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri = ResourceIri.makeNew(anythingProject.shortcode)
         // This resource is present in the Incunabula project 0803
         val linkedResourceIri = zeitgloeckleinIri
 
         val createResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = Map(
@@ -1432,9 +1432,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         // subjectClassConstraint for hasOtherThingValue is anything:Thing
         val linkProperty = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue".toSmartIri
 
-        val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values =
@@ -1447,9 +1447,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("not create a resource with invalid custom permissions") {
-        val resourceIri   = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(anythingProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = Map.empty,
@@ -1461,7 +1461,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("not create a resource with a value that has invalid custom permissions") {
-        val resourceIri                                            = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri                                            = ResourceIri.makeNew(anythingProject.shortcode)
         val values: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1475,7 +1475,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "invalid thing",
           values = values,
@@ -1487,9 +1487,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("not create a resource that uses a class from another non-shared project") {
-        val resourceIri   = sf.makeRandomResourceIri(incunabulaProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(incunabulaProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "test thing",
           values = Map.empty,
@@ -1637,10 +1637,10 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           .map(actual => assert(actual)(failsWithA[BadRequestException]))
       },
       test("mark a resource as deleted") {
-        val resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri = ResourceIri.makeNew(anythingProject.shortcode)
         val createReq   = CreateResourceRequestV2(
           CreateResourceV2(
-            Some(ResourceIri.unsafeFrom(resourceIri)),
+            Some(resourceIri),
             "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
             "test label",
             Map.empty,
@@ -1713,9 +1713,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test(
         "not accept custom resource permissions that would give the requesting user a higher permission on a resource than the default",
       ) {
-        val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1728,9 +1728,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test(
         "accept custom resource permissions that would give the requesting user a higher permission on a resource than the default if the user is a system admin",
       ) {
-        val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1743,9 +1743,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test(
         "accept custom resource permissions that would give the requesting user a higher permission on a resource than the default if the user is a project admin",
       ) {
-        val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
+        val resourceIri   = ResourceIri.makeNew(imagesProject.shortcode)
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = Map.empty,
@@ -1758,7 +1758,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test(
         "not accept custom value permissions that would give the requesting user a higher permission on a value than the default",
       ) {
-        val resourceIri                                                 = sf.makeRandomResourceIri(imagesProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(imagesProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/00FF/images/v2#stueckzahl".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1772,7 +1772,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1785,7 +1785,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test(
         "accept custom value permissions that would give the requesting user a higher permission on a value than the default if the user is a system admin",
       ) {
-        val resourceIri                                                 = sf.makeRandomResourceIri(imagesProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(imagesProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/00FF/images/v2#stueckzahl".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1799,7 +1799,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1812,7 +1812,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
       test(
         "accept custom value permissions that would give the requesting user a higher permission on a value than the default if the user is a project admin",
       ) {
-        val resourceIri                                                 = sf.makeRandomResourceIri(imagesProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(imagesProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/00FF/images/v2#stueckzahl".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -1826,7 +1826,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
           label = "test bildformat",
           values = inputValues,
@@ -1837,8 +1837,8 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           .as(assertCompletes)
       },
       test("create a resource with version history so we can test erasing it") {
-        val resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
-        resourceIriToErase.set(resourceIri)
+        val resourceIri = ResourceIri.makeNew(anythingProject.shortcode)
+        resourceIriToErase.set(resourceIri.value)
         val resourceClassIri: SmartIri                                  = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri
         val propertyIri: SmartIri                                       = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext".toSmartIri
         val standoffTagUUIDsToErase                                     = collection.mutable.Set.empty[UUID]
@@ -1857,7 +1857,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = resourceClassIri,
           label = "test thing",
           values = inputValues,
@@ -1866,7 +1866,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
 
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceIri)
+          outputResource <- getResource(resourceIri.value)
           firstTextValue  = outputResource.values(propertyIri).head.asInstanceOf[ReadTextValueV2]
           _               = firstValueIriToErase.set(firstTextValue.valueIri)
           _               = for (standoffTag <- firstTextValue.valueContent.standoff) {
@@ -1876,7 +1876,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           updateValueResponse <- ZIO.serviceWithZIO[ValuesResponderV2](
                                    _.updateValueV2(
                                      UpdateValueContentV2(
-                                       resourceIri = resourceIri,
+                                       resourceIri = resourceIri.value,
                                        resourceClassIri = resourceClassIri,
                                        propertyIri = propertyIri,
                                        valueIri = firstValueIriToErase.get,
@@ -1894,7 +1894,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
                                    ),
                                  )
           _                = secondValueIriToErase.set(updateValueResponse.valueIri)
-          updatedResource <- getResource(resourceIri)
+          updatedResource <- getResource(resourceIri.value)
           secondTextValue  = updatedResource.values(propertyIri).head.asInstanceOf[ReadTextValueV2]
           _                = secondValueIriToErase.set(secondTextValue.valueIri)
           _                = for (standoffTag <- firstTextValue.valueContent.standoff) {
@@ -1921,10 +1921,8 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("not erase a resource if another resource has a link to it") {
-        val resourceWithLinkIri = ResourceIri.unsafeFrom(
-          sf.makeRandomResourceIri(anythingProject.shortcode),
-        )
-        val resourceClassIri =
+        val resourceWithLinkIri = ResourceIri.makeNew(anythingProject.shortcode)
+        val resourceClassIri    =
           ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri)
         val linkValuePropertyIri =
           PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue".toSmartIri)
@@ -1948,7 +1946,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
 
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceWithLinkIri.toString)
+          outputResource <- getResource(resourceWithLinkIri.value)
           linkValue       = outputResource.findLinkValues(linkValuePropertyIri).head
           // Try to erase the first resource.
           eraseRequest = DeleteOrEraseResourceRequestV2(
@@ -1999,10 +1997,10 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("erase a deleted resource") {
-        val resourceIri = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri = ResourceIri.makeNew(anythingProject.shortcode)
         val createReq   = CreateResourceRequestV2(
           CreateResourceV2(
-            Some(ResourceIri.unsafeFrom(resourceIri)),
+            Some(resourceIri),
             "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
             "test label for resource to be deleted then erased",
             Map.empty,
@@ -2094,7 +2092,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("create a resource with a value that has custom UUID") {
-        val resourceIri                                                 = sf.makeRandomResourceIri(anythingProject.shortcode)
+        val resourceIri                                                 = ResourceIri.makeNew(anythingProject.shortcode)
         val inputValues: Map[SmartIri, Seq[CreateValueInNewResourceV2]] = Map(
           "http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri -> Seq(
             CreateValueInNewResourceV2(
@@ -2109,7 +2107,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
           ),
         )
         val inputResource = CreateResourceV2(
-          resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
+          resourceIri = Some(resourceIri),
           resourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
           label = "thing with custom value UUID",
           values = inputValues,
@@ -2118,9 +2116,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
 
         for {
           _              <- resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)))
-          outputResource <- getResource(resourceIri)
+          outputResource <- getResource(resourceIri.value)
           _              <- checkCreateResource(
-                 inputResourceIri = resourceIri,
+                 inputResourceIri = resourceIri.value,
                  inputResource = inputResource,
                  outputResource = outputResource,
                  defaultResourcePermissions = defaultAnythingResourcePermissions,

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -43,7 +43,7 @@ import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.resources.repo.GetStandoffTagByUUIDQuery

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -30,8 +30,8 @@ import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.service.ActiveValue
 import org.knora.webapi.slice.resources.repo.service.ResourceModel
 import org.knora.webapi.slice.resources.repo.service.ResourceModel.ActiveResource

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -30,7 +30,7 @@ import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.resources.repo.service.ActiveValue
 import org.knora.webapi.slice.resources.repo.service.ResourceModel
@@ -548,7 +548,7 @@ final case class TestHelper(
     createReq = CreateResourceRequestV2(createRes, rootUser, uuid)
     res      <- resourcesResponderV2.createResource(createReq)
     created  <- resourceRepo
-                 .findActiveById(ResourceIri.unsafeFrom(res.resources.head.resourceIri.toSmartIri))
+                 .findActiveById(ResourceIri.unsafeFrom(res.resources.head.resourceIri))
                  .someOrFail(IllegalStateException("Resource not found"))
   } yield created
 
@@ -562,7 +562,7 @@ final case class TestHelper(
     createReq = CreateResourceRequestV2(createRes, rootUser, uuid)
     resource <- resourcesResponderV2.createResource(createReq).map(_.resources.head)
     created  <- resourceRepo
-                 .findActiveById(ResourceIri.unsafeFrom(resource.resourceIri.toSmartIri))
+                 .findActiveById(ResourceIri.unsafeFrom(resource.resourceIri))
                  .someOrFail(IllegalStateException("Resource not found"))
     values <- ZIO
                 .foreach(resource.values.toList) { (s, vs) =>

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -30,7 +30,7 @@ import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.service.ActiveValue
 import org.knora.webapi.slice.resources.repo.service.ResourceModel

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -435,7 +435,7 @@ final case class TestHelper(
       "@id"              -> Json.Str(resource.iri.toString),
       "@type"            -> Json.Str(ontologyIri.makeClass("Thing").toComplexSchema.toIri),
       "anything:hasText" -> Json.Obj(
-        "@id"                           -> Json.Str(value.iri.toComplexSchema.toIri),
+        "@id"                           -> Json.Str(value.iri.value),
         "@type"                         -> Json.Str("knora-api:TextValue"),
         "knora-api:textValueAsXml"      -> Json.Str(textValueAsXml),
         "knora-api:textValueHasMapping" -> Json.Obj(

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -30,8 +30,8 @@ import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
 import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.resources.repo.service.ActiveValue
 import org.knora.webapi.slice.resources.repo.service.ResourceModel
 import org.knora.webapi.slice.resources.repo.service.ResourceModel.ActiveResource

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesEraseSpec.scala
@@ -287,7 +287,7 @@ final case class TestHelper(
                   )
       value <- valuesResponder.createValueV2(createVal, rootUser, uuid)
       value <- valueRepo
-                 .findActiveById(ValueIri.unsafeFrom(value.valueIri.toSmartIri))
+                 .findActiveById(ValueIri.unsafeFrom(value.valueIri))
                  .someOrFail(IllegalStateException("Value not found"))
     } yield value
 
@@ -308,7 +308,7 @@ final case class TestHelper(
     for {
       response <- valuesResponder.updateValueV2(update, rootUser, UUID.randomUUID())
       updated  <- valueRepo
-                   .findActiveById(ValueIri.unsafeFrom(response.valueIri.toSmartIri))
+                   .findActiveById(ValueIri.unsafeFrom(response.valueIri))
                    .someOrFail(IllegalStateException("Value not found"))
     } yield updated
 
@@ -324,7 +324,7 @@ final case class TestHelper(
                   )
       value <- valuesResponder.createValueV2(createVal, rootUser, uuid)
       value <- valueRepo
-                 .findActiveById(ValueIri.unsafeFrom(value.valueIri.toSmartIri))
+                 .findActiveById(ValueIri.unsafeFrom(value.valueIri))
                  .someOrFail(IllegalStateException("Value not found"))
     } yield value
 
@@ -340,7 +340,7 @@ final case class TestHelper(
                   )
       value <- valuesResponder.createValueV2(createVal, rootUser, uuid)
       value <- valueRepo
-                 .findActiveById(ValueIri.unsafeFrom(value.valueIri.toSmartIri))
+                 .findActiveById(ValueIri.unsafeFrom(value.valueIri))
                  .someOrFail(IllegalStateException("Value not found"))
     } yield value
 
@@ -361,7 +361,7 @@ final case class TestHelper(
     for {
       response <- valuesResponder.updateValueV2(update, rootUser, UUID.randomUUID())
       updated  <- valueRepo
-                   .findActiveById(ValueIri.unsafeFrom(response.valueIri.toSmartIri))
+                   .findActiveById(ValueIri.unsafeFrom(response.valueIri))
                    .someOrFail(IllegalStateException("Value not found"))
     } yield updated
 
@@ -422,7 +422,7 @@ final case class TestHelper(
       uuid      <- Random.nextUUID
       value     <- valuesResponder.createValueV2(createVal, rootUser, uuid)
       value     <- valueRepo
-                 .findActiveById(ValueIri.unsafeFrom(value.valueIri.toSmartIri))
+                 .findActiveById(ValueIri.unsafeFrom(value.valueIri))
                  .someOrFail(IllegalStateException("Value not found"))
     } yield value
 
@@ -452,7 +452,7 @@ final case class TestHelper(
       uuid      <- Random.nextUUID
       value     <- valuesResponder.updateValueV2(updateVal, rootUser, uuid)
       value     <- valueRepo
-                 .findActiveById(ValueIri.unsafeFrom(value.valueIri.toSmartIri))
+                 .findActiveById(ValueIri.unsafeFrom(value.valueIri))
                  .someOrFail(IllegalStateException("Value not found"))
     } yield value
 
@@ -569,7 +569,7 @@ final case class TestHelper(
                   ZIO
                     .foreach(vs) { v =>
                       valueRepo
-                        .findActiveById(ValueIri.unsafeFrom(v.valueIri.toSmartIri))
+                        .findActiveById(ValueIri.unsafeFrom(v.valueIri))
                         .someOrFail(IllegalStateException("Value not found"))
                     }
                     .map((s, _))

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -2966,7 +2966,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     ) {
       val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
       val inputResource = CreateResourceV2(
-        resourceIri = Some(resourceIri.toSmartIri),
+        resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
         resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
         label = "test bildformat",
         values = Map.empty,
@@ -3003,7 +3003,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     ) {
       val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
       val inputResource = CreateResourceV2(
-        resourceIri = Some(resourceIri.toSmartIri),
+        resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
         resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
         label = "test bildformat",
         values = Map.empty,
@@ -3040,7 +3040,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       val resourceIri = sf.makeRandomResourceIri(imagesProject.shortcode)
 
       val inputResource = CreateResourceV2(
-        resourceIri = Some(resourceIri.toSmartIri),
+        resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
         resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
         label = "test bildformat",
         values = Map.empty,

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -2965,7 +2965,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     test(
       "not accept custom value permissions that would give the requesting user a higher permission on a value than the default",
     ) {
-      val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
+      val resourceIri   = ResourceIri.makeNew(imagesProject.shortcode).value
       val inputResource = CreateResourceV2(
         resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
         resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
@@ -3002,7 +3002,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     test(
       "accept custom value permissions that would give the requesting user a higher permission on a value than the default if the user is a system admin",
     ) {
-      val resourceIri   = sf.makeRandomResourceIri(imagesProject.shortcode)
+      val resourceIri   = ResourceIri.makeNew(imagesProject.shortcode).value
       val inputResource = CreateResourceV2(
         resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),
         resourceClassIri = "http://0.0.0.0:3333/ontology/00FF/images/v2#bildformat".toSmartIri,
@@ -3038,7 +3038,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     test(
       "accept custom value permissions that would give the requesting user a higher permission on a value than the default if the user is a project admin",
     ) {
-      val resourceIri = sf.makeRandomResourceIri(imagesProject.shortcode)
+      val resourceIri = ResourceIri.makeNew(imagesProject.shortcode).value
 
       val inputResource = CreateResourceV2(
         resourceIri = Some(ResourceIri.unsafeFrom(resourceIri)),

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -867,7 +867,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         val resourceIri        = aThingIri
         val propertyIri        = Anything.hasInteger.smartIri
         val intValue           = 1000
-        val newValueVersionIri = sf.makeRandomValueIri(resourceIri)
+        val newValueVersionIri = ValueIri.makeNew(ResourceIri.unsafeFrom(resourceIri)).value
 
         val updateParams = UpdateValueContentV2(
           resourceIri = resourceIri,
@@ -1183,7 +1183,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           resourceIri,
           resourceClassIri,
           propertyIri,
-          ValueIri.unsafeFrom(intValueForRsyncIri.get.toSmartIri),
+          ValueIri.unsafeFrom(intValueForRsyncIri.get),
           valueTypeIri = KA.IntValue.toSmartIri,
           deleteComment = deleteComment,
           deleteDate = Some(deleteDate),
@@ -1195,7 +1195,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           _                        <- checkValueIsDeleted(
                  resourceIri,
                  maybeResourceLastModDate,
-                 ValueIri.unsafeFrom(intValueForRsyncIri.get.toSmartIri),
+                 ValueIri.unsafeFrom(intValueForRsyncIri.get),
                  customDeleteDate = Some(deleteDate),
                  deleteComment = deleteComment,
                  requestingUser = anythingUser1,
@@ -2903,7 +2903,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         ResourceIri.unsafeFrom(zeitgloeckleinIri),
         ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri),
         PropertyIri.unsafeFrom(propertyIri),
-        ValueIri.unsafeFrom(zeitgloeckleinCommentWithStandoffIri.get.toSmartIri),
+        ValueIri.unsafeFrom(zeitgloeckleinCommentWithStandoffIri.get),
         valueTypeIri = KA.TextValue.toSmartIri,
         deleteComment = Some("this value was incorrect"),
         apiRequestId = randomUUID,
@@ -2914,7 +2914,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         _                        <- checkValueIsDeleted(
                ResourceIri.unsafeFrom(zeitgloeckleinIri),
                maybeResourceLastModDate,
-               ValueIri.unsafeFrom(zeitgloeckleinCommentWithStandoffIri.get.toSmartIri),
+               ValueIri.unsafeFrom(zeitgloeckleinCommentWithStandoffIri.get),
                requestingUser = incunabulaMemberUser,
              )
         // There==  no standoff link values left in the resource.
@@ -2928,7 +2928,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     test("delete a link between two resources") {
       val resourceIri          = ResourceIri.unsafeFrom("http://rdfh.ch/0803/cb1a74e3e2f6")
       val linkValuePropertyIri = PropertyIri.unsafeFrom(KA.HasLinkToValue.toSmartIri)
-      val linkValueIRI         = ValueIri.unsafeFrom(linkValueIri.get.toSmartIri)
+      val linkValueIRI         = ValueIri.unsafeFrom(linkValueIri.get)
       val deleteParams         = DeleteValueV2(
         resourceIri,
         ResourceClassIri.unsafeFrom(KA.LinkObj.toSmartIri),
@@ -2955,7 +2955,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         ResourceIri.unsafeFrom(zeitgloeckleinIri),
         ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri),
         propertyIri,
-        ValueIri.unsafeFrom("http://rdfh.ch/0803/c5058f3a/values/c3295339".toSmartIri),
+        ValueIri.unsafeFrom("http://rdfh.ch/0803/c5058f3a/values/c3295339"),
         valueTypeIri = KA.TextValue.toSmartIri,
         apiRequestId = randomUUID,
       )

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -34,6 +34,7 @@ import org.knora.webapi.models.filemodels.FileType
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.KnoraIris.*
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.search.repo.GetResourceWithSpecifiedPropertiesGravsearchQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService
@@ -175,7 +176,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
   ): ZIO[SearchResponderV2, Throwable, ReadResourceV2] = {
     val gravsearchQuery: String =
       GetResourceWithSpecifiedPropertiesGravsearchQuery.build(
-        resourceIri = ResourceIri.unsafeFrom(resourceIri.toSmartIri),
+        resourceIri = ResourceIri.unsafeFrom(resourceIri),
         propertyIris = propertyIrisForGravsearch.map(PropertyIri.unsafeFrom),
       )
     for {
@@ -529,7 +530,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         )
       },
       test("delete an integer value that belongs to a property of another ontology") {
-        val resourceIri      = ResourceIri.unsafeFrom(freetestWithAPropertyFromAnythingOntologyIri.toSmartIri)
+        val resourceIri      = ResourceIri.unsafeFrom(freetestWithAPropertyFromAnythingOntologyIri)
         val propertyIri      = Anything.hasIntegerUsedByOtherOntologies
         val resourceClassIri = ResourceClassIri.unsafeFrom(
           "http://0.0.0.0:3333/ontology/0001/freetest/v2#FreetestWithAPropertyFromAnythingOntology".toSmartIri,
@@ -1131,7 +1132,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           .map(actual => assert(actual)(failsWithA[NotFoundException]))
       },
       test("not delete an integer value if the requesting user does not have DeletePermission on the value") {
-        val resourceIri      = ResourceIri.unsafeFrom(aThingIri.toSmartIri)
+        val resourceIri      = ResourceIri.unsafeFrom(aThingIri)
         val propertyIri      = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri)
         val resourceClassIri = ResourceClassIri.unsafeFrom(Anything.thingClass.smartIri)
         val deleteParams     = DeleteValueV2(
@@ -1147,7 +1148,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           .map(actual => assert(actual)(failsWithA[ForbiddenException]))
       },
       test("delete an integer value") {
-        val resourceIri      = ResourceIri.unsafeFrom(aThingIri.toSmartIri)
+        val resourceIri      = ResourceIri.unsafeFrom(aThingIri)
         val propertyIri      = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri)
         val resourceClassIri = ResourceClassIri.unsafeFrom(Anything.thingClass.smartIri)
         val deleteParams     = DeleteValueV2(
@@ -1171,7 +1172,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         } yield assertCompletes
       },
       test("delete an integer value, specifying a custom delete date") {
-        val resourceIri         = ResourceIri.unsafeFrom(aThingIri.toSmartIri)
+        val resourceIri         = ResourceIri.unsafeFrom(aThingIri)
         val propertyIri         = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri)
         val resourceClassIri    = ResourceClassIri.unsafeFrom(Anything.thingClass.smartIri)
         val deleteDate: Instant = Instant.now
@@ -2884,7 +2885,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     },
     test("not delete a standoff link directly") {
       val deleteParams = DeleteValueV2(
-        ResourceIri.unsafeFrom(zeitgloeckleinIri.toSmartIri),
+        ResourceIri.unsafeFrom(zeitgloeckleinIri),
         ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri),
         PropertyIri.unsafeFrom(KA.HasStandoffLinkToValue.toSmartIri),
         standoffLinkValueIri.asValueIri,
@@ -2898,7 +2899,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       val propertyIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book_comment".toSmartIri
 
       val deleteParams = DeleteValueV2(
-        ResourceIri.unsafeFrom(zeitgloeckleinIri.toSmartIri),
+        ResourceIri.unsafeFrom(zeitgloeckleinIri),
         ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri),
         PropertyIri.unsafeFrom(propertyIri),
         ValueIri.unsafeFrom(zeitgloeckleinCommentWithStandoffIri.get.toSmartIri),
@@ -2910,7 +2911,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         maybeResourceLastModDate <- getResourceLastModificationDate(zeitgloeckleinIri, incunabulaMemberUser)
         _                        <- valuesResponder(_.deleteValueV2(deleteParams, incunabulaMemberUser))
         _                        <- checkValueIsDeleted(
-               ResourceIri.unsafeFrom(zeitgloeckleinIri.toSmartIri),
+               ResourceIri.unsafeFrom(zeitgloeckleinIri),
                maybeResourceLastModDate,
                ValueIri.unsafeFrom(zeitgloeckleinCommentWithStandoffIri.get.toSmartIri),
                requestingUser = incunabulaMemberUser,
@@ -2924,7 +2925,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       } yield assertTrue(!resource.values.contains(KA.HasStandoffLinkToValue.toSmartIri))
     },
     test("delete a link between two resources") {
-      val resourceIri          = ResourceIri.unsafeFrom("http://rdfh.ch/0803/cb1a74e3e2f6".toSmartIri)
+      val resourceIri          = ResourceIri.unsafeFrom("http://rdfh.ch/0803/cb1a74e3e2f6")
       val linkValuePropertyIri = PropertyIri.unsafeFrom(KA.HasLinkToValue.toSmartIri)
       val linkValueIRI         = ValueIri.unsafeFrom(linkValueIri.get.toSmartIri)
       val deleteParams         = DeleteValueV2(
@@ -2950,7 +2951,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     test("not delete a value if the property's cardinality doesn't allow it") {
       val propertyIri  = PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#title".toSmartIri)
       val deleteParams = DeleteValueV2(
-        ResourceIri.unsafeFrom(zeitgloeckleinIri.toSmartIri),
+        ResourceIri.unsafeFrom(zeitgloeckleinIri),
         ResourceClassIri.unsafeFrom("http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri),
         propertyIri,
         ValueIri.unsafeFrom("http://rdfh.ch/0803/c5058f3a/values/c3295339".toSmartIri),

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -35,6 +35,7 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.KnoraIris.*
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.search.repo.GetResourceWithSpecifiedPropertiesGravsearchQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService

--- a/modules/testkit/src/main/scala/org/knora/webapi/models/filemodels/FileModels.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/models/filemodels/FileModels.scala
@@ -124,12 +124,10 @@ sealed abstract case class UploadFileRequest private (
     valuePropertyIRI: Option[SmartIri] = None,
     project: Option[Project] = None,
   ): CreateResourceV2 = {
-    implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
-
     val projectOrDefault =
       project.getOrElse(SharedTestDataADM.anythingProject)
     val resourceIRIOrDefault =
-      resourceIri.getOrElse(stringFormatter.makeRandomResourceIri(projectOrDefault.shortcode))
+      resourceIri.getOrElse(ResourceIri.makeNew(projectOrDefault.shortcode).value)
     val resourceClassIRIOrDefault: SmartIri =
       resourceClassIRI.getOrElse(FileModelUtil.getFileRepresentationClassIri(fileType))
     val fileValuePropertyIRIOrDefault: SmartIri =

--- a/modules/testkit/src/main/scala/org/knora/webapi/models/filemodels/FileModels.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/models/filemodels/FileModels.scala
@@ -8,7 +8,6 @@ package org.knora.webapi.models.filemodels
 import java.time.Instant
 import java.util.UUID
 
-import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceV2
@@ -17,6 +16,7 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
+import org.knora.webapi.slice.common.ResourceIri
 
 sealed abstract case class UploadFileRequest private (
   fileType: FileType,
@@ -157,7 +157,7 @@ sealed abstract case class UploadFileRequest private (
     )
 
     CreateResourceV2(
-      resourceIri = Some(resourceIRIOrDefault.toSmartIri),
+      resourceIri = Some(ResourceIri.unsafeFrom(resourceIRIOrDefault)),
       resourceClassIri = resourceClassIRIOrDefault,
       label = label,
       values = Map(fileValuePropertyIRIOrDefault -> values),

--- a/modules/testkit/src/main/scala/org/knora/webapi/models/filemodels/FileModelsSpec.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/models/filemodels/FileModelsSpec.scala
@@ -22,6 +22,7 @@ import org.knora.webapi.messages.v2.responder.valuemessages.StillImageVectorFile
 import org.knora.webapi.models.filemodels.FileType.*
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.common.ResourceIri
 
 object FileModelsSpec extends ZIOSpecDefault {
 
@@ -345,12 +346,12 @@ object FileModelsSpec extends ZIOSpecDefault {
           val project                    = SharedTestDataADM.beolProject
           val shortcode                  = project.shortcode
           val label                      = "a custom label"
-          val resourceIRI                = sf.makeRandomResourceIri(shortcode)
+          val resourceIRI                = ResourceIri.makeNew(shortcode).value
           val comment                    = Some("This is a custom comment")
           val internalMimetype           = Some("application/msword")
           val originalFilename           = Some("document-file.docm")
           val originalMimeType           = Some("application/vnd.ms-word.document.macroEnabled.12")
-          val customValueIRI             = Some(sf.makeRandomResourceIri(shortcode).toSmartIri)
+          val customValueIRI             = Some(ResourceIri.makeNew(shortcode).value.toSmartIri)
           val customValueUUID            = Some(UUID.randomUUID())
           val customValueCreationDate    = Some(Instant.now())
           val valuePermissions           = Some("V knora-admin:UnknownUser,knora-admin:KnownUser|M knora-admin:ProjectMember")
@@ -455,8 +456,8 @@ object FileModelsSpec extends ZIOSpecDefault {
       ),
       suite("creating a ChangeFileRequest")(
         test("create a valid representation of a DocumentRepresentation with default values") {
-          val resourceIRI = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
-          val valueIRI    = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
+          val resourceIRI = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
+          val valueIRI    = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
 
           val change = ChangeFileRequest.make(
             fileType = FileType.DocumentFile(),
@@ -477,8 +478,8 @@ object FileModelsSpec extends ZIOSpecDefault {
           )
         },
         test("create a valid representation of a DocumentRepresentation with custom values") {
-          val resourceIRI  = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
-          val valueIRI     = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
+          val resourceIRI  = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
+          val valueIRI     = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
           val pageCount    = Some(33)
           val dimX         = Some(44)
           val dimY         = Some(55)
@@ -510,8 +511,8 @@ object FileModelsSpec extends ZIOSpecDefault {
           )
         },
         test("create a valid representation of a StillImageRepresentation with default values") {
-          val resourceIRI = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
-          val valueIRI    = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
+          val resourceIRI = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
+          val valueIRI    = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
 
           val change = ChangeFileRequest.make(
             fileType = FileType.StillImageFile(),
@@ -531,8 +532,8 @@ object FileModelsSpec extends ZIOSpecDefault {
           )
         },
         test("create a valid representation of a MovingImageRepresentation with default values") {
-          val resourceIRI = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
-          val valueIRI    = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
+          val resourceIRI = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
+          val valueIRI    = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
 
           val change = ChangeFileRequest.make(
             fileType = MovingImageFile(),
@@ -552,8 +553,8 @@ object FileModelsSpec extends ZIOSpecDefault {
           )
         },
         test("create a valid representation of a AudioRepresentation with default values") {
-          val resourceIRI = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
-          val valueIRI    = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
+          val resourceIRI = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
+          val valueIRI    = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
 
           val change = ChangeFileRequest.make(
             fileType = FileType.AudioFile,
@@ -571,8 +572,8 @@ object FileModelsSpec extends ZIOSpecDefault {
           )
         },
         test("create a valid representation of a TextRepresentation with default values") {
-          val resourceIRI = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
-          val valueIRI    = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
+          val resourceIRI = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
+          val valueIRI    = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
 
           val change = ChangeFileRequest.make(
             fileType = FileType.TextFile,
@@ -590,8 +591,8 @@ object FileModelsSpec extends ZIOSpecDefault {
           )
         },
         test("create a valid representation of a ArchiveRepresentation with default values") {
-          val resourceIRI = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
-          val valueIRI    = sf.makeRandomResourceIri(Shortcode.unsafeFrom("0000"))
+          val resourceIRI = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
+          val valueIRI    = ResourceIri.makeNew(Shortcode.unsafeFrom("0000")).value
 
           val change = ChangeFileRequest.make(
             fileType = FileType.ArchiveFile,
@@ -611,8 +612,8 @@ object FileModelsSpec extends ZIOSpecDefault {
       ),
       suite("generating a JSON-LD representation of a ChangeFileRequest")(
         test("correctly serialize a DocumentRepresentation with default values") {
-          val resourceIRI = sf.makeRandomResourceIri(Shortcode.unsafeFrom("7777"))
-          val valueIRI    = sf.makeRandomResourceIri(Shortcode.unsafeFrom("7777"))
+          val resourceIRI = ResourceIri.makeNew(Shortcode.unsafeFrom("7777")).value
+          val valueIRI    = ResourceIri.makeNew(Shortcode.unsafeFrom("7777")).value
 
           val documentRepresentation = ChangeFileRequest.make(
             fileType = FileType.DocumentFile(),
@@ -639,8 +640,8 @@ object FileModelsSpec extends ZIOSpecDefault {
           assertTrue(actual == Right(expected))
         },
         test("correctly serialize a DocumentRepresentation with custom values") {
-          val resourceIRI = sf.makeRandomResourceIri(Shortcode.unsafeFrom("7777"))
-          val valueIRI    = sf.makeRandomResourceIri(Shortcode.unsafeFrom("7777"))
+          val resourceIRI = ResourceIri.makeNew(Shortcode.unsafeFrom("7777")).value
+          val valueIRI    = ResourceIri.makeNew(Shortcode.unsafeFrom("7777")).value
           val className   = "CustomDocumentRepresentation"
           val prefix      = "onto"
 

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
@@ -7,14 +7,13 @@ package org.knora.webapi.testservices
 import sttp.client4.*
 import zio.*
 
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.rdf.JsonLDDocument
 import org.knora.webapi.models.filemodels.FileType
 import org.knora.webapi.models.filemodels.UploadFileRequest
 import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.testservices.RequestsUpdates.RequestUpdate
 import org.knora.webapi.testservices.TestDspIngestClient.UploadedFile
 
@@ -70,10 +69,8 @@ object TestResourcesApiClient {
       ),
     )
 
-  def getResource(resourceIri: String)(implicit
-    sf: StringFormatter,
-  ): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
-    ZIO.attempt(ResourceIri.unsafeFrom(sf.toSmartIri(resourceIri))).flatMap(getResource)
+  def getResource(resourceIri: String): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
+    ZIO.attempt(ResourceIri.unsafeFrom(resourceIri)).flatMap(getResource)
 
   def getResource(
     resourceIri: ResourceIri,

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestResourcesApiClient.scala
@@ -69,7 +69,9 @@ object TestResourcesApiClient {
       ),
     )
 
-  def getResource(resourceIri: String): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
+  def getResource(
+    resourceIri: String,
+  ): ZIO[TestResourcesApiClient, Throwable, Response[Either[String, JsonLDDocument]]] =
     ZIO.attempt(ResourceIri.unsafeFrom(resourceIri)).flatMap(getResource)
 
   def getResource(

--- a/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
@@ -14,6 +14,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 import org.knora.webapi.slice.common.KnoraIris.*
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 
 /**
  * Holds an optional, mutable IRI for use in tests.

--- a/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
@@ -44,7 +44,7 @@ class MutableTestIri { self =>
   def asProjectIri: ProjectIri                                 = ProjectIri.unsafeFrom(self.get)
   def asUserIri: UserIri                                       = UserIri.unsafeFrom(self.get)
   def asGroupIri: GroupIri                                     = GroupIri.unsafeFrom(self.get)
-  def asResourceIri: ResourceIri = ResourceIri.unsafeFrom(self.get)
+  def asResourceIri: ResourceIri                               = ResourceIri.unsafeFrom(self.get)
   def asValueIri(implicit sf: StringFormatter): ValueIri       = ValueIri.unsafeFrom(self.get.toSmartIri)
 
   override def toString: String = maybeIri match {

--- a/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
@@ -13,6 +13,7 @@ import org.knora.webapi.slice.admin.domain.model.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 import org.knora.webapi.slice.common.KnoraIris.*
+import org.knora.webapi.slice.common.ResourceIri
 
 /**
  * Holds an optional, mutable IRI for use in tests.
@@ -43,7 +44,7 @@ class MutableTestIri { self =>
   def asProjectIri: ProjectIri                                 = ProjectIri.unsafeFrom(self.get)
   def asUserIri: UserIri                                       = UserIri.unsafeFrom(self.get)
   def asGroupIri: GroupIri                                     = GroupIri.unsafeFrom(self.get)
-  def asResourceIri(implicit sf: StringFormatter): ResourceIri = ResourceIri.unsafeFrom(self.get.toSmartIri)
+  def asResourceIri: ResourceIri = ResourceIri.unsafeFrom(self.get)
   def asValueIri(implicit sf: StringFormatter): ValueIri       = ValueIri.unsafeFrom(self.get.toSmartIri)
 
   override def toString: String = maybeIri match {

--- a/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/util/MutableTestIri.scala
@@ -46,7 +46,7 @@ class MutableTestIri { self =>
   def asUserIri: UserIri                                       = UserIri.unsafeFrom(self.get)
   def asGroupIri: GroupIri                                     = GroupIri.unsafeFrom(self.get)
   def asResourceIri: ResourceIri                               = ResourceIri.unsafeFrom(self.get)
-  def asValueIri(implicit sf: StringFormatter): ValueIri       = ValueIri.unsafeFrom(self.get.toSmartIri)
+  def asValueIri: ValueIri                                     = ValueIri.unsafeFrom(self.get)
 
   override def toString: String = maybeIri match {
     case Some(iri) => iri

--- a/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
@@ -33,6 +33,8 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.OntologyName
 import org.knora.webapi.util.Base64UrlCheckDigit
@@ -323,16 +325,6 @@ sealed trait SmartIri extends Ordered[SmartIri] with KnoraContentV2[SmartIri] { 
   def isKnoraDataIri: Boolean
 
   /**
-   * Returns `true` if this is a Knora resource IRI.
-   */
-  def isKnoraResourceIri: Boolean
-
-  /**
-   * Returns `true` if this is a Knora value IRI.
-   */
-  def isKnoraValueIri: Boolean
-
-  /**
    * Returns `true` if this is a Knora standoff IRI.
    */
   def isKnoraStandoffIri: Boolean
@@ -398,16 +390,6 @@ sealed trait SmartIri extends Ordered[SmartIri] with KnoraContentV2[SmartIri] { 
     getProjectCode
       .toRight("No project shortcode in IRI")
       .flatMap(str => Shortcode.from(str))
-
-  /**
-   * Returns the IRI's resource ID, if any.
-   */
-  def getResourceID: Option[String]
-
-  /**
-   * Returns the IRI's value ID, if any.
-   */
-  def getValueID: Option[String]
 
   /**
    * Returns the IRI's standoff start index, if any.
@@ -500,24 +482,6 @@ sealed trait SmartIri extends Ordered[SmartIri] with KnoraContentV2[SmartIri] { 
    * [[DataConversionException]] if this IRI is not a Knora entity IRI.
    */
   def fromLinkPropToLinkValueProp: SmartIri
-
-  /**
-   * If this is a Knora data IRI representing a resource, returns an ARK URL for the resource. Throws
-   * [[DataConversionException]] if this IRI is not a Knora resource IRI.
-   *
-   * @param maybeTimestamp an optional timestamp indicating the point in the resource's version history that the ARK URL should
-   *                       cite.
-   */
-  def fromResourceIriToArkUrl(maybeTimestamp: Option[Instant] = None): String
-
-  /**
-   * If this is a Knora data IRI representing a value, returns an ARK URL for the value. Throws
-   * [[DataConversionException]] if this IRI is not a Knora value IRI.
-   *
-   * @param maybeTimestamp an optional timestamp indicating the point in the value's version history that the ARK URL should
-   *                       cite.
-   */
-  def fromValueIriToArkUrl(valueUUID: UUID, maybeTimestamp: Option[Instant] = None): String
 
   override def equals(obj: scala.Any): Boolean =
     // See the comment at the top of the SmartIri trait.
@@ -968,10 +932,6 @@ class StringFormatter private (
 
     override def getProjectCode: Option[String] = iriInfo.projectCode
 
-    override def getResourceID: Option[String] = iriInfo.resourceID
-
-    override def getValueID: Option[String] = iriInfo.valueID
-
     override def getStandoffStartIndex: Option[Int] = iriInfo.standoffStartIndex
 
     private lazy val ontologyFromEntity: SmartIri =
@@ -1273,26 +1233,6 @@ class StringFormatter private (
 
     override def fromLinkPropToLinkValueProp: SmartIri = asLinkValueProp
 
-    override def isKnoraResourceIri: Boolean =
-      if (!isKnoraDataIri) {
-        false
-      } else {
-        (iriInfo.projectCode, iriInfo.resourceID, iriInfo.valueID) match {
-          case (Some(_), Some(_), None) => true
-          case _                        => false
-        }
-      }
-
-    override def isKnoraValueIri: Boolean =
-      if (!isKnoraDataIri) {
-        false
-      } else {
-        (iriInfo.projectCode, iriInfo.resourceID, iriInfo.valueID) match {
-          case (Some(_), Some(_), Some(_)) => true
-          case _                           => false
-        }
-      }
-
     override def isKnoraStandoffIri: Boolean =
       if (!isKnoraDataIri) {
         false
@@ -1303,47 +1243,6 @@ class StringFormatter private (
         }
       }
 
-    override def fromResourceIriToArkUrl(maybeTimestamp: Option[Instant] = None): String = {
-      if (!isKnoraResourceIri) {
-        throw DataConversionException(s"IRI $iri is not a Knora resource IRI")
-      }
-
-      val arkUrlTry = Try {
-        makeArkUrl(
-          projectID = iriInfo.projectCode.get,
-          resourceID = iriInfo.resourceID.get,
-          maybeValueUUID = None,
-          maybeTimestamp = maybeTimestamp,
-        )
-
-      }
-
-      arkUrlTry match {
-        case Success(arkUrl) => arkUrl
-        case Failure(ex)     => throw DataConversionException(s"Can't generate ARK URL for IRI <$iri>: ${ex.getMessage}")
-      }
-    }
-
-    override def fromValueIriToArkUrl(valueUUID: UUID, maybeTimestamp: Option[Instant] = None): String = {
-      if (!isKnoraValueIri) {
-        throw DataConversionException(s"IRI $iri is not a Knora value IRI")
-      }
-
-      val arkUrlTry = Try {
-        makeArkUrl(
-          projectID = iriInfo.projectCode.get,
-          resourceID = iriInfo.resourceID.get,
-          maybeValueUUID = Some(valueUUID),
-          maybeTimestamp = maybeTimestamp,
-        )
-
-      }
-
-      arkUrlTry match {
-        case Success(arkUrl) => arkUrl
-        case Failure(ex)     => throw DataConversionException(s"Can't generate ARK URL for IRI <$iri>: ${ex.getMessage}")
-      }
-    }
   }
 
   /**
@@ -1511,15 +1410,35 @@ class StringFormatter private (
   }
 
   /**
-   * Creates a new resource IRI based on a UUID.
+   * Generates an ARK URL for a resource.
    *
-   * @param shortcode the project's shortcode.
-   * @return a new resource IRI.
+   * @param resourceIri    the resource IRI.
+   * @param maybeTimestamp an optional timestamp for the resource's version history.
+   * @return an ARK URL that can be resolved to obtain the resource.
    */
-  def makeRandomResourceIri(shortcode: Shortcode): IRI = {
-    val knoraResourceID = UuidUtil.makeRandomBase64EncodedUuid
-    s"http://$IriDomain/$shortcode/$knoraResourceID"
-  }
+  def resourceIriToArkUrl(resourceIri: ResourceIri, maybeTimestamp: Option[Instant] = None): String =
+    makeArkUrl(
+      projectID = resourceIri.shortcode.value,
+      resourceID = resourceIri.resourceId.value,
+      maybeValueUUID = None,
+      maybeTimestamp = maybeTimestamp,
+    )
+
+  /**
+   * Generates an ARK URL for a value.
+   *
+   * @param valueIri       the value IRI.
+   * @param valueUUID      the value's UUID.
+   * @param maybeTimestamp an optional timestamp for the value's version history.
+   * @return an ARK URL that can be resolved to obtain the value.
+   */
+  def valueIriToArkUrl(valueIri: ValueIri, valueUUID: UUID, maybeTimestamp: Option[Instant] = None): String =
+    makeArkUrl(
+      projectID = valueIri.shortcode.value,
+      resourceID = valueIri.resourceId.value,
+      maybeValueUUID = Some(valueUUID),
+      maybeTimestamp = maybeTimestamp,
+    )
 
   /**
    * Creates a mapping IRI based on a project IRI and a mapping name.

--- a/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
@@ -275,9 +275,6 @@ object StringFormatter {
   }
 
   def isKnoraOntologyIri(iri: SmartIri): Boolean = iri.isKnoraApiV2DefinitionIri && iri.getOntologyName.isInternal
-
-  def makeValueIri(resourceIri: IRI, uuid: UUID): IRI =
-    s"$resourceIri/values/${UuidUtil.base64Encode(uuid)}"
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
@@ -1525,21 +1525,6 @@ class StringFormatter private (
   }
 
   /**
-   * Creates a new value IRI based on a UUID.
-   *
-   * @param resourceIri the IRI of the resource that will contain the value.
-   * @param givenUUID   the optional given UUID of the value. If not provided, create a random one.
-   * @return a new value IRI.
-   */
-  def makeRandomValueIri(resourceIri: IRI, givenUUID: Option[UUID] = None): IRI = {
-    val valueUUID = givenUUID match {
-      case Some(uuid: UUID) => UuidUtil.base64Encode(uuid)
-      case _                => UuidUtil.makeRandomBase64EncodedUuid
-    }
-    s"$resourceIri/values/$valueUUID"
-  }
-
-  /**
    * Creates a mapping IRI based on a project IRI and a mapping name.
    *
    * @param projectIri the IRI of the project the mapping will belong to.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
@@ -24,6 +24,7 @@ import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetRequ
 import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV2
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 
 /**
@@ -1451,7 +1452,7 @@ final case class InferringGravsearchTypeInspector(
               // A variable is compared with an IRI, which must be a resource IRI.
               // Index them both in usageIndex.entitiesComparedInFilters.
 
-              if (!rightIriRef.iri.isKnoraResourceIri) {
+              if (ResourceIri.from(rightIriRef.iri).isLeft) {
                 throw GravsearchException(
                   s"IRI ${rightIriRef.toSparql}, used in a comparison, is not a Knora resource IRI",
                 )

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -418,7 +418,7 @@ case class ReadResourceV2(
 
     // Make an ARK URL without a version timestamp.
 
-    val resourceSmartIri: SmartIri = resourceIri.toSmartIri
+    val parsedResourceIri = ResourceIri.unsafeFrom(resourceIri)
 
     val arkUrlProp: IRI = targetSchema match {
       case ApiV2Simple  => KnoraApiV2Simple.ArkUrl
@@ -427,7 +427,7 @@ case class ReadResourceV2(
 
     val arkUrlAsJsonLD: (IRI, JsonLDObject) =
       arkUrlProp -> JsonLDUtil.datatypeValueToJsonLDObject(
-        value = resourceSmartIri.fromResourceIriToArkUrl(),
+        value = stringFormatter.resourceIriToArkUrl(parsedResourceIri),
         datatype = Xsd.Uri.toSmartIri,
       )
 
@@ -442,7 +442,7 @@ case class ReadResourceV2(
 
     val versionArkUrlAsJsonLD: (IRI, JsonLDObject) =
       versionArkUrlProp -> JsonLDUtil.datatypeValueToJsonLDObject(
-        value = resourceSmartIri.fromResourceIriToArkUrl(maybeTimestamp = Some(arkTimestamp)),
+        value = stringFormatter.resourceIriToArkUrl(parsedResourceIri, maybeTimestamp = Some(arkTimestamp)),
         datatype = Xsd.Uri.toSmartIri,
       )
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -32,6 +32,7 @@ import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
+import org.knora.webapi.slice.common.ResourceIri
 
 /**
  * An abstract trait for messages that can be sent to `ResourcesResponderV2`.
@@ -548,7 +549,7 @@ case class CreateValueInNewResourceV2(
  * @param creationDate     the optional creation date of the resource.
  */
 case class CreateResourceV2(
-  resourceIri: Option[SmartIri],
+  resourceIri: Option[ResourceIri],
   resourceClassIri: SmartIri,
   label: String,
   values: Map[SmartIri, Seq[CreateValueInNewResourceV2]],

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -47,7 +47,7 @@ import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -47,8 +47,8 @@ import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -47,7 +47,7 @@ import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -47,9 +47,9 @@ import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.Value.StringValue
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ResourceOps.*
@@ -323,7 +323,7 @@ sealed trait ReadValueV2 {
           case jsonLDObject: JsonLDObject =>
             // Add the value's metadata.
 
-            val valueSmartIri = valueIri.toSmartIri
+            val parsedValueIri = ValueIri.unsafeFrom(valueIri)
 
             val requiredMetadata = Map(
               JsonLDKeywords.ID   -> JsonLDString(valueIri),
@@ -337,12 +337,12 @@ sealed trait ReadValueV2 {
               ),
               ValueHasUUID -> JsonLDString(UuidUtil.base64Encode(valueHasUUID)),
               ArkUrl       -> JsonLDUtil.datatypeValueToJsonLDObject(
-                value = valueSmartIri.fromValueIriToArkUrl(valueUUID = valueHasUUID),
+                value = stringFormatter.valueIriToArkUrl(parsedValueIri, valueUUID = valueHasUUID),
                 datatype = OntologyConstants.Xsd.Uri.toSmartIri,
               ),
               VersionArkUrl -> JsonLDUtil.datatypeValueToJsonLDObject(
-                value = valueSmartIri
-                  .fromValueIriToArkUrl(valueUUID = valueHasUUID, maybeTimestamp = Some(valueCreationDate)),
+                value = stringFormatter
+                  .valueIriToArkUrl(parsedValueIri, valueUUID = valueHasUUID, maybeTimestamp = Some(valueCreationDate)),
                 datatype = OntologyConstants.Xsd.Uri.toSmartIri,
               ),
             )

--- a/webapi/src/main/scala/org/knora/webapi/responders/IriService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/IriService.scala
@@ -18,6 +18,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.KnoraIris.KnoraIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.CheckIriExistsQuery
 import org.knora.webapi.slice.ontology.repo.IsClassUsedInDataQuery
@@ -128,9 +129,10 @@ final case class IriService(
     makeUnusedIriRec(attempts = MAX_IRI_ATTEMPTS)
   }
 
-  def checkIriExists(iri: IRI): Task[Boolean]      = triplestore.query(CheckIriExistsQuery.build(iri))
-  def checkIriExists(iri: KnoraIri): Task[Boolean] = checkIriExists(iri.smartIri)
-  def checkIriExists(iri: SmartIri): Task[Boolean] = triplestore.query(CheckIriExistsQuery.build(iri))
+  def checkIriExists(iri: IRI): Task[Boolean]         = triplestore.query(CheckIriExistsQuery.build(iri))
+  def checkIriExists(iri: KnoraIri): Task[Boolean]    = checkIriExists(iri.smartIri)
+  def checkIriExists(iri: SmartIri): Task[Boolean]    = triplestore.query(CheckIriExistsQuery.build(iri))
+  def checkIriExists(iri: StringValue): Task[Boolean] = checkIriExists(iri.value)
 }
 
 object IriService {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -215,8 +215,8 @@ final case class ResourcesResponderV2(
         project <- projectService
                      .findById(resource.projectADM.id)
                      .someOrFail(NotFoundException.notFound(resource.projectADM.id))
-        resourceIri <- iriConverter
-                         .asResourceIri(updateResourceMetadataRequestV2.resourceIri)
+        resourceIri <- ZIO
+                         .fromEither(ResourceIri.from(updateResourceMetadataRequestV2.resourceIri))
                          .mapError(BadRequestException.apply)
         resourceClassIri <- iriConverter
                               .asResourceClassIri(internalResourceClassIri)
@@ -298,7 +298,8 @@ final case class ResourcesResponderV2(
         // Generate SPARQL for marking the resource as deleted.
         requestingUserIri <-
           ZIO.fromEither(UserIri.from(deleteResourceV2.requestingUser.id)).mapError(e => Exception(e)).orDie
-        resourceIri <- iriConverter.asResourceIri(deleteResourceV2.resourceIri).mapError(BadRequestException.apply)
+        resourceIri <-
+          ZIO.fromEither(ResourceIri.from(deleteResourceV2.resourceIri)).mapError(BadRequestException.apply)
         sparqlUpdate = DeleteResourceQuery.build(
                          project = resource.projectADM,
                          resourceIri = resourceIri,
@@ -351,7 +352,9 @@ final case class ResourcesResponderV2(
 
       otherResources <-
         ZIO
-          .foreach(result.results.bindings.map(_.rowMap.get("other")).flatten.toSet)(iriConverter.asResourceIri)
+          .foreach(result.results.bindings.map(_.rowMap.get("other")).flatten.toSet)(s =>
+            ZIO.fromEither(ResourceIri.from(s)),
+          )
           .mapError(DataConversionException.apply)
     } yield otherResources
 
@@ -390,7 +393,7 @@ final case class ResourcesResponderV2(
 
       _ <- ensureNoConflictingChange(resource, deleteResourceV2.maybeLastModificationDate)
 
-      resourceIri <- iriConverter.asResourceIri(deleteResourceV2.resourceIri).mapError(BadRequestException.apply)
+      resourceIri <- ZIO.fromEither(ResourceIri.from(deleteResourceV2.resourceIri)).mapError(BadRequestException.apply)
       _           <- ensureResourceIsNotInUse(resourceIri)
 
       lastModificationDate = resource.lastModificationDate.getOrElse(resource.creationDate)
@@ -454,7 +457,7 @@ final case class ResourcesResponderV2(
 
         _ <- ensureNoConflictingChange(resource, eraseResourceV2.maybeLastModificationDate)
 
-        resourceIri <- iriConverter.asResourceIri(eraseResourceV2.resourceIri).mapError(BadRequestException.apply)
+        resourceIri <- ZIO.fromEither(ResourceIri.from(eraseResourceV2.resourceIri)).mapError(BadRequestException.apply)
         _           <- ensureResourceIsNotInUse(resourceIri)
 
         // Do the update.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -55,7 +55,7 @@ import org.knora.webapi.slice.admin.domain.service.LegalInfoService
 import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
@@ -1206,7 +1206,7 @@ final case class ResourcesResponderV2(
 
     for {
       // Make a Gravsearch query.
-      resIri                         <- ZIO.fromEither(ResourceIri.from(resourceIri.toSmartIri)).mapError(BadRequestException(_))
+      resIri                         <- ZIO.fromEither(ResourceIri.from(resourceIri)).mapError(BadRequestException(_))
       gravsearchQueryForIncomingLinks = GetIncomingImageLinksGravsearchQuery.build(resIri)
 
       // Run the query.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -41,8 +41,8 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.service.IriConverter

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -41,7 +41,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.domain.InternalIri
@@ -526,7 +526,7 @@ final class ValuesResponderV2(
       // Generate a SPARQL update.
       sparqlUpdate <- CreateLinkQuery.build(
                         project = resourceInfo.projectADM,
-                        resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri.toSmartIri),
+                        resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                         linkUpdate = sparqlTemplateLinkUpdate,
                         newValueUUID = newValueUUID,
                         creationDate = creationDate,
@@ -1022,7 +1022,7 @@ final class ValuesResponderV2(
 
         result <- ChangeLinkTargetQuery.build(
                     project = resourceInfo.projectADM,
-                    linkSourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri.toSmartIri),
+                    linkSourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                     linkUpdateForCurrentLink = sparqlTemplateLinkUpdateForCurrentLink,
                     linkUpdateForNewLink = sparqlTemplateLinkUpdateForNewLink,
                     maybeComment = newLinkValue.comment,
@@ -1054,7 +1054,7 @@ final class ValuesResponderV2(
 
         result <- ChangeLinkMetadataQuery.build(
                     project = resourceInfo.projectADM,
-                    linkSourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri.toSmartIri),
+                    linkSourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                     linkUpdate = sparqlTemplateLinkUpdate,
                     maybeComment = newLinkValue.comment,
                   )
@@ -1406,7 +1406,7 @@ final class ValuesResponderV2(
       linkUpdates  <- ZIO.collectAll(linkUpdateTasks)
       sparqlUpdate <- DeleteValueQuery.build(
                         project = resourceInfo.projectADM,
-                        resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri.toSmartIri),
+                        resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                         propertyIri = PropertyIri.unsafeFrom(propertyIri),
                         valueIri = ValueIri.unsafeFrom(currentValue.valueIri.toSmartIri),
                         maybeDeleteComment = deleteComment,
@@ -1529,7 +1529,7 @@ final class ValuesResponderV2(
           Seq(propertyInfo.entityInfoContent.propertyIri) ++ maybeStandoffLinkToPropertyIri,
         )(iri => ZIO.fromEither(PropertyIri.from(iri)).mapError(BadRequestException(_)))
 
-      resIri <- ZIO.fromEither(ResourceIri.from(resourceIri.toSmartIri)).mapError(BadRequestException(_))
+      resIri <- ZIO.fromEither(ResourceIri.from(resourceIri)).mapError(BadRequestException(_))
 
       // Make a Gravsearch query.
       gravsearchQuery =

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -589,7 +589,7 @@ final class ValuesResponderV2(
       _ <- valueRepo.updateValuePermissions(
              projectDataGraph = ProjectService.projectDataNamedGraphV2(resourceInfo.projectADM),
              resourceIri = InternalIri(resourceInfo.resourceIri),
-             valueIri = ValueIri.unsafeFrom(currentValue.valueIri.toSmartIri),
+             valueIri = ValueIri.unsafeFrom(currentValue.valueIri),
              newPermissions = newValuePermissionLiteral,
              currentTime = Instant.now,
            )
@@ -1078,7 +1078,7 @@ final class ValuesResponderV2(
   ): Task[SuccessResponseV2] =
     canRemoveValue(req, requestingUser, onlyHistory).flatMap { case (_, _, value) =>
       for {
-        valueIri         <- ZIO.succeed(ValueIri.unsafeFrom(value.valueIri.toSmartIri))
+        valueIri         <- ZIO.succeed(ValueIri.unsafeFrom(value.valueIri))
         _                <- failBadRequestForStandoffWithLinks(value)
         allPrevious      <- valueRepo.findAllPrevious(valueIri)
         isLink            = cond(value) { case _: ReadLinkValueV2 => true }
@@ -1175,7 +1175,7 @@ final class ValuesResponderV2(
       ZIO
         .fromOption(for {
           values <- resourceInfo.values.get(submittedInternalPropertyIri)
-          curVal <- values.find(_.valueIri == deleteValue.valueIri.toString)
+          curVal <- values.find(_.valueIri == deleteValue.valueIri.value)
         } yield curVal)
         .orElseFail(
           NotFoundException(
@@ -1408,7 +1408,7 @@ final class ValuesResponderV2(
                         project = resourceInfo.projectADM,
                         resourceIri = ResourceIri.unsafeFrom(resourceInfo.resourceIri),
                         propertyIri = PropertyIri.unsafeFrom(propertyIri),
-                        valueIri = ValueIri.unsafeFrom(currentValue.valueIri.toSmartIri),
+                        valueIri = ValueIri.unsafeFrom(currentValue.valueIri),
                         maybeDeleteComment = deleteComment,
                         linkUpdates = linkUpdates,
                         currentTime = deleteDate.getOrElse(Instant.now),

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -425,7 +425,7 @@ final class ValuesResponderV2(
       newValueIri <-
         iriService.checkOrCreateEntityIri(
           maybeValueIri,
-          stringFormatter.makeRandomValueIri(resourceInfo.resourceIri, Some(newValueUUID)),
+          ValueIri.from(ResourceIri.unsafeFrom(resourceInfo.resourceIri), newValueUUID).value,
         )
 
       // Make a creation date for the new value
@@ -878,7 +878,7 @@ final class ValuesResponderV2(
       newValueIri <-
         iriService.checkOrCreateEntityIri(
           newValueVersionIri,
-          stringFormatter.makeRandomValueIri(resourceInfo.resourceIri),
+          ValueIri.makeNew(ResourceIri.unsafeFrom(resourceInfo.resourceIri)).value,
         )
 
       // If we're updating a text value, update direct links and LinkValues for any resource references in Standoff.
@@ -1752,7 +1752,7 @@ final class ValuesResponderV2(
       newLinkValueIri <-
         iriService.checkOrCreateEntityIri(
           customNewLinkValueIri,
-          stringFormatter.makeRandomValueIri(sourceResourceInfo.resourceIri),
+          ValueIri.makeNew(ResourceIri.unsafeFrom(sourceResourceInfo.resourceIri)).value,
         )
 
       linkUpdate =
@@ -1908,7 +1908,7 @@ final class ValuesResponderV2(
           newLinkValueIri <-
             iriService.checkOrCreateEntityIri(
               customNewLinkValueIri,
-              stringFormatter.makeRandomValueIri(sourceResourceInfo.resourceIri),
+              ValueIri.makeNew(ResourceIri.unsafeFrom(sourceResourceInfo.resourceIri)).value,
             )
 
         } yield SparqlTemplateLinkUpdate(
@@ -1955,7 +1955,7 @@ final class ValuesResponderV2(
    * @return the new value IRI.
    */
   private def makeUnusedValueIri(resourceIri: IRI): Task[IRI] =
-    iriService.makeUnusedIri(stringFormatter.makeRandomValueIri(resourceIri))
+    iriService.makeUnusedIri(ValueIri.makeNew(ResourceIri.unsafeFrom(resourceIri)).value)
 }
 
 object ValuesResponderV2 {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -41,8 +41,8 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.service.IriConverter

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -41,7 +41,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraGroupRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.domain.InternalIri

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -41,6 +41,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.admin.model.*
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
@@ -884,7 +885,7 @@ final case class CreateResourceV2Handler(
    * @return the new value IRI.
    */
   private def makeUnusedValueIri(resourceIri: IRI): Task[IRI] =
-    iriService.makeUnusedIri(stringFormatter.makeRandomValueIri(resourceIri))
+    iriService.makeUnusedIri(ValueIri.makeNew(ResourceIri.unsafeFrom(resourceIri)).value)
 
   /**
    * The permissions that are granted by every `knora-base:LinkValue` describing a standoff link.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -420,7 +420,7 @@ final case class CreateResourceV2Handler(
             newValueIri <-
               iriService.checkOrCreateEntityIri(
                 valueToCreate.customValueIri,
-                StringFormatter.makeValueIri(resourceIri, newValueUUID),
+                ValueIri.from(ResourceIri.unsafeFrom(resourceIri), newValueUUID).value,
               )
 
             // Make a creation date for the value. If a custom creation date is given for a value, consider that otherwise

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -40,6 +40,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraProjectRepo
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.admin.model.*
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
@@ -91,8 +92,10 @@ final case class CreateResourceV2Handler(
       _         <- ensureUserHasPermission(createResourceRequestV2, projectIri)
 
       resourceIri <- iriService.checkOrCreateEntityIri(
-                       createResourceRequestV2.createResource.resourceIri,
-                       stringFormatter.makeRandomResourceIri(shortcode),
+                       createResourceRequestV2.createResource.resourceIri.map(ri =>
+                         stringFormatter.toSmartIri(ri.value),
+                       ),
+                       ResourceIri.makeNew(shortcode).value,
                      )
       taskResult <- IriLocker.runWithIriLock(createResourceRequestV2.apiRequestID, resourceIri)(
                       makeTask(createResourceRequestV2, resourceIri),

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -91,12 +91,11 @@ final case class CreateResourceV2Handler(
       shortcode  = createResourceRequestV2.createResource.projectADM.shortcode
       _         <- ensureUserHasPermission(createResourceRequestV2, projectIri)
 
-      resourceIri <- iriService.checkOrCreateEntityIri(
-                       createResourceRequestV2.createResource.resourceIri.map(ri =>
-                         stringFormatter.toSmartIri(ri.value),
-                       ),
-                       ResourceIri.makeNew(shortcode).value,
-                     )
+      resourceIri <-
+        iriService.checkOrCreateEntityIri(
+          createResourceRequestV2.createResource.resourceIri.map(ri => stringFormatter.toSmartIri(ri.value)),
+          ResourceIri.makeNew(shortcode).value,
+        )
       taskResult <- IriLocker.runWithIriLock(createResourceRequestV2.apiRequestID, resourceIri)(
                       makeTask(createResourceRequestV2, resourceIri),
                     )

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ValuesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ValuesRestService.scala
@@ -30,7 +30,7 @@ import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.v2.ValueUuid
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.ApiComplexV2JsonLdRequestParser
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.FormatOptions

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ValuesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ValuesRestService.scala
@@ -143,7 +143,7 @@ final class ValuesRestService(
            )
       requestedValueIris <- ZIO.foreach(request.orderedValueIris) { iriStr =>
                               ZIO
-                                .fromEither(ValueIri.from(iriStr.toSmartIri))
+                                .fromEither(ValueIri.from(iriStr))
                                 .mapError(e => BadRequestException(s"Invalid value IRI: $e"))
                             }
     } yield (propertySmartIri, requestedValueIris)

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/V3ErrorInfo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/V3ErrorInfo.scala
@@ -12,7 +12,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.api.v3.V3ErrorCode.NotFounds
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 sealed trait V3ErrorInfo {
   def message: String

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -40,6 +40,7 @@ import org.knora.webapi.slice.admin.domain.service.UserService
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.api.v2.mapping.CreateStandoffMappingForm
 import org.knora.webapi.slice.common.KnoraIris.*
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.common.jena.ModelOps.*
@@ -110,14 +111,7 @@ final case class ApiComplexV2JsonLdRequestParser(
       for {
         model             <- ModelOps.fromJsonLd(injectedStr)
         resource          <- ZIO.fromEither(model.singleRootResource)
-        resourceIriOption <-
-          ZIO
-            .foreach(resource.uri)(
-              converter
-                .asSmartIri(_)
-                .mapError(_.getMessage)
-                .flatMap(iri => ZIO.fromEither(KnoraIris.ResourceIri.from(iri))),
-            )
+        resourceIriOption <- ZIO.foreach(resource.uri)(uri => ZIO.fromEither(ResourceIri.from(uri)))
         resourceClassIri <- resourceClassIri(resource)
       } yield RootResource(resource, resourceIriOption, resourceClassIri)
 
@@ -143,7 +137,7 @@ final case class ApiComplexV2JsonLdRequestParser(
              .fail("No updated resource metadata provided")
              .when(label.isEmpty && permissions.isEmpty && newModificationDate.isEmpty)
     } yield UpdateResourceMetadataRequestV2(
-      resourceIri.smartIri.toString,
+      resourceIri.value,
       r.resourceClassSmartIri,
       lastModificationDate,
       label,
@@ -166,7 +160,7 @@ final case class ApiComplexV2JsonLdRequestParser(
       deleteDate           <- r.deleteDateOption
       lastModificationDate <- r.lastModificationDateOption
     } yield DeleteOrEraseResourceRequestV2(
-      resourceIri.smartIri.toString,
+      resourceIri.value,
       r.resourceClassSmartIri,
       deleteComment,
       deleteDate,
@@ -314,7 +308,7 @@ final case class ApiComplexV2JsonLdRequestParser(
       attachedToUser <- attachedToUser(r.resource, requestingUser, project.id)
       values         <- extractValues(r.resource, project.shortcode)
       createResource  = CreateResourceV2(
-                         r.resourceIri.map(_.smartIri),
+                         r.resourceIri,
                          r.resourceClassSmartIri,
                          label,
                          values,
@@ -468,7 +462,7 @@ final case class ApiComplexV2JsonLdRequestParser(
                          case (Some(valueContentV2), _) =>
                            ZIO.succeed(
                              UpdateValueContentV2(
-                               resourceIri.smartIri.toString,
+                               resourceIri.value,
                                r.resourceClassSmartIri,
                                v.propertySmartIri,
                                valueIri.smartIri.toString,
@@ -481,7 +475,7 @@ final case class ApiComplexV2JsonLdRequestParser(
                          case (_, Some(permissions)) =>
                            ZIO.succeed(
                              UpdateValuePermissionsV2(
-                               resourceIri.smartIri.toString,
+                               resourceIri.value,
                                r.resourceClassSmartIri,
                                v.propertySmartIri,
                                valueIri.smartIri.toString,
@@ -509,7 +503,7 @@ final case class ApiComplexV2JsonLdRequestParser(
         valuePermissions  <- v.hasPermissionsOption
         valueContent      <- getValueContent(v, resourceIri.shortcode)
       } yield CreateValueV2(
-        resourceIri.smartIri.toString,
+        resourceIri.value,
         r.resourceClassSmartIri,
         v.propertyIri.smartIri,
         valueContent,

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -112,7 +112,7 @@ final case class ApiComplexV2JsonLdRequestParser(
         model             <- ModelOps.fromJsonLd(injectedStr)
         resource          <- ZIO.fromEither(model.singleRootResource)
         resourceIriOption <- ZIO.foreach(resource.uri)(uri => ZIO.fromEither(ResourceIri.from(uri)))
-        resourceClassIri <- resourceClassIri(resource)
+        resourceClassIri  <- resourceClassIri(resource)
       } yield RootResource(resource, resourceIriOption, resourceClassIri)
 
     private def resourceClassIri(r: Resource): IO[String, ResourceClassIri] = ZIO

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -41,6 +41,7 @@ import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.api.v2.mapping.CreateStandoffMappingForm
 import org.knora.webapi.slice.common.KnoraIris.*
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.common.jena.ModelOps.*

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -275,8 +275,7 @@ final case class ApiComplexV2JsonLdRequestParser(
 
     private def valueIri(valueResource: Resource): IO[String, Option[ValueIri]] = ZIO
       .fromOption(valueResource.uri)
-      .flatMap(converter.asSmartIri(_).mapError(_.getMessage).asSomeError)
-      .flatMap(iri => ZIO.fromEither(ValueIri.from(iri)).asSomeError)
+      .flatMap(uri => ZIO.fromEither(ValueIri.from(uri)).asSomeError)
       .unsome
 
     private def valuePropertyIri(valueStatement: Statement) =
@@ -398,12 +397,13 @@ final case class ApiComplexV2JsonLdRequestParser(
     for {
       v                       <- ValueResource.from(statement)
       cnt                     <- getValueContent(v, shortcode)
+      customValueIri          <- ZIO.foreach(v.valueIri)(vi => converter.asSmartIri(vi.value).mapError(_.getMessage))
       customValueUuid         <- v.valueHasUuidOption
       customValueCreationDate <- v.valueCreationDateOption
       permissions             <- v.hasPermissionsOption
     } yield (
       v.propertyIri,
-      CreateValueInNewResourceV2(cnt, v.valueIri.map(_.smartIri), customValueUuid, customValueCreationDate, permissions),
+      CreateValueInNewResourceV2(cnt, customValueIri, customValueUuid, customValueCreationDate, permissions),
     )
 
   def attachedToUser(r: Resource, requestingUser: User, projectIri: ProjectIri): IO[String, User] =
@@ -433,8 +433,7 @@ final case class ApiComplexV2JsonLdRequestParser(
 
   private def newValueVersionIri(r: ValueResource, valueIri: ValueIri): IO[String, Option[ValueIri]] =
     r.newValueVersionIriOption.some
-      .flatMap(converter.asSmartIri(_).mapError(_.getMessage).asSomeError)
-      .flatMap(iri => ZIO.fromEither(ValueIri.from(iri)).asSomeError)
+      .flatMap(uri => ZIO.fromEither(ValueIri.from(uri)).asSomeError)
       .filterOrFail(newV => newV != valueIri)(
         Some(s"The IRI of a new value version cannot be the same as the IRI of the current version"),
       )
@@ -457,20 +456,21 @@ final case class ApiComplexV2JsonLdRequestParser(
         valueIri           <- v.valueIriOrFail
         valueCreationDate  <- v.valueCreationDateOption
         valuePermissions   <- v.hasPermissionsOption
-        newValueVersionIri <- newValueVersionIri(v, valueIri)
-        valueContent       <- getValueContent(v, resourceIri.shortcode).map(Some(_)).orElse(ZIO.none)
-        updateValue        <- (valueContent, valuePermissions) match
+        newValueVersionIri    <- newValueVersionIri(v, valueIri)
+        newValueVersionSmtIri <- ZIO.foreach(newValueVersionIri)(vi => converter.asSmartIri(vi.value).mapError(_.getMessage))
+        valueContent          <- getValueContent(v, resourceIri.shortcode).map(Some(_)).orElse(ZIO.none)
+        updateValue           <- (valueContent, valuePermissions) match
                          case (Some(valueContentV2), _) =>
                            ZIO.succeed(
                              UpdateValueContentV2(
                                resourceIri.value,
                                r.resourceClassSmartIri,
                                v.propertySmartIri,
-                               valueIri.smartIri.toString,
+                               valueIri.value,
                                valueContentV2,
                                valuePermissions,
                                valueCreationDate,
-                               newValueVersionIri.map(_.smartIri),
+                               newValueVersionSmtIri,
                              ),
                            )
                          case (_, Some(permissions)) =>
@@ -479,11 +479,11 @@ final case class ApiComplexV2JsonLdRequestParser(
                                resourceIri.value,
                                r.resourceClassSmartIri,
                                v.propertySmartIri,
-                               valueIri.smartIri.toString,
+                               valueIri.value,
                                v.valueType,
                                permissions,
                                valueCreationDate,
-                               newValueVersionIri.map(_.smartIri),
+                               newValueVersionSmtIri,
                              ),
                            )
                          case _ => ZIO.fail("No value content or permissions provided")
@@ -499,6 +499,7 @@ final case class ApiComplexV2JsonLdRequestParser(
         r                 <- RootResource.fromJsonLd(str)
         resourceIri       <- r.resourceIriOrFail
         v                 <- ValueResource.from(r)
+        customValueIri    <- ZIO.foreach(v.valueIri)(vi => converter.asSmartIri(vi.value).mapError(_.getMessage))
         valueUuid         <- v.valueHasUuidOption
         valueCreationDate <- v.valueCreationDateOption
         valuePermissions  <- v.hasPermissionsOption
@@ -508,7 +509,7 @@ final case class ApiComplexV2JsonLdRequestParser(
         r.resourceClassSmartIri,
         v.propertyIri.smartIri,
         valueContent,
-        v.valueIri.map(_.smartIri),
+        customValueIri,
         valueUuid,
         valueCreationDate,
         valuePermissions,

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -450,16 +450,17 @@ final case class ApiComplexV2JsonLdRequestParser(
   def updateValueV2fromJsonLd(str: String): IO[String, UpdateValueV2] =
     ZIO.scoped {
       for {
-        r                  <- RootResource.fromJsonLd(str)
-        resourceIri        <- r.resourceIriOrFail
-        v                  <- ValueResource.from(r)
-        valueIri           <- v.valueIriOrFail
-        valueCreationDate  <- v.valueCreationDateOption
-        valuePermissions   <- v.hasPermissionsOption
+        r                     <- RootResource.fromJsonLd(str)
+        resourceIri           <- r.resourceIriOrFail
+        v                     <- ValueResource.from(r)
+        valueIri              <- v.valueIriOrFail
+        valueCreationDate     <- v.valueCreationDateOption
+        valuePermissions      <- v.hasPermissionsOption
         newValueVersionIri    <- newValueVersionIri(v, valueIri)
-        newValueVersionSmtIri <- ZIO.foreach(newValueVersionIri)(vi => converter.asSmartIri(vi.value).mapError(_.getMessage))
-        valueContent          <- getValueContent(v, resourceIri.shortcode).map(Some(_)).orElse(ZIO.none)
-        updateValue           <- (valueContent, valuePermissions) match
+        newValueVersionSmtIri <-
+          ZIO.foreach(newValueVersionIri)(vi => converter.asSmartIri(vi.value).mapError(_.getMessage))
+        valueContent <- getValueContent(v, resourceIri.shortcode).map(Some(_)).orElse(ZIO.none)
+        updateValue  <- (valueContent, valuePermissions) match
                          case (Some(valueContentV2), _) =>
                            ZIO.succeed(
                              UpdateValueContentV2(

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
@@ -17,7 +17,6 @@ import org.knora.webapi.slice.ontology.domain.model.OntologyName
 
 object KnoraIris {
 
-  opaque type ValueId    = NonEmptyString
   opaque type EntityName = NonEmptyString
 
   trait KnoraIri { self =>
@@ -70,19 +69,6 @@ object KnoraIris {
     def from(iri: SmartIri): Either[String, PropertyIri] = Right(PropertyIri(iri))
   }
 
-  final case class ValueIri private (
-    smartIri: SmartIri,
-    shortcode: Shortcode,
-    resourceId: ResourceId,
-    valueId: ValueId,
-  ) extends KnoraIri {
-    def sameResourceAs(other: ValueIri): Boolean =
-      this.shortcode == other.shortcode && this.resourceId == other.resourceId
-
-    override def equals(other: Any): Boolean = super.equals(other)
-    override def hashCode(): Int             = super.hashCode()
-  }
-
   final case class ResourceClassIri private (smartIri: SmartIri) extends KnoraIri {
     def ontologyIri: OntologyIri = OntologyIri.unsafeFrom(smartIri.getOntologyFromEntity)
     def name: String             = smartIri.getEntityName
@@ -100,21 +86,6 @@ object KnoraIris {
       else Left(s"Not an API v2 complex IRI ${iri.toString}")
 
     def from(iri: SmartIri): Either[String, ResourceClassIri] = Right(ResourceClassIri(iri))
-  }
-
-  object ValueIri {
-
-    def unsafeFrom(iri: SmartIri): ValueIri = from(iri).fold(e => throw IllegalArgumentException(e), identity)
-
-    def from(iri: SmartIri): Either[String, ValueIri] =
-      if iri.isKnoraValueIri then
-        // the following three calls are safe because we checked that the
-        // shortcode, resourceId and valueId are present in isKnoraValueIri
-        val shortcode  = iri.getProjectShortcode.getOrElse(throw Exception())
-        val resourceId = ResourceId.unsafeFrom(iri.getResourceID.getOrElse(throw Exception()))
-        val valueId    = NonEmptyString.unsafeFrom(iri.getValueID.getOrElse(throw Exception()))
-        Right(ValueIri(iri, shortcode, resourceId, valueId))
-      else Left(s"<$iri> is not a Knora value IRI")
   }
 
   final case class OntologyIri private (smartIri: SmartIri) extends KnoraIri { self =>

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
@@ -12,7 +12,6 @@ import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
-import org.knora.webapi.slice.common.ResourceIri.ResourceId
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.OntologyName
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
@@ -12,12 +12,12 @@ import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.common.ResourceIri.ResourceId
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.OntologyName
 
 object KnoraIris {
 
-  opaque type ResourceId = NonEmptyString
   opaque type ValueId    = NonEmptyString
   opaque type EntityName = NonEmptyString
 
@@ -112,7 +112,7 @@ object KnoraIris {
         // the following three calls are safe because we checked that the
         // shortcode, resourceId and valueId are present in isKnoraValueIri
         val shortcode  = iri.getProjectShortcode.getOrElse(throw Exception())
-        val resourceId = NonEmptyString.unsafeFrom(iri.getResourceID.getOrElse(throw Exception()))
+        val resourceId = ResourceId.unsafeFrom(iri.getResourceID.getOrElse(throw Exception()))
         val valueId    = NonEmptyString.unsafeFrom(iri.getValueID.getOrElse(throw Exception()))
         Right(ValueIri(iri, shortcode, resourceId, valueId))
       else Left(s"<$iri> is not a Knora value IRI")

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/KnoraIris.scala
@@ -7,8 +7,6 @@ package org.knora.webapi.slice.common
 
 import eu.timepit.refined.types.string.NonEmptyString
 
-import java.net.URI
-
 import org.knora.webapi.OntologySchema
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
@@ -105,9 +103,6 @@ object KnoraIris {
     def from(iri: SmartIri): Either[String, ResourceClassIri] = Right(ResourceClassIri(iri))
   }
 
-  // `ValueIri` and `ResourceIri` have no different internal representation.
-  // Thus, we only provide functions which create these from a `SmartIri`.
-  // The `fromApiV2Complex` is not required as these Iris are not part of the API v2 complex schema.
   object ValueIri {
 
     def unsafeFrom(iri: SmartIri): ValueIri = from(iri).fold(e => throw IllegalArgumentException(e), identity)
@@ -121,26 +116,6 @@ object KnoraIris {
         val valueId    = NonEmptyString.unsafeFrom(iri.getValueID.getOrElse(throw Exception()))
         Right(ValueIri(iri, shortcode, resourceId, valueId))
       else Left(s"<$iri> is not a Knora value IRI")
-  }
-
-  final case class ResourceIri private (smartIri: SmartIri, shortcode: Shortcode, resourceId: ResourceId)
-      extends KnoraIri {
-    override def equals(other: Any): Boolean = super.equals(other)
-    override def hashCode(): Int             = super.hashCode()
-    val latestArkUrl: URI                    = URI.create(smartIri.fromResourceIriToArkUrl(None))
-  }
-  object ResourceIri {
-
-    def unsafeFrom(iri: SmartIri): ResourceIri = from(iri).fold(e => throw IllegalArgumentException(e), identity)
-
-    def from(iri: SmartIri): Either[String, ResourceIri] =
-      if iri.isKnoraResourceIri then
-        // the following two calls are safe because we checked that the
-        // shortcode and resourceId are present in isKnoraResourceIri
-        val shortcode  = iri.getProjectShortcode.getOrElse(throw Exception())
-        val resourceId = NonEmptyString.unsafeFrom(iri.getResourceID.getOrElse(throw Exception()))
-        Right(ResourceIri(iri, shortcode, resourceId))
-      else Left(s"<$iri> is not a Knora resource IRI")
   }
 
   final case class OntologyIri private (smartIri: SmartIri) extends KnoraIri { self =>

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -5,26 +5,29 @@
 
 package org.knora.webapi.slice.common
 
-import eu.timepit.refined.types.string.NonEmptyString
-
 import java.util.UUID
 import scala.util.matching.Regex
 
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
-import org.knora.webapi.slice.common.ResourceIri.ResourceId
 import org.knora.webapi.slice.common.Value.StringValue
+
+final case class ResourceId private (override val value: String) extends StringValue
+
+object ResourceId extends StringValueCompanion[ResourceId] {
+  private val ResourceIdRegex: Regex = """^[A-Za-z0-9_-]+$""".r
+
+  def from(value: String): Either[String, ResourceId] = value match {
+    case ResourceIdRegex() => Right(ResourceId(value))
+    case _                 => Left(s"<$value> is not a valid resource ID")
+  }
+}
 
 final case class ResourceIri private (override val value: String, shortcode: Shortcode, resourceId: ResourceId)
     extends StringValue
 
 object ResourceIri extends StringValueCompanion[ResourceIri] {
-
-  opaque type ResourceId = NonEmptyString
-  object ResourceId {
-    def unsafeFrom(value: String): ResourceId = NonEmptyString.unsafeFrom(value)
-  }
 
   private val ResourceIriRegex: Regex =
     """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r
@@ -36,7 +39,7 @@ object ResourceIri extends StringValueCompanion[ResourceIri] {
 
   def from(value: String): Either[String, ResourceIri] = value match {
     case ResourceIriRegex(sc, id) =>
-      Shortcode.from(sc).map(shortcode => ResourceIri(value, shortcode, NonEmptyString.unsafeFrom(id)))
+      Shortcode.from(sc).map(shortcode => ResourceIri(value, shortcode, ResourceId.unsafeFrom(id)))
     case _ => Left(s"<$value> is not a Knora resource IRI")
   }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -22,6 +22,9 @@ final case class ResourceIri private (override val value: String, shortcode: Sho
 object ResourceIri extends StringValueCompanion[ResourceIri] {
 
   opaque type ResourceId = NonEmptyString
+  object ResourceId {
+    def unsafeFrom(value: String): ResourceId = NonEmptyString.unsafeFrom(value)
+  }
 
   private val ResourceIriRegex: Regex =
     """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import eu.timepit.refined.types.string.NonEmptyString
+
+import java.util.UUID
+import scala.util.matching.Regex
+
+import dsp.valueobjects.UuidUtil
+import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.common.ResourceIri.ResourceId
+import org.knora.webapi.slice.common.Value.StringValue
+
+final case class ResourceIri private (override val value: String, shortcode: Shortcode, resourceId: ResourceId)
+    extends StringValue
+
+object ResourceIri extends StringValueCompanion[ResourceIri] {
+
+  opaque type ResourceId = NonEmptyString
+
+  private val ResourceIriRegex: Regex =
+    """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r
+
+  def makeNew(shortcode: Shortcode): ResourceIri = {
+    val id = UuidUtil.base64Encode(UUID.randomUUID)
+    unsafeFrom(s"http://rdfh.ch/$shortcode/$id")
+  }
+
+  def from(value: String): Either[String, ResourceIri] = value match {
+    case ResourceIriRegex(sc, id) =>
+      Shortcode.from(sc).map(shortcode => ResourceIri(value, shortcode, NonEmptyString.unsafeFrom(id)))
+    case _ => Left(s"<$value> is not a Knora resource IRI")
+  }
+
+  def from(iri: SmartIri): Either[String, ResourceIri] = from(iri.toString)
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -39,7 +39,11 @@ object ResourceIri extends StringValueCompanion[ResourceIri] {
 
   def from(value: String): Either[String, ResourceIri] = value match {
     case ResourceIriRegex(sc, id) =>
-      Shortcode.from(sc).map(shortcode => ResourceIri(value, shortcode, ResourceId.unsafeFrom(id)))
+      // unsafe is safe here since the regex already ensures
+      // the constraints for both code and id
+      val shortcode  = Shortcode.unsafeFrom(sc)
+      val resourceId = ResourceId.unsafeFrom(id)
+      Right(ResourceIri(value, shortcode, resourceId))
     case _ => Left(s"<$value> is not a Knora resource IRI")
   }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ValueIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ValueIri.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import java.util.UUID
+import scala.util.matching.Regex
+
+import dsp.valueobjects.UuidUtil
+import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.common.Value.StringValue
+
+final case class ValueId private (override val value: String) extends StringValue
+
+object ValueId extends StringValueCompanion[ValueId] {
+  private val ValueIdRegex: Regex = """^[A-Za-z0-9_-]+$""".r
+
+  def from(value: String): Either[String, ValueId] = value match {
+    case ValueIdRegex() => Right(ValueId(value))
+    case _              => Left(s"<$value> is not a valid value ID")
+  }
+}
+
+final case class ValueIri private (
+  override val value: String,
+  shortcode: Shortcode,
+  resourceId: ResourceId,
+  valueId: ValueId,
+) extends StringValue {
+  def sameResourceAs(other: ValueIri): Boolean =
+    this.shortcode == other.shortcode && this.resourceId == other.resourceId
+}
+
+object ValueIri extends StringValueCompanion[ValueIri] {
+
+  private val ValueIriRegex: Regex =
+    """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)/values/([A-Za-z0-9_-]+)$""".r
+
+  def makeNew(resourceIri: ResourceIri): ValueIri = {
+    val id = UuidUtil.base64Encode(UUID.randomUUID)
+    unsafeFrom(s"http://rdfh.ch/${resourceIri.shortcode}/${resourceIri.resourceId}/values/$id")
+  }
+
+  def from(resourceIri: ResourceIri, uuid: UUID): ValueIri = {
+    val id = UuidUtil.base64Encode(uuid)
+    unsafeFrom(s"http://rdfh.ch/${resourceIri.shortcode}/${resourceIri.resourceId}/values/$id")
+  }
+
+  def from(value: String): Either[String, ValueIri] = value match {
+    case ValueIriRegex(sc, resId, valId) =>
+      // unsafe is safe here since the regex already ensures
+      // the constraints for shortcode, resourceId, and valueId
+      val shortcode  = Shortcode.unsafeFrom(sc)
+      val resourceId = ResourceId.unsafeFrom(resId)
+      val valueId    = ValueId.unsafeFrom(valId)
+      Right(ValueIri(value, shortcode, resourceId, valueId))
+    case _ => Left(s"<$value> is not a Knora value IRI")
+  }
+
+  def from(iri: SmartIri): Either[String, ValueIri] = from(iri.toString)
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/service/IriConverter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/service/IriConverter.scala
@@ -16,7 +16,6 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri
 
@@ -48,9 +47,6 @@ final case class IriConverter(sf: StringFormatter) {
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.fromApiV2Complex(sIri)))
   def asPropertyIri(iri: String): IO[String, PropertyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.from(sIri)))
-
-  def asResourceIri(iri: String): IO[String, ResourceIri] =
-    ZIO.fromEither(ResourceIri.from(iri))
 
   def asOntologyIriApiV2Complex(iri: String): IO[String, OntologyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(OntologyIri.fromApiV2Complex(sIri)))

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/service/IriConverter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/service/IriConverter.scala
@@ -16,7 +16,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.domain.InternalIri
 
@@ -50,7 +50,7 @@ final case class IriConverter(sf: StringFormatter) {
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(PropertyIri.from(sIri)))
 
   def asResourceIri(iri: String): IO[String, ResourceIri] =
-    asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(ResourceIri.from(sIri)))
+    ZIO.fromEither(ResourceIri.from(iri))
 
   def asOntologyIriApiV2Complex(iri: String): IO[String, OntologyIri] =
     asSmartIri(iri).mapError(_.getMessage).flatMap(sIri => ZIO.fromEither(OntologyIri.fromApiV2Complex(sIri)))

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/api/service/ExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/api/service/ExportService.scala
@@ -42,6 +42,7 @@ import org.knora.webapi.slice.api.v3.`export`.MetadataRecord
 import org.knora.webapi.slice.api.v3.export_.ExportedResource
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.domain.LanguageCode
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.infrastructure.CsvService
@@ -76,8 +77,6 @@ final case class ExportService(
   ): Task[String] = {
     import zio.json.*
 
-    given StringFormatter = sf
-
     for {
       resourceIris  <- findResources.findResources(project, None)
       readResources <- readResources.readResourcesSequencePar(
@@ -94,7 +93,7 @@ final case class ExportService(
                   val description = descriptionProp.flatMap(r.values.get(_).flatMap(_.headOption))
                   MetadataRecord(
                     id = r.resourceIri.toString,
-                    pid = r.resourceIri.toSmartIri.fromResourceIriToArkUrl(),
+                    pid = sf.resourceIriToArkUrl(ResourceIri.unsafeFrom(r.resourceIri)),
                     label = Map("en" -> r.label),
                     accessRights = "Full Open Access",
                     legalInfo = LegalInfo.publicDomain,
@@ -216,7 +215,7 @@ final case class ExportService(
     val arkEntryTask: Task[ListMap[String, String]] =
       if includeArkUrls then
         ZIO
-          .attempt(resource.resourceIri.toSmartIri.fromResourceIriToArkUrl())
+          .attempt(sf.resourceIriToArkUrl(ResourceIri.unsafeFrom(resource.resourceIri)))
           .orDie
           .map(url => ListMap("ARK URL" -> url))
       else ZIO.succeed(ListMap.empty)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
@@ -17,7 +17,7 @@ import java.time.Instant
 
 import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
@@ -17,8 +17,8 @@ import java.time.Instant
 
 import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
@@ -22,7 +22,7 @@ import dsp.errors.SparqlGenerationException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
@@ -22,8 +22,8 @@ import dsp.errors.SparqlGenerationException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
@@ -20,8 +20,8 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
@@ -20,7 +20,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
@@ -24,7 +24,7 @@ import java.util.UUID
 import dsp.errors.SparqlGenerationException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
@@ -24,8 +24,8 @@ import java.util.UUID
 import dsp.errors.SparqlGenerationException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuery.scala
@@ -17,7 +17,7 @@ import java.time.Instant
 
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuery.scala
@@ -17,8 +17,8 @@ import java.time.Instant
 
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 
 object DeleteResourceQuery extends QueryBuilderHelper {

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
@@ -21,7 +21,7 @@ import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
@@ -21,9 +21,9 @@ import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
@@ -21,7 +21,7 @@ import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
@@ -21,9 +21,9 @@ import dsp.errors.SparqlGenerationException
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuery.scala
@@ -12,8 +12,8 @@ import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
 
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
 
 object EraseResourceQuery extends QueryBuilderHelper {

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuery.scala
@@ -12,7 +12,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
 
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
@@ -38,7 +38,7 @@ import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.domain.InternalIri
@@ -191,7 +191,7 @@ final case class ResourcesRepoLive(triplestore: TriplestoreService)(implicit val
     .asScala
     .map { stmt =>
       val p = PropertyIri.unsafeFrom(stmt.getPredicate.toString.toSmartIri)
-      val v = ResourceIri.unsafeFrom(stmt.getObject.toString.toSmartIri)
+      val v = ResourceIri.unsafeFrom(stmt.getObject.toString)
       (p, v)
     }
     .toList
@@ -236,7 +236,7 @@ final case class ResourcesRepoLive(triplestore: TriplestoreService)(implicit val
     val isDeleted              = row.getRequired("isDeleted", s => Right(s.toBoolean))
     val label                  = row.getRequired("label")
     val resourceClassIri       = row.getRequired("clazz", s => ResourceClassIri.from(s.toSmartIri))
-    val hasStandoffLinkTo      = row.get("hasStandoffLinkTo", s => ResourceIri.from(s.toSmartIri))
+    val hasStandoffLinkTo      = row.get("hasStandoffLinkTo", s => ResourceIri.from(s))
     val hasStandoffLinkToValue = row.get("hasStandoffLinkToValue", s => ValueIri.from(s.toSmartIri))
     val attachedToUser         = row.getRequired("attachedToUser", UserIri.from)
     val creationDate           = row.getRequired("creationDate", s => Try(Instant.parse(s)).toEither.left.map(_.getMessage))

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
@@ -38,7 +38,7 @@ import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.domain.InternalIri

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
@@ -38,9 +38,9 @@ import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.FileValueTypeSpecificInfo

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
@@ -38,9 +38,9 @@ import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.FileValueTypeSpecificInfo

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
@@ -202,7 +202,7 @@ final case class ResourcesRepoLive(triplestore: TriplestoreService)(implicit val
     .asScala
     .map { stmt =>
       val p = PropertyIri.unsafeFrom(stmt.getPredicate.toString.toSmartIri)
-      val v = ValueIri.unsafeFrom(stmt.getObject.toString.toSmartIri)
+      val v = ValueIri.unsafeFrom(stmt.getObject.toString)
       (p, v)
     }
     .toList
@@ -237,7 +237,7 @@ final case class ResourcesRepoLive(triplestore: TriplestoreService)(implicit val
     val label                  = row.getRequired("label")
     val resourceClassIri       = row.getRequired("clazz", s => ResourceClassIri.from(s.toSmartIri))
     val hasStandoffLinkTo      = row.get("hasStandoffLinkTo", s => ResourceIri.from(s))
-    val hasStandoffLinkToValue = row.get("hasStandoffLinkToValue", s => ValueIri.from(s.toSmartIri))
+    val hasStandoffLinkToValue = row.get("hasStandoffLinkToValue", s => ValueIri.from(s))
     val attachedToUser         = row.getRequired("attachedToUser", UserIri.from)
     val creationDate           = row.getRequired("creationDate", s => Try(Instant.parse(s)).toEither.left.map(_.getMessage))
     val attachedToProject      = row.getRequired("attachedToProject", ProjectIri.from)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
@@ -69,7 +69,7 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
   def findByIds(iris: Seq[ValueIri]) = ZIO.foreach(iris)(findById)
 
   def findById(iri: ValueIri): Task[Option[ValueModel]] =
-    val id                                                      = Rdf.iri(iri.toString)
+    val id                                                      = Rdf.iri(iri.value)
     val (clazz, isDeleted, previousValue, lastModificationDate) =
       (variable("valueClass"), variable("isDeleted"), variable("previousValue"), variable("lastModificationDate"))
 
@@ -89,7 +89,7 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
     val query = Queries.CONSTRUCT(graphP).where(whereP)
     triplestore
       .queryRdfModel(Construct(query))
-      .flatMap(_.getResource(iri.toString).map(_.map(_.res)))
+      .flatMap(_.getResource(iri.value).map(_.map(_.res)))
       .flatMap(mapResult)
 
   private def mapResult(maybe: Option[Resource]): Task[Option[ValueModel]] =
@@ -99,11 +99,11 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
         ZIO
           .fromEither(
             for {
-              valueIri      <- resource.uri.fold(Left("Value IRI not found"))(s => ValueIri.from(s.toSmartIri))
+              valueIri      <- resource.uri.fold(Left("Value IRI not found"))(s => ValueIri.from(s))
               lastModified  <- resource.objectInstantOption(KnoraBase.LastModificationDate)
               isDeleted     <- resource.objectBooleanOption(KnoraBase.IsDeleted).map(_.getOrElse(false))
               valueClassIri <- resource.rdfType.fold(Left("Value class IRI not found"))(s => Right(InternalIri(s)))
-              previousValue <- resource.objectUriOption(KnoraBase.PreviousValue, s => ValueIri.from(s.toSmartIri))
+              previousValue <- resource.objectUriOption(KnoraBase.PreviousValue, s => ValueIri.from(s))
             } yield
               if isDeleted then Some(DeletedValue(valueIri, valueClassIri, previousValue, lastModified))
               else Some(ActiveValue(valueIri, valueClassIri, previousValue, lastModified)),
@@ -121,16 +121,16 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
 
   def findPreviousValue(valueIri: ValueIri): Task[Option[ValueIri]] = {
     val previous = variable("previous")
-    val where    = iri(valueIri.toString).has(KB.previousValue, previous)
+    val where    = iri(valueIri.value).has(KB.previousValue, previous)
     val query    = Queries.SELECT(previous).where(where)
     triplestore
       .query(Select(query))
       .map(_.getFirstRow)
-      .map(_.flatMap(row => row.rowMap.get("previous").map(_.toSmartIri).map(ValueIri.unsafeFrom)))
+      .map(_.flatMap(row => row.rowMap.get("previous").map(ValueIri.unsafeFrom)))
   }
 
   def eraseValue(project: KnoraProject)(valueIri: ValueIri): Task[Unit] = {
-    val value         = iri(valueIri.toString)
+    val value         = iri(valueIri.value)
     val (p, o)        = (variable("p"), variable("o"))
     val (s, oo)       = (variable("s"), variable("oo"))
     val delete        = value.has(p, o)
@@ -155,7 +155,7 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
 
   /* Deletes the subject/predicate/object triple pointed to by a LinkValue. */
   def eraseValueDirectLink(project: KnoraProject)(valueIri: ValueIri): Task[Unit] = {
-    val value            = iri(valueIri.toString)
+    val value            = iri(valueIri.value)
     val (s, p, o)        = spo
     val delete           = s.has(p, o)
     val projectDataGraph = Rdf.iri(ProjectService.projectDataNamedGraphV2(project).value)
@@ -178,7 +178,7 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
     currentTime: Instant,
   ): Task[Unit] = {
     val resource = iri(resourceIri.value)
-    val value    = iri(valueIri.toString)
+    val value    = iri(valueIri.value)
 
     val (resourceLastModDate, currentValuePerms) =
       (variable("resourceLastModificationDate"), variable("currentValuePermissions"))
@@ -212,7 +212,7 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
     currentTime: Instant,
   ): Task[Unit] = {
     val valuesClause = orderedValueIris.zipWithIndex.map { case (valueIri, idx) =>
-      s"    (<${valueIri.toString}> $idx)"
+      s"    (<${valueIri.value}> $idx)"
     }
       .mkString("\n")
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
@@ -25,8 +25,8 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.v2.responder.valuemessages.ValueContentV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.ProjectService
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given_Conversion_String_Property
 import org.knora.webapi.slice.common.jena.ResourceOps.*

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
@@ -58,7 +58,6 @@ final case class DeletedValue(
 
 final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: StringFormatter)
     extends QueryBuilderHelper {
-  import org.knora.webapi.messages.IriConversions.ConvertibleIri
 
   def findActiveById(iri: ValueIri): Task[Option[ActiveValue]] =
     findById(iri).map(_.collect { case v: ActiveValue => v })

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
@@ -25,7 +25,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.v2.responder.valuemessages.ValueContentV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.ProjectService
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given_Conversion_String_Property

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/service/MetadataService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/service/MetadataService.scala
@@ -22,6 +22,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.api.v2.metadata.ResourceMetadataDto
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.SparqlTimeout
@@ -98,8 +99,9 @@ final case class MetadataService(
                   val classIri =
                     row.rowMap.getOrElse(classIriVar, throwEx(classIriVar)).toSmartIri.toComplexSchema.toIri
                   val resourceIri         = row.rowMap.getOrElse(resourceIriVar, throwEx(resourceIriVar))
-                  val arkUrl              = resourceIri.toSmartIri.fromResourceIriToArkUrl(None)
-                  val arkUrlWithTimestamp = resourceIri.toSmartIri.fromResourceIriToArkUrl(Some(now))
+                  val parsedResourceIri   = ResourceIri.unsafeFrom(resourceIri)
+                  val arkUrl              = sf.resourceIriToArkUrl(parsedResourceIri)
+                  val arkUrlWithTimestamp = sf.resourceIriToArkUrl(parsedResourceIri, Some(now))
                   val label               = row.rowMap.getOrElse(labelVar, throwEx(labelVar))
                   val creatorIri          =
                     row.rowMap.getOrElse(creatorIriVar, throwEx(creatorIriVar)).toSmartIri.toComplexSchema.toIri

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ValueContentValidator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ValueContentValidator.scala
@@ -13,7 +13,7 @@ import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceReq
 import org.knora.webapi.messages.v2.responder.valuemessages.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.service.LegalInfoService
-import org.knora.webapi.slice.common.service.IriConverter
+import org.knora.webapi.slice.common.ResourceIri
 
 /**
  * A service that validates values in requests that create resources with values or create/update values.
@@ -23,7 +23,6 @@ import org.knora.webapi.slice.common.service.IriConverter
  * - Ensuring that file values have valid legal information
  */
 final case class ValueContentValidator(
-  private val iriConverter: IriConverter,
   private val legalInfoService: LegalInfoService,
 ) {
 
@@ -42,7 +41,7 @@ final case class ValueContentValidator(
     extractShortcode(resourceIri).flatMap(validateValueContent(vc, _))
 
   private def extractShortcode(resourceIri: IRI): IO[String, Shortcode] =
-    iriConverter.asResourceIri(resourceIri).map(_.shortcode)
+    ZIO.fromEither(ResourceIri.from(resourceIri)).map(_.shortcode)
 
   private def validateValueContent(vc: ValueContentV2, inProject: Shortcode): IO[String, Unit] =
     ensureNoCrossProjectLink(vc, inProject) *> ensureValidLegalInfo(vc, inProject)

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuery.scala
@@ -5,8 +5,8 @@
 
 package org.knora.webapi.slice.search.repo
 
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 
 object GetIncomingImageLinksGravsearchQuery extends QueryBuilderHelper {
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuery.scala
@@ -5,7 +5,7 @@
 
 package org.knora.webapi.slice.search.repo
 
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 
 object GetIncomingImageLinksGravsearchQuery extends QueryBuilderHelper {

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuery.scala
@@ -6,7 +6,7 @@
 package org.knora.webapi.slice.search.repo
 
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
 
 object GetResourceWithSpecifiedPropertiesGravsearchQuery extends QueryBuilderHelper {

--- a/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuery.scala
@@ -6,8 +6,8 @@
 package org.knora.webapi.slice.search.repo
 
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 
 object GetResourceWithSpecifiedPropertiesGravsearchQuery extends QueryBuilderHelper {
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/api/v3/NotFoundSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/api/v3/NotFoundSpec.scala
@@ -4,20 +4,17 @@
  */
 
 package org.knora.webapi.slice.api.v3
-import zio.*
 import zio.json.*
 import zio.test.*
 
-import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.slice.common.service.IriConverter
+import org.knora.webapi.slice.common.ResourceIri
 
 object NotFoundSpec extends ZIOSpecDefault {
   override val spec = suite("NotFoundSpec")(
     test("NotFound.from(ResourceIri) should create a NotFound instance with the correct message and error details") {
-      for {
-        resourceIri <- ZIO.serviceWithZIO[IriConverter](_.asResourceIri("http://rdfh.ch/0001/abcd1234"))
-        actual       = NotFound.from(resourceIri)
-      } yield assertTrue(
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/abcd1234")
+      val actual      = NotFound.from(resourceIri)
+      assertTrue(
         actual.toJsonPretty == """{
                                  |  "message" : "The resource with IRI 'http://rdfh.ch/0001/abcd1234' was not found.",
                                  |  "errors" : [
@@ -32,5 +29,5 @@ object NotFoundSpec extends ZIOSpecDefault {
                                  |}""".stripMargin,
       )
     },
-  ).provide(IriConverter.layer, StringFormatter.test)
+  )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
@@ -11,7 +11,7 @@ import zio.test.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.KnoraIrisSpec.test
 import org.knora.webapi.slice.common.service.IriConverter
 object KnoraIrisSpec extends ZIOSpecDefault {

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
@@ -21,11 +21,6 @@ object KnoraIrisSpec extends ZIOSpecDefault {
   private val internalPropertyIri     = "http://www.knora.org/ontology/0001/anything#hasListItem"
   private val apiV2ComplexPropertyIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasListItem"
 
-  private val internalResourceClassIri     = "http://www.knora.org/ontology/0001/anything#Thing"
-  private val apiV2ComplexResourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"
-
-  private val resourceIri = "http://rdfh.ch/080C/Ef9heHjPWDS7dMR_gGax2Q"
-
   private val propertyIriSuite = suite("PropertyIri")(
     suite("from")(
       test("should return a PropertyIri") {

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
@@ -11,7 +11,6 @@ import zio.test.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.KnoraIrisSpec.test
 import org.knora.webapi.slice.common.service.IriConverter
@@ -126,39 +125,8 @@ object KnoraIrisSpec extends ZIOSpecDefault {
     ),
   )
 
-  private val resourceIriSuite = suite("ResourceIri")(
-    suite("from")(
-      test("should return a ResourceIri") {
-        val validIris = Seq(resourceIri)
-        check(Gen.fromIterable(validIris)) { iri =>
-          for {
-            sIri  <- converter(_.asSmartIri(iri))
-            actual = ResourceIri.from(sIri)
-          } yield assertTrue(actual.map(_.smartIri) == Right(sIri))
-        }
-      },
-      test("should fail for an invalid ResourceIri") {
-        val invalidIris = Seq(
-          "http://example.com/ontology#Foo",
-          internalResourceClassIri,
-          apiV2ComplexResourceClassIri,
-          internalPropertyIri,
-          apiV2ComplexPropertyIri,
-          valueIri,
-        )
-        check(Gen.fromIterable(invalidIris)) { iri =>
-          for {
-            sIri  <- converter(_.asSmartIri(iri))
-            actual = ResourceIri.from(sIri)
-          } yield assertTrue(actual == Left(s"<${sIri.toIri}> is not a Knora resource IRI"))
-        }
-      },
-    ),
-  )
-
   val spec = suite("KnoraIris")(
     resourceClassIriSuite,
-    resourceIriSuite,
     propertyIriSuite,
     valueIriSuite,
   ).provide(IriConverter.layer, StringFormatter.test)

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
@@ -11,7 +11,6 @@ import zio.test.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.KnoraIrisSpec.test
 import org.knora.webapi.slice.common.service.IriConverter
 object KnoraIrisSpec extends ZIOSpecDefault {
@@ -25,7 +24,6 @@ object KnoraIrisSpec extends ZIOSpecDefault {
   private val internalResourceClassIri     = "http://www.knora.org/ontology/0001/anything#Thing"
   private val apiV2ComplexResourceClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"
 
-  private val valueIri    = "http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A"
   private val resourceIri = "http://rdfh.ch/080C/Ef9heHjPWDS7dMR_gGax2Q"
 
   private val propertyIriSuite = suite("PropertyIri")(
@@ -95,39 +93,8 @@ object KnoraIrisSpec extends ZIOSpecDefault {
     ),
   )
 
-  private val valueIriSuite = suite("ValueIri")(
-    suite("from")(
-      test("should return a ValueIri") {
-        val validIris = Seq(valueIri)
-        check(Gen.fromIterable(validIris)) { iri =>
-          for {
-            sIri  <- converter(_.asSmartIri(iri))
-            actual = ValueIri.from(sIri)
-          } yield assertTrue(actual.map(_.smartIri) == Right(sIri))
-        }
-      },
-      test("should fail for an invalid ValueIri") {
-        val invalidIris = Seq(
-          "http://example.com/ontology#Foo",
-          internalResourceClassIri,
-          apiV2ComplexResourceClassIri,
-          internalPropertyIri,
-          apiV2ComplexPropertyIri,
-          resourceIri,
-        )
-        check(Gen.fromIterable(invalidIris)) { iri =>
-          for {
-            sIri  <- converter(_.asSmartIri(iri))
-            actual = ValueIri.from(sIri)
-          } yield assertTrue(actual == Left(s"<${sIri.toIri}> is not a Knora value IRI"))
-        }
-      },
-    ),
-  )
-
   val spec = suite("KnoraIris")(
     resourceClassIriSuite,
     propertyIriSuite,
-    valueIriSuite,
   ).provide(IriConverter.layer, StringFormatter.test)
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/KnoraIrisSpec.scala
@@ -11,7 +11,7 @@ import zio.test.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.common.KnoraIrisSpec.test
 import org.knora.webapi.slice.common.service.IriConverter

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ResourceIriSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ResourceIriSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import zio.test.*
+
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+
+object ResourceIriSpec extends ZIOSpecDefault {
+
+  private val validResourceIri = "http://rdfh.ch/080C/Ef9heHjPWDS7dMR_gGax2Q"
+
+  val spec = suite("ResourceIri")(
+    suite("from")(
+      test("should return a ResourceIri for a valid IRI") {
+        val actual = ResourceIri.from(validResourceIri)
+        assertTrue(
+          actual.isRight,
+          actual.toOption.get.value == validResourceIri,
+          actual.toOption.get.shortcode == Shortcode.unsafeFrom("080C"),
+        )
+      },
+      test("should fail for an invalid ResourceIri") {
+        val invalidIris = Seq(
+          "http://example.com/ontology#Foo",
+          "http://www.knora.org/ontology/0001/anything#Thing",
+          "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing",
+          "http://www.knora.org/ontology/0001/anything#hasListItem",
+          "http://0.0.0.0:3333/ontology/0001/anything/v2#hasListItem",
+          "http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A",
+        )
+        check(Gen.fromIterable(invalidIris)) { iri =>
+          val actual = ResourceIri.from(iri)
+          assertTrue(actual == Left(s"<$iri> is not a Knora resource IRI"))
+        }
+      },
+    ),
+    suite("makeNew")(
+      test("should create a valid ResourceIri") {
+        val shortcode   = Shortcode.unsafeFrom("0001")
+        val resourceIri = ResourceIri.makeNew(shortcode)
+        assertTrue(
+          resourceIri.value.startsWith("http://rdfh.ch/0001/"),
+          resourceIri.shortcode == shortcode,
+          ResourceIri.from(resourceIri.value).isRight,
+        )
+      },
+      test("should create unique IRIs") {
+        val shortcode = Shortcode.unsafeFrom("0001")
+        val iri1      = ResourceIri.makeNew(shortcode)
+        val iri2      = ResourceIri.makeNew(shortcode)
+        assertTrue(iri1.value != iri2.value)
+      },
+    ),
+  )
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ValueIriSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ValueIriSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import zio.test.*
+
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+
+object ValueIriSpec extends ZIOSpecDefault {
+
+  private val validValueIri = "http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A"
+
+  val spec = suite("ValueIri")(
+    suite("from")(
+      test("should return a ValueIri for a valid IRI") {
+        val actual = ValueIri.from(validValueIri)
+        assertTrue(
+          actual.isRight,
+          actual.toOption.get.value == validValueIri,
+          actual.toOption.get.shortcode == Shortcode.unsafeFrom("0001"),
+          actual.toOption.get.resourceId == ResourceId.unsafeFrom("thing-with-history"),
+          actual.toOption.get.valueId == ValueId.unsafeFrom("xZisRC3jPkcplt1hQQdb-A"),
+        )
+      },
+      test("should fail for an invalid ValueIri") {
+        val invalidIris = Seq(
+          "http://example.com/ontology#Foo",
+          "http://www.knora.org/ontology/0001/anything#Thing",
+          "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing",
+          "http://www.knora.org/ontology/0001/anything#hasListItem",
+          "http://0.0.0.0:3333/ontology/0001/anything/v2#hasListItem",
+          "http://rdfh.ch/080C/Ef9heHjPWDS7dMR_gGax2Q",
+        )
+        check(Gen.fromIterable(invalidIris)) { iri =>
+          val actual = ValueIri.from(iri)
+          assertTrue(actual == Left(s"<$iri> is not a Knora value IRI"))
+        }
+      },
+    ),
+    suite("makeNew")(
+      test("should create a valid ValueIri") {
+        val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
+        val valueIri    = ValueIri.makeNew(resourceIri)
+        assertTrue(
+          valueIri.value.startsWith("http://rdfh.ch/0001/thing1/values/"),
+          valueIri.shortcode == Shortcode.unsafeFrom("0001"),
+          valueIri.resourceId == ResourceId.unsafeFrom("thing1"),
+          ValueIri.from(valueIri.value).isRight,
+        )
+      },
+      test("should create unique IRIs") {
+        val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
+        val iri1        = ValueIri.makeNew(resourceIri)
+        val iri2        = ValueIri.makeNew(resourceIri)
+        assertTrue(iri1.value != iri2.value)
+      },
+    ),
+    suite("sameResourceAs")(
+      test("should return true for values on the same resource") {
+        val iri1 = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/val1")
+        val iri2 = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/val2")
+        assertTrue(iri1.sameResourceAs(iri2))
+      },
+      test("should return false for values on different resources") {
+        val iri1 = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/val1")
+        val iri2 = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing2/values/val1")
+        assertTrue(!iri1.sameResourceAs(iri2))
+      },
+    ),
+  )
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuerySpec.scala
@@ -16,7 +16,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object ChangeLinkMetadataQuerySpec extends ZIOSpecDefault {
@@ -37,7 +37,7 @@ object ChangeLinkMetadataQuerySpec extends ZIOSpecDefault {
     Set.empty,
     Set.empty,
   )
-  private val testLinkSourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1".toSmartIri)
+  private val testLinkSourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
   private val testLinkTargetIri   = "http://rdfh.ch/0001/thing2"
   private val testNewLinkValueIri = "http://rdfh.ch/0001/thing1/values/newLinkValue"

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuerySpec.scala
@@ -19,7 +19,7 @@ import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object ChangeLinkTargetQuerySpec extends ZIOSpecDefault {
@@ -40,7 +40,7 @@ object ChangeLinkTargetQuerySpec extends ZIOSpecDefault {
     Set.empty,
     Set.empty,
   )
-  private val testLinkSourceIri             = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1".toSmartIri)
+  private val testLinkSourceIri             = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri           = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
   private val testCurrentLinkTargetIri      = "http://rdfh.ch/0001/thing2"
   private val testNewLinkTargetIri          = "http://rdfh.ch/0001/thing3"

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec.scala
@@ -19,7 +19,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.RestrictedView
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
 object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
@@ -41,7 +41,7 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
     Set.empty,
   )
 
-  private val testResourceIri      = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing".toSmartIri)
+  private val testResourceIri      = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
   private val testResourceClassIri =
     ResourceClassIri.unsafeFrom("http://www.knora.org/ontology/0001/anything#Thing".toSmartIri)
   private val testLastModificationDate = LastModificationDate.from(Instant.parse("2023-08-01T10:30:00Z"))

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuerySpec.scala
@@ -18,7 +18,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object CreateLinkQuerySpec extends ZIOSpecDefault {
@@ -40,7 +40,7 @@ object CreateLinkQuerySpec extends ZIOSpecDefault {
     Set.empty,
   )
 
-  private val testResourceIri         = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1".toSmartIri)
+  private val testResourceIri         = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri     = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
   private val testLinkTargetIri       = "http://rdfh.ch/0001/thing2"
   private val testNewLinkValueIri     = "http://rdfh.ch/0001/thing1/values/newLinkValue"

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuerySpec.scala
@@ -15,7 +15,7 @@ import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 object DeleteResourceQuerySpec extends ZIOSpecDefault {
 
@@ -37,7 +37,7 @@ object DeleteResourceQuerySpec extends ZIOSpecDefault {
   )
 
   private val dataNamedGraph = "http://www.knora.org/data/0001/anything"
-  private val resourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history".toSmartIri)
+  private val resourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-with-history")
   private val currentTime    = Instant.parse("2024-01-01T10:00:00Z")
   private val requestingUser = UserIri.unsafeFrom("http://rdfh.ch/users/root")
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteResourceQuerySpec.scala
@@ -9,8 +9,6 @@ import zio.test.*
 
 import java.time.Instant
 
-import org.knora.webapi.messages.IriConversions.ConvertibleIri
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
@@ -18,8 +16,6 @@ import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.ResourceIri
 
 object DeleteResourceQuerySpec extends ZIOSpecDefault {
-
-  private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   private val testProject = Project(
     ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001"),

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
@@ -19,7 +19,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
@@ -19,8 +19,8 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object DeleteValueQuerySpec extends ZIOSpecDefault {

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
@@ -19,7 +19,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
@@ -41,7 +41,7 @@ object DeleteValueQuerySpec extends ZIOSpecDefault {
     Set.empty,
     Set.empty,
   )
-  private val testResourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1".toSmartIri)
+  private val testResourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testPropertyIri    = PropertyIri.unsafeFrom("http://www.knora.org/ontology/0001/anything#hasText".toSmartIri)
   private val testValueIri       = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/value1".toSmartIri)
   private val testCurrentTime    = Instant.parse("2024-01-15T10:30:00Z")

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
@@ -19,8 +19,8 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.KnoraIris.ValueIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
 object DeleteValueQuerySpec extends ZIOSpecDefault {

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
@@ -43,7 +43,7 @@ object DeleteValueQuerySpec extends ZIOSpecDefault {
   )
   private val testResourceIri    = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testPropertyIri    = PropertyIri.unsafeFrom("http://www.knora.org/ontology/0001/anything#hasText".toSmartIri)
-  private val testValueIri       = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/value1".toSmartIri)
+  private val testValueIri       = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/value1")
   private val testCurrentTime    = Instant.parse("2024-01-15T10:30:00Z")
   private val testRequestingUser = UserIri.unsafeFrom("http://rdfh.ch/users/root")
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuerySpec.scala
@@ -12,7 +12,7 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 object EraseResourceQuerySpec extends ZIOSpecDefault {
 
@@ -33,7 +33,7 @@ object EraseResourceQuerySpec extends ZIOSpecDefault {
     Set.empty,
   )
 
-  private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_history".toSmartIri)
+  private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing_with_history")
 
   override def spec: Spec[TestEnvironment, Any] = suite("EraseResourceQuery")(
     test("build should produce the expected SPARQL query") {

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/EraseResourceQuerySpec.scala
@@ -7,16 +7,12 @@ package org.knora.webapi.slice.resources.repo
 
 import zio.test.*
 
-import org.knora.webapi.messages.IriConversions.ConvertibleIri
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.ResourceIri
 
 object EraseResourceQuerySpec extends ZIOSpecDefault {
-
-  private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   private val testProject = Project(
     ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001"),

--- a/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuerySpec.scala
@@ -7,13 +7,9 @@ package org.knora.webapi.slice.search.repo
 
 import zio.test.*
 
-import org.knora.webapi.messages.IriConversions.*
-import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.ResourceIri
 
 object GetIncomingImageLinksGravsearchQuerySpec extends ZIOSpecDefault {
-
-  implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetIncomingImageLinksGravsearchQuerySpec.scala
@@ -9,13 +9,13 @@ import zio.test.*
 
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 object GetIncomingImageLinksGravsearchQuerySpec extends ZIOSpecDefault {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
-  private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing".toSmartIri)
+  private val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
 
   override val spec: Spec[Any, Nothing] = suite("GetIncomingImageLinksGravsearchQuery")(
     test("build should produce the expected Gravsearch CONSTRUCT query") {

--- a/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/search/repo/GetResourceWithSpecifiedPropertiesGravsearchQuerySpec.scala
@@ -10,13 +10,13 @@ import zio.test.*
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.KnoraIris.ResourceIri
+import org.knora.webapi.slice.common.ResourceIri
 
 object GetResourceWithSpecifiedPropertiesGravsearchQuerySpec extends ZIOSpecDefault {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
-  private val resourceIri  = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing".toSmartIri)
+  private val resourceIri  = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
   private val propertyIris = Seq(
     PropertyIri.unsafeFrom("http://www.knora.org/ontology/knora-base#hasStillImageFileValue".toSmartIri),
     PropertyIri.unsafeFrom("http://www.knora.org/ontology/knora-base#hasStandoffLinkTo".toSmartIri),


### PR DESCRIPTION
Extracts `ResourceIri` and `ValueIri` from the `KnoraIris` hierarchy into standalone `StringValue` case classes with built-in validation, removing the dependency on `SmartIri` for construction and usage. This eliminates unnecessary indirection through `IriConverter` and `StringFormatter` at call sites, simplifying both production code and tests.

Unlike ontology, class, and property IRIs, `ResourceIri` and `ValueIri` do not have different ontology schema representations (complex vs. simple), so they never needed the `SmartIri` machinery. This makes them safe to extract into plain validated string types.

Also consolidates the `ResourceId` opaque type into the `ResourceIri` companion and removes dead code from `StringFormatter` and `IriConverter`.

Slightly [related is the documentation update PR](https://github.com/dasch-swiss/dsp-api/pull/4073).