### PR TITLE
fix(project-migration): Include system admin project members as normal users in export (DEV-6281)

### DIFF
--- a/docs/03-endpoints/api-v3/project-migration.md
+++ b/docs/03-endpoints/api-v3/project-migration.md
@@ -139,7 +139,7 @@ The import handles users referenced in the export with the following logic. User
 | Lookup Result | Behavior |
 | --- | --- |
 | **Found by IRI** | Verifies that email and username match the existing user. Logs warnings for profile differences (e.g. name). Strips the user's profile triples from the export data and keeps only memberships scoped to the imported project (e.g. `isInProject`, `isInGroup`). Because the triplestore upload is additive, the user's existing data and memberships in other projects on the target instance are not affected. |
-| **Not found at all** | Creates the user as a new user. Strips `isInSystemAdminGroup` (set to `false`). Removes any cross-project memberships. |
+| **Not found at all** | Creates the user as a new user. Strips `isInSystemAdminGroup` (set to `false`) — defense-in-depth, since the export already sets the flag to `false` (see *System administrators* below). Removes any cross-project memberships. |
 | **No IRI match, but email or username collision** | Fails with an error message identifying the conflict. |
 
 **Root user**: If the export contains the root user (either as an existing user match or as a new user), the import **fails**. Resources referencing the root user require pre-migration cleanup before import. See [Root User Cleanup](../../10-migration-guides/root-user-cleanup.md) for instructions.

--- a/docs/03-endpoints/api-v3/project-migration.md
+++ b/docs/03-endpoints/api-v3/project-migration.md
@@ -144,6 +144,8 @@ The import handles users referenced in the export with the following logic. User
 
 **Root user**: If the export contains the root user (either as an existing user match or as a new user), the import **fails**. Resources referencing the root user require pre-migration cleanup before import. See [Root User Cleanup](../../10-migration-guides/root-user-cleanup.md) for instructions.
 
+**System administrators**: Project members or project admins who also belong to the SystemAdmin group on the source instance are included in the export, but the `isInSystemAdminGroup` flag is set to `false` in the exported admin data. System-admin membership is a property of the source instance and does not carry over to the target instance.
+
 **Cross-project membership scoping**: Both export and import strip cross-project membership triples to ensure the package is self-contained:
 
 - `isInProject` references to other projects are removed.

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminDataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminDataQuery.scala
@@ -5,11 +5,8 @@
 
 package org.knora.webapi.slice.`export`.domain
 
-import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.sparqlbuilder.core.query.ConstructQuery
 import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 
 import org.knora.webapi.slice.admin.AdminConstants.adminDataNamedGraph
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
@@ -20,15 +17,16 @@ import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraAdmin as KA
 object AdminDataQuery extends QueryBuilderHelper {
 
   // NOTE: If you change the query structure here, also update buildWithReferencedUsers below.
+  // Project members who are also system admins are included in the export. The
+  // `isInSystemAdminGroup` flag is stripped later by AdminModelScoping.stripSystemAdminFlag
+  // so the exported package does not carry the source instance's system-admin membership.
   def build(project: ProjectIri): ConstructQuery = {
     val projectIri                   = toRdfIri(project)
     val (projectPred, projectObj)    = (variable("projectPred"), variable("projectObj"))
     val (user, userPred, userObj)    = (variable("user"), variable("userPred"), variable("userObj"))
     val (group, groupPred, groupObj) = (variable("group"), variable("groupPred"), variable("groupObj"))
-    val userPattern                  = GraphPatterns.and(
-      user.isA(KA.User).andHas(userPred, userObj).andHas(KA.isInProject, projectIri),
-      GraphPatterns.filterNotExists(user.has(KA.isInSystemAdminGroup, Rdf.literalOfType("true", XSD.BOOLEAN))),
-    )
+    val userPattern                  =
+      user.isA(KA.User).andHas(userPred, userObj).andHas(KA.isInProject, projectIri)
     Queries
       .CONSTRUCT(
         projectIri.has(projectPred, projectObj),
@@ -50,9 +48,8 @@ object AdminDataQuery extends QueryBuilderHelper {
    * Builds the admin data CONSTRUCT query including an additional UNION branch for
    * users referenced by attachedToUser in the project's data graph.
    *
-   * The additional branch fetches all triples for the referenced users without the
-   * SystemAdmin exclusion filter. Since SparqlBuilder does not support VALUES blocks,
-   * the query is assembled via string interpolation.
+   * Since SparqlBuilder does not support VALUES blocks, the query is assembled via
+   * string interpolation.
    *
    * Note: The referenced user IRIs are inlined in a VALUES clause. For projects with
    * a very large number of distinct referenced users, this could produce a long query
@@ -87,7 +84,6 @@ object AdminDataQuery extends QueryBuilderHelper {
          |      ?user a knora-admin:User ;
          |        ?userPred ?userObj ;
          |        knora-admin:isInProject <$projectIri> .
-         |      FILTER NOT EXISTS { ?user knora-admin:isInSystemAdminGroup "true"^^<${XSD.BOOLEAN}> . }
          |    } UNION {
          |      ?user a knora-admin:User ;
          |        ?userPred ?userObj .

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminDataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminDataQuery.scala
@@ -18,7 +18,7 @@ object AdminDataQuery extends QueryBuilderHelper {
 
   // NOTE: If you change the query structure here, also update buildWithReferencedUsers below.
   // Project members who are also system admins are included in the export. The
-  // `isInSystemAdminGroup` flag is stripped later by AdminModelScoping.stripSystemAdminFlag
+  // `isInSystemAdminGroup` flag is rewritten to false later by AdminModelScoping.clearSystemAdminFlag
   // so the exported package does not carry the source instance's system-admin membership.
   def build(project: ProjectIri): ConstructQuery = {
     val projectIri                   = toRdfIri(project)

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminModelScoping.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminModelScoping.scala
@@ -23,7 +23,7 @@ import org.knora.webapi.messages.OntologyConstants.KnoraAdmin
 object AdminModelScoping {
 
   // Shared Jena property/resource constants for admin model operations.
-  // Package-private so rewriteExistingUserTriples / rewriteNewUserTriples can reuse them.
+  // Package-private so the import service (ProjectMigrationImportService) can reuse them.
   private[domain] val isInProjectProp           = ResourceFactory.createProperty(KnoraAdmin.IsInProject)
   private[domain] val isInGroupProp             = ResourceFactory.createProperty(KnoraAdmin.IsInGroup)
   private[domain] val isInProjectAdminGroupProp = ResourceFactory.createProperty(KnoraAdmin.IsInProjectAdminGroup)
@@ -96,7 +96,7 @@ object AdminModelScoping {
   }
 
   /**
-   * Replaces `isInSystemAdminGroup "true"` triples with `"false"` for all users in the model.
+   * Rewrites `isInSystemAdminGroup` triples to `"false"^^xsd:boolean` for every user in the model.
    *
    * Project members/admins who are also system administrators on the source instance must be
    * included in the export (otherwise they are silently dropped from the project), but the
@@ -104,20 +104,27 @@ object AdminModelScoping {
    * `isInSystemAdminGroup` property has cardinality 1 on `knora-admin:User`, so the triple is
    * rewritten to `false` rather than removed.
    *
+   * For any user carrying one or more `isInSystemAdminGroup` statements, all such statements are
+   * removed and a single `"false"^^xsd:boolean` triple is added. This enforces the invariant
+   * unconditionally and tolerates malformed literals that would throw `DatatypeFormatException`
+   * if passed to `Literal.getBoolean`.
+   *
    * @param model the admin data Jena model (mutated in-place)
+   * @return the IRIs of users whose flag was demoted from `true` to `false` — for audit logging
    */
-  def stripSystemAdminFlag(model: Model): Unit = {
+  def clearSystemAdminFlag(model: Model): List[String] = {
     val falseLiteral = ResourceFactory.createTypedLiteral(false)
     val users        = model.listSubjectsWithProperty(RDF.`type`, userType).asScala.toList
-    users.foreach { user =>
-      val trueStatements = user
-        .listProperties(isInSystemAdminGroupProp)
-        .asScala
-        .filter(stmt => stmt.getObject.isLiteral && stmt.getLiteral.getBoolean)
-        .toList
-      trueStatements.foreach(model.remove)
-      if (trueStatements.nonEmpty)
+    users.flatMap { user =>
+      val existing = user.listProperties(isInSystemAdminGroupProp).asScala.toList
+      if (existing.isEmpty) None
+      else {
+        val wasTrue =
+          existing.exists(stmt => stmt.getObject.isLiteral && stmt.getLiteral.getLexicalForm.equalsIgnoreCase("true"))
+        existing.foreach(model.remove)
         val _ = model.add(user, isInSystemAdminGroupProp, falseLiteral)
+        Option.when(wasTrue)(user.getURI)
+      }
     }
   }
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminModelScoping.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminModelScoping.scala
@@ -94,4 +94,30 @@ object AdminModelScoping {
 
     statementsToRemove.foreach(model.remove)
   }
+
+  /**
+   * Replaces `isInSystemAdminGroup "true"` triples with `"false"` for all users in the model.
+   *
+   * Project members/admins who are also system administrators on the source instance must be
+   * included in the export (otherwise they are silently dropped from the project), but the
+   * source instance's system-admin membership must not leak into the imported project. The
+   * `isInSystemAdminGroup` property has cardinality 1 on `knora-admin:User`, so the triple is
+   * rewritten to `false` rather than removed.
+   *
+   * @param model the admin data Jena model (mutated in-place)
+   */
+  def stripSystemAdminFlag(model: Model): Unit = {
+    val falseLiteral = ResourceFactory.createTypedLiteral(false)
+    val users        = model.listSubjectsWithProperty(RDF.`type`, userType).asScala.toList
+    users.foreach { user =>
+      val trueStatements = user
+        .listProperties(isInSystemAdminGroupProp)
+        .asScala
+        .filter(stmt => stmt.getObject.isLiteral && stmt.getLiteral.getBoolean)
+        .toList
+      trueStatements.foreach(model.remove)
+      if (trueStatements.nonEmpty)
+        val _ = model.add(user, isInSystemAdminGroupProp, falseLiteral)
+    }
+  }
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportService.scala
@@ -138,17 +138,27 @@ final class ProjectMigrationExportService(
       rdfStr  <- triplestore.queryRdf(Construct(queryStr))
 
       // Step 3: Parse result into Jena model, scope memberships, write as NQuads
-      model <- ZIO.attempt {
-                 val m = org.apache.jena.rdf.model.ModelFactory.createDefaultModel()
-                 RDFDataMgr.read(
-                   m,
-                   java.io.ByteArrayInputStream(rdfStr.getBytes(java.nio.charset.StandardCharsets.UTF_8)),
-                   JenaLang.TURTLE,
-                 )
-                 AdminModelScoping.removeNonProjectMemberships(m, project.id.value)
-                 AdminModelScoping.stripSystemAdminFlag(m)
-                 m
-               }
+      parsed <- ZIO.attempt {
+                  val m = org.apache.jena.rdf.model.ModelFactory.createDefaultModel()
+                  RDFDataMgr.read(
+                    m,
+                    java.io.ByteArrayInputStream(rdfStr.getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+                    JenaLang.TURTLE,
+                  )
+                  AdminModelScoping.removeNonProjectMemberships(m, project.id.value)
+                  val demoted = AdminModelScoping.clearSystemAdminFlag(m)
+                  (m, demoted)
+                }
+      (model, demotedSysAdmins) = parsed
+
+      // Audit-log any users whose source-instance system-admin membership was rewritten to false.
+      _ <-
+        ZIO.when(demotedSysAdmins.nonEmpty)(
+          ZIO.logWarning(
+            s"$taskId: Export rewrote isInSystemAdminGroup from true to false for ${demotedSysAdmins.size} user(s): " +
+              demotedSysAdmins.mkString(", "),
+          ),
+        )
 
       // Warn if root user is in the export
       _ <- ZIO.foreachDiscard(AdminModelScoping.findRootUserIri(model))(iri =>

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportService.scala
@@ -146,6 +146,7 @@ final class ProjectMigrationExportService(
                    JenaLang.TURTLE,
                  )
                  AdminModelScoping.removeNonProjectMemberships(m, project.id.value)
+                 AdminModelScoping.stripSystemAdminFlag(m)
                  m
                }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationImportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationImportService.scala
@@ -276,7 +276,9 @@ final class ProjectMigrationImportService(
    * 1. Strips built-in user triples (SystemUser, AnonymousUser) — they already exist on every instance.
    * 2. For each remaining user, looks up by IRI, email, and username:
    *    - Found by IRI: verify identity match, log profile diffs, rewrite to scoped memberships only.
-   *    - Not found at all: fail on root user, strip SystemAdmin, scope memberships.
+   *    - Not found at all: fail on root user, strip SystemAdmin (defense-in-depth — the export already
+   *      rewrites the flag to false via [[AdminModelScoping.clearSystemAdminFlag]]; this guards against
+   *      tampering with admin.nq between export and import), scope memberships.
    *    - No IRI match but email/username collision: fail with details.
    */
   private def prepareAdminModel(model: Model, projectIri: ProjectIri): Task[Unit] = for {
@@ -433,6 +435,10 @@ final class ProjectMigrationImportService(
 
   /**
    * For a new user: fail on root, strip cross-project memberships and SystemAdmin.
+   *
+   * The export already rewrites `isInSystemAdminGroup` to `false` via
+   * [[AdminModelScoping.clearSystemAdminFlag]]; the strip below is defense-in-depth against
+   * tampered admin.nq bags where the flag could be re-asserted as `true`.
    */
   private def rewriteNewUserTriples(
     model: Model,
@@ -446,7 +452,7 @@ final class ProjectMigrationImportService(
         s"Import contains the root user '${userResource.getURI}'. Resources referencing root require pre-migration cleanup.",
       )
 
-    // Strip isInSystemAdminGroup
+    // Strip isInSystemAdminGroup (defense-in-depth — export already rewrites to false)
     val sysAdminProp = AdminModelScoping.isInSystemAdminGroupProp
     val sysAdminStmt = userResource.getProperty(sysAdminProp)
     if (sysAdminStmt != null && sysAdminStmt.getObject.isLiteral && sysAdminStmt.getLiteral.getBoolean)

--- a/webapi/src/test/scala/org/knora/webapi/slice/export/domain/AdminDataQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/export/domain/AdminDataQuerySpec.scala
@@ -17,16 +17,16 @@ object AdminDataQuerySpec extends ZIOSpecDefault {
   private val testUser2      = UserIri.unsafeFrom("http://rdfh.ch/users/user002")
 
   override def spec: Spec[TestEnvironment, Any] = suite("AdminDataQuerySpec")(
-    suite("build (project members only)")(
-      test("should exclude system admin users with FILTER NOT EXISTS") {
+    suite("build (project members)")(
+      test("should include all project members, including system admins") {
         val query       = AdminDataQuery.build(testProjectIri)
         val queryString = query.getQueryString
         assertTrue(
-          queryString.contains("FILTER NOT EXISTS"),
-          queryString.contains("isInSystemAdminGroup"),
+          !queryString.contains("FILTER NOT EXISTS"),
+          !queryString.contains("isInSystemAdminGroup"),
         )
       },
-      test("should still include non-admin users in the project") {
+      test("should include the project member pattern") {
         val query       = AdminDataQuery.build(testProjectIri)
         val queryString = query.getQueryString
         assertTrue(
@@ -58,20 +58,17 @@ object AdminDataQuerySpec extends ZIOSpecDefault {
           queryStr.contains(testUser2.value),
         )
       },
-      test("referenced users branch has no SystemAdmin FILTER NOT EXISTS") {
+      test("has no SystemAdmin filter on any branch") {
         val queryStr = AdminDataQuery.buildWithReferencedUsers(testProjectIri, Set(testUser1))
-        // The query has two UNION branches for users:
-        // 1. Project members with FILTER NOT EXISTS for SystemAdmin
-        // 2. Referenced users with VALUES but no SystemAdmin filter
-        // The referenced users branch should NOT have a second FILTER NOT EXISTS
-        val branchesWithFilterNotExists = "FILTER NOT EXISTS".r.findAllIn(queryStr).length
-        assertTrue(branchesWithFilterNotExists == 1)
+        assertTrue(
+          !queryStr.contains("FILTER NOT EXISTS"),
+          !queryStr.contains("isInSystemAdminGroup"),
+        )
       },
       test("includes project member pattern alongside referenced users") {
         val queryStr = AdminDataQuery.buildWithReferencedUsers(testProjectIri, Set(testUser1))
         assertTrue(
           queryStr.contains("knora-admin:isInProject"),
-          queryStr.contains("FILTER NOT EXISTS"),
           queryStr.contains("VALUES ?user"),
         )
       },

--- a/webapi/src/test/scala/org/knora/webapi/slice/export/domain/AdminModelScopingSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/export/domain/AdminModelScopingSpec.scala
@@ -10,6 +10,8 @@ import org.apache.jena.rdf.model.ResourceFactory
 import org.apache.jena.vocabulary.RDF
 import zio.test.*
 
+import scala.jdk.CollectionConverters.*
+
 import org.knora.webapi.messages.OntologyConstants.KnoraAdmin
 
 object AdminModelScopingSpec extends ZIOSpecDefault {
@@ -106,6 +108,37 @@ object AdminModelScopingSpec extends ZIOSpecDefault {
       val user = model.getResource(userIri)
       val prop = ResourceFactory.createProperty(KnoraAdmin.IsInProjectAdminGroup)
       assertTrue(!user.hasProperty(prop, model.createResource(otherProjectIri)))
+    },
+    test("stripSystemAdminFlag replaces true with false") {
+      val model        = createModel()
+      val sysAdminProp = ResourceFactory.createProperty(KnoraAdmin.IsInSystemAdminGroup)
+      val user         = model.getResource(userIri)
+      user.addProperty(sysAdminProp, ResourceFactory.createTypedLiteral(true))
+      AdminModelScoping.stripSystemAdminFlag(model)
+      val stmts = user.listProperties(sysAdminProp).asScala.toList
+      assertTrue(
+        stmts.size == 1,
+        stmts.forall(s => s.getObject.isLiteral && !s.getLiteral.getBoolean),
+      )
+    },
+    test("stripSystemAdminFlag leaves non-system-admin users untouched") {
+      val model        = createModel()
+      val sysAdminProp = ResourceFactory.createProperty(KnoraAdmin.IsInSystemAdminGroup)
+      val user         = model.getResource(userIri)
+      user.addProperty(sysAdminProp, ResourceFactory.createTypedLiteral(false))
+      AdminModelScoping.stripSystemAdminFlag(model)
+      val stmts = user.listProperties(sysAdminProp).asScala.toList
+      assertTrue(
+        stmts.size == 1,
+        stmts.forall(s => s.getObject.isLiteral && !s.getLiteral.getBoolean),
+      )
+    },
+    test("stripSystemAdminFlag does nothing when the flag is absent") {
+      val model = createModel()
+      AdminModelScoping.stripSystemAdminFlag(model)
+      val user         = model.getResource(userIri)
+      val sysAdminProp = ResourceFactory.createProperty(KnoraAdmin.IsInSystemAdminGroup)
+      assertTrue(user.listProperties(sysAdminProp).asScala.isEmpty)
     },
   )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/export/domain/AdminModelScopingSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/export/domain/AdminModelScopingSpec.scala
@@ -109,36 +109,54 @@ object AdminModelScopingSpec extends ZIOSpecDefault {
       val prop = ResourceFactory.createProperty(KnoraAdmin.IsInProjectAdminGroup)
       assertTrue(!user.hasProperty(prop, model.createResource(otherProjectIri)))
     },
-    test("stripSystemAdminFlag replaces true with false") {
+    test("replaces isInSystemAdminGroup true with false and reports the demoted user") {
       val model        = createModel()
       val sysAdminProp = ResourceFactory.createProperty(KnoraAdmin.IsInSystemAdminGroup)
       val user         = model.getResource(userIri)
       user.addProperty(sysAdminProp, ResourceFactory.createTypedLiteral(true))
-      AdminModelScoping.stripSystemAdminFlag(model)
-      val stmts = user.listProperties(sysAdminProp).asScala.toList
+      val demoted = AdminModelScoping.clearSystemAdminFlag(model)
+      val stmts   = user.listProperties(sysAdminProp).asScala.toList
       assertTrue(
         stmts.size == 1,
         stmts.forall(s => s.getObject.isLiteral && !s.getLiteral.getBoolean),
+        demoted == List(userIri),
       )
     },
-    test("stripSystemAdminFlag leaves non-system-admin users untouched") {
+    test("keeps existing false flag as false and does not report a demotion") {
       val model        = createModel()
       val sysAdminProp = ResourceFactory.createProperty(KnoraAdmin.IsInSystemAdminGroup)
       val user         = model.getResource(userIri)
       user.addProperty(sysAdminProp, ResourceFactory.createTypedLiteral(false))
-      AdminModelScoping.stripSystemAdminFlag(model)
-      val stmts = user.listProperties(sysAdminProp).asScala.toList
+      val demoted = AdminModelScoping.clearSystemAdminFlag(model)
+      val stmts   = user.listProperties(sysAdminProp).asScala.toList
       assertTrue(
         stmts.size == 1,
         stmts.forall(s => s.getObject.isLiteral && !s.getLiteral.getBoolean),
+        demoted.isEmpty,
       )
     },
-    test("stripSystemAdminFlag does nothing when the flag is absent") {
-      val model = createModel()
-      AdminModelScoping.stripSystemAdminFlag(model)
+    test("does nothing when isInSystemAdminGroup is absent") {
+      val model        = createModel()
+      val demoted      = AdminModelScoping.clearSystemAdminFlag(model)
       val user         = model.getResource(userIri)
       val sysAdminProp = ResourceFactory.createProperty(KnoraAdmin.IsInSystemAdminGroup)
-      assertTrue(user.listProperties(sysAdminProp).asScala.isEmpty)
+      assertTrue(
+        user.listProperties(sysAdminProp).asScala.isEmpty,
+        demoted.isEmpty,
+      )
+    },
+    test("tolerates malformed literals by overwriting them with false") {
+      val model        = createModel()
+      val sysAdminProp = ResourceFactory.createProperty(KnoraAdmin.IsInSystemAdminGroup)
+      val user         = model.getResource(userIri)
+      user.addProperty(sysAdminProp, model.createLiteral("not a boolean"))
+      val demoted = AdminModelScoping.clearSystemAdminFlag(model)
+      val stmts   = user.listProperties(sysAdminProp).asScala.toList
+      assertTrue(
+        stmts.size == 1,
+        stmts.forall(s => s.getObject.isLiteral && !s.getLiteral.getBoolean),
+        demoted.isEmpty,
+      )
     },
   )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportServiceSpec.scala
@@ -6,13 +6,21 @@
 package org.knora.webapi.slice.`export`.domain
 
 import com.typesafe.config.ConfigFactory
+import org.apache.jena.rdf.model.Model
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.riot.Lang as JenaLang
+import org.apache.jena.riot.RDFDataMgr
 import zio.*
 import zio.config.typesafe.TypesafeConfigProvider
 import zio.nio.file.Files
 import zio.nio.file.Path
 import zio.test.*
 
+import java.io.IOException
+import scala.jdk.CollectionConverters.*
+
 import org.knora.bagit.BagIt
+import org.knora.bagit.BagItError
 import org.knora.webapi.TestDataFactory
 import org.knora.webapi.messages.util.rdf.QuadFormat
 import org.knora.webapi.messages.util.rdf.SparqlSelectResult
@@ -174,6 +182,32 @@ object ProjectMigrationExportServiceSpec extends ZIOSpecDefault {
       }
       .retry(Schedule.spaced(100.millis) && Schedule.recurs(100))
 
+  /** Reads a file from inside a BagIt zip and returns its contents as a UTF-8 string. */
+  private def readBagFile(zipFile: Path, relPath: String): ZIO[Any, IOException | BagItError, String] =
+    ZIO.scoped {
+      for {
+        tempDir     <- Files.createTempDirectoryScoped(Some("verify-bag"), Seq.empty)
+        pair        <- BagIt.readAndValidateZip(zipFile, Some(tempDir))
+        (_, bagRoot) = pair
+        bytes       <- Files.readAllBytes(bagRoot / relPath)
+      } yield new String(bytes.toArray)
+    }
+
+  /** Parses N-Quads content into a Jena `Model` (unions all named graphs). */
+  private def parseNQuads(content: String): Model = {
+    val dataset = org.apache.jena.query.DatasetFactory.create()
+    RDFDataMgr.read(
+      dataset,
+      new java.io.ByteArrayInputStream(content.getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+      JenaLang.NQUADS,
+    )
+    val unioned = ModelFactory.createDefaultModel()
+    unioned.add(dataset.getDefaultModel)
+    dataset.listNames().asScala.foreach(name => unioned.add(dataset.getNamedModel(name)))
+    dataset.close()
+    unioned
+  }
+
   override def spec: Spec[Any, Any] = suite("ProjectMigrationExportService")(
     test("export with skipAssets=false calls ingest exportProject") {
       for {
@@ -309,21 +343,13 @@ object ProjectMigrationExportServiceSpec extends ZIOSpecDefault {
              |  knora-admin:belongsToProject <$projectIri> .
              |""".stripMargin
         for {
-          env    <- makeTestEnv
-          _      <- env.constructRdfRef.set(constructResult)
-          task   <- env.service.createExport(testProject, testUser, skipAssets = true)
-          result <- pollUntilDone(env.service, task.id)
-          // Read the admin.nq output from the BagIt zip
+          env            <- makeTestEnv
+          _              <- env.constructRdfRef.set(constructResult)
+          task           <- env.service.createExport(testProject, testUser, skipAssets = true)
+          result         <- pollUntilDone(env.service, task.id)
           zipFile        <- env.storage.exportBagItZipPath(task.id)
-          adminNqContent <- ZIO.scoped {
-                              Files.createTempDirectoryScoped(Some("verify-scoping"), Seq.empty).flatMap { tempDir =>
-                                BagIt.readAndValidateZip(zipFile, Some(tempDir)).flatMap { case (_, bagRoot) =>
-                                  val adminNq = bagRoot / "data" / "rdf" / "admin.nq"
-                                  Files.readAllBytes(adminNq).map(bytes => new String(bytes.toArray))
-                                }
-                              }
-                            }
-          _ <- env.service.deleteExport(task.id).catchAllCause(_ => ZIO.unit)
+          adminNqContent <- readBagFile(zipFile, "data/rdf/admin.nq")
+          _              <- env.service.deleteExport(task.id).catchAllCause(_ => ZIO.unit)
         } yield assertTrue(
           result.status == DataTaskStatus.Completed,
           adminNqContent.contains(projectIri),       // project membership retained
@@ -350,20 +376,22 @@ object ProjectMigrationExportServiceSpec extends ZIOSpecDefault {
           task           <- env.service.createExport(testProject, testUser, skipAssets = true)
           result         <- pollUntilDone(env.service, task.id)
           zipFile        <- env.storage.exportBagItZipPath(task.id)
-          adminNqContent <- ZIO.scoped {
-                              Files.createTempDirectoryScoped(Some("verify-sysadmin"), Seq.empty).flatMap { tempDir =>
-                                BagIt.readAndValidateZip(zipFile, Some(tempDir)).flatMap { case (_, bagRoot) =>
-                                  val adminNq = bagRoot / "data" / "rdf" / "admin.nq"
-                                  Files.readAllBytes(adminNq).map(bytes => new String(bytes.toArray))
-                                }
-                              }
-                            }
-          _ <- env.service.deleteExport(task.id).catchAllCause(_ => ZIO.unit)
+          adminNqContent <- readBagFile(zipFile, "data/rdf/admin.nq")
+          adminModel      = parseNQuads(adminNqContent)
+          sysAdminUser    = adminModel.getResource("http://rdfh.ch/users/sysadmin001")
+          sysAdminProp    =
+            org.apache.jena.rdf.model.ResourceFactory.createProperty(
+              "http://www.knora.org/ontology/knora-admin#isInSystemAdminGroup",
+            )
+          sysAdminStmts = sysAdminUser.listProperties(sysAdminProp).asScala.toList
+          _            <- env.service.deleteExport(task.id).catchAllCause(_ => ZIO.unit)
         } yield assertTrue(
           result.status == DataTaskStatus.Completed,
-          adminNqContent.contains("sysadmin001"),                     // system admin user retained
-          !adminNqContent.contains("isInSystemAdminGroup> \"true\""), // flag stripped
-          adminNqContent.contains("isInSystemAdminGroup> \"false\""), // flag set to false
+          // system admin user is retained in the export
+          sysAdminUser.listProperties().hasNext,
+          // exactly one isInSystemAdminGroup triple remains, and it is literal false
+          sysAdminStmts.size == 1,
+          sysAdminStmts.forall(s => s.getObject.isLiteral && !s.getLiteral.getBoolean),
         )
       },
     ),

--- a/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportServiceSpec.scala
@@ -330,6 +330,42 @@ object ProjectMigrationExportServiceSpec extends ZIOSpecDefault {
           !adminNqContent.contains("projects/OTHER"), // cross-project membership stripped
         )
       },
+      test("export keeps system admin project members but strips isInSystemAdminGroup flag") {
+        val ka              = "http://www.knora.org/ontology/knora-admin#"
+        val projectIri      = testProject.id.value
+        val constructResult =
+          s"""@prefix knora-admin: <$ka> .
+             |@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+             |<$projectIri> a knora-admin:knoraProject ;
+             |  knora-admin:projectShortcode "0001" .
+             |<http://rdfh.ch/users/sysadmin001> a knora-admin:User ;
+             |  knora-admin:username "sysadminUser" ;
+             |  knora-admin:email "sysadmin@example.com" ;
+             |  knora-admin:isInProject <$projectIri> ;
+             |  knora-admin:isInSystemAdminGroup "true"^^xsd:boolean .
+             |""".stripMargin
+        for {
+          env            <- makeTestEnv
+          _              <- env.constructRdfRef.set(constructResult)
+          task           <- env.service.createExport(testProject, testUser, skipAssets = true)
+          result         <- pollUntilDone(env.service, task.id)
+          zipFile        <- env.storage.exportBagItZipPath(task.id)
+          adminNqContent <- ZIO.scoped {
+                              Files.createTempDirectoryScoped(Some("verify-sysadmin"), Seq.empty).flatMap { tempDir =>
+                                BagIt.readAndValidateZip(zipFile, Some(tempDir)).flatMap { case (_, bagRoot) =>
+                                  val adminNq = bagRoot / "data" / "rdf" / "admin.nq"
+                                  Files.readAllBytes(adminNq).map(bytes => new String(bytes.toArray))
+                                }
+                              }
+                            }
+          _ <- env.service.deleteExport(task.id).catchAllCause(_ => ZIO.unit)
+        } yield assertTrue(
+          result.status == DataTaskStatus.Completed,
+          adminNqContent.contains("sysadmin001"),                     // system admin user retained
+          !adminNqContent.contains("isInSystemAdminGroup> \"true\""), // flag stripped
+          adminNqContent.contains("isInSystemAdminGroup> \"false\""), // flag set to false
+        )
+      },
     ),
   ).provide(configLayer) @@ TestAspect.withLiveClock @@ TestAspect.withLiveRandom @@ TestAspect.timeout(30.seconds)
 }


### PR DESCRIPTION
Project members or project admins who were also members of the SystemAdmin group on the source instance were silently dropped from project exports, so they disappeared from the project after re-import.

The export SPARQL `CONSTRUCT` no longer filters out system-admin users; instead the `isInSystemAdminGroup` flag is rewritten to `false` in the exported admin data. The source instance's system-admin membership therefore does not leak into the target instance, but the user keeps their project/group memberships.

Fixes [DEV-6281](https://linear.app/dasch/issue/DEV-6281/projectadminprojectmember-wird-falschlich-aus-dem-projekt-entfernt).