### PR TITLE
chore: Remove unused CLEAN_TMP_DIR env vars from Sipi config (DEV-5090)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,6 @@ services:
       - SIPI_WEBAPI_PORT=3333
       - KNORA_WEBAPI_KNORA_API_EXTERNAL_HOST=0.0.0.0
       - KNORA_WEBAPI_KNORA_API_EXTERNAL_PORT=3333
-      - CLEAN_TMP_DIR_USER=clean_tmp_dir_user
-      - CLEAN_TMP_DIR_PW=clean_tmp_dir_pw
     # entrypoint: [ "valgrind", "--leak-check=yes", "/sipi/sipi" ] ## uncomment to run SIPI under valgrind
     # command: --config=/sipi/config/sipi.docker-test-config.lua ## command variant to start the sipi container with test routes enabled
     command: --config=/sipi/config/sipi.docker-config.lua

--- a/modules/testkit/src/main/scala/org/knora/webapi/testcontainers/SipiTestContainer.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testcontainers/SipiTestContainer.scala
@@ -68,8 +68,6 @@ object SipiTestContainer {
       .withEnv("SIPI_EXTERNAL_PORT", "1024")
       .withEnv("SIPI_WEBAPI_HOSTNAME", SipiTestContainer.localHostAddress)
       .withEnv("SIPI_WEBAPI_PORT", "3333")
-      .withEnv("CLEAN_TMP_DIR_USER", "clean_tmp_dir_user")
-      .withEnv("CLEAN_TMP_DIR_PW", "clean_tmp_dir_pw")
       .withCommand("--config=/sipi/config/sipi.docker-config.lua")
       .withClasspathResourceMapping(
         "/sipi.docker-config.lua",


### PR DESCRIPTION
## Summary

- Remove `CLEAN_TMP_DIR_USER` and `CLEAN_TMP_DIR_PW` env vars from `docker-compose.yml` and `SipiTestContainer.scala`
- The clean_tmp_dir Sipi endpoint these vars supported was already removed; the cron job inside the Sipi container that called it no longer exists