### PR TITLE
fix(docker): fix dsp-api healthcheck curl missing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -242,7 +242,7 @@ lazy val webapi: Project = Project(id = "webapi", base = file("webapi"))
     ).collect { case (key, Some(value)) => (key, value) },
     dockerCommands += Cmd(
       "RUN",
-      "apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*",
+      "apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*",
     ), // install jq for container healthcheck
     dockerCommands += Cmd(
       """HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=30s \


### PR DESCRIPTION
<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->

### Description

<!-- Please add a short description of the changes -->
PR https://github.com/dasch-swiss/dsp-api/pull/4075 updated the dsp-api base image which no longer has `curl` installed by default, but we need `curl` for the healthcheck, so healthcheck is currently broken and deployment to dev.dasch.swiss fails:
```json
{
    "Start": "2026-04-14T12:02:04.47705805Z",
    "End": "2026-04-14T12:02:04.565365619Z",
    "ExitCode": 1,
    "Output": "Health route is not responding\n/opt/docker/scripts/healthcheck.sh: line 4: curl: command not found\n"
}
```
This PR installs `curl` to restore healthcheck functionatlity.

<!-- * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->

<!-- * **What is the current behavior?** (You can also link to an open issue here) -->

<!-- * **What is the new behavior (if this is a feature change)?** -->

<!-- * **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?) -->

<!-- * **Other information**: -->
