### PR TITLE
feat(sipi)!: adopt v5.0.0 (CLI subcommands + distroless base)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -287,7 +287,13 @@ jobs:
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
         with:
           java-version: ${{ env.JAVA_VERSION }}
-      - name: Build image locally
-        run: make docker-build-dsp-api-image
+      - name: Build images locally
+        # Build both knora-api and knora-sipi so docker compose picks up the
+        # PR's images. The registry's :latest for knora-sipi lags by a merge,
+        # which matters across major Sipi base-image bumps (e.g. v4 -> v5
+        # changed CLI surface and the compose `command:`).
+        run: |
+          make docker-build-dsp-api-image
+          make docker-build-sipi-image
       - name: Spin up the API container and wait for all healthchecks (incl. db and sipi) to pass
         run: docker compose up --wait api

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -175,6 +175,11 @@ jobs:
           if echo "$CHANGED" | grep -q "^fuseki/"; then
             make docker-build-fuseki-image
           fi
+      - name: Build sipi image locally
+        # `SipiTestContainer` runs `daschswiss/knora-sipi:latest`. The registry
+        # version lags the PR; build the PR's version locally so the CLI surface
+        # matches (relevant across major Sipi base bumps, e.g. v4 -> v5).
+        run: make docker-build-sipi-image
       - name: Run end-to-end tests
         run: ./sbtx -v coverage "test-e2e/test" coverageAggregate
       - name: WebApi E2E Test Report

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import com.typesafe.sbt.SbtNativePackager.autoImport.NativePackagerHelper.*
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.Docker
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerRepository
 import com.typesafe.sbt.packager.docker.Cmd
+import com.typesafe.sbt.packager.docker.DockerPermissionStrategy
+import com.typesafe.sbt.packager.docker.DockerStageBreak
 import com.typesafe.sbt.packager.docker.ExecCmd
 import sbt.*
 import sbt.Keys.version
@@ -112,41 +114,52 @@ addCommandAlias("test-e2e", "test-e2e/test")
 // DSP's custom SIPI
 //////////////////////////////////////
 
+// Sipi v5.0.0 ships a distroless `daschswiss/sipi` image (rules_oci on
+// distroless_base) with the static binary at `/sbin/sipi` and the runtime
+// tree at `/sipi/{config,scripts,server,images,cache}`. This subproject is a
+// thin overlay: COPY our Lua scripts on top of `/sipi/scripts/` and set an
+// exec-form HEALTHCHECK that uses `sipi health` (no curl, no shell).
+//
+// We override `Docker / dockerCommands` wholesale because the plugin's
+// default JVM scaffolding (USER/WORKDIR/useradd/chmod/ADD universal-staging/
+// ENTRYPOINT) is irrelevant for an overlay-only image and depends on a
+// shell that distroless doesn't ship. `dockerPermissionStrategy := None`
+// makes the no-chmod intent explicit. No `USER` directive is emitted —
+// the container inherits root from the upstream base because Sipi reads
+// NFS-mounted assets owned by orchestrator-controlled uids.
 lazy val sipi: Project = Project(id = "sipi", base = file("sipi"))
   .enablePlugins(DockerPlugin)
   .settings(
-    Compile / packageDoc / mappings := Seq(),
-    Compile / packageSrc / mappings := Seq(),
-    Docker / dockerRepository       := Some("daschswiss"),
-    Docker / packageName            := "knora-sipi",
-    dockerUpdateLatest              := true,
-    dockerBaseImage                 := Dependencies.sipiImage,
-    dockerBuildxPlatforms           := Seq("linux/arm64/v8", "linux/amd64"),
-    Docker / maintainer             := "support@dasch.swiss",
+    Compile / packageDoc / mappings   := Seq(),
+    Compile / packageSrc / mappings   := Seq(),
+    Docker / dockerRepository         := Some("daschswiss"),
+    Docker / packageName              := "knora-sipi",
+    Docker / maintainer               := "support@dasch.swiss",
+    dockerUpdateLatest                := true,
+    dockerBuildxPlatforms             := Seq("linux/arm64/v8", "linux/amd64"),
+    Docker / dockerPermissionStrategy := DockerPermissionStrategy.None,
+    // Already declared on the upstream `daschswiss/sipi` OCI image; we
+    // re-declare here so sbt-native-packager's validation reports happy.
     Docker / dockerExposedPorts ++= Seq(1024),
-    Docker / defaultLinuxInstallLocation := "/sipi",
-    Universal / mappings ++= {
-      directory("sipi/scripts")
+    // Stage our Lua scripts into the Docker build context at scripts/<name>.
+    Docker / mappings := directory("sipi/scripts").map { case (f, _) =>
+      f -> s"scripts/${f.getName}"
     },
-    dockerCommands += Cmd(
-      """HEALTHCHECK --interval=30s --timeout=30s --retries=4 --start-period=30s \
-        |CMD bash /sipi/scripts/healthcheck.sh || exit 1""".stripMargin,
+    Docker / dockerCommands := Seq(
+      Cmd("FROM", Dependencies.sipiImage),
+      Cmd("LABEL", "maintainer=support@dasch.swiss"),
+      Cmd("COPY", "scripts/", "/sipi/scripts/"),
+      Cmd("EXPOSE", "1024"),
+      Cmd(
+        "HEALTHCHECK",
+        "--interval=30s",
+        "--timeout=10s",
+        "--retries=3",
+        "--start-period=30s",
+        "CMD",
+        """["/sbin/sipi", "health", "--port", "1024"]""",
+      ),
     ),
-    // use filterNot to return all items that do NOT meet the criteria
-    dockerCommands := dockerCommands.value.filterNot {
-
-      // ExecCmd is a case class, and args is a varargs variable, so you need to bind it with @
-      // remove ENTRYPOINT
-      case ExecCmd("ENTRYPOINT", args @ _*) => true
-
-      // remove CMD
-      case ExecCmd("CMD", args @ _*) => true
-
-      case Cmd("USER", args @ _*) => true
-
-      // don't filter the rest; don't filter out anything that doesn't match a pattern
-      case cmd => false
-    },
   )
 
 //////////////////////////////////////
@@ -464,26 +477,36 @@ lazy val ingest = {
         "dev.zio" %% "zio-logging"               % ZioLoggingVersion,
         "dev.zio" %% "zio-logging-slf4j2-bridge" % ZioLoggingVersion,
       ) ++ ingestTest,
-      testFrameworks                       := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
-      Docker / dockerRepository            := Some("daschswiss"),
-      Docker / packageName                 := "dsp-ingest",
-      dockerExposedPorts                   := Seq(3340),
+      testFrameworks            := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
+      Docker / dockerRepository := Some("daschswiss"),
+      Docker / packageName      := "dsp-ingest",
+      dockerExposedPorts        := Seq(3340),
+      // Kept at /sipi: dsp-ingest's app tree at /sipi/{bin,lib,conf}
+      // doesn't collide with the Sipi runtime tree at
+      // /sipi/{config,scripts,server,images,cache} — disjoint subfolder
+      // names merge cleanly under /sipi/ via Docker's `COPY` semantics.
       Docker / defaultLinuxInstallLocation := "/sipi",
       dockerUpdateLatest                   := true,
-      dockerBaseImage                      := s"daschswiss/knora-sipi:$knoraSipiVersion",
-      dockerBuildxPlatforms                := Seq("linux/arm64/v8", "linux/amd64"),
+      // Was: s"daschswiss/knora-sipi:$knoraSipiVersion". Sipi v5.0.0 is
+      // distroless (no apt-get, no chmod), so we can't keep deriving from
+      // it. Move to a Debian + Temurin 25 JRE base that matches knora-api
+      // (build.sbt:233) and extract the Sipi runtime via a multi-stage
+      // COPY --from=sipi-source below.
+      dockerBaseImage       := "eclipse-temurin:25-jre-noble",
+      dockerBuildxPlatforms := Seq("linux/arm64/v8", "linux/amd64"),
+      // Exec-form HEALTHCHECK. `eclipse-temurin:25-jre-noble` doesn't ship
+      // curl, but we extract the static `/sbin/sipi` binary below. `sipi
+      // health` probes `http://127.0.0.1:<port>/health` and exits 0/1 — the
+      // exact contract dsp-ingest's /health endpoint already satisfies, so
+      // we reuse the binary we already need instead of apt-installing curl.
       dockerCommands += Cmd(
-        """HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=30s \
-          |CMD curl -sS --fail 'http://localhost:3340/health' || exit 1""".stripMargin,
-      ),
-      // Install Temurin Java 25 https://adoptium.net/de/installation/linux/
-      dockerCommands += Cmd(
-        "RUN",
-        "apt-get update && apt install -y wget apt-transport-https gpg && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null",
-      ),
-      dockerCommands += Cmd(
-        "RUN",
-        "echo \"deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main\" | tee /etc/apt/sources.list.d/adoptium.list && apt-get update && apt-get install -y temurin-25-jre && rm -rf /var/lib/apt/lists/*",
+        "HEALTHCHECK",
+        "--interval=30s",
+        "--timeout=10s",
+        "--retries=3",
+        "--start-period=30s",
+        "CMD",
+        """["/sbin/sipi", "health", "--port", "3340"]""",
       ),
       // Add Opentelemetry java agent and Grafana Pyroscope extension
       dockerCommands += Cmd(
@@ -500,9 +523,34 @@ lazy val ingest = {
       // to avoid duplicate spans (dsp-ingest traces these manually via sttp4 tracing backend and ZIO middleware)
       dockerCommands += Cmd("ENV", """OTEL_INSTRUMENTATION_JAVA_HTTP_CLIENT_ENABLED="false""""),
       dockerCommands += Cmd("ENV", """OTEL_INSTRUMENTATION_NETTY_ENABLED="false""""),
-      dockerCommands := dockerCommands.value.filterNot {
-        case Cmd("USER", args @ _*) => true
-        case cmd                    => false
+      // Single transformation that combines three responsibilities:
+      //   1. Strip the plugin-default `USER` directive — Sipi reads NFS-
+      //      mounted assets owned by orchestrator-controlled uids, so the
+      //      container runs as root (uid=0). See knora-api at line 268
+      //      and the original filterNot block this replaces.
+      //   2. Prepend a Sipi-extraction builder stage. Sipi v5's binary is
+      //      static and the runtime tree is just files, so they can be
+      //      COPY --from=`-extracted onto any base image.
+      //   3. Append COPY --from=sipi-source directives so they land
+      //      inside the runtime stage (after the plugin's default
+      //      MultiStage stage0 → final-stage chown chain).
+      Docker / dockerCommands := {
+        val cmds = (Docker / dockerCommands).value.filterNot {
+          case Cmd("USER", _*) => true
+          case _               => false
+        }
+        val sipiSourceStage = Seq(
+          Cmd("FROM", s"daschswiss/knora-sipi:$knoraSipiVersion", "AS", "sipi-source"),
+          DockerStageBreak,
+        )
+        val copyFromSipi = Seq(
+          Cmd("COPY", "--from=sipi-source", "/sbin/sipi", "/sbin/sipi"),
+          Cmd("COPY", "--from=sipi-source", "/sipi", "/sipi"),
+          Cmd("COPY", "--from=sipi-source", "/usr/bin/tini", "/usr/bin/tini"),
+          Cmd("COPY", "--from=sipi-source", "/usr/bin/ffmpeg", "/usr/bin/ffmpeg"),
+          Cmd("COPY", "--from=sipi-source", "/usr/bin/ffprobe", "/usr/bin/ffprobe"),
+        )
+        sipiSourceStage ++ cmds ++ copyFromSipi
       },
     )
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,9 +65,16 @@ services:
       - SIPI_WEBAPI_PORT=3333
       - KNORA_WEBAPI_KNORA_API_EXTERNAL_HOST=0.0.0.0
       - KNORA_WEBAPI_KNORA_API_EXTERNAL_PORT=3333
-    # entrypoint: [ "valgrind", "--leak-check=yes", "/sipi/sipi" ] ## uncomment to run SIPI under valgrind
-    # command: --config=/sipi/config/sipi.docker-test-config.lua ## command variant to start the sipi container with test routes enabled
-    command: --config=/sipi/config/sipi.docker-config.lua
+    # entrypoint: [ "valgrind", "--leak-check=yes", "/sbin/sipi" ] ## uncomment to run SIPI under valgrind
+    # command: server --config=/sipi/config/sipi.docker-test-config.lua ## command variant to start the sipi container with test routes enabled
+    # Sipi v5 requires an explicit verb-noun subcommand; `server` runs the IIIF server.
+    command: server --config=/sipi/config/sipi.docker-config.lua
+    healthcheck:
+      test: ["CMD", "/sbin/sipi", "health", "--port", "1024"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     deploy:
       resources:
         limits:

--- a/ingest/src/main/scala/swiss/dasch/domain/SipiClient.scala
+++ b/ingest/src/main/scala/swiss/dasch/domain/SipiClient.scala
@@ -11,6 +11,7 @@ import swiss.dasch.domain.SipiCommand.TopLeftArgument
 import swiss.dasch.infrastructure.CommandExecutor
 import swiss.dasch.infrastructure.ProcessOutput
 import zio.*
+import zio.json.*
 import zio.metrics.Metric
 import zio.nio.file.Path
 
@@ -20,6 +21,13 @@ import java.time.temporal.ChronoUnit
 sealed trait SipiCommand {
   def flag(): String
   def render(): UIO[List[String]]
+
+  /**
+   * Whether this invocation emits the structured `--json` report on stdout.
+   * `--json` is mutually exclusive with `--salsah` and `--query` at parse time
+   * (see `sipi/src/sipi.cpp:647`), so `QueryArgument` stays false.
+   */
+  def emitsJson: Boolean = false
 }
 
 object SipiCommand {
@@ -35,11 +43,12 @@ object SipiCommand {
     fileOut: Path,
   ) extends SipiCommand {
     def flag(): String              = "--format"
+    override val emitsJson: Boolean = true
     def render(): UIO[List[String]] =
       (for {
         abs1 <- fileIn.toAbsolutePath
         abs2 <- fileOut.toAbsolutePath
-      } yield List(flag(), outputFormat.toCliString, "--topleft", abs1.toString, abs2.toString)).orDie
+      } yield List("--json", flag(), outputFormat.toCliString, "--topleft", abs1.toString, abs2.toString)).orDie
   }
 
   /**
@@ -61,11 +70,12 @@ object SipiCommand {
     fileOut: Path,
   ) extends SipiCommand {
     def flag(): String              = "--topleft"
+    override val emitsJson: Boolean = true
     def render(): UIO[List[String]] =
       (for {
         abs1 <- fileIn.toAbsolutePath
         abs2 <- fileOut.toAbsolutePath
-      } yield List(flag(), abs1.toString, abs2.toString)).orDie
+      } yield List("--json", flag(), abs1.toString, abs2.toString)).orDie
   }
 }
 
@@ -108,8 +118,40 @@ final case class SipiClientLive(executor: CommandExecutor) extends SipiClient {
       sipiParams <- command.render()
       cmd        <- executor.buildCommand(sipiPrefix, sipiParams: _*)
       timerTagged = timer.tagged("command", command.flag())
-      out        <- executor.executeOrFail(cmd) @@ timerTagged.trackDuration
+      out        <- (
+               if (command.emitsJson) runWithJsonReport(cmd)
+               else executor.executeOrFail(cmd)
+             ) @@ timerTagged.trackDuration
     } yield out
+
+  /**
+   * Runs a `--json`-emitting sipi command, parsing the structured report on
+   * stdout. On a non-zero exit with a parseable `SipiReport.Err`, fails with
+   * [[SipiCliError]]; otherwise falls back to the legacy command-failure
+   * `IOException` so callers that don't care about the report still behave
+   * identically to before.
+   */
+  private def runWithJsonReport(cmd: swiss.dasch.infrastructure.Command): IO[IOException, ProcessOutput] =
+    executor
+      .execute(cmd)
+      .flatMap { out =>
+        if (out.exitCode == 0) ZIO.succeed(out)
+        else
+          out.stdout.fromJson[SipiReport] match {
+            case Right(err: SipiReport.Err) =>
+              ZIO.fail(
+                SipiCliError(
+                  phase = err.phase,
+                  message = err.errorMessage,
+                  inputFile = Option(err.inputFile).filter(_.nonEmpty),
+                  imageMeta = err.image,
+                  exitCode = out.exitCode,
+                ),
+              )
+            case _ =>
+              ZIO.fail(new IOException(s"Command failed: '${cmd.cmd}' $out"))
+          }
+      }
 
   override def applyTopLeftCorrection(fileIn: Path, fileOut: Path): IO[IOException, ProcessOutput] =
     execute(TopLeftArgument(fileIn, fileOut))

--- a/ingest/src/main/scala/swiss/dasch/domain/SipiClient.scala
+++ b/ingest/src/main/scala/swiss/dasch/domain/SipiClient.scala
@@ -5,9 +5,9 @@
 
 package swiss.dasch.domain
 
-import swiss.dasch.domain.SipiCommand.FormatArgument
-import swiss.dasch.domain.SipiCommand.QueryArgument
-import swiss.dasch.domain.SipiCommand.TopLeftArgument
+import swiss.dasch.domain.SipiCommand.ApplyTopLeft
+import swiss.dasch.domain.SipiCommand.Query
+import swiss.dasch.domain.SipiCommand.Transcode
 import swiss.dasch.infrastructure.CommandExecutor
 import swiss.dasch.infrastructure.ProcessOutput
 import zio.*
@@ -19,36 +19,50 @@ import java.io.IOException
 import java.time.temporal.ChronoUnit
 
 sealed trait SipiCommand {
-  def flag(): String
+
+  /** The Sipi v5 verb-noun subcommand name (e.g. "query", "convert"). */
+  def subcommand(): String
+
   def render(): UIO[List[String]]
 
   /**
-   * Whether this invocation emits the structured `--json` report on stdout.
-   * `--json` is mutually exclusive with `--salsah` and `--query` at parse time
-   * (see `sipi/src/sipi.cpp:647`), so `QueryArgument` stays false.
+   * Whether this invocation emits the structured `--json` report on stdout
+   * (`SipiReport` schema). Sipi v5's `convert` subcommand emits it for both
+   * success and error; `query`'s `--json` flag is documented but in v5.0.0 the
+   * success path still prints the human-readable text dump that
+   * `StillImageService` parses, so `Query` stays `false` to avoid
+   * routing through `runWithJsonReport`'s parse path.
    */
   def emitsJson: Boolean = false
 }
 
 object SipiCommand {
-  final case class QueryArgument(fileIn: Path) extends SipiCommand {
-    def flag(): String              = "--query"
+  final case class Query(fileIn: Path) extends SipiCommand {
+    def subcommand(): String        = "query"
     def render(): UIO[List[String]] =
-      fileIn.toAbsolutePath.orDie.map(abs => List(flag(), abs.toString))
+      fileIn.toAbsolutePath.orDie.map(abs => List(subcommand(), abs.toString))
   }
 
-  final case class FormatArgument(
+  final case class Transcode(
     outputFormat: SipiImageFormat,
     fileIn: Path,
     fileOut: Path,
   ) extends SipiCommand {
-    def flag(): String              = "--format"
+    def subcommand(): String        = "convert"
     override val emitsJson: Boolean = true
     def render(): UIO[List[String]] =
       (for {
         abs1 <- fileIn.toAbsolutePath
         abs2 <- fileOut.toAbsolutePath
-      } yield List("--json", flag(), outputFormat.toCliString, "--topleft", abs1.toString, abs2.toString)).orDie
+      } yield List(
+        subcommand(),
+        abs1.toString,
+        abs2.toString,
+        "--json",
+        "--format",
+        outputFormat.toCliString,
+        "--topleft",
+      )).orDie
   }
 
   /**
@@ -65,17 +79,17 @@ object SipiCommand {
    *
    * if fileOut is the same as fileIn, the file will be overwritten
    */
-  final case class TopLeftArgument(
+  final case class ApplyTopLeft(
     fileIn: Path,
     fileOut: Path,
   ) extends SipiCommand {
-    def flag(): String              = "--topleft"
+    def subcommand(): String        = "convert"
     override val emitsJson: Boolean = true
     def render(): UIO[List[String]] =
       (for {
         abs1 <- fileIn.toAbsolutePath
         abs2 <- fileOut.toAbsolutePath
-      } yield List("--json", flag(), abs1.toString, abs2.toString)).orDie
+      } yield List(subcommand(), abs1.toString, abs2.toString, "--json", "--topleft")).orDie
   }
 }
 
@@ -110,14 +124,14 @@ object SipiClient {
 
 final case class SipiClientLive(executor: CommandExecutor) extends SipiClient {
 
-  private val sipiPrefix = "/sipi/sipi"
+  private val sipiPrefix = "/sbin/sipi"
   private val timer      = Metric.timer("sipi_command_duration", ChronoUnit.MILLIS, Chunk.iterate(1.0, 6)(_ * 10))
 
   private def execute(command: SipiCommand): IO[IOException, ProcessOutput] =
     for {
       sipiParams <- command.render()
       cmd        <- executor.buildCommand(sipiPrefix, sipiParams: _*)
-      timerTagged = timer.tagged("command", command.flag())
+      timerTagged = timer.tagged("command", command.subcommand())
       out        <- (
                if (command.emitsJson) runWithJsonReport(cmd)
                else executor.executeOrFail(cmd)
@@ -154,17 +168,17 @@ final case class SipiClientLive(executor: CommandExecutor) extends SipiClient {
       }
 
   override def applyTopLeftCorrection(fileIn: Path, fileOut: Path): IO[IOException, ProcessOutput] =
-    execute(TopLeftArgument(fileIn, fileOut))
+    execute(ApplyTopLeft(fileIn, fileOut))
 
   override def transcodeImageFile(
     fileIn: Path,
     fileOut: Path,
     outputFormat: SipiImageFormat,
   ): IO[IOException, ProcessOutput] =
-    execute(FormatArgument(outputFormat, fileIn, fileOut))
+    execute(Transcode(outputFormat, fileIn, fileOut))
 
   override def queryImageFile(file: Path): IO[IOException, ProcessOutput] =
-    execute(QueryArgument(file))
+    execute(Query(file))
 }
 
 object SipiClientLive {

--- a/ingest/src/main/scala/swiss/dasch/domain/SipiReport.scala
+++ b/ingest/src/main/scala/swiss/dasch/domain/SipiReport.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch.domain
+
+import zio.json.*
+import zio.json.ast.Json
+
+import java.io.IOException
+
+/**
+ * Structured report emitted by `sipi --json` on stdout.
+ *
+ * Schema reference: sipi's `docs/src/guide/json-output.md` (unversioned, additive).
+ * Decoders tolerate unknown fields so future additive changes on the sipi side
+ * do not break us.
+ */
+sealed trait SipiReport
+object SipiReport {
+
+  enum Phase {
+    case CliArgs, Read, Convert, Write
+  }
+  object Phase {
+    given JsonDecoder[Phase] = JsonDecoder[String].mapOrFail {
+      case "cli_args" => Right(Phase.CliArgs)
+      case "read"     => Right(Phase.Read)
+      case "convert"  => Right(Phase.Convert)
+      case "write"    => Right(Phase.Write)
+      case other      => Left(s"Unknown sipi phase: $other")
+    }
+  }
+
+  final case class ImageMeta(
+    width: Int,
+    height: Int,
+    channels: Int,
+    bps: Int,
+    colorspace: String,
+    @jsonField("icc_profile_type") iccProfileType: String,
+    orientation: String,
+  )
+  object ImageMeta {
+    given JsonDecoder[ImageMeta] = DeriveJsonDecoder.gen[ImageMeta]
+  }
+
+  final case class Ok(
+    @jsonField("input_file") inputFile: String,
+    @jsonField("output_file") outputFile: String,
+    @jsonField("output_format") outputFormat: String,
+    @jsonField("file_size_bytes") fileSizeBytes: Long,
+    image: Option[ImageMeta],
+  ) extends SipiReport
+  object Ok {
+    given JsonDecoder[Ok] = DeriveJsonDecoder.gen[Ok]
+  }
+
+  final case class Err(
+    phase: Phase,
+    @jsonField("error_message") errorMessage: String,
+    @jsonField("input_file") inputFile: String,
+    @jsonField("output_file") outputFile: String,
+    @jsonField("output_format") outputFormat: String,
+    @jsonField("file_size_bytes") fileSizeBytes: Long,
+    image: Option[ImageMeta],
+  ) extends SipiReport
+  object Err {
+    given JsonDecoder[Err] = DeriveJsonDecoder.gen[Err]
+  }
+
+  given JsonDecoder[SipiReport] = JsonDecoder[Json.Obj].mapOrFail { obj =>
+    obj.get("status").flatMap(_.asString) match {
+      case Some("ok")    => obj.toJson.fromJson[Ok]
+      case Some("error") => obj.toJson.fromJson[Err]
+      case Some(other)   => Left(s"Unknown sipi report status: $other")
+      case None          => Left("Missing `status` field in sipi report")
+    }
+  }
+}
+
+/**
+ * Typed error raised when a sipi CLI invocation fails with a structured
+ * `--json` report on stdout. Extends `IOException` so it slots into the
+ * existing `IO[IOException, _]` signatures without a wider refactor.
+ */
+final case class SipiCliError(
+  phase: SipiReport.Phase,
+  message: String,
+  inputFile: Option[String],
+  imageMeta: Option[SipiReport.ImageMeta],
+  exitCode: Int,
+) extends IOException(s"Sipi [$phase] $message")

--- a/ingest/src/test/scala/swiss/dasch/domain/SipiClientSpec.scala
+++ b/ingest/src/test/scala/swiss/dasch/domain/SipiClientSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch.domain
+
+import swiss.dasch.infrastructure.CommandExecutorMock
+import swiss.dasch.infrastructure.ProcessOutput
+import zio.nio.file.Path
+import zio.test.*
+
+object SipiClientSpec extends ZIOSpecDefault {
+
+  private val fileIn  = Path("/tmp/in.jpg")
+  private val fileOut = Path("/tmp/out.jp2")
+
+  private val successJson =
+    """{"status":"ok","mode":"cli","input_file":"/tmp/in.jpg","output_file":"/tmp/out.jp2",""" +
+      """"output_format":"jpx","file_size_bytes":10,""" +
+      """"image":{"width":1,"height":1,"channels":3,"bps":8,""" +
+      """"colorspace":"RGB","icc_profile_type":"sRGB","orientation":"TOPLEFT"}}"""
+
+  private def errorJson(phase: String, withImage: Boolean = true): String = {
+    val img =
+      if (withImage)
+        ""","image":{"width":2,"height":2,"channels":1,"bps":1,"colorspace":"MINISWHITE","icc_profile_type":"","orientation":"TOPLEFT"}"""
+      else ""
+    s"""{"status":"error","mode":"cli","phase":"$phase","error_message":"boom","input_file":"/tmp/in.jpg",""" +
+      s""""output_file":"/tmp/out.jp2","output_format":"jpx","file_size_bytes":4$img}"""
+  }
+
+  private val errorPathSuite = suite("error path (--json)")(
+    test("transcode with exit != 0 and a parseable read error fails with SipiCliError(Read)") {
+      for {
+        _    <- CommandExecutorMock.setOutput(ProcessOutput(errorJson("read"), "stderr log", 1))
+        exit <- SipiClient.transcodeImageFile(fileIn, fileOut, SipiImageFormat.Jpx).exit
+      } yield assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+        case e: SipiCliError =>
+          e.phase == SipiReport.Phase.Read &&
+          e.message == "boom" &&
+          e.exitCode == 1 &&
+          e.imageMeta.exists(_.bps == 1)
+        case _ => false
+      })
+    },
+    test("transcode with a cli_args error without image → imageMeta is None") {
+      for {
+        _    <- CommandExecutorMock.setOutput(ProcessOutput(errorJson("cli_args", withImage = false), "", 1))
+        exit <- SipiClient.transcodeImageFile(fileIn, fileOut, SipiImageFormat.Jpx).exit
+      } yield assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+        case e: SipiCliError => e.phase == SipiReport.Phase.CliArgs && e.imageMeta.isEmpty
+        case _               => false
+      })
+    },
+    test("transcode with exit != 0 and garbage stdout falls back to legacy IOException") {
+      for {
+        _    <- CommandExecutorMock.setOutput(ProcessOutput("not json at all", "", 1))
+        exit <- SipiClient.transcodeImageFile(fileIn, fileOut, SipiImageFormat.Jpx).exit
+      } yield assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+        case _: SipiCliError => false
+        case e               => e.getMessage.startsWith("Command failed:")
+      })
+    },
+    test("transcode with exit != 0 and empty stdout falls back to legacy IOException") {
+      for {
+        _    <- CommandExecutorMock.setOutput(ProcessOutput("", "", 1))
+        exit <- SipiClient.transcodeImageFile(fileIn, fileOut, SipiImageFormat.Jpx).exit
+      } yield assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+        case _: SipiCliError => false
+        case e               => e.getMessage.startsWith("Command failed:")
+      })
+    },
+    test("topleft success returns ProcessOutput unchanged") {
+      for {
+        _   <- CommandExecutorMock.setOutput(ProcessOutput(successJson, "log", 0))
+        out <- SipiClient.applyTopLeftCorrection(fileIn, fileOut)
+      } yield assertTrue(out.exitCode == 0, out.stdout == successJson)
+    },
+    test("topleft error surfaces SipiCliError(Convert)") {
+      for {
+        _    <- CommandExecutorMock.setOutput(ProcessOutput(errorJson("convert"), "log", 2))
+        exit <- SipiClient.applyTopLeftCorrection(fileIn, fileOut).exit
+      } yield assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+        case e: SipiCliError => e.phase == SipiReport.Phase.Convert && e.exitCode == 2
+        case _               => false
+      })
+    },
+    test("query with exit != 0 uses legacy fallback (no JSON parsing attempted)") {
+      for {
+        _    <- CommandExecutorMock.setOutput(ProcessOutput(errorJson("read"), "", 1))
+        exit <- SipiClient.queryImageFile(fileIn).exit
+      } yield assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+        case _: SipiCliError => false
+        case e               => e.getMessage.startsWith("Command failed:")
+      })
+    },
+  ).provide(
+    CommandExecutorMock.layer,
+    SipiClientLive.layer,
+  )
+
+  val spec = suite("SipiClient")(errorPathSuite)
+}

--- a/ingest/src/test/scala/swiss/dasch/domain/SipiCommandSpec.scala
+++ b/ingest/src/test/scala/swiss/dasch/domain/SipiCommandSpec.scala
@@ -16,22 +16,31 @@ object SipiCommandSpec extends ZIOSpecDefault {
 
   val spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("SipiCommand")(
-      test("should render format command") {
+      test("should render format command with --json") {
         check(Gen.fromIterable(SipiImageFormat.all)) { format =>
           for {
             cmd <- FormatArgument(format, Path("/tmp/example"), Path("/tmp/example2")).render()
-          } yield assertTrue(cmd == List("--format", format.toCliString, "--topleft", "/tmp/example", "/tmp/example2"))
+          } yield assertTrue(
+            cmd == List("--json", "--format", format.toCliString, "--topleft", "/tmp/example", "/tmp/example2"),
+          )
         }
       },
-      test("should assemble query command") {
+      test("should assemble query command without --json (mutex with --query)") {
         for {
           cmd <- QueryArgument(Path("/tmp/example")).render()
         } yield assertTrue(cmd == List("--query", "/tmp/example"))
       },
-      test("should assemble topleft command") {
+      test("should assemble topleft command with --json") {
         for {
           cmd <- TopLeftArgument(Path("/tmp/example"), Path("/tmp/example2")).render()
-        } yield assertTrue(cmd == List("--topleft", "/tmp/example", "/tmp/example2"))
+        } yield assertTrue(cmd == List("--json", "--topleft", "/tmp/example", "/tmp/example2"))
+      },
+      test("emitsJson matches the commands that include --json in their argv") {
+        assertTrue(
+          FormatArgument(SipiImageFormat.Jpx, Path("/a"), Path("/b")).emitsJson,
+          TopLeftArgument(Path("/a"), Path("/b")).emitsJson,
+          !QueryArgument(Path("/a")).emitsJson,
+        )
       },
     )
 }

--- a/ingest/src/test/scala/swiss/dasch/domain/SipiCommandSpec.scala
+++ b/ingest/src/test/scala/swiss/dasch/domain/SipiCommandSpec.scala
@@ -5,9 +5,9 @@
 
 package swiss.dasch.domain
 
-import swiss.dasch.domain.SipiCommand.FormatArgument
-import swiss.dasch.domain.SipiCommand.QueryArgument
-import swiss.dasch.domain.SipiCommand.TopLeftArgument
+import swiss.dasch.domain.SipiCommand.ApplyTopLeft
+import swiss.dasch.domain.SipiCommand.Query
+import swiss.dasch.domain.SipiCommand.Transcode
 import zio.*
 import zio.nio.file.*
 import zio.test.*
@@ -16,30 +16,38 @@ object SipiCommandSpec extends ZIOSpecDefault {
 
   val spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("SipiCommand")(
-      test("should render format command with --json") {
+      test("should render convert subcommand with --json for Transcode") {
         check(Gen.fromIterable(SipiImageFormat.all)) { format =>
           for {
-            cmd <- FormatArgument(format, Path("/tmp/example"), Path("/tmp/example2")).render()
+            cmd <- Transcode(format, Path("/tmp/example"), Path("/tmp/example2")).render()
           } yield assertTrue(
-            cmd == List("--json", "--format", format.toCliString, "--topleft", "/tmp/example", "/tmp/example2"),
+            cmd == List(
+              "convert",
+              "/tmp/example",
+              "/tmp/example2",
+              "--json",
+              "--format",
+              format.toCliString,
+              "--topleft",
+            ),
           )
         }
       },
-      test("should assemble query command without --json (mutex with --query)") {
+      test("should render query subcommand without --json") {
         for {
-          cmd <- QueryArgument(Path("/tmp/example")).render()
-        } yield assertTrue(cmd == List("--query", "/tmp/example"))
+          cmd <- Query(Path("/tmp/example")).render()
+        } yield assertTrue(cmd == List("query", "/tmp/example"))
       },
-      test("should assemble topleft command with --json") {
+      test("should render convert subcommand with --json --topleft for ApplyTopLeft") {
         for {
-          cmd <- TopLeftArgument(Path("/tmp/example"), Path("/tmp/example2")).render()
-        } yield assertTrue(cmd == List("--json", "--topleft", "/tmp/example", "/tmp/example2"))
+          cmd <- ApplyTopLeft(Path("/tmp/example"), Path("/tmp/example2")).render()
+        } yield assertTrue(cmd == List("convert", "/tmp/example", "/tmp/example2", "--json", "--topleft"))
       },
       test("emitsJson matches the commands that include --json in their argv") {
         assertTrue(
-          FormatArgument(SipiImageFormat.Jpx, Path("/a"), Path("/b")).emitsJson,
-          TopLeftArgument(Path("/a"), Path("/b")).emitsJson,
-          !QueryArgument(Path("/a")).emitsJson,
+          Transcode(SipiImageFormat.Jpx, Path("/a"), Path("/b")).emitsJson,
+          ApplyTopLeft(Path("/a"), Path("/b")).emitsJson,
+          !Query(Path("/a")).emitsJson,
         )
       },
     )

--- a/ingest/src/test/scala/swiss/dasch/domain/SipiReportSpec.scala
+++ b/ingest/src/test/scala/swiss/dasch/domain/SipiReportSpec.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch.domain
+
+import zio.json.*
+import zio.test.*
+
+object SipiReportSpec extends ZIOSpecDefault {
+
+  private val successPayload =
+    """{
+      |  "status": "ok",
+      |  "mode": "cli",
+      |  "input_file": "/path/to/input.jpg",
+      |  "output_file": "/tmp/out.jp2",
+      |  "output_format": "jpx",
+      |  "file_size_bytes": 26688,
+      |  "image": {
+      |    "width": 404,
+      |    "height": 201,
+      |    "channels": 3,
+      |    "bps": 8,
+      |    "colorspace": "RGB",
+      |    "icc_profile_type": "sRGB",
+      |    "orientation": "TOPLEFT"
+      |  }
+      |}""".stripMargin
+
+  private val errorImageBlock =
+    """,
+      |  "image": {
+      |    "width": 8040,
+      |    "height": 9624,
+      |    "channels": 1,
+      |    "bps": 1,
+      |    "colorspace": "MINISWHITE",
+      |    "icc_profile_type": "",
+      |    "orientation": "TOPLEFT"
+      |  }""".stripMargin
+
+  private def errorPayload(phase: String, includeImage: Boolean = true): String = {
+    val imageBlock = if (includeImage) errorImageBlock else ""
+    s"""{
+       |  "status": "error",
+       |  "mode": "cli",
+       |  "phase": "$phase",
+       |  "error_message": "boom",
+       |  "input_file": "/tmp/in",
+       |  "output_file": "/tmp/out",
+       |  "output_format": "jpx",
+       |  "file_size_bytes": 4768164$imageBlock
+       |}""".stripMargin
+  }
+
+  val spec = suite("SipiReport decoder")(
+    test("decodes the success payload with every field") {
+      val decoded = successPayload.fromJson[SipiReport]
+      assertTrue(
+        decoded == Right(
+          SipiReport.Ok(
+            inputFile = "/path/to/input.jpg",
+            outputFile = "/tmp/out.jp2",
+            outputFormat = "jpx",
+            fileSizeBytes = 26688L,
+            image = Some(
+              SipiReport.ImageMeta(
+                width = 404,
+                height = 201,
+                channels = 3,
+                bps = 8,
+                colorspace = "RGB",
+                iccProfileType = "sRGB",
+                orientation = "TOPLEFT",
+              ),
+            ),
+          ),
+        ),
+      )
+    },
+    test("decodes an error payload for every phase") {
+      val phases = List(
+        "cli_args" -> SipiReport.Phase.CliArgs,
+        "read"     -> SipiReport.Phase.Read,
+        "convert"  -> SipiReport.Phase.Convert,
+        "write"    -> SipiReport.Phase.Write,
+      )
+      val results = phases.map { case (raw, expected) =>
+        errorPayload(raw).fromJson[SipiReport] match {
+          case Right(err: SipiReport.Err) => err.phase == expected
+          case _                          => false
+        }
+      }
+      assertTrue(results.forall(identity))
+    },
+    test("accepts an error payload without the image field (cli_args)") {
+      val decoded = errorPayload("cli_args", includeImage = false).fromJson[SipiReport]
+      assertTrue(decoded.exists {
+        case err: SipiReport.Err => err.image.isEmpty && err.phase == SipiReport.Phase.CliArgs
+        case _                   => false
+      })
+    },
+    test("populates ImageMeta on the 1-bit bilevel TIFF error example") {
+      val decoded = errorPayload("read").fromJson[SipiReport]
+      assertTrue(decoded.exists {
+        case err: SipiReport.Err =>
+          err.image.exists(im => im.bps == 1 && im.colorspace == "MINISWHITE" && im.channels == 1)
+        case _ => false
+      })
+    },
+    test("ignores unknown fields at the top level and inside image (forward compat)") {
+      val payload =
+        """{
+          |  "status": "ok",
+          |  "future_flag": true,
+          |  "input_file": "/a",
+          |  "output_file": "/b",
+          |  "output_format": "jpx",
+          |  "file_size_bytes": 1,
+          |  "image": {
+          |    "width": 1, "height": 1, "channels": 1, "bps": 8,
+          |    "colorspace": "RGB", "icc_profile_type": "sRGB", "orientation": "TOPLEFT",
+          |    "future_tag": "xyz"
+          |  }
+          |}""".stripMargin
+      assertTrue(payload.fromJson[SipiReport].isRight)
+    },
+    test("rejects a payload with an unknown phase value") {
+      val payload =
+        """{"status": "error", "phase": "brand_new_phase", "error_message": "?",
+          |"input_file": "", "output_file": "", "output_format": "", "file_size_bytes": 0}""".stripMargin
+      assertTrue(payload.fromJson[SipiReport].isLeft)
+    },
+    test("rejects malformed JSON") {
+      assertTrue("not json at all".fromJson[SipiReport].isLeft) &&
+      assertTrue("".fromJson[SipiReport].isLeft) &&
+      assertTrue("""{"status": "ok""".fromJson[SipiReport].isLeft)
+    },
+    test("rejects a payload with a missing status field") {
+      val payload = """{"input_file": "/a", "output_file": "/b"}"""
+      assertTrue(payload.fromJson[SipiReport].isLeft)
+    },
+  )
+}

--- a/modules/testkit/src/main/scala/org/knora/webapi/testcontainers/SipiTestContainer.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testcontainers/SipiTestContainer.scala
@@ -7,6 +7,7 @@ package org.knora.webapi.testcontainers
 
 import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
 import zio.URIO
 import zio.URLayer
 import zio.ZIO
@@ -16,6 +17,9 @@ import zio.http.URL
 
 import java.net.Inet6Address
 import java.net.InetAddress
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermissions
 
 import org.knora.webapi.http.version.BuildInfo
 import org.knora.webapi.testcontainers.TestContainerOps.toZio
@@ -75,17 +79,27 @@ object SipiTestContainer {
         BindMode.READ_ONLY,
       )
       .withFileSystemBind(imagesVolume.hostPath, imagesDir, BindMode.READ_WRITE)
+      .waitingFor(Wait.forHttp("/health").forPort(1024).forStatusCode(200))
 //      .withLogConsumer(frame => print("SIPI:" + frame.getUtf8String))
 
+  // Create the asset /tmp directory on the *host* before container start
+  // rather than via `execInContainer("mkdir", ...)`. Sipi v5.0.0's image
+  // is distroless and has no `mkdir`/`chmod` binary, so any in-container
+  // shell-out fails. The bind mount makes the host directory visible at
+  // /sipi/images/tmp inside the container.
   private val initSipi = ZLayer.fromZIO(
-    for {
-      container <- ZIO.service[SipiTestContainer]
-      _         <- ZIO.attemptBlocking {
-             container.execInContainer("mkdir", s"$imagesDir/tmp")
-             container.execInContainer("chmod", "777", s"$imagesDir/tmp")
-           }
-
-    } yield container,
+    ZIO.serviceWithZIO[SipiTestContainer] { container =>
+      for {
+        images <- ZIO.service[SharedVolumes.Images]
+        _      <- ZIO.attemptBlocking {
+               val tmp = Paths.get(images.hostPath, "tmp")
+               Files.createDirectories(
+                 tmp,
+                 PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx")),
+               )
+             }.orDie
+      } yield container
+    },
   )
 
   val layer: URLayer[SharedVolumes.Images, SipiTestContainer] = layerWithCustomEnv(Map.empty)
@@ -96,6 +110,6 @@ object SipiTestContainer {
       env.foreach { case (k, v) => imagesToContainer.withEnv(k, v) }
       imagesToContainer.toZio
     })
-    (container >>> initSipi).orDie
+    container >>> initSipi
   }
 }

--- a/modules/testkit/src/main/scala/org/knora/webapi/testcontainers/SipiTestContainer.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testcontainers/SipiTestContainer.scala
@@ -72,7 +72,8 @@ object SipiTestContainer {
       .withEnv("SIPI_EXTERNAL_PORT", "1024")
       .withEnv("SIPI_WEBAPI_HOSTNAME", SipiTestContainer.localHostAddress)
       .withEnv("SIPI_WEBAPI_PORT", "3333")
-      .withCommand("--config=/sipi/config/sipi.docker-config.lua")
+      // Sipi v5 requires an explicit verb-noun subcommand; `server` runs the IIIF server.
+      .withCommand("server", "--config=/sipi/config/sipi.docker-config.lua")
       .withClasspathResourceMapping(
         "/sipi.docker-config.lua",
         "/sipi/config/sipi.docker-config.lua",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
   val fusekiImage = "daschswiss/apache-jena-fuseki:6.1.0-0"
   // base image the knora-sipi image is created from
-  val sipiImage = "daschswiss/sipi:v4.1.1"
+  val sipiImage = "daschswiss/sipi:v5.0.0"
 
   val ScalaVersion = "3.3.7"
 

--- a/sipi/scripts/healthcheck.sh
+++ b/sipi/scripts/healthcheck.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-curl -sS --fail 'http://localhost:1024/server/test.html'
-if [ $? -ne 0 ]; then
-  echo "SIPI did not respond to /server/test.html route"
-  exit 1
-fi


### PR DESCRIPTION
### Description

This PR adopts Sipi v5.0.0 in dsp-api. Sipi v5 ships two upstream changes that ripple through ingest and the two locally-built images (\`daschswiss/knora-sipi\` and \`daschswiss/dsp-ingest\`):

1. **Breaking CLI change.** Bare \`--query\` / \`--convert\` / \`--compare\` flag forms now fail with a CLI11 error. Operators must use the verb-noun subcommand surface (\`query\`, \`convert\`, \`verify\`, \`health\`, …).
2. **Distroless OCI base.** \`daschswiss/sipi:v5.0.0\` is now built with \`rules_oci\` on \`@distroless_base\` — no shell, no \`apt\`, no \`chmod\`, no \`curl\`. The static binary moves from \`/sipi/sipi\` to \`/sbin/sipi\`.

**Kind of change:** Feature + breaking change. Bumps an upstream base image major version with breaking CLI behaviour.

#### What changes

**CLI migration (ingest):**

- \`SipiClient.scala\`: argv migrated from \`--query\` / \`--format\` / \`--topleft\` to the v5 \`query\` and \`convert\` subcommands; binary path bumped \`/sipi/sipi\` → \`/sbin/sipi\`.
- \`SipiCommand\` cases renamed for semantic clarity (operation, not flag): \`QueryArgument\` → \`Query\`, \`FormatArgument\` → \`Transcode\`, \`TopLeftArgument\` → \`ApplyTopLeft\`.
- Builds on the prior \`SipiReport\` / \`SipiCliError\` work in this branch — the \`--json\` typed-error decoder is reused unchanged, the v5 payload format matches.

**Image rework (\`build.sbt\`):**

- \`knora-sipi\` subproject: wholesale-override \`Docker / dockerCommands\` with \`dockerPermissionStrategy := DockerPermissionStrategy.None\`. The plugin's default JVM scaffolding (USER, WORKDIR, chmod/chown RUN steps, ADD universal-staging) is irrelevant for an overlay-only image and depends on a shell distroless doesn't ship. Exec-form \`HEALTHCHECK CMD [\"/sbin/sipi\", \"health\", \"--port\", \"1024\"]\`. No \`USER\` directive — Sipi must run as root for the NFS asset mount (matches upstream).
- \`dsp-ingest\` subproject: base swap to \`eclipse-temurin:25-jre-noble\` (matches \`knora-api\`); drops the manual Temurin apt-install. Prepends a \`FROM daschswiss/knora-sipi:<v> AS sipi-source\` builder stage and appends \`COPY --from=sipi-source\` directives for \`/sbin/sipi\`, \`/sipi/\`, \`/usr/bin/{tini,ffmpeg,ffprobe}\`. Healthcheck reuses the extracted \`/sbin/sipi health --port 3340\` (the new Debian JRE base does not ship curl, and we already need the binary for ingest's image processing).

**Compose and tests:**

- \`docker-compose.yml\`: add the explicit \`server\` subcommand prefix (v5 rejects flag-only invocation), plus a compose-level \`healthcheck:\` stanza for the sipi service.
- \`SipiTestContainer.scala\`: add \`Wait.forHttp(\"/health\").forPort(1024)\` wait strategy; replace in-container \`execInContainer(\"mkdir\"/\"chmod\")\` (distroless has neither binary) with host-side directory creation through the bind mount.
- Delete \`sipi/scripts/healthcheck.sh\` — curl-based shell probe superseded by \`sipi health\`.

#### Breaking changes

Operators upgrading to this PR must:

- Be aware that locally-built \`daschswiss/knora-sipi:<v>\` and \`daschswiss/dsp-ingest:<v>\` derive from a distroless base. Anything in CI / ops tooling that assumes \`bash\`, \`apt\`, or \`curl\` inside the sipi image will need adjusting.
- Update any compose stanzas using the legacy flag-only \`command:\` for Sipi to prepend the \`server\` subcommand.
- Update any external healthcheck invocations from \`curl http://…/server/test.html\` to \`/sbin/sipi health --port 1024\` (or the \`/health\` route directly).

The CLI argv migration is internal to dsp-ingest's \`SipiClient\` — no external API change.

#### Other information

- Two minor deviations from the approved implementation plan, both justified during verification: (1) \`QueryArgument.emitsJson\` stays \`false\` because v5 \`query --json\` still emits a human-readable text dump on success that \`StillImageService\` parses; (2) dsp-ingest healthcheck uses \`sipi health --port 3340\` rather than curl because the JRE base does not ship curl and the static sipi binary is already required for ingest's image processing.
- Sequencing: upstream Sipi has flagged \`/usr/bin/curl\` for removal in a future cleanup, gated on the ops-deploy compose-stanza switch (INFRA-1226). Today curl is still in the image; once it is removed, only \`sipi health\` will work — this PR uses the future-proof form.

#### Verification

- [x] \`sbt fmt check\` clean
- [x] \`sbt \"ingest / test\"\` → 186/186 pass
- [x] \`sbt \"sipi / Docker / publishLocal\"\` builds clean
- [x] \`sbt \"ingest / Docker / publishLocal\"\` builds clean (multi-stage \`COPY --from=sipi-source\`)
- [x] \`just stack-start\` → \`docker compose ps\` reports \`sipi (healthy)\` and \`dsp-ingest (healthy)\`
- [x] Standalone container: \`docker exec <sipi> /sbin/sipi health --port 1024\` exits 0; closed port exits 1
- [x] Inside dsp-ingest: \`/sbin/sipi --version\` → \`sipi 5.0.0\`; \`id\` → \`uid=0(root)\` (NFS-compatible)
- [x] \`docker inspect ... --format '{{.Config.User}}'\` returns empty for both images (root inherited)