### PR TITLE
chore(deps): bump sipi to v4.1.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
   val fusekiImage = "daschswiss/apache-jena-fuseki:5.5.0-3"
   // base image the knora-sipi image is created from
-  val sipiImage = "daschswiss/sipi:v4.1.0"
+  val sipiImage = "daschswiss/sipi:v4.1.1"
 
   val ScalaVersion = "3.3.7"
 


### PR DESCRIPTION
### Description

Bumps the sipi base image used for the `knora-sipi` Docker image from `v4.1.0` to `v4.1.1` ([release notes](https://github.com/dasch-swiss/sipi/releases/tag/v4.1.1)).