### PR TITLE
docs: add XSD regex patterns documentation to query-language.md

### DIFF
--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -444,6 +444,41 @@ In the complex schema, use it on the object of the text value's
 FILTER regex(?titleStr, "Zeit", "i")
 ```
 
+> **Note:** SPARQL regex uses [XSD/XQuery regex syntax](https://www.w3.org/TR/xpath-functions/#regex-syntax),
+> which differs from PCRE (Perl-compatible) regex. Some patterns you may know
+> from other languages will not work. See the tables below for supported patterns.
+
+#### Supported Regex Patterns
+
+| Pattern | Description | Example | Status |
+|---------|-------------|---------|--------|
+| `^text` | Starts with | `^Zeit` | ✅ Supported |
+| `text$` | Ends with | `Zeit$` | ✅ Supported |
+| `text` | Contains | `Zeit` | ✅ Supported |
+| `.` | Any character | `Z.it` | ✅ Supported |
+| `[abc]` | Character class | `[Zz]eit` | ✅ Supported |
+| `a\|b` | Alternation | `Zeit\|Time` | ✅ Supported |
+| `*`, `+`, `?` | Quantifiers | `Ze*it` | ✅ Supported |
+| `{n,m}` | Repetition | `e{1,2}` | ✅ Supported |
+
+#### Patterns That Do NOT Work
+
+| Pattern | Reason | Workaround |
+|---------|--------|------------|
+| `^text$` | Exact match not supported | Use equality comparison instead of regex |
+| `[^abc]` | Negated character class | Rewrite using alternation or positive match |
+
+#### Escaping Special Characters
+
+To match literal special characters, escape with backslash:
+
+```sparql
+FILTER regex(?title, "\\*", "i")  -- matches literal asterisk
+FILTER regex(?title, "\\.", "i")  -- matches literal period
+```
+
+Note: In SPARQL strings, use double backslash (`\\`) for escape sequences.
+
 ### Searching for Text Markup
 
 To refer to standoff markup in text values, you must write your query in the complex

--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -445,7 +445,7 @@ FILTER regex(?titleStr, "Zeit", "i")
 ```
 
 > **Note:** SPARQL regex uses [XSD/XQuery regex syntax](https://www.w3.org/TR/xpath-functions/#regex-syntax),
-> which differs from PCRE (Perl-compatible) regex. Some patterns you may know
+> Some patterns you may know
 > from other languages will not work. See the tables below for supported patterns.
 
 #### Supported Regex Patterns

--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -462,7 +462,7 @@ FILTER regex(?titleStr, "Zeit", "i")
 | `a\|b` | Alternation | `Zeit\|Time` | ✅ Supported |
 | `*`, `+`, `?` | Quantifiers | `Ze*it` | ✅ Supported |
 | `{n,m}` | Repetition | `e{1,2}` | ✅ Supported |
-| `\d`, `\w`, `\s` | Shorthand character classes | `\\d+` | ✅ Supported |
+| `[0-9]` | Digit (use instead of `\d`) | `[0-9]+` | ✅ Supported |
 
 #### Escaping Special Characters
 

--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -454,30 +454,26 @@ FILTER regex(?titleStr, "Zeit", "i")
 |---------|-------------|---------|--------|
 | `^text` | Starts with | `^Zeit` | ✅ Supported |
 | `text$` | Ends with | `Zeit$` | ✅ Supported |
+| `^text$` | Exact match | `^Zeit$` | ✅ Supported |
 | `text` | Contains | `Zeit` | ✅ Supported |
 | `.` | Any character | `Z.it` | ✅ Supported |
 | `[abc]` | Character class | `[Zz]eit` | ✅ Supported |
+| `[^abc]` | Negated character class | `[^0-9]eit` | ✅ Supported |
 | `a\|b` | Alternation | `Zeit\|Time` | ✅ Supported |
 | `*`, `+`, `?` | Quantifiers | `Ze*it` | ✅ Supported |
 | `{n,m}` | Repetition | `e{1,2}` | ✅ Supported |
-
-#### Patterns That Do NOT Work
-
-| Pattern | Reason | Workaround |
-|---------|--------|------------|
-| `^text$` | Exact match not supported | Use equality comparison instead of regex |
-| `[^abc]` | Negated character class | Rewrite using alternation or positive match |
+| `\d`, `\w`, `\s` | Shorthand character classes | `\\d+` | ✅ Supported |
 
 #### Escaping Special Characters
 
-To match literal special characters, escape with backslash:
+To match literal special characters, use double backslash in SPARQL strings:
 
 ```sparql
 FILTER regex(?title, "\\*", "i")  -- matches literal asterisk
 FILTER regex(?title, "\\.", "i")  -- matches literal period
 ```
 
-Note: In SPARQL strings, use double backslash (`\\`) for escape sequences.
+Note: SPARQL requires escaping the backslash itself, so `\\` in the query string becomes `\` in the regex pattern.
 
 ### Searching for Text Markup
 

--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -451,7 +451,7 @@ FILTER regex(?titleStr, "Zeit", "i")
 #### Supported Regex Patterns
 
 | Pattern | Description | Example | Status |
-|---------|-------------|---------|--------|
+| ------- | ----------- | ------- | ------ |
 | `^text` | Starts with | `^Zeit` | ✅ Supported |
 | `text$` | Ends with | `Zeit$` | ✅ Supported |
 | `^text$` | Exact match | `^Zeit$` | ✅ Supported |


### PR DESCRIPTION
- Add note explaining SPARQL uses XSD/XQuery regex syntax (not PCRE)
- Add "Supported Regex Patterns" table with working patterns
- Add "Patterns That Do NOT Work" table with workarounds
- Add escaping examples for special characters
- Link to W3C XQuery regex specification

Related: DEV-6298

<!-- Important! Please follow the guidelines for naming Pull Requests:
https://docs.dasch.swiss/latest/developers/contribution/ -->
