### PR TITLE
refactor: Clarify "single root resource" parser error message (DEV-6317)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -111,6 +111,7 @@ final case class ApiComplexV2JsonLdRequestParser(
       val injectedStr = injectOrderIndices(str)
       for {
         model             <- ModelOps.fromJsonLd(injectedStr)
+        _                 <- ZIO.fromEither(ensureNoSelfLink(model))
         resource          <- ZIO.fromEither(model.singleRootResource)
         resourceIriOption <- ZIO.foreach(resource.uri)(uri => ZIO.fromEither(ResourceIri.from(uri)))
         resourceClassIri  <- resourceClassIri(resource)
@@ -120,6 +121,27 @@ final case class ApiComplexV2JsonLdRequestParser(
       .fromOption(r.rdfType)
       .orElseFail("No root resource class IRI found")
       .flatMap(converter.asResourceClassIriApiV2Complex)
+
+    private def ensureNoSelfLink(model: Model): Either[String, Unit] =
+      val targetProp = model.createProperty(LinkValueHasTargetIri)
+      val selfLink   = model
+        .listStatements(null, targetProp, null)
+        .asScala
+        .iterator
+        .filter(_.getObject.isURIResource)
+        .map { st =>
+          val target    = st.getObject.asResource
+          val valueNode = st.getSubject
+          val owners    = model
+            .listStatements(null, null, valueNode)
+            .asScala
+            .map(_.getSubject)
+            .collect { case r if r.isURIResource => r }
+            .toSet
+          Option.when(owners.contains(target))(target.getURI)
+        }
+        .collectFirst { case Some(uri) => uri }
+      selfLink.toLeft(()).left.map(uri => s"A resource cannot link to itself: <$uri>")
   }
 
   def updateResourceMetadataRequestV2(

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/jena/ModelOps.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/jena/ModelOps.scala
@@ -52,9 +52,12 @@ object ModelOps { self =>
       val candidates = subs -- objs
       candidates match {
         case iris if iris.size == 1 => Right(iris.head)
-        case iris if iris.isEmpty   => Left("Expected a single root resource. No root resource found in model")
-        case iris                   =>
-          Left(s"Expected a single root resource. Multiple root resources found in model: ${iris.mkString(", ")}")
+        case iris if iris.isEmpty   =>
+          Left("Expected a tree shaped graph with a single root resource. No root resource found in model")
+        case iris =>
+          Left(
+            s"Expected a tree shaped graph with a single root resource. Multiple root resources found in model: ${iris.mkString(", ")}",
+          )
       }
 
     def singleSubjectWithPropertyOption(property: Property): Either[String, Option[Resource]] =

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
@@ -356,6 +356,29 @@ object ApiComplexV2JsonLdRequestParserSpec extends ZIOSpecDefault {
         ),
       )
     },
+    test("should reject a LinkValue that targets the resource itself") {
+      val selfLinkJson =
+        s"""
+           |{
+           |  "@id" : "http://rdfh.ch/0001/a-thing",
+           |  "@type" : "ex:Thing",
+           |  "ex:hasOtherThingValue" : {
+           |    "@type" : "ka:LinkValue",
+           |    "ka:linkValueHasTargetIri" : {
+           |      "@id" : "http://rdfh.ch/0001/a-thing"
+           |    }
+           |  },
+           |  "@context": {
+           |    "ka": "http://api.knora.org/ontology/knora-api/v2#",
+           |    "ex": "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+           |  }
+           |}""".stripMargin
+      for {
+        result <- service(_.createValueV2FromJsonLd(selfLinkJson)).either
+      } yield assertTrue(
+        result == Left("A resource cannot link to itself: <http://rdfh.ch/0001/a-thing>"),
+      )
+    },
     test("should parse UriValueContentV2") {
       for {
         actual <-

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/jena/ModelOpsSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/jena/ModelOpsSpec.scala
@@ -63,7 +63,9 @@ object ModelOpsSpec extends ZIOSpecDefault {
       for {
         model <- ModelOps.fromTurtle("")
       } yield assertTrue(
-        model.singleRootResource == Left("Expected a single root resource. No root resource found in model"),
+        model.singleRootResource == Left(
+          "Expected a tree shaped graph with a single root resource. No root resource found in model",
+        ),
       )
     },
     test("should fail with more than a single root resource, uri resources") {
@@ -76,7 +78,7 @@ object ModelOpsSpec extends ZIOSpecDefault {
                                  |""".stripMargin)
       } yield assertTrue(
         model.singleRootResource == Left(
-          "Expected a single root resource. Multiple root resources found in model: http://example.org/root1, http://example.org/root2",
+          "Expected a tree shaped graph with a single root resource. Multiple root resources found in model: http://example.org/root1, http://example.org/root2",
         ),
       )
     },


### PR DESCRIPTION
Improves error messages returned by the JSON-LD request parser used by `/v2/values` (POST/PUT) and `/v2/resources` (POST). Both ends of the issue surfaced in [DEV-6317](https://linear.app/dasch/issue/DEV-6317/cryptic-error-message-when-resource-references-itself-in-linkvalue) — the cryptic top-level error and the missing self-link rejection — are addressed.

## New / changed error messages

| Message | When it is returned |
| --- | --- |
| `A resource cannot link to itself: <iri>` | The root resource's `@id` appears as `kb:linkValueHasTargetIri` and point to the same resource, creating a cycle. Previously this fell through to the generic root-resource error below. |
| `Expected a tree shaped graph with a single root resource. No root resource found in model` | The parsed RDF model contains no resource without incoming edges. Previously: `Expected a single root resource. No root resource found in model`. |
| `Expected a tree shaped graph with a single root resource. Multiple root resources found in model: <iri1>, <iri2>` | The parsed RDF model contains more than one resource without incoming edges — e.g. two top-level resources in one payload. Previously: `Expected a single root resource. Multiple root resources found in model: …`. |

All three are returned as HTTP 400 with the message in the JSON body.

## Why

The original `Expected a single root resource.` text was technically _kind of_ accurate but didn't tell the API user what shape of payload the parser accepts; naming the tree-shape requirement makes that explicit. The dedicated self-link error replaces a misleading "no root resource found" 400 that gave no clue the actual cause was a forbidden self-reference.