### PR TITLE
chore(deps): bump sipi to v4.1.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
   val fusekiImage = "daschswiss/apache-jena-fuseki:5.5.0-2"
   // base image the knora-sipi image is created from
-  val sipiImage = "daschswiss/sipi:v4.0.1"
+  val sipiImage = "daschswiss/sipi:v4.1.0"
 
   val ScalaVersion = "3.3.7"
 


### PR DESCRIPTION
## Summary

Bumps the `daschswiss/sipi` base image from `v4.0.1` to `v4.1.0` in `project/Dependencies.scala`. The version is used as the `dockerBaseImage` for `daschswiss/knora-sipi` and is embedded in `BuildInfo.knoraSipiVersion` (consumed by the ingest service's local-dev docker invocation).

Upstream changes in [sipi v4.1.0](https://github.com/dasch-swiss/sipi/releases/tag/v4.1.0):

- `fix`: resilient JPEG metadata + YCCK + CMYK APP14 + XMP scanner (DEV-6250, DEV-6257, DEV-6259)
- `fix`: support 1-bit bilevel TIFF (DEV-6249)
- `feat`: `--json` CLI flag for structured output (opt-in — not consumed in this PR)
- `build`: sipi migrated its own build to Nix end-to-end (internal to sipi, no effect on the published container)

No breaking changes — no config format changes, no new required env vars, no entrypoint changes.

## Test plan

- [x] CI — full build and test suite on the PR
- [ ] `sbt compile` (verified locally)
- [ ] `sbt "testOnly *CommandExecutorLiveSpec*"` (verified locally — passes; asserts the embedded version string)
- [ ] `make docker-build-sipi-image` (CI)
- [ ] Integration tests pinned to exact version: `SIPI_USE_EXACT_VERSION=true make test-it` (CI)

## Follow-up

A draft PR will adopt the new `--json` flag in the ingest service to surface structured error messages from sipi CLI failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)