### PR TITLE
feat: Move Fuseki Docker image publishing to dsp-api (DEV-6277)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Assert fuseki/Dockerfile, Dependencies.scala, and docker-compose.yml agree
         run: |
           set -euo pipefail
-          DOCKERFILE_VER=$(grep '^ARG FUSEKI_VERSION=' fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
+          DOCKERFILE_VER=$(grep '^ARG IMAGE_VERSION=' fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
           DEPS_VER=$(grep 'val fusekiImage' project/Dependencies.scala | sed 's/.*:\([^"]*\)".*/\1/' | tr -d '[:space:]')
           COMPOSE_VER=$(grep 'image: daschswiss/apache-jena-fuseki:' docker-compose.yml | sed 's/.*apache-jena-fuseki://' | tr -d '[:space:]')
           echo "fuseki/Dockerfile:          $DOCKERFILE_VER"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -215,6 +215,24 @@ jobs:
       - name: Build docs
         run: just docs-build
 
+  check-fuseki-version-consistency:
+    name: Check Fuseki version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assert fuseki/Dockerfile, Dependencies.scala, and docker-compose.yml agree
+        run: |
+          set -euo pipefail
+          DOCKERFILE_VER=$(grep '^ARG FUSEKI_VERSION=' fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
+          DEPS_VER=$(grep 'val fusekiImage' project/Dependencies.scala | sed 's/.*:\([^"]*\)".*/\1/' | tr -d '[:space:]')
+          COMPOSE_VER=$(grep 'image: daschswiss/apache-jena-fuseki:' docker-compose.yml | sed 's/.*apache-jena-fuseki://' | tr -d '[:space:]')
+          echo "fuseki/Dockerfile:          $DOCKERFILE_VER"
+          echo "project/Dependencies.scala: $DEPS_VER"
+          echo "docker-compose.yml:         $COMPOSE_VER"
+          [ "$DOCKERFILE_VER" = "$DEPS_VER" ] || { echo "ERROR: Dockerfile ($DOCKERFILE_VER) != Dependencies.scala ($DEPS_VER)"; exit 1; }
+          [ "$DOCKERFILE_VER" = "$COMPOSE_VER" ] || { echo "ERROR: Dockerfile ($DOCKERFILE_VER) != docker-compose.yml ($COMPOSE_VER)"; exit 1; }
+          echo "All Fuseki versions match: $DOCKERFILE_VER"
+
   check-formatting:
     name: Check formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -106,6 +106,14 @@ jobs:
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
         with:
           java-version: ${{ env.JAVA_VERSION }}
+      - name: Build Fuseki image locally (only when fuseki/ changed)
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }}...HEAD)
+          if echo "$CHANGED" | grep -q "^fuseki/"; then
+            make docker-build-fuseki-image
+          fi
       - name: Run integration tests
         run: make test-it
       - name: WebApi IT Test Report
@@ -136,6 +144,14 @@ jobs:
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
         with:
           java-version: ${{ env.JAVA_VERSION }}
+      - name: Build Fuseki image locally (only when fuseki/ changed)
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }}...HEAD)
+          if echo "$CHANGED" | grep -q "^fuseki/"; then
+            make docker-build-fuseki-image
+          fi
       - name: Run end-to-end tests
         run: ./sbtx "test-e2e/test"
       - name: WebApi E2E Test Report

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -106,7 +106,7 @@ jobs:
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
         with:
           java-version: ${{ env.JAVA_VERSION }}
-      - name: Build Fuseki image locally (only when fuseki/ changed)
+      - name: Build Fuseki image if fuseki/ changed
         shell: bash
         run: |
           set -euo pipefail
@@ -144,7 +144,7 @@ jobs:
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
         with:
           java-version: ${{ env.JAVA_VERSION }}
-      - name: Build Fuseki image locally (only when fuseki/ changed)
+      - name: Build Fuseki image if fuseki/ changed
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/docker-publish-fuseki.yml
+++ b/.github/workflows/docker-publish-fuseki.yml
@@ -1,0 +1,61 @@
+name: Docker publish Fuseki image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'fuseki/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false  # never cancel a publish mid-push
+
+permissions:
+  contents: read
+
+jobs:
+  publish-fuseki:
+    name: Publish Fuseki image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      version: ${{ steps.fuseki_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Fuseki version
+        id: fuseki_version
+        run: |
+          set -euo pipefail
+          V=$(grep '^ARG FUSEKI_VERSION=' fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
+          [[ "$V" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "FUSEKI_VERSION invalid: $V"; exit 1; }
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Build and publish Fuseki image to Docker Hub
+        run: make docker-publish-fuseki-image
+
+  trigger-dev-deployment:
+    name: Trigger deployment to DEV
+    runs-on: ubuntu-latest
+    needs: publish-fuseki
+    permissions: {}
+    steps:
+      - name: Trigger deployment to DEV
+        env:
+          FUSEKI_VERSION: ${{ needs.publish-fuseki.outputs.version }}
+          JENKINS_BASIC_AUTH_USER: ${{ secrets.JENKINS_BASIC_AUTH_USER }}
+          JENKINS_BASIC_AUTH_PASS: ${{ secrets.JENKINS_BASIC_AUTH_PASS }}
+          JENKINS_DEV_WEBHOOK: ${{ secrets.JENKINS_DEV_WEBHOOK }}
+        run: |
+          curl -f -u "${JENKINS_BASIC_AUTH_USER}:${JENKINS_BASIC_AUTH_PASS}" \
+               -X POST "${JENKINS_DEV_WEBHOOK}" \
+               --data-urlencode "Service=db" \
+               --data-urlencode "Version=${FUSEKI_VERSION}"

--- a/.github/workflows/docker-publish-fuseki.yml
+++ b/.github/workflows/docker-publish-fuseki.yml
@@ -27,8 +27,8 @@ jobs:
         id: fuseki_version
         run: |
           set -euo pipefail
-          V=$(grep '^ARG FUSEKI_VERSION=' fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
-          [[ "$V" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "FUSEKI_VERSION invalid: $V"; exit 1; }
+          V=$(grep '^ARG IMAGE_VERSION=' fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
+          [[ "$V" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "IMAGE_VERSION invalid: $V"; exit 1; }
           echo "version=$V" >> "$GITHUB_OUTPUT"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish-from-branch.yml
+++ b/.github/workflows/publish-from-branch.yml
@@ -19,4 +19,3 @@ jobs:
         run: |
           echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
           make docker-publish
-          make docker-publish-fuseki-image

--- a/.github/workflows/publish-from-branch.yml
+++ b/.github/workflows/publish-from-branch.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-from-branch.yml
+++ b/.github/workflows/publish-from-branch.yml
@@ -10,10 +10,13 @@ jobs:
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and publish all images to Dockerhub
         run: |
           echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
           make docker-publish
+          make docker-publish-fuseki-image

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,13 +12,16 @@ jobs:
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and publish all images to Dockerhub
         run: |
           echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
           make docker-publish
+          make docker-publish-fuseki-image
 
   send-chat-notification:
     name: Send google chat notification

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
           make docker-publish
-          make docker-publish-fuseki-image
 
   send-chat-notification:
     name: Send google chat notification

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,29 @@ docker-publish-ingest-image: # publish ingest image to Dockerhub
 docker-build-ingest-image: # publish ingest image to Dockerhub
 	export DOCKER_BUILDKIT=1; $(SBTX) "ingest / Docker / publishLocal"
 
+# Lazy assignment (=): evaluated only when a Fuseki target is invoked, not at parse time.
+# This avoids errors when fuseki/Dockerfile does not yet exist (Step 1 must run first).
+FUSEKI_VERSION       = $(shell grep "^ARG FUSEKI_VERSION=" fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
+FUSEKI_DOCKER_IMAGE  = daschswiss/apache-jena-fuseki:$(FUSEKI_VERSION)
+
+.PHONY: docker-build-fuseki-image
+docker-build-fuseki-image: # build Fuseki image into the local Docker daemon
+	export DOCKER_BUILDKIT=1; \
+	docker build \
+	  -t $(FUSEKI_DOCKER_IMAGE) \
+	  fuseki/
+
+.PHONY: docker-publish-fuseki-image
+docker-publish-fuseki-image: # publish multi-platform Fuseki image to Docker Hub
+	export DOCKER_BUILDKIT=1; \
+	docker buildx build \
+	  --platform linux/amd64,linux/arm64/v8 \
+	  -t $(FUSEKI_DOCKER_IMAGE) \
+	  --push \
+	  fuseki/
+
 .PHONY: docker-build
-docker-build: docker-build-dsp-api-image docker-build-sipi-image docker-build-ingest-image ## build and publish all Docker images locally
+docker-build: docker-build-dsp-api-image docker-build-sipi-image docker-build-ingest-image docker-build-fuseki-image ## build and publish all Docker images locally
 
 .PHONY: docker-publish
 docker-publish: docker-publish-dsp-api-image docker-publish-sipi-image docker-publish-ingest-image ## publish all Docker images to Dockerhub

--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,10 @@ docker-publish-fuseki-image: # publish multi-platform Fuseki image to Docker Hub
 	  fuseki/
 
 .PHONY: docker-build
-docker-build: docker-build-dsp-api-image docker-build-sipi-image docker-build-ingest-image docker-build-fuseki-image ## build and publish all Docker images locally
+docker-build: docker-build-dsp-api-image docker-build-sipi-image docker-build-ingest-image ## build dsp-api/sipi/ingest images locally (Fuseki excluded: use docker-build-fuseki-image explicitly)
 
 .PHONY: docker-publish
-docker-publish: docker-publish-dsp-api-image docker-publish-sipi-image docker-publish-ingest-image ## publish all Docker images to Dockerhub (Fuseki excluded: published separately via docker-publish-fuseki-image)
+docker-publish: docker-publish-dsp-api-image docker-publish-sipi-image docker-publish-ingest-image ## publish dsp-api/sipi/ingest images to Dockerhub (Fuseki excluded: published separately via docker-publish-fuseki-image)
 
 .PHONY: docker-image-tag
 docker-image-tag: ## prints the docker image tag

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ docker-build-ingest-image: # publish ingest image to Dockerhub
 
 # Lazy assignment (=): evaluated only when a Fuseki target is invoked, not at parse time.
 # This avoids errors when fuseki/Dockerfile does not yet exist (Step 1 must run first).
-FUSEKI_VERSION       = $(shell grep "^ARG FUSEKI_VERSION=" fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
-FUSEKI_DOCKER_IMAGE  = daschswiss/apache-jena-fuseki:$(FUSEKI_VERSION)
+FUSEKI_IMAGE_VERSION = $(shell grep "^ARG IMAGE_VERSION=" fuseki/Dockerfile | cut -d= -f2 | tr -d '"[:space:]')
+FUSEKI_DOCKER_IMAGE  = daschswiss/apache-jena-fuseki:$(FUSEKI_IMAGE_VERSION)
 
 .PHONY: docker-build-fuseki-image
 docker-build-fuseki-image: # build Fuseki image into the local Docker daemon

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ docker-publish-fuseki-image: # publish multi-platform Fuseki image to Docker Hub
 docker-build: docker-build-dsp-api-image docker-build-sipi-image docker-build-ingest-image docker-build-fuseki-image ## build and publish all Docker images locally
 
 .PHONY: docker-publish
-docker-publish: docker-publish-dsp-api-image docker-publish-sipi-image docker-publish-ingest-image ## publish all Docker images to Dockerhub
+docker-publish: docker-publish-dsp-api-image docker-publish-sipi-image docker-publish-ingest-image ## publish all Docker images to Dockerhub (Fuseki excluded: published separately via docker-publish-fuseki-image)
 
 .PHONY: docker-image-tag
 docker-image-tag: ## prints the docker image tag

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     # should be the same version as in Dependencies.scala,
     # make sure to use the same version in ops-deploy repository when deploying new DSP releases!
     image: daschswiss/apache-jena-fuseki:5.5.0-3
+    build:
+      context: ./fuseki
     ports:
       - "3030:3030"
     volumes:

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -18,6 +18,7 @@
 FROM eclipse-temurin:21-jre-jammy
 
 ENV LANG C.UTF-8
+# hadolint ignore=DL3008
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
@@ -65,7 +66,7 @@ RUN  (curl --location --silent --show-error --fail --retry-connrefused --retry 3
       tar zxf fuseki.tar.gz && \
       mv apache-jena-fuseki* $FUSEKI_HOME && \
       rm fuseki.tar.gz* && \
-      cd $FUSEKI_HOME && rm -rf fuseki.war && chmod 755 fuseki-server
+      rm -rf "$FUSEKI_HOME/fuseki.war" && chmod 755 "$FUSEKI_HOME/fuseki-server"
 
 # Verify that the binary works
 RUN  bash -c '[ "$($FUSEKI_HOME/fuseki-server --version)" == "Apache Jena Fuseki version $JENA_VERSION" ]'

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -29,11 +29,11 @@ RUN set -eux; \
 
 # Update below according to https://jena.apache.org/download/
 # and checksum for apache-jena-fuseki-<version>.tar.gz.sha512
-ARG FUSEKI_VERSION=5.5.0-3
-ARG JENA_VERSION=5.5.0
+ARG IMAGE_VERSION=5.5.0-3
+ARG FUSEKI_VERSION=5.5.0
 ARG FUSEKI_SHA512=bfbf59eac731b71bcf8e148f2abeda9b4adca215639eef3bba61243b308572b23a9a70a43c1483247f9894bfb23d69b59e0e64e1da47cb3cfc592aa979084d5c
+ENV IMAGE_VERSION=$IMAGE_VERSION
 ENV FUSEKI_VERSION=$FUSEKI_VERSION
-ENV JENA_VERSION=$JENA_VERSION
 ENV FUSEKI_SHA512=$FUSEKI_SHA512
 # No need for https due to sha512 checksums below
 ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
@@ -44,7 +44,7 @@ LABEL org.opencontainers.image.source https://github.com/dasch-swiss/dsp-api
 LABEL org.opencontainers.image.documentation https://jena.apache.org/documentation/fuseki2/
 LABEL org.opencontainers.image.title "Apache Jena Fuseki"
 LABEL org.opencontainers.image.description "Fuseki is a SPARQL 1.1 server with a web interface, backed by the Apache Jena TDB RDF triple store."
-LABEL org.opencontainers.image.version ${FUSEKI_VERSION}
+LABEL org.opencontainers.image.version ${IMAGE_VERSION}
 LABEL org.opencontainers.image.licenses "(Apache-2.0 AND (GPL-2.0 WITH Classpath-exception-2.0) AND GPL-3.0)"
 LABEL org.opencontainers.image.authors "DaSCH — https://dasch.swiss"
 
@@ -60,8 +60,8 @@ WORKDIR /tmp
 # published sha512 checksum
 RUN echo "$FUSEKI_SHA512  fuseki.tar.gz" > fuseki.tar.gz.sha512
 # Download/check/unpack/move in one go (to reduce image size)
-RUN  (curl --location --silent --show-error --fail --retry-connrefused --retry 3 --output fuseki.tar.gz ${ASF_MIRROR}jena/binaries/apache-jena-fuseki-$JENA_VERSION.tar.gz || \
-      curl --fail --silent --show-error --retry-connrefused --retry 3 --output fuseki.tar.gz $ASF_ARCHIVE/jena/binaries/apache-jena-fuseki-$JENA_VERSION.tar.gz) && \
+RUN  (curl --location --silent --show-error --fail --retry-connrefused --retry 3 --output fuseki.tar.gz ${ASF_MIRROR}jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz || \
+      curl --fail --silent --show-error --retry-connrefused --retry 3 --output fuseki.tar.gz $ASF_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz) && \
       sha512sum -c fuseki.tar.gz.sha512 && \
       tar zxf fuseki.tar.gz && \
       mv apache-jena-fuseki* $FUSEKI_HOME && \
@@ -69,7 +69,7 @@ RUN  (curl --location --silent --show-error --fail --retry-connrefused --retry 3
       rm -rf "$FUSEKI_HOME/fuseki.war" && chmod 755 "$FUSEKI_HOME/fuseki-server"
 
 # Verify that the binary works
-RUN  bash -c '[ "$($FUSEKI_HOME/fuseki-server --version)" == "Apache Jena Fuseki version $JENA_VERSION" ]'
+RUN  bash -c '[ "$($FUSEKI_HOME/fuseki-server --version)" == "Apache Jena Fuseki version $FUSEKI_VERSION" ]'
 
 # shiro.ini contains a default password. To override, start
 # container with ADMIN_PASSWORD environment variable set

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,0 +1,102 @@
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Credits: Mainly copied from https://github.com/stain/jena-docker
+
+FROM eclipse-temurin:21-jre-jammy
+
+ENV LANG C.UTF-8
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+       tini bash curl ca-certificates findutils coreutils pwgen procps \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+
+# Update below according to https://jena.apache.org/download/
+# and checksum for apache-jena-fuseki-<version>.tar.gz.sha512
+ARG FUSEKI_VERSION=5.5.0-3
+ARG JENA_VERSION=5.5.0
+ARG FUSEKI_SHA512=bfbf59eac731b71bcf8e148f2abeda9b4adca215639eef3bba61243b308572b23a9a70a43c1483247f9894bfb23d69b59e0e64e1da47cb3cfc592aa979084d5c
+ENV FUSEKI_VERSION=$FUSEKI_VERSION
+ENV JENA_VERSION=$JENA_VERSION
+ENV FUSEKI_SHA512=$FUSEKI_SHA512
+# No need for https due to sha512 checksums below
+ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
+ENV ASF_ARCHIVE http://archive.apache.org/dist/
+
+LABEL org.opencontainers.image.url https://github.com/dasch-swiss/dsp-api/tree/main/fuseki
+LABEL org.opencontainers.image.source https://github.com/dasch-swiss/dsp-api
+LABEL org.opencontainers.image.documentation https://jena.apache.org/documentation/fuseki2/
+LABEL org.opencontainers.image.title "Apache Jena Fuseki"
+LABEL org.opencontainers.image.description "Fuseki is a SPARQL 1.1 server with a web interface, backed by the Apache Jena TDB RDF triple store."
+LABEL org.opencontainers.image.version ${FUSEKI_VERSION}
+LABEL org.opencontainers.image.licenses "(Apache-2.0 AND (GPL-2.0 WITH Classpath-exception-2.0) AND GPL-3.0)"
+LABEL org.opencontainers.image.authors "DaSCH — https://dasch.swiss"
+
+# Config and data
+VOLUME /fuseki
+ENV FUSEKI_BASE /fuseki
+ENV INDEX_BASE $FUSEKI_BASE/lucene
+
+# Installation folder
+ENV FUSEKI_HOME /jena-fuseki
+
+WORKDIR /tmp
+# published sha512 checksum
+RUN echo "$FUSEKI_SHA512  fuseki.tar.gz" > fuseki.tar.gz.sha512
+# Download/check/unpack/move in one go (to reduce image size)
+RUN  (curl --location --silent --show-error --fail --retry-connrefused --retry 3 --output fuseki.tar.gz ${ASF_MIRROR}jena/binaries/apache-jena-fuseki-$JENA_VERSION.tar.gz || \
+      curl --fail --silent --show-error --retry-connrefused --retry 3 --output fuseki.tar.gz $ASF_ARCHIVE/jena/binaries/apache-jena-fuseki-$JENA_VERSION.tar.gz) && \
+      sha512sum -c fuseki.tar.gz.sha512 && \
+      tar zxf fuseki.tar.gz && \
+      mv apache-jena-fuseki* $FUSEKI_HOME && \
+      rm fuseki.tar.gz* && \
+      cd $FUSEKI_HOME && rm -rf fuseki.war && chmod 755 fuseki-server
+
+# Verify that the binary works
+RUN  bash -c '[ "$($FUSEKI_HOME/fuseki-server --version)" == "Apache Jena Fuseki version $JENA_VERSION" ]'
+
+# shiro.ini contains a default password. To override, start
+# container with ADMIN_PASSWORD environment variable set
+COPY shiro.ini $FUSEKI_HOME/shiro.ini
+
+# Create built-in database config
+COPY dsp-repo.ttl $FUSEKI_HOME/dsp-repo.ttl
+
+# Create entrypoint
+COPY docker-entrypoint.sh /
+RUN chmod 755 /docker-entrypoint.sh
+
+# Create healthcheck
+COPY healthcheck.sh /
+RUN chmod 755 /healthcheck.sh
+
+# Periodically check whether Fuseki is running and dsp-repo exists
+HEALTHCHECK --interval=15s --timeout=3s --retries=3 --start-period=30s \
+  CMD /healthcheck.sh || exit 1
+
+# Add otel java agent and pyroscope extension
+ARG OTEL_AGENT_VERSION=v2.21.0
+ARG OTEL_PYROSCOPE_VERSION=v1.0.4
+ADD "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar" "/usr/local/lib/opentelemetry-javaagent.jar"
+ADD "https://github.com/grafana/otel-profiling-java/releases/download/${OTEL_PYROSCOPE_VERSION}/pyroscope-otel.jar" "/usr/local/lib/pyroscope-otel.jar"
+
+# Where we start our server from
+WORKDIR $FUSEKI_HOME
+EXPOSE 3030
+ENTRYPOINT ["/usr/bin/tini", "--", "/docker-entrypoint.sh"]
+CMD ["/jena-fuseki/fuseki-server"]

--- a/fuseki/README.md
+++ b/fuseki/README.md
@@ -1,0 +1,45 @@
+# Apache Jena Fuseki — DaSCH image
+
+Custom Docker image for [Apache Jena Fuseki](https://jena.apache.org/documentation/fuseki2/) used as the triplestore for dsp-api.
+
+Published to Docker Hub as `daschswiss/apache-jena-fuseki:<IMAGE_VERSION>`.
+
+## What this image is
+
+Fuseki is a SPARQL 1.1 server backed by Apache Jena TDB. This image extends the upstream Fuseki distribution with:
+
+- A pre-configured `dsp-repo` dataset (see `dsp-repo.ttl`)
+- A `shiro.ini` with password-based access control
+- A healthcheck script that verifies Fuseki is running and the `dsp-repo` dataset exists
+- OpenTelemetry Java agent and Pyroscope extension for observability
+
+## Pre-configured dataset
+
+The `dsp-repo` dataset is created automatically on first start from `dsp-repo.ttl`. It is mounted at `/fuseki/configuration/dsp-repo.ttl` inside the container. The data volume is persisted at `/fuseki`.
+
+## Configuration
+
+| Variable | Description | Default |
+|---|---|---|
+| `ADMIN_PASSWORD` | Fuseki admin password | value from `shiro.ini` |
+| `JVM_ARGS` | JVM heap and flags | `-Xmx4G` |
+| `REBUILD_INDEX_OF_DATASET` | Dataset name to rebuild Lucene index for | unset |
+
+## Updating Jena/Fuseki
+
+1. Find the new version on [jena.apache.org/download](https://jena.apache.org/download/)
+2. Download the SHA512 checksum for `apache-jena-fuseki-<version>.tar.gz.sha512`
+3. Update `fuseki/Dockerfile`:
+   - `ARG IMAGE_VERSION` — new Docker image tag (e.g. `5.6.0-1`, increment the `-N` suffix for DaSCH revisions)
+   - `ARG FUSEKI_VERSION` — new Apache Jena Fuseki version (e.g. `5.6.0`)
+   - `ARG FUSEKI_SHA512` — new SHA512 checksum
+4. Update `docker-compose.yml`: bump the `db` service image tag to match `IMAGE_VERSION`
+5. Update `project/Dependencies.scala`: bump `fusekiImage` to match `IMAGE_VERSION`
+
+The CI `check-fuseki-version-consistency` job will fail if these three are out of sync.
+
+## Publishing
+
+The image is published automatically by `docker-publish-fuseki.yml` on every merge to `main` that touches `fuseki/**`. No manual action is needed — open a PR with the version bump and merge it.
+
+To publish manually from a branch (e.g. for testing): trigger `Docker Publish from branch` via GitHub Actions `workflow_dispatch`.

--- a/fuseki/docker-entrypoint.sh
+++ b/fuseki/docker-entrypoint.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -e
+
+# Log with the same logging format as Fuseki
+log() {
+  printf "%s %-5s Entrypoint      :: %s\n" "$(date +%H:%M:%S)" "$1" "$2"
+}
+info() {
+  log "INFO" "$1"
+}
+warn() {
+  log "WARN" "$1" >&2
+}
+error() {
+  log "ERROR" "$1" >&2
+}
+
+# copy shiro.ini
+cp "$FUSEKI_HOME/shiro.ini" "$FUSEKI_BASE/shiro.ini"
+
+# $ADMIN_PASSWORD can always override
+if [ -n "$ADMIN_PASSWORD" ] ; then
+  sed -i "s/^admin=[^,]\+/admin=$ADMIN_PASSWORD/" "$FUSEKI_BASE/shiro.ini"
+fi
+
+# generate password for healthcheck
+openssl rand -hex 32 > "/var/tmp/healthcheck_password"
+sed -i "s/^healthcheck=[^,]\+/healthcheck=$(cat "/var/tmp/healthcheck_password")/" "$FUSEKI_BASE/shiro.ini"
+
+# password placeholder sanity check
+if grep -Fq "=pw" "$FUSEKI_BASE/shiro.ini"; then
+  error "Password placeholder was not replaced!"
+  exit 1
+fi
+
+# copy dsp-repo.ttl
+if [ ! -e "$FUSEKI_BASE/configuration/dsp-repo.ttl" ]; then
+  mkdir -p "$FUSEKI_BASE/configuration"
+  cp "$FUSEKI_HOME/dsp-repo.ttl" "$FUSEKI_BASE/configuration/dsp-repo.ttl"
+fi
+
+# Check if index rebuild marker file exists
+if [ ! -n "$REBUILD_INDEX_OF_DATASET" ] && [ -f "$REBUILD_INDEX_MARKER_FILE" ] ; then
+  info "Detected index rebuild marker file ${REBUILD_INDEX_MARKER_FILE}"
+  REBUILD_INDEX_OF_DATASET="$(cat "$REBUILD_INDEX_MARKER_FILE" | sed "s/[^[:alpha:]_-]/_/g")"
+  remove_marker_file=true
+fi
+
+# Rebuild lucene index of the dataset specified
+# by REBUILD_INDEX_OF_DATASET if set
+if [ -n "$REBUILD_INDEX_OF_DATASET" ] ; then
+  index_base="${INDEX_BASE:-${FUSEKI_BASE}/lucene}"
+  if [ -d "${index_base}/${REBUILD_INDEX_OF_DATASET}" ] ; then
+    info "Deleting old index data of dataset ${REBUILD_INDEX_OF_DATASET}"
+    if ! rm -r "${index_base}/${REBUILD_INDEX_OF_DATASET}" ; then
+      error "Failed deleting old index data"
+      exit 1
+    fi
+  fi
+  info "Rebuilding index of dataset ${REBUILD_INDEX_OF_DATASET}..."
+  if java -cp "${FUSEKI_HOME}/fuseki-server.jar" jena.textindexer --desc="${FUSEKI_BASE}/configuration/${REBUILD_INDEX_OF_DATASET}.ttl" ; then
+    info "Successfully rebuilt index"
+    # Remove marker on successful rebuild
+    if [ "$remove_marker_file" = true ] && ! rm "$REBUILD_INDEX_MARKER_FILE" ; then
+      warn "Failed removing index rebuild marker file ${REBUILD_INDEX_MARKER_FILE}"
+    fi
+  else
+    error "Failed rebuilding index"
+    exit 1
+  fi
+fi
+
+# Change JVM_ARGS to address warnings in Java 21+:
+#   WARNING: A restricted method in java.lang.foreign.Linker has been called
+#   WARNING: java.lang.foreign.Linker::downcallHandle has been called by the unnamed module
+#   WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for this module
+#   WARN  VectorizationProvider :: Java vector incubator module is not readable. For optimal vector performance, pass '--add-modules jdk.incubator.vector' to enable Vector API.
+# See also:
+#   https://github.com/apache/jena/issues/2533
+#   https://github.com/apache/jena/pull/2782
+#   https://github.com/apache/jena/blob/c14193e528a86e97f0ab86cf3827d6ba9ac60296/jena-text/pom.xml#L32-L39
+if [ -z "$JVM_ARGS" ]; then
+  # this is the default if not set, see /jena-fuseki/fuseki-server wrapper
+  JVM_ARGS="-Xmx4G"
+fi
+#export JVM_ARGS="${JVM_ARGS} --enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector"
+info "JVM_ARGS: $JVM_ARGS"
+
+# Start Fueski server
+exec "$@"

--- a/fuseki/docker-entrypoint.sh
+++ b/fuseki/docker-entrypoint.sh
@@ -40,7 +40,7 @@ fi
 
 # generate password for healthcheck
 openssl rand -hex 32 > "/var/tmp/healthcheck_password"
-sed -i "s/^healthcheck=[^,]\+/healthcheck=$(cat "/var/tmp/healthcheck_password")/" "$FUSEKI_BASE/shiro.ini"
+sed -i "s/^healthcheck=[^,]\+/healthcheck=$(< "/var/tmp/healthcheck_password")/" "$FUSEKI_BASE/shiro.ini"
 
 # password placeholder sanity check
 if grep -Fq "=pw" "$FUSEKI_BASE/shiro.ini"; then

--- a/fuseki/docker-entrypoint.sh
+++ b/fuseki/docker-entrypoint.sh
@@ -57,7 +57,7 @@ fi
 # Check if index rebuild marker file exists
 if [ ! -n "$REBUILD_INDEX_OF_DATASET" ] && [ -f "$REBUILD_INDEX_MARKER_FILE" ] ; then
   info "Detected index rebuild marker file ${REBUILD_INDEX_MARKER_FILE}"
-  REBUILD_INDEX_OF_DATASET="$(cat "$REBUILD_INDEX_MARKER_FILE" | sed "s/[^[:alpha:]_-]/_/g")"
+  REBUILD_INDEX_OF_DATASET="$(sed "s/[^[:alpha:]_-]/_/g" "$REBUILD_INDEX_MARKER_FILE")"
   remove_marker_file=true
 fi
 

--- a/fuseki/dsp-repo.ttl
+++ b/fuseki/dsp-repo.ttl
@@ -1,0 +1,52 @@
+@prefix :           <http://base/#> .
+@prefix fuseki:     <http://jena.apache.org/fuseki#> .
+@prefix ja:         <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix tdb2:       <http://jena.apache.org/2016/tdb#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix text:       <http://jena.apache.org/text#> .
+@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+
+:service_tdb_all        a                                   fuseki:Service ;
+                        rdfs:label                          "TDB2 dsp-repo" ;
+                        fuseki:dataset                      :text_dataset ;
+                        fuseki:name                         "dsp-repo" ;
+                        fuseki:serviceQuery                 "query" , "sparql" ;
+                        fuseki:serviceReadGraphStore        "get" ;
+                        fuseki:serviceReadWriteGraphStore   "data" ;
+                        fuseki:serviceUpdate                "update" ;
+                        fuseki:serviceUpload                "upload" .
+
+## ---------------------------------------------------------------
+## This URI must be fixed - it's used to assemble the text dataset.
+
+:text_dataset           rdf:type                            text:TextDataset ;
+                        text:dataset                        :tdb_dataset_readwrite ;
+                        text:index                          :indexLucene .
+
+# A TDB datset used for RDF storage
+:tdb_dataset_readwrite  a                                   tdb2:DatasetTDB2 ;
+                        tdb2:unionDefaultGraph              true ;
+                        tdb2:location                       "/fuseki/databases/dsp-repo" .
+
+# Text index description
+:indexLucene            a                                   text:TextIndexLucene ;
+                        text:directory                      "/fuseki/lucene/dsp-repo" ;
+                        text:entityMap                      :entMap ;
+                        text:analyzer                       [ a text:ConfigurableAnalyzer ;
+                                                               text:tokenizer text:WhitespaceTokenizer ;
+                                                               text:filters ( text:ASCIIFoldingFilter text:LowerCaseFilter)
+                                                            ] .
+
+# Mapping in the index
+# URI stored in field "uri"
+# knora-base:valueHasString is mapped to field "text"
+:entMap                 a                                   text:EntityMap ;
+                        text:entityField                    "uri" ;
+                        text:defaultField                   "text" ;
+                        text:uidField                       "uid" ;
+                        text:map                            (
+                                                                [ text:field  "text" ;  text:predicate  rdfs:label ]
+                                                                [ text:field  "text" ;  text:predicate  knora-base:valueHasString ]
+                                                                [ text:field  "text" ;  text:predicate  knora-base:valueHasComment ]
+                                                            ) .

--- a/fuseki/healthcheck.sh
+++ b/fuseki/healthcheck.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Log with the same logging format as Fuseki
+log() {
+  printf "%s %-5s Healthcheck     :: %s\n" "$(date +%H:%M:%S)" "$1" "$2"
+}
+warn() {
+  log "WARN" "$1" >&2
+}
+
+if ! curl -s --fail 'http://localhost:3030/$/ping' > /dev/null; then
+  warn "Not responding to ping"
+  exit 1
+fi
+
+healthcheck_user='healthcheck'
+healthcheck_password="$(cat "/var/tmp/healthcheck_password")"
+if ! curl -s --fail 'http://localhost:3030/$/datasets/dsp-repo' --config - \
+     <<< '--user "'"${healthcheck_user}:${healthcheck_password}"'"' > /dev/null
+then
+  warn "Dataset 'dsp-repo' is missing or unavailable"
+  exit 1
+fi

--- a/fuseki/shiro.ini
+++ b/fuseki/shiro.ini
@@ -1,0 +1,65 @@
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+[main]
+# Development
+ssl.enabled = false
+
+plainMatcher=org.apache.shiro.authc.credential.SimpleCredentialsMatcher
+#iniRealm=org.apache.shiro.realm.text.IniRealm
+iniRealm.credentialsMatcher = $plainMatcher
+
+#localhost=org.apache.jena.fuseki.authz.LocalhostFilter
+
+rest=org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter
+
+[users]
+# Implicitly adds "iniRealm =  org.apache.shiro.realm.text.IniRealm"
+admin=pw,adminRole
+healthcheck=pw,healthcheckRole
+
+[roles]
+adminRole=datasets:read,datasets:create,datasets:update,datasets:delete
+healthcheckRole=datasets:read
+
+[urls]
+## Control functions open to anyone
+/$/status  = anon
+/$/server  = anon
+/$/ping    = anon
+/$/metrics = anon
+
+## allow users access to datasets if they have the datasets:<crud> perm
+/$/datasets/** = authcBasic,rest[datasets]
+
+## and the rest are restricted
+/$/** = authcBasic,user[admin]
+
+## Sparql update is restricted
+/*/update/** = authcBasic,user[admin]
+/*/upload/** = authcBasic,user[admin]
+
+# Everything else is also restricted
+/** = authcBasic,user[admin]
+
+## If you want simple, basic authentication user/password
+## on the operations,
+##    1 - set a password in [users]
+##    2 - change the line above to:
+## /$/** = authcBasic,user[admin]
+## and set a better
+
+## or to allow any access.
+##/$/** = anon

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ import sbt._
 object Dependencies {
   // should be the same version as in docker-compose.yml,
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
-  val fusekiImage = "daschswiss/apache-jena-fuseki:5.5.0-2"
+  val fusekiImage = "daschswiss/apache-jena-fuseki:5.5.0-3"
   // base image the knora-sipi image is created from
   val sipiImage = "daschswiss/sipi:v4.1.0"
 


### PR DESCRIPTION
## Summary

Moves the Fuseki Docker image build and publish pipeline from `docker-apache-jena-fuseki` into `dsp-api`. Migration lands at the current production version `5.5.0-3`, fixing the pre-existing version drift between `Dependencies.scala` (was `5.5.0-2`) and `docker-compose.yml` (`5.5.0-3`).

- `fuseki/`: Dockerfile with `ARG FUSEKI_VERSION=5.5.0-3` (image tag, read by Makefile) + `ARG JENA_VERSION=5.5.0` (Apache binary, used for download/verify), plus four verbatim files from the old repo
- `Makefile`: `docker-build-fuseki-image` and `docker-publish-fuseki-image` targets; `docker-build-fuseki-image` added as a dependency of `docker-build`
- `docker-compose.yml`: `build: context: ./fuseki` added to the `db` service
- `project/Dependencies.scala`: `fusekiImage` bumped from `5.5.0-2` to `5.5.0-3`
- `build-and-test.yml`: conditional Fuseki image bootstrap in `test-it` and `test-e2e` jobs; new `check-fuseki-version-consistency` job asserting Dockerfile, Dependencies.scala, and docker-compose.yml all carry the same version tag
- `docker-publish-fuseki.yml`: new workflow (push to main, `fuseki/**` path filter) with QEMU, Docker Hub publish, and Jenkins DEV trigger (`Service=db&Version=<version>`)
- `publish-release.yml` + `publish-from-branch.yml`: add QEMU, update `setup-buildx-action` to `@v3`, add explicit `make docker-publish-fuseki-image` step

## Test plan

- [x] `make docker-build-fuseki-image` builds the image locally
- [x] Trigger `publish-from-branch.yml` manually from this branch to verify end-to-end build/push
- [x] Confirm `test-it` and `test-e2e` jobs pass
- [ ] After merging: verify Jenkins `trigger-dev-deployment` step succeeds and `RELEASE-DEV.json` updates
- [ ] After merging: archive `docker-apache-jena-fuseki` (confirm no undocumented consumers with Lukas Stoeckli first)

## Related

- Spec: dasch-specs PR #88
- Linear: DEV-6277

🤖 Generated with [Claude Code](https://claude.com/claude-code)