### PR TITLE
docs: Add development guides and introduce fix-markdownlint skill (DEV-6231)

### DIFF
--- a/.claude/skills/fix-markdownlint/SKILL.md
+++ b/.claude/skills/fix-markdownlint/SKILL.md
@@ -1,0 +1,29 @@
+---
+title: 'Fix Markdownlint'
+allowed-tools: Bash(npx markdownlint-cli:*), Read, Edit, Glob
+argument-hint: <file-or-directory>
+description: Run markdownlint and fix issues. Use when the user asks to "fix markdown", "lint markdown", "fix markdownlint", or "markdownlint".
+---
+
+## Context
+
+- Config file: `.markdownlint.yml` in the project root
+- CI disables MD013 (line-length) and MD040 (fenced-code-language) — the skill must match this
+
+## Your task
+
+1. Determine the target: use the argument if provided, otherwise default to `"docs/**/*.md"`
+2. Run `npx markdownlint-cli -c .markdownlint.yml --disable MD013 MD040 -- <target>` to find issues
+3. If no issues are found, report that and stop
+4. For each issue, read the affected file and fix the problem using Edit
+5. Re-run the linter (same command) to verify all issues are resolved
+6. Report what was fixed
+
+## Common fixes
+
+- **MD033/no-inline-html**: Only `<br>` and `<center>` are allowed inline HTML elements
+- **MD060/table-column-style**: Align table pipes with header pipes
+
+## Execution
+
+Fix all issues in a single pass. Re-run the linter after fixing to confirm. Do not send any other text besides the tool calls.

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,4 @@
+---
+exclude_paths:
+  - "docs/**"
+  - "**/*.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Each slice typically contains:
 - **Repository Pattern**: Data access abstraction
 - **Service Layer**: Business logic separation
 - **Dependency Injection**: ZIO layers for service composition
+- **Value Types**: Use `Value[A]` (e.g. `StringValue`, `BooleanValue`, `IntValue`) to make domain models type-safe with validated construction. See `docs/development/dsp-api-value-types.md` for details.
 
 ## Testing Guidelines
 

--- a/docs/03-endpoints/api-admin/groups.md
+++ b/docs/03-endpoints/api-admin/groups.md
@@ -112,7 +112,7 @@ specified by the `id` in the request body as below:
 
 Example Group Information stored in admin named graph: :
 
-```
+```turtle
 <http://rdfh.ch/groups/[shortcode]/[UUID]>
      rdf:type knora-admin:UserGroup ;
      knora-admin:groupName "Name of the group" ;

--- a/docs/03-endpoints/api-admin/permissions.md
+++ b/docs/03-endpoints/api-admin/permissions.md
@@ -56,7 +56,7 @@ included in the request body, for example:
       }
     ]
 }
-``` 
+```
 
 In addition, in the body of the request, it is possible to specify a custom IRI (of 
 [DSP IRI](../api-v2/knora-iris.md#iris-for-data) form) for a permission through

--- a/docs/03-endpoints/api-admin/users.md
+++ b/docs/03-endpoints/api-admin/users.md
@@ -208,7 +208,7 @@ Note: In order to add a user to a project admin group, the user needs to be memb
 
 The following is an example for user information stored in the `admin` named graph:
 
-```
+```turtle
 <http://rdfh.ch/users/c266a56709>
     rdf:type knora-admin:User ;
     knora-admin:username "user01.user1"^^xsd:string ;

--- a/docs/03-endpoints/api-v2/editing-resources.md
+++ b/docs/03-endpoints/api-v2/editing-resources.md
@@ -4,7 +4,7 @@
 
 To create a new resources, use this route:
 
-```
+```text
 HTTP POST to http://host/v2/resources
 ```
 
@@ -229,7 +229,7 @@ You can modify the following metadata attached to a resource:
 
 To do this, use this route:
 
-```
+```text
 HTTP PUT to http://host/v2/resources
 ```
 
@@ -290,7 +290,7 @@ normal query results.
 
 To mark a resource as deleted, use this route:
 
-```
+```text
 HTTP POST to http://host/v2/resources/delete
 ```
 
@@ -395,7 +395,7 @@ Normally, resources are not actually removed from the triplestore; they are only
 [Deleting a Resource](#deleting-a-resource)). However, sometimes it is necessary to erase a resource from the
 triplestore. To do so, use this route:
 
-```
+```text
 HTTP POST to http://host/v2/resources/erase
 ```
 

--- a/docs/03-endpoints/api-v2/editing-values.md
+++ b/docs/03-endpoints/api-v2/editing-values.md
@@ -4,7 +4,7 @@
 
 To create a value in an existing resource, use this route:
 
-```
+```text
 HTTP POST to http://host/v2/values
 ```
 
@@ -254,7 +254,7 @@ Files can be ingested into DSP using SIPI or DSP-INGEST (experimental).
 The first step is to upload one or more files to SIPI, using a `multipart/form-data` request, where `sipihost`
 represents the host and port on which SIPI is running:
 
-```
+```text
 HTTP POST to http://sipihost/upload?token=TOKEN
 ```
 
@@ -429,7 +429,7 @@ pointing to a `knora-api:ArchiveFileValue`.
 
 To update a value, use this route:
 
-```
+```text
 HTTP PUT to http://host/v2/values
 ```
 
@@ -525,7 +525,7 @@ query results.
 
 To mark a value as deleted, use this route:
 
-```
+```text
 HTTP POST to http://host/v2/values/delete
 ```
 

--- a/docs/03-endpoints/api-v2/getting-lists.md
+++ b/docs/03-endpoints/api-v2/getting-lists.md
@@ -5,7 +5,7 @@
 In order to request a complete list, make a HTTP GET request to the `lists` route, 
 appending the Iri of the list's root node (URL-encoded):
 
-```
+```text
 HTTP GET to http://host/v2/lists/listRootNodeIri
 ```
 
@@ -18,7 +18,7 @@ The response to a list request is a `List` (see interface `List` in module `List
 In order to request a single node of a list, make a HTTP GET request to the `node` route, 
 appending the node's Iri (URL-encoded):
 
-```
+```text
 HTTP GET to http://host/v2/node/nodeIri
 ```
 

--- a/docs/03-endpoints/api-v2/knora-iris.md
+++ b/docs/03-endpoints/api-v2/knora-iris.md
@@ -37,14 +37,14 @@ Each internal ontology has an IRI, which is also the IRI of the named
 graph that contains the ontology in the triplestore. An internal
 ontology IRI has the form:
 
-```
+```text
 http://www.knora.org/ontology/PROJECT_SHORTCODE/ONTOLOGY_NAME
 ```
 
 For example, the internal ontology IRI based on project code `0001` and ontology
 name `example` would be:
 
-```
+```text
 http://www.knora.org/ontology/0001/example
 ```
 
@@ -75,7 +75,7 @@ human-readable documentation.
 
 The IRI of an external Knora ontology has the form:
 
-```
+```text
 http://HOST[:PORT]/ontology/PROJECT_SHORTCODE/ONTOLOGY_NAME/API_VERSION
 ```
 
@@ -154,7 +154,7 @@ affect other ontologies or data that are based on it.
 
 There is currently one project for shared ontologies:
 
-```
+```text
 http://www.knora.org/ontology/knora-base#DefaultSharedOntologiesProject
 ```
 

--- a/docs/03-endpoints/api-v2/ontology-information.md
+++ b/docs/03-endpoints/api-v2/ontology-information.md
@@ -24,7 +24,7 @@ Requests for ontology metadata can return information about more than one
 ontology, unlike other requests for ontology information. To get metadata
 about all ontologies:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/metadata
 ```
 
@@ -193,7 +193,7 @@ The response is in the complex API v2 schema. Sample response:
 To get metadata about the ontologies that belong to one or more particular
 projects:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/metadata/PROJECT_IRI[/PROJECT_IRI...]
 ```
 
@@ -224,7 +224,7 @@ Example response for the `anything` test project
 An ontology can be queried either by using an API route directly or by
 simply dereferencing the ontology IRI. The API route is as follows:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/allentities/ONTOLOGY_IRI
 ```
 
@@ -233,7 +233,7 @@ or the simple schema. The response will be in the same schema. For
 example, if the server is running on `0.0.0.0:3333`, you can request
 the `knora-api` ontology in the complex schema as follows:
 
-```
+```text
 HTTP GET to http://0.0.0.0:3333/v2/ontologies/allentities/http%3A%2F%2Fapi.knora.org%2Fontology%2Fknora-api%2Fv2
 ```
 
@@ -965,7 +965,7 @@ editing the value of a property. For more information on the
 
 To get the definition of a class, use the following route:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/classes/CLASS_IRI
 ```
 
@@ -1215,7 +1215,7 @@ Ontology updates always use the complex schema.
 
 An ontology is always created within a particular project.
 
-```
+```text
 HTTP POST to http://host/v2/ontologies
 ```
 
@@ -1239,7 +1239,7 @@ The ontology name must follow the rules given in
 The ontology metadata can have an optional comment given in the request 
 body as:
 
-```
+```json
 "rdfs:comment": "some comment",
 ``` 
 
@@ -1248,7 +1248,7 @@ created in the default shared ontologies project,
 `http://www.knora.org/ontology/knora-base#DefaultSharedOntologiesProject`,
 and the request must have this additional boolean property:
 
-```
+```json
 "knora-api:isShared" : true
 ```
 
@@ -1267,7 +1267,7 @@ be a valid XML [NCName](https://www.w3.org/TR/xml-names/#NT-NCName).
 One can modify an ontology's metadata by updating its `rdfs:label` or `rdfs:comment` 
 or both. The example below shows the request for changing the label of an ontology.
 
-```
+```text
 HTTP PUT to http://host/v2/ontologies/metadata
 ```
 
@@ -1312,7 +1312,7 @@ ontology's metadata.
 
 ### Deleting an Ontology's comment
 
-```
+```text
 HTTP DELETE to http://host/v2/ontologies/comment/ONTOLOGY_IRI?lastModificationDate=ONTOLOGY_LAST_MODIFICATION_DATE
 ```
 
@@ -1326,7 +1326,7 @@ updated metadata.
 
 An ontology can be deleted only if it is not used in data.
 
-```
+```text
 HTTP DELETE to http://host/v2/ontologies/ONTOLOGY_IRI?lastModificationDate=ONTOLOGY_LAST_MODIFICATION_DATE
 ```
 
@@ -1338,7 +1338,7 @@ confirmation message.
 
 To check whether an ontology can be deleted:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/candeleteontology/ONTOLOGY_IRI
 ```
 
@@ -1355,7 +1355,7 @@ The response will look like this:
 
 ### Creating a Class Without Cardinalities
 
-```
+```text
 HTTP POST to http://host/v2/ontologies/classes
 ```
 
@@ -1410,7 +1410,7 @@ This can work if the new class will have cardinalities for properties
 that have no `knora-api:subjectType`, or if the new class will be a
 subclass of their `knora-api:subjectType`.
 
-```
+```text
 HTTP POST to http://host/v2/ontologies/classes
 ```
 
@@ -1478,7 +1478,7 @@ definition (but not any of the other entities in the ontology).
 
 This operation is permitted even if the class is used in data.
 
-```
+```text
 HTTP PUT to http://host/v2/ontologies/classes
 ```
 
@@ -1519,7 +1519,7 @@ To get the current labels use the [class definition](#querying-class-definition)
 
 This operation is permitted even if the class is used in data.
 
-```
+```text
 HTTP PUT to http://host/v2/ontologies/classes
 ```
 
@@ -1561,7 +1561,7 @@ To get the current comments use the [class definition](#querying-class-definitio
 
 This operation is permitted even if the class is used in data.
 
-```
+```text
 HTTP DELETE to http://host/v2/ontologies/classes/comment/CLASS_IRI?lastModificationDate=ONTOLOGY_LAST_MODIFICATION_DATE
 ```
 
@@ -1573,7 +1573,7 @@ A successful response will be a JSON-LD document providing the class definition.
 
 ### Creating a Property
 
-```
+```text
 HTTP POST to http://host/v2/ontologies/properties
 ```
 
@@ -1664,7 +1664,7 @@ property definition (but not any of the other entities in the ontology).
 
 This operation is permitted even if the property is used in data.
 
-```
+```text
 HTTP PUT to http://host/v2/ontologies/properties
 ```
 
@@ -1702,7 +1702,7 @@ either as an object or as an array of objects.
 
 This operation is permitted even if the property is used in data.
 
-```
+```text
 HTTP PUT to http://host/v2/ontologies/properties
 ```
 
@@ -1740,7 +1740,7 @@ either as an object or as an array of objects.
 
 This operation is permitted even if the property is used in data.
 
-```
+```text
 HTTP DELETE to http://host/v2/ontologies/properties/comment/PROPERTY_IRI?lastModificationDate=ONTOLOGY_LAST_MODIFICATION_DATE
 ```
 
@@ -1756,7 +1756,7 @@ A successful response will be a JSON-LD document providing the property definiti
 
 This operation is permitted even if the property is used in data.
 
-```
+```text
 HTTP PUT to http://host/v2/ontologies/properties/guielement
 ```
 
@@ -1800,7 +1800,7 @@ the property definition, submit the request without those predicates.
 If the class (or any of its sub-classes) is used in data, 
 it is not allowed to add cardinalities `owl:minCardinality` greater than 0 or `owl:cardinality 1` to the class.
 
-```
+```text
 HTTP POST to http://host/v2/ontologies/cardinalities
 ```
 
@@ -1879,7 +1879,7 @@ A partial update of the ontology will not be performed.
     This means that currently it is necessary to maintain the cardinalities on all subproperties of a property 
     in sync with the cardinalities on the superproperty.
 
-```
+```text
 HTTP PUT to http://host/v2/ontologies/cardinalities
 ```
 
@@ -1927,7 +1927,7 @@ If any of the "Pre-Update Checks" fail the endpoint will respond with a _400 Bad
 The "Pre-Update Checks" are available on a dedicated endpoint.
 For a check whether a particular cardinality can be set on a class/property combination, use the following request:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/canreplacecardinalities/CLASS_IRI?propertyIri=PROPERTY_IRI&newCardinality=[0-1|1|1-n|0-n]
 ```
 
@@ -1981,7 +1981,7 @@ Success:
 
 To check whether all class's cardinalities can be replaced:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/canreplacecardinalities/CLASS_IRI
 ```
 
@@ -2005,7 +2005,7 @@ If a class is used in data, it is only allowed to delete a cardinality, if the
 property a cardinality refers to, is not used inside the data. Also, the property
 isn't allowed to be used inside the data in any subclasses of this class.
 
-```
+```text
 HTTP PATCH to http://host/v2/ontologies/cardinalities
 ```
 
@@ -2052,7 +2052,7 @@ definition (but not any of the other entities in the ontology).
 
 To check whether a class's cardinality can be deleted:
 
-```
+```text
 HTTP POST to http://host/v2/ontologies/candeletecardinalities
 ```
 
@@ -2071,7 +2071,7 @@ The response will look like this:
 
 To change the GUI order of one or more cardinalities in a class:
 
-```
+```text
 HTTP PUT to http://host/v2/ontologies/guiorder
 ```
 
@@ -2120,7 +2120,7 @@ are ignored; only the `GUI_ORDER_VALUE` is changed.
 A property can be deleted only if no other ontology entity refers to it,
 and if it is not used in data.
 
-```
+```text
 HTTP DELETE to http://host/v2/ontologies/properties/PROPERTY_IRI?lastModificationDate=ONTOLOGY_LAST_MODIFICATION_DATE
 ```
 
@@ -2136,7 +2136,7 @@ ontology's metadata.
 
 To check whether a property can be deleted:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/candeleteproperty/PROPERTY_IRI
 ```
 
@@ -2156,7 +2156,7 @@ The response will look like this:
 A class can be deleted only if no other ontology entity refers to it,
 and if it is not used in data.
 
-```
+```text
 HTTP DELETE to http://host/v2/ontologies/classes/CLASS_IRI?lastModificationDate=ONTOLOGY_LAST_MODIFICATION_DATE
 ```
 
@@ -2168,7 +2168,7 @@ ontology's metadata.
 
 To check whether a class can be deleted:
 
-```
+```text
 HTTP GET to http://host/v2/ontologies/candeleteclass/CLASS_IRI
 ```
 

--- a/docs/03-endpoints/api-v2/permalinks.md
+++ b/docs/03-endpoints/api-v2/permalinks.md
@@ -93,7 +93,7 @@ For details, see [Archival Resource Key (ARK) Identifiers](../../05-internals/de
 
 The format of a Knora project ARK URL is as follows:
 
-```
+```text
 http://HOST/ark:/NAAN/VERSION/PROJECT
 ```
 
@@ -105,7 +105,7 @@ and `PROJECT` is the project's [short-code](knora-iris.md#project-short-codes).
 For example, given a project with ID `0001`, and using the DaSCH's ARK resolver
 hostname and NAAN, the ARK URL for the project itself is:
 
-```
+```text
 http://ark.dasch.swiss/ark:/72163/1/0001
 ```
 
@@ -115,7 +115,7 @@ This could redirect to a page describing the project.
 
 The format of a Knora resource ARK URL is as follows:
 
-```
+```text
 http://HOST/ark:/NAAN/VERSION/PROJECT/RESOURCE_UUID[.TIMESTAMP]
 ```
 
@@ -129,13 +129,13 @@ For example, given the Knora resource IRI `http://rdfh.ch/0001/0C-0L1kORryKzJAJx
 and using the DaSCH's ARK resolver hostname and NAAN, the corresponding
 ARK URL without a timestamp is:
 
-```
+```text
 http://ark.dasch.swiss/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY
 ```
 
 The same ARK URL with an optional timestamp is:
 
-```
+```text
 http://ark.dasch.swiss/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY.20180604T085622513Z
 ```
 
@@ -146,7 +146,7 @@ resource at the time when the URL is resolved.
 
 The format of a Knora value ARK URL is as follows:
 
-```
+```text
 http://HOST/ark:/NAAN/VERSION/PROJECT/RESOURCE_UUID/VALUE_UUID[.TIMESTAMP]
 ```
 
@@ -161,13 +161,13 @@ For example, given a value with `knora-api:valueHasUUID "4OOf3qJUTnCDXlPNnygSzQ"
 `http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ`, and using the DaSCH's ARK resolver
 hostname and NAAN, the corresponding ARK URL without a timestamp is:
 
-```
+```text
 http://ark.dasch.swiss/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY/4OOf3qJUTnCDXlPNnygSzQX
 ```
 
 The same ARK URL with an optional timestamp is:
 
-```
+```text
 http://ark.dasch.swiss/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY/4OOf3qJUTnCDXlPNnygSzQX.20180604T085622513Z
 ```
 

--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -40,7 +40,7 @@ For a more detailed overview of Gravsearch, see
 
 The recommended way to submit a Gravsearch query is via HTTP POST:
 
-```
+```text
 HTTP POST to http://host/v2/searchextended
 ```
 
@@ -51,7 +51,7 @@ is sent unencoded as the HTTP request message body, in the UTF-8 charset.
 It is also possible to submit a Gravsearch query using HTTP GET. The entire
 query must be URL-encoded and included as the last element of the URL path:
 
-```
+```text
 HTTP GET to http://host/v2/searchextended/QUERY
 ```
 
@@ -61,7 +61,7 @@ formats (see [Responses Describing Resources](reading-and-searching-resources.md
 To request the number of results rather than the results themselves, you can
 do a count query:
 
-```
+```text
 HTTP POST to http://host/v2/searchextended/count
 ```
 
@@ -91,7 +91,7 @@ To write a query in the simple schema, use the `knora-api` ontology in
 the simple schema, and use the simple schema for any other DSP ontologies
 the query refers to, e.g.:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
 ```
@@ -105,7 +105,7 @@ To write a query in the complex schema, use the `knora-api` ontology in
 the complex schema, and use the complex schema for any other DSP ontologies
 the query refers to, e.g.:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
 ```
@@ -134,7 +134,7 @@ in its link value `incunabula:partOfValue`. But in case B is marked as the main 
 B does not have a link value pointing to A because in fact B is pointed to by A.
 Instead, B has a virtual property `knora-api:hasIncomingLink` containing A's link value:
 
-```
+```json
 "knora-api:hasIncomingLinkValue" : {
     "@id" : "http://rdfh.ch/A/values/xy",
     "@type" : "knora-api:LinkValue",
@@ -165,7 +165,7 @@ since B is the main resource.
 The dedicated endpoint for querying the incoming links was introduced in DSP-API
 version [v31.10.0](https://github.com/dasch-swiss/dsp-api/releases/tag/v31.10.0).
 
-```
+```text
 HTTP GET to http://host/v2/searchIncomingLinks/[resourceIri]?offset=[pageNumber]
 ```
 
@@ -175,7 +175,7 @@ must be URL-encoded and included as the last element of the URL path.
 Here is an example of the request for the resource `http://rdfh.ch/0001/a-thing-picture`
 with the page number 1:
 
-```
+```text
 http://host/v2/searchIncomingLinks/http%3A%2F%2Frdfh.ch%2F0001%2Fa-thing-picture?offset=1
 ```
 
@@ -285,7 +285,7 @@ must be represented as a query variable.
 In the simple schema, a variable representing a DSP-API value can be used
 directly in a `FILTER` expression. For example:
 
-```
+```sparql
 ?book incunabula:title ?title .
 FILTER(?title = "Zeitglöcklein des Lebens und Leidens Christi")
 ```
@@ -311,7 +311,7 @@ Note that in the simple schema, uniqueness is not guaranteed (as opposed to the 
 A DSP-API value may not be represented as the literal object of a predicate;
 for example, this is not allowed:
 
-```
+```sparql
 ?book incunabula:title "Zeitglöcklein des Lebens und Leidens Christi" .
 ```
 
@@ -321,7 +321,7 @@ In the complex schema, variables representing DSP-API values are not literals.
 You must add something to the query (generally a statement) to get a literal
 from a DSP-API value. For example:
 
-```
+```sparql
 ?book incunabula:title ?title .
 ?title knora-api:valueAsString "Zeitglöcklein des Lebens und Leidens Christi" .
 ```
@@ -330,7 +330,7 @@ Here the type of `?title` is `knora-api:TextValue`. Note that no `FILTER` is nee
 in this example. But if you want to use a different comparison operator,
 you need a `FILTER`:
 
-```
+```sparql
 ?page incunabula:seqnum ?seqnum .
 ?seqnum knora-api:intValueAsInt ?seqnumInt .
 FILTER(?seqnumInt <= 10)
@@ -347,7 +347,7 @@ available in Gravsearch.
 In the simple schema, you can compare a date value directly with a `knora-api:Date`
 in a `FILTER`:
 
-```
+```sparql
 ?book incunabula:pubdate ?pubdate .
 FILTER(?pubdate < "JULIAN:1497"^^knora-api:Date)
 ```
@@ -357,7 +357,7 @@ passing it the variable representing the date value. The date literal used
 in the comparison must still be a `knora-api:Date` in the simple schema.
 This is the only case in which you can use both schemas in a single query:
 
-```
+```sparql
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX knora-api-simple: <http://api.knora.org/ontology/knora-api/simple/v2#>
@@ -377,7 +377,7 @@ text markup (see [Matching Standoff Dates](#matching-standoff-dates)).
 
 Note that the given date value for comparison must have the following format: 
   
-```
+```text
 (GREGORIAN|JULIAN|ISLAMIC):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?
 ```
     
@@ -403,7 +403,7 @@ This function can only be used as the top-level expression in a `FILTER`.
 For example, to search for titles that contain the words 'Zeitglöcklein' and
 'Lebens':
 
-```
+```sparql
 ?book incunabule:title ?title .
 FILTER knora-api:matchText(?title, "Zeitglöcklein Lebens")
 ```
@@ -413,14 +413,14 @@ FILTER knora-api:matchText(?title, "Zeitglöcklein Lebens")
 To filter a text value by language in the simple schema, use the SPARQL `lang` function
 on the text value, e.g.:
 
-```
+```sparql
 FILTER(lang(?text) = "fr")
 ```
 
 In the complex schema, the `lang` function is not supported. Use the text
 value's `knora-api:textValueHasLanguage` predicate instead:
 
-```
+```sparql
 ?text knora-api:textValueHasLanguage "fr" .
 ```
 
@@ -430,7 +430,7 @@ The [SPARQL `regex` function](https://www.w3.org/TR/2013/REC-sparql11-query-2013
 is supported. In the simple schema, you can use it directly on the text value,
 e.g.
 
-```
+```sparql
 ?book incunabula:title ?title .
 FILTER regex(?title, "Zeit", "i")
 ```
@@ -438,7 +438,7 @@ FILTER regex(?title, "Zeit", "i")
 In the complex schema, use it on the object of the text value's
 `knora-api:valueAsString` predicate:
 
-```
+```sparql
 ?book incunabula:title ?title .
 ?title knora-api:valueAsString ?titleStr .
 FILTER regex(?titleStr, "Zeit", "i")
@@ -467,7 +467,7 @@ function takes three arguments:
 This function can only be used as the top-level expression in a `FILTER`.
 For example:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX standoff: <http://api.knora.org/ontology/standoff/v2#>
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
@@ -494,7 +494,7 @@ value containing a standoff link to another resource, the most efficient
 way is to use the property `knora-api:hasStandoffLinkTo`, whose subjects and objects
 are resources. This property is automatically maintained by the API. For example:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
 
@@ -525,7 +525,7 @@ use the function `knora-api:standoffLink`. It takes three arguments:
 This function can only be used as the top-level expression in a `FILTER`.
 For example:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX standoff: <http://api.knora.org/ontology/standoff/v2#>
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
@@ -556,7 +556,7 @@ in the search results, you need to add a statement like
 `?letter knora-api:hasStandoffLinkTo ?person .` to the `WHERE` clause and to the
 `CONSTRUCT` clause:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX standoff: <http://api.knora.org/ontology/standoff/v2#>
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
@@ -588,7 +588,7 @@ of one of its subclasses. For example, here we are looking for a text containing
 an `anything:StandoffEventTag` (which is a project-specific subclass of `knora-api:StandoffDateTag`)
 representing an event that occurred sometime during the month of December 2016:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
 PREFIX knora-api-simple: <http://api.knora.org/ontology/knora-api/simple/v2#>
@@ -614,7 +614,7 @@ tag. In that case, we can use the inferred property
 `knora-api:standoffTagHasStartAncestor`. We can modify the previous example to
 do this:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX standoff: <http://api.knora.org/ontology/standoff/v2#>
 PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
@@ -641,20 +641,20 @@ This can be done in the same ways in the simple or complex schema:
 
 Using a string literal object:
 
-```
+```sparql
 ?book rdfs:label "Zeitglöcklein des Lebens und Leidens Christi" .
 ```
 
 Using a variable and a FILTER:
 
-```
+```sparql
 ?book rdfs:label ?label .
 FILTER(?label = "Zeitglöcklein des Lebens und Leidens Christi")
 ```
 
 Using the `regex` function:
 
-```
+```sparql
 ?book rdfs:label ?bookLabel .
 FILTER regex(?bookLabel, "Zeit", "i")
 ```
@@ -663,7 +663,7 @@ To match words in an `rdfs:label` using the full-text search index, use the
 `knora-api:matchLabel` function, which works like `knora-api:matchText`,
 except that the first argument is a variable representing a resource:
 
-```
+```sparql
 FILTER knora-api:matchLabel(?book, "Zeitglöcklein")
 ```
 
@@ -673,7 +673,7 @@ A `FILTER` can compare a variable with another variable or IRI
 representing a resource. For example, to find a letter whose
 author and recipient are different persons:
 
-```
+```sparql
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 
@@ -692,7 +692,7 @@ OFFSET 0
 
 To find a letter whose author is not a person with a specified IRI:
 
-```
+```sparql
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 
@@ -750,7 +750,7 @@ different types of compound resources defined in different ontologies).
 
 `OFFSET` is set to 0 to get the first page of results.
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 
 CONSTRUCT {
@@ -785,7 +785,7 @@ Let's assume the client is not interested in all of the book's pages,
 but just in first ten of them. In that case, the sequence number can be
 restricted using a `FILTER` that is added to the query's `WHERE` clause:
 
-```
+```sparql
 FILTER (?seqnum <= 10)
 ```
 
@@ -795,7 +795,7 @@ the first ten pages are returned.
 This query would be exactly the same in the complex schema, except for
 the expansion of the `knora-api` prefix:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 ```
 
@@ -804,7 +804,7 @@ PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 Here we are looking for regions of pages that are part of books that have a
 particular title. In the simple schema:
 
-```
+```sparql
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 
@@ -830,7 +830,7 @@ CONSTRUCT {
 
 In the complex schema:
 
-```
+```sparql
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 
@@ -865,7 +865,7 @@ Here the IRI of the main resource is already known and we want specific informat
 about it, as well as about related resources. In this case, the IRI of the main
 resource must be assigned to a variable using `BIND`:
 
-```
+```sparql
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 
@@ -891,7 +891,7 @@ CONSTRUCT {
 This query would be the same in the complex schema, except for the prefix
 expansions:
 
-```
+```sparql
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 ```
@@ -902,7 +902,7 @@ Since list nodes are represented by their IRI in the complex schema,
 uniqueness is guranteed (as opposed to the simple schema).
 Also all the subnodes of the given list node are considered a match.
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
 
@@ -936,7 +936,7 @@ or the subject's specific type (if it is a value).
 
 For example, consider this query that uses a non-DSP property:
 
-```
+```sparql
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -952,7 +952,7 @@ CONSTRUCT {
 
 This produces the error message:
 
-```
+```text
 The types of one or more entities could not be determined:
   ?book, <http://purl.org/dc/terms/title>, ?title
 ```
@@ -961,7 +961,7 @@ To solve this problem, it is enough to specify the types of `?book` and
 `?title`; the type of the expected object of `dcterms:title` can then be inferred
 from the type of `?title`.
 
-```
+```sparql
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -983,7 +983,7 @@ CONSTRUCT {
 It would also be possible to annotate the property itself, using the predicate `knora-api:objectType`;
 then the type of `?title` would be inferred:
 
-```
+```sparql
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -1007,7 +1007,7 @@ its object is supposed to be a literal.
 
 Here is another example, using a non-DSP class:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
@@ -1022,13 +1022,13 @@ CONSTRUCT {
 
 This produces the error message:
 
-```
+```text
 Types could not be determined for one or more entities: ?person
 ```
 
 The solution is to specify that `?person` is a `knora-api:Resource`:
 
-```
+```sparql
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
@@ -1047,7 +1047,7 @@ CONSTRUCT {
 Gravsearch will also reject a query if an entity is used with inconsistent types.
 For example:
 
-```
+```sparql
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 
@@ -1064,7 +1064,7 @@ CONSTRUCT {
 
 This returns the error message:
 
-```
+```text
 One or more entities have inconsistent types:
 
 <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#pubdate>
@@ -1079,7 +1079,7 @@ This is because the `incunabula` ontology says that the object of `incunabula:pu
 but the `FILTER` expression compares `?pubdate` with an `xsd:string`. The solution is to specify the
 type of the literal in the `FILTER`:
 
-```
+```sparql
 PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 

--- a/docs/03-endpoints/api-v2/reading-and-searching-resources.md
+++ b/docs/03-endpoints/api-v2/reading-and-searching-resources.md
@@ -96,7 +96,7 @@ server's test data), make a HTTP GET request to the `resources`
 route (path segment `resources` in the API call) and append the
 URL-encoded IRI:
 
-```
+```text
 HTTP GET to http://host/v2/resources/http%3A%2F%2Frdfh.ch%2Fc5058f3a
 ```
 
@@ -107,7 +107,7 @@ can be queried in one requested is limited. See the settings for
 
 More formally, the URL looks like this:
 
-```
+```text
 HTTP GET to http://host/v2/resources/resourceIRI(/anotherResourceIri)*
 ```
 
@@ -138,7 +138,7 @@ same timestamp.
 
 To get a specific value of a resource, use this route:
 
-```
+```text
 HTTP GET to http://host/v2/values/resourceIRI/valueUUID
 ```
 
@@ -175,7 +175,7 @@ its **current** version
 To get a list of the changes that have been made to a resource since its creation,
 use this route:
 
-```
+```text
 HTTP GET to http://host/v2/resources/history/resourceIRI[?startDate=START_DATE&endDate=END_DATE]
 ```
 
@@ -245,7 +245,7 @@ and type), without its values.
 This works exactly like making a conventional resource request, using
 the path segment `resourcespreview`:
 
-```
+```text
 HTTP GET to http://host/v2/resourcespreview/resourceIRI(/anotherResourceIri)*
 ```
 
@@ -253,7 +253,7 @@ HTTP GET to http://host/v2/resourcespreview/resourceIRI(/anotherResourceIri)*
 
 DSP can return a graph of connections between resources, e.g. for generating a network diagram.
 
-```
+```text
 HTTP GET to http://host/v2/graph/resourceIRI[depth=Integer]
 [direction=outbound|inbound|both][excludeProperty=propertyIri]
 ```
@@ -349,7 +349,7 @@ syntax need to be escaped. If a user wants to search for the string "Zeit-Glöck
 needs to type "Zeit\-Glöcklein". The special characters that need escaping are: 
 `+`, `-`, `&`, `|`, `!`, `(`, `)`, `[`, `]`, `{`, `}`, `^`, `"`, `~`, `*`, `?`, `:`, `\`, `/`
 
-```
+```text
 HTTP GET to http://host/v2/searchbylabel/searchValue[limitToResourceClass=resourceClassIRI]
 [limitToProject=projectIRI][offset=Integer]
 ```
@@ -367,7 +367,7 @@ For performance reasons, standoff markup is not queried for this route.
 To request the number of results rather than the results themselves, you can
 do a count query:
 
-```
+```text
 HTTP GET to http://host/v2/searchbylabel/count/searchValue[limitToResourceClass=resourceClassIRI][limitToProject=projectIRI][offset=Integer]
 ```
 
@@ -397,7 +397,7 @@ are converted into their ASCII equivalents, if one exists, e.g. `é` or `ä` are
 
 Please note that the search terms have to be URL-encoded.
 
-```
+```text
 HTTP GET to http://host/v2/search/searchValue[limitToResourceClass=resourceClassIRI]
 [limitToStandoffClass=standoffClassIri][limitToProject=projectIRI][offset=Integer]
 ```
@@ -411,13 +411,13 @@ A search term may contain wildcards. A `?` represents a single character.
 It has to be URL-encoded as `%3F` since it has a special meaning in the URL syntax. 
 For example, the term `Uniform` can be search for like this:
 
-```
+```text
 HTTP GET to http://host/v2/search/Unif%3Frm
 ```
 
 A `*` represents zero, one or multiple characters. For example, the term `Uniform` can be searched for like this:
 
-```
+```text
 HTTP GET to http://host/v2/search/Uni*m
 ```
 
@@ -435,7 +435,7 @@ file value attached to each matching resource.
 To request the number of results rather than the results themselves, you can
 do a count query:
 
-```
+```text
 HTTP GET to http://host/v2/search/count/searchValue[limitToResourceClass=resourceClassIRI][limitToStandoffClass=standoffClassIri][limitToProject=projectIRI][offset=Integer]
 ```
 
@@ -462,7 +462,7 @@ To generate a IIIF manifest for a resource, containing
 the still image representations that have `knora-api:isPartOf` (or a subproperty)
 pointing to that resource:
 
-```
+```text
 HTTP GET to http://host/v2/resources//iiifmanifest/RESOURCE_IRI
 ```
 
@@ -472,7 +472,7 @@ To facilitate the development of tabular user interfaces for data entry, it is
 possible to get a paged list of all the resources belonging to a particular
 class in a given project, sorted by the value of a property:
 
-```
+```text
 HTTP GET to http://host/v2/resources?resourceClass=RESOURCE_CLASS_IRI&page=PAGE[&orderByProperty=PROPERTY_IRI]
 ```
 
@@ -496,7 +496,7 @@ in [Gravsearch](query-language.md)).
 To get a list of the changes that have been made to a resource and its values since its creation as events ordered by 
 date:
 
-```
+```text
 HTTP GET to http://host/v2/resources/resourceHistoryEvents/<resourceIRI>
 ```
 
@@ -638,7 +638,7 @@ payload needed to update the value of the resource's `lastModificationDate`, see
 To get a list of the changes that have been made to the resources and their values of a project as events ordered by 
 date:
 
-```
+```text
 HTTP GET to http://host/v2/resources/projectHistoryEvents/<projectIRI>
 ```
 

--- a/docs/03-endpoints/api-v2/text/custom-standoff.md
+++ b/docs/03-endpoints/api-v2/text/custom-standoff.md
@@ -229,7 +229,7 @@ are missing: what is the meaning of the date?). In the example above,
 the standoff class is `anything:StandoffEventTag` which has the
 following definition in the ontology `anything-onto.ttl`:
 
-```
+```turtle
 anything:StandoffEventTag rdf:type owl:Class ;
 
     rdfs:subClassOf knora-base:StandoffDateTag,
@@ -428,13 +428,13 @@ by DSP-API.
 The mapping has to be sent as a multipart request to the standoff route
 using the path segment `mapping`:
 
-```
+```text
 HTTP POST http://host/v2/mapping
 ```
 
 The multipart request consists of two named parts:
 
-```
+```json
 "json":
 
   {

--- a/docs/03-endpoints/api-v2/text/tei-xml.md
+++ b/docs/03-endpoints/api-v2/text/tei-xml.md
@@ -22,7 +22,7 @@ DSP-API offers a built-in conversion form standard standoff entities (defined in
 In order to obtain a resource as a TEI document, the following request has to be performed. 
 Please note that the URL parameters have to be URL-encoded.
 
-```
+```text
 HTTP GET to http://host/v2/tei/resourceIri?textProperty=textPropertyIri
 ```
 
@@ -34,7 +34,7 @@ The test data contain the resource `http://rdfh.ch/0001/thing_with_richtext_with
 with the text property `http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext` 
 that can be converted to TEI as follows:
 
-```
+```text
 HTTP GET to http://host/v2/tei/http%3A%2F%2Frdfh.ch%2F0001%2Fthing_with_richtext_with_markup?textProperty=http%3A%2F%2F0.0.0.0%3A3333%2Fontology%2F0001%2Fanything%2Fv2%23hasRichtext
 ```
 
@@ -113,7 +113,7 @@ The Gravsearch template is a simple text file with the files extension `.txt`.
 
 A Gravsearch template may look like this (see `test_data/test_route/texts/beol/gravsearch.txt`):
 
-```
+```sparql
 PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -439,6 +439,6 @@ You can use the functions `knora-api:iaf` and `knora-api:dateformat` in your own
 
 The complete request looks like this:
 
-```
+```text
 HTTP GET request to http://host/v2/tei/resourceIri&textProperty=textPropertyIri&mappingIri=mappingIri&gravsearchTemplateIri=gravsearchTemplateIri&teiHeaderXSLTIri=teiHeaderXSLTIri
 ```

--- a/docs/03-endpoints/instrumentation/metrics.md
+++ b/docs/03-endpoints/instrumentation/metrics.md
@@ -44,14 +44,14 @@ to replace dynamic path segments with slugs (e.g. `/projects/shortcode/0000` wit
 Like this, requesting different projects by identifier will add multiple values to the histogram of a single route,
 instead of creating a histogram for each project:
 
-```
+```text
 zio_http_request_duration_seconds_bucket{method="GET",path="/admin/projects/shortcode/:shortcode",status="200",le="0.005"} 0.0 1676481606015
 ...
 ```
 
 Instead of:
 
-```
+```text
 zio_http_request_duration_seconds_bucket{method="GET",path="/admin/projects/shortcode/0000",status="200",le="0.005"} 0.0 1676481606015
 zio_http_request_duration_seconds_bucket{method="GET",path="/admin/projects/shortcode/0001",status="200",le="0.005"} 0.0 1676481606015
 ...

--- a/docs/08-faq/index.md
+++ b/docs/08-faq/index.md
@@ -55,7 +55,7 @@ about the subjects and objects of properties, rather than to enforce restriction
 This is, in fact, what RDFS reasoners do in practice. For example, consider these
 statements:
 
-```
+```turtle
 example:hasAuthor rdfs:range example:Person .
 data:book1 example:hasAuthor data:oxygen .
 ```

--- a/docs/development/dsp-api-value-types.md
+++ b/docs/development/dsp-api-value-types.md
@@ -1,0 +1,112 @@
+# Value Types
+
+A Value Object is an object that measures, quantifies, or describes a concept in your domain model. 
+Validated, type-safe wrappers for primitive values exist. 
+For example `StringValue` guarantees that its content passed validation at construction time, 
+so downstream code can use it without re-checking.
+Use value types to make the domain model type-safe.
+
+## Core hierarchy
+
+```text
+Value[A]            — base trait, provides `def value: A` and `toString` delegating to `value`
+├── StringValue     — type alias for Value[String]
+├── IntValue        — type alias for Value[Int]
+└── BooleanValue    — type alias for Value[Boolean]
+```
+
+Defined in `webapi/src/main/scala/org/knora/webapi/slice/common/ValueTypes.scala`.
+
+## Defining a StringValue
+
+A minimal definition has two parts — a case class with a private constructor and a
+companion extending `StringValueCompanion`:
+
+```scala
+final case class Shortcode private (override val value: String) extends StringValue
+
+object Shortcode extends StringValueCompanion[Shortcode] {
+  private val shortcodeRegex: Regex = "^\\p{XDigit}{4}$".r
+
+  def from(value: String): Either[String, Shortcode] = value match {
+    case v if shortcodeRegex.matches(v.toUpperCase) => Right(Shortcode(v.toUpperCase()))
+    case _ => Left(s"Shortcode is invalid: $value")
+  }
+}
+```
+
+What you get for free:
+
+| Method       | Source        | Behaviour                                                  |
+|--------------|---------------|------------------------------------------------------------|
+| `from`       | You implement | Validates and returns `Either[String, A]`                  |
+| `unsafeFrom` | `WithFrom`    | Calls `from`, throws `IllegalArgumentException` on `Left`  |
+| `toString`   | `Value[A]`    | Returns `value.toString` — the raw string                  |
+
+The private constructor ensures every instance went through `from` (or `unsafeFrom`).
+
+## Extra parsed fields
+
+When the raw string contains structure worth exposing, parse it once in `from` and store
+the parts as additional fields:
+
+```scala
+final case class ResourceIri private (
+  override val value: String,
+  shortcode: Shortcode,
+  resourceId: ResourceId,
+) extends StringValue
+
+object ResourceIri extends StringValueCompanion[ResourceIri] {
+  private val ResourceIriRegex: Regex =
+    """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r
+
+  def from(value: String): Either[String, ResourceIri] = value match {
+    case ResourceIriRegex(sc, id) =>
+      Right(ResourceIri(value, Shortcode.unsafeFrom(sc), ResourceId.unsafeFrom(id)))
+    case _ => Left(s"<$value> is not a Knora resource IRI")
+  }
+}
+```
+
+The `unsafeFrom` calls inside `from` are safe because the regex already guarantees the
+sub-parts are valid.
+
+## Validation combinators
+
+`StringValueCompanion` provides reusable checks that can be composed with
+`fromValidations`:
+
+```scala
+object Description extends StringValueCompanion[Description] {
+  def from(value: String): Either[String, Description] =
+    fromValidations("Description", Description.apply, value)(nonEmpty, maxLength(500), noLineBreaks)
+}
+```
+
+Available combinators: `nonEmpty`, `noLineBreaks`, `maxLength(n)`, `isUri`, `absoluteUri`.
+
+## String interpolation
+
+Because `Value[A].toString` returns `value.toString`, a `StringValue` can be dropped
+directly into string interpolation without calling `.value`:
+
+```scala
+val resourceIri: ResourceIri = ...
+val valueId: ValueId = ...
+
+// toString is called implicitly — these are equivalent:
+s"$resourceIri/values/$valueId"
+s"${resourceIri.value}/values/${valueId.value}"
+uri"/v3/projects/$project/"
+```
+
+This is particularly useful in URI, IRI construction and SPARQL query building where IRIs are
+composed from validated parts:
+
+```scala
+def makeNew(resourceIri: ResourceIri): ValueIri = {
+  val id = ValueId.makeNew
+  unsafeFrom(s"$resourceIri/values/$id")
+}
+```


### PR DESCRIPTION
Add Value Types and SPARQL/Gravsearch queries development guides. 

Introduce  `/fix-markdownlint` skill to match CI run. 

Exclude markdown checks from Codacy's analysis, the markdownlint should be the only check.