### PR TITLE
fix(export): fix CSV export timeout for large resource classes (DEV-6288)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/export/api/service/ExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/api/service/ExportService.scala
@@ -150,6 +150,7 @@ final case class ExportService(
                          withDeleted = false,
                          queryStandoff = true,
                          skipRetrievalChecks = true,
+                         standoffTagFilter = Some(footnoteTagIri),
                        )
 
       propertyIriInfos <- propertyIriInfos(selectedProperties)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
@@ -20,6 +20,8 @@ import java.util.UUID
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.IRI
 import org.knora.webapi.messages.SmartIri
+import scala.util.chaining.scalaUtilChainingOps
+
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
 
@@ -150,20 +152,11 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
 
     val standoffPatterns =
       if (queryStandoff)
-        standoffTagFilter match {
-          case Some(tagIri) =>
-            Seq(
-              valueObject.has(KnoraBase.valueHasStandoff, standoffNode),
-              standoffNode.isA(Rdf.iri(tagIri.toIri)).andHas(standoffProperty, standoffValue),
-            )
-          case None =>
-            Seq(
-              valueObject.has(KnoraBase.valueHasStandoff, standoffNode),
-              standoffNode
-                .has(standoffProperty, standoffValue)
-                .andHas(KnoraBase.targetHasOriginalXMLID, targetOriginalXMLID),
-            )
-        }
+        Seq(valueObject.has(KnoraBase.valueHasStandoff, standoffNode))
+          .pipe(_ :+ (standoffTagFilter match {
+            case Some(tagIri) => standoffNode.isA(Rdf.iri(tagIri.toIri)).andHas(standoffProperty, standoffValue)
+            case None         => standoffNode.has(standoffProperty, standoffValue).andHas(KnoraBase.targetHasOriginalXMLID, targetOriginalXMLID)
+          }))
       else Seq.empty
 
     val linkPatterns =
@@ -281,33 +274,22 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
     // Standoff UNION
     val standoffUnion: Seq[GraphPattern] =
       if (queryStandoff) {
-        val standoffPattern = standoffTagFilter match {
-          case Some(tagIri) =>
-            valueObject
-              .has(KnoraBase.valueHasStandoff, standoffNode)
-              .and(standoffNode.isA(Rdf.iri(tagIri.toIri)))
-              .and(
-                standoffNode
-                  .has(standoffProperty, standoffValue)
-                  .andHas(KnoraBase.standoffTagHasStartIndex, startIndex),
-              )
-              .filter(Expressions.gte(startIndex, Rdf.literalOf(0)))
-          case None =>
-            valueObject
-              .has(KnoraBase.valueHasStandoff, standoffNode)
-              .and(
-                standoffNode
-                  .has(standoffProperty, standoffValue)
-                  .andHas(KnoraBase.standoffTagHasStartIndex, startIndex),
-              )
-              .and(
-                standoffTag
-                  .has(KnoraBase.standoffTagHasInternalReference, targetStandoffTag)
-                  .and(targetStandoffTag.has(KnoraBase.standoffTagHasOriginalXMLID, targetOriginalXMLID))
-                  .optional(),
-              )
-              .filter(Expressions.gte(startIndex, Rdf.literalOf(0)))
-        }
+        val standoffNodeContent = standoffNode.has(standoffProperty, standoffValue).andHas(KnoraBase.standoffTagHasStartIndex, startIndex)
+        val standoffPattern = valueObject
+          .has(KnoraBase.valueHasStandoff, standoffNode)
+          .pipe(base => standoffTagFilter match {
+            case Some(tagIri) => base.and(standoffNode.isA(Rdf.iri(tagIri.toIri))).and(standoffNodeContent)
+            case None =>
+              base
+                .and(standoffNodeContent)
+                .and(
+                  standoffTag
+                    .has(KnoraBase.standoffTagHasInternalReference, targetStandoffTag)
+                    .and(targetStandoffTag.has(KnoraBase.standoffTagHasOriginalXMLID, targetOriginalXMLID))
+                    .optional(),
+                )
+          })
+          .filter(Expressions.gte(startIndex, Rdf.literalOf(0)))
 
         Seq(GraphPatterns.union(valueObjectBlockWithFilter, standoffPattern))
       } else Seq(valueObjectBlockWithFilter)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
@@ -80,10 +80,11 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
     maybeValueUuid: Option[UUID] = None,
     maybeVersionDate: Option[Instant] = None,
     maybeValueIri: Option[IRI] = None,
+    standoffTagFilter: Option[SmartIri] = None,
   ): String = {
     val valuesClause = resourceIris.map(iri => s"<$iri>").mkString(" ")
 
-    val constructPatterns = buildConstructPatterns(withDeleted, queryStandoff, queryAllNonStandoff)
+    val constructPatterns = buildConstructPatterns(withDeleted, queryStandoff, queryAllNonStandoff, standoffTagFilter)
     val wherePatterns     = buildWherePatterns(
       preview,
       withDeleted,
@@ -93,6 +94,7 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
       maybeValueUuid,
       maybeVersionDate,
       maybeValueIri,
+      standoffTagFilter,
     )
 
     // Assemble with string interpolation because SparqlBuilder does not support VALUES blocks.
@@ -113,6 +115,7 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
     withDeleted: Boolean,
     queryStandoff: Boolean,
     queryAllNonStandoff: Boolean,
+    standoffTagFilter: Option[SmartIri],
   ): Seq[TriplePattern] = {
     val resourceMetadata = Seq(
       resource
@@ -147,12 +150,20 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
 
     val standoffPatterns =
       if (queryStandoff)
-        Seq(
-          valueObject.has(KnoraBase.valueHasStandoff, standoffNode),
-          standoffNode
-            .has(standoffProperty, standoffValue)
-            .andHas(KnoraBase.targetHasOriginalXMLID, targetOriginalXMLID),
-        )
+        standoffTagFilter match {
+          case Some(tagIri) =>
+            Seq(
+              valueObject.has(KnoraBase.valueHasStandoff, standoffNode),
+              standoffNode.isA(Rdf.iri(tagIri.toIri)).andHas(standoffProperty, standoffValue),
+            )
+          case None =>
+            Seq(
+              valueObject.has(KnoraBase.valueHasStandoff, standoffNode),
+              standoffNode
+                .has(standoffProperty, standoffValue)
+                .andHas(KnoraBase.targetHasOriginalXMLID, targetOriginalXMLID),
+            )
+        }
       else Seq.empty
 
     val linkPatterns =
@@ -175,6 +186,7 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
     maybeValueUuid: Option[UUID],
     maybeVersionDate: Option[Instant],
     maybeValueIri: Option[IRI],
+    standoffTagFilter: Option[SmartIri],
   ): Seq[GraphPattern] = {
     val resourceTypePattern: GraphPattern =
       resource.has(RDF.TYPE, resourceType).and(resourceType.has(subClassOfPath, KnoraBase.Resource))
@@ -216,6 +228,7 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
             maybeValueUuid,
             maybeVersionDate,
             maybeValueIri,
+            standoffTagFilter,
           ),
         )
       else Seq.empty
@@ -234,6 +247,7 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
     maybeValueUuid: Option[UUID],
     maybeVersionDate: Option[Instant],
     maybeValueIri: Option[IRI],
+    standoffTagFilter: Option[SmartIri],
   ): GraphPattern = {
     val valueRetrievalPatterns: GraphPattern = maybeVersionDate match {
       case Some(versionDate) =>
@@ -267,20 +281,33 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
     // Standoff UNION
     val standoffUnion: Seq[GraphPattern] =
       if (queryStandoff) {
-        val standoffPattern = valueObject
-          .has(KnoraBase.valueHasStandoff, standoffNode)
-          .and(
-            standoffNode
-              .has(standoffProperty, standoffValue)
-              .andHas(KnoraBase.standoffTagHasStartIndex, startIndex),
-          )
-          .and(
-            standoffTag
-              .has(KnoraBase.standoffTagHasInternalReference, targetStandoffTag)
-              .and(targetStandoffTag.has(KnoraBase.standoffTagHasOriginalXMLID, targetOriginalXMLID))
-              .optional(),
-          )
-          .filter(Expressions.gte(startIndex, Rdf.literalOf(0)))
+        val standoffPattern = standoffTagFilter match {
+          case Some(tagIri) =>
+            valueObject
+              .has(KnoraBase.valueHasStandoff, standoffNode)
+              .and(standoffNode.isA(Rdf.iri(tagIri.toIri)))
+              .and(
+                standoffNode
+                  .has(standoffProperty, standoffValue)
+                  .andHas(KnoraBase.standoffTagHasStartIndex, startIndex),
+              )
+              .filter(Expressions.gte(startIndex, Rdf.literalOf(0)))
+          case None =>
+            valueObject
+              .has(KnoraBase.valueHasStandoff, standoffNode)
+              .and(
+                standoffNode
+                  .has(standoffProperty, standoffValue)
+                  .andHas(KnoraBase.standoffTagHasStartIndex, startIndex),
+              )
+              .and(
+                standoffTag
+                  .has(KnoraBase.standoffTagHasInternalReference, targetStandoffTag)
+                  .and(targetStandoffTag.has(KnoraBase.standoffTagHasOriginalXMLID, targetOriginalXMLID))
+                  .optional(),
+              )
+              .filter(Expressions.gte(startIndex, Rdf.literalOf(0)))
+        }
 
         Seq(GraphPatterns.union(valueObjectBlockWithFilter, standoffPattern))
       } else Seq(valueObjectBlockWithFilter)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
@@ -16,12 +16,11 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 
 import java.time.Instant
 import java.util.UUID
+import scala.util.chaining.scalaUtilChainingOps
 
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.IRI
 import org.knora.webapi.messages.SmartIri
-import scala.util.chaining.scalaUtilChainingOps
-
 import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
 
@@ -155,7 +154,10 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
         Seq(valueObject.has(KnoraBase.valueHasStandoff, standoffNode))
           .pipe(_ :+ (standoffTagFilter match {
             case Some(tagIri) => standoffNode.isA(Rdf.iri(tagIri.toIri)).andHas(standoffProperty, standoffValue)
-            case None         => standoffNode.has(standoffProperty, standoffValue).andHas(KnoraBase.targetHasOriginalXMLID, targetOriginalXMLID)
+            case None         =>
+              standoffNode
+                .has(standoffProperty, standoffValue)
+                .andHas(KnoraBase.targetHasOriginalXMLID, targetOriginalXMLID)
           }))
       else Seq.empty
 
@@ -274,21 +276,24 @@ object GetResourcePropertiesAndValuesQuery extends QueryBuilderHelper {
     // Standoff UNION
     val standoffUnion: Seq[GraphPattern] =
       if (queryStandoff) {
-        val standoffNodeContent = standoffNode.has(standoffProperty, standoffValue).andHas(KnoraBase.standoffTagHasStartIndex, startIndex)
+        val standoffNodeContent =
+          standoffNode.has(standoffProperty, standoffValue).andHas(KnoraBase.standoffTagHasStartIndex, startIndex)
         val standoffPattern = valueObject
           .has(KnoraBase.valueHasStandoff, standoffNode)
-          .pipe(base => standoffTagFilter match {
-            case Some(tagIri) => base.and(standoffNode.isA(Rdf.iri(tagIri.toIri))).and(standoffNodeContent)
-            case None =>
-              base
-                .and(standoffNodeContent)
-                .and(
-                  standoffTag
-                    .has(KnoraBase.standoffTagHasInternalReference, targetStandoffTag)
-                    .and(targetStandoffTag.has(KnoraBase.standoffTagHasOriginalXMLID, targetOriginalXMLID))
-                    .optional(),
-                )
-          })
+          .pipe(base =>
+            standoffTagFilter match {
+              case Some(tagIri) => base.and(standoffNode.isA(Rdf.iri(tagIri.toIri))).and(standoffNodeContent)
+              case None         =>
+                base
+                  .and(standoffNodeContent)
+                  .and(
+                    standoffTag
+                      .has(KnoraBase.standoffTagHasInternalReference, targetStandoffTag)
+                      .and(targetStandoffTag.has(KnoraBase.standoffTagHasOriginalXMLID, targetOriginalXMLID))
+                      .optional(),
+                  )
+            },
+          )
           .filter(Expressions.gte(startIndex, Rdf.literalOf(0)))
 
         Seq(GraphPatterns.union(valueObjectBlockWithFilter, standoffPattern))

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceLive.scala
@@ -23,6 +23,7 @@ import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.repo.GetResourcePropertiesAndValuesQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.SparqlTimeout
 
 trait ReadResourcesService {
   def readResourcesSequence(
@@ -123,6 +124,7 @@ final case class ReadResourcesServiceLive(
                 queryStandoff = queryStandoff,
                 standoffTagFilter = standoffTagFilter,
               ),
+              if (queryStandoff) SparqlTimeout.Maintenance else SparqlTimeout.Standard,
             ),
           )
           .flatMap(_.asExtended)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceLive.scala
@@ -45,6 +45,7 @@ trait ReadResourcesService {
     withDeleted: Boolean = true,
     queryStandoff: Boolean = false,
     skipRetrievalChecks: Boolean = false,
+    standoffTagFilter: Option[SmartIri] = None,
   ): Task[ReadResourcesSequenceV2]
 
   def getResources(
@@ -103,6 +104,7 @@ final case class ReadResourcesServiceLive(
     markDeletions: Boolean = false,
     showDeletedValues: Boolean = false,
     skipRetrievalChecks: Boolean = false,
+    standoffTagFilter: Option[SmartIri] = None,
   ): Task[ReadResourcesSequenceV2] = {
     val resourceIriStrings = resourceIris.distinct.map(_.value)
     for {
@@ -119,6 +121,7 @@ final case class ReadResourcesServiceLive(
                 maybeVersionDate = versionDate.map(_.value),
                 queryAllNonStandoff = true,
                 queryStandoff = queryStandoff,
+                standoffTagFilter = standoffTagFilter,
               ),
             ),
           )
@@ -176,6 +179,7 @@ final case class ReadResourcesServiceLive(
     withDeleted: Boolean = true,
     queryStandoff: Boolean = false,
     skipRetrievalChecks: Boolean = false,
+    standoffTagFilter: Option[SmartIri] = None,
   ): Task[ReadResourcesSequenceV2] =
     ZIO
       .foreachPar(Chunk.fromIterable(resourceIris).grouped(500).map(_.toSeq).toArray) { resourceIris =>
@@ -189,6 +193,7 @@ final case class ReadResourcesServiceLive(
           withDeleted = withDeleted,
           queryStandoff = queryStandoff,
           skipRetrievalChecks = skipRetrievalChecks,
+          standoffTagFilter = standoffTagFilter,
         )
       }
       .withParallelism(5)

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -381,9 +381,10 @@ case class TriplestoreServiceLive(
       case SparqlTimeout.Gravsearch  => triplestoreConfig.gravsearchTimeout
     }
 
-    val params  = Map(("query", query.sparql), ("timeout", timeout.toSeconds.toString))
-    val uri     = targetHostUri.addPath(paths.query)
-    val request = authenticatedRequest.post(uri).header("Accept", acceptMimeType).body(params)
+    val params      = Map(("query", query.sparql), ("timeout", timeout.toSeconds.toString))
+    val uri         = targetHostUri.addPath(paths.query)
+    val readTimeout = FiniteDuration(timeout.toSeconds + 10, TimeUnit.SECONDS)
+    val request     = authenticatedRequest.post(uri).header("Accept", acceptMimeType).body(params).readTimeout(readTimeout)
     trackQueryDuration(query, doHttpRequest(request).map(_.body.merge))
   }
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuerySpec.scala
@@ -722,5 +722,27 @@ object GetResourcePropertiesAndValuesQuerySpec extends ZIOSpecDefault {
       val actual = render(maybeVersionDate = Some(versionDate), maybeValueUuid = Some(valueUuid))
       assertTrue(actual == expectedVersionDateWithUuid)
     },
+    test("standoffTagFilter - type constraint in SPARQL, no targetHasOriginalXMLID (U-2)") {
+      val footnoteTagIri = sf.toSmartIri("http://www.knora.org/ontology/standoff#StandoffFootnoteTag")
+      val actual         = GetResourcePropertiesAndValuesQuery.build(
+        resourceIris = Seq(resourceIri1),
+        preview = false,
+        withDeleted = false,
+        queryAllNonStandoff = true,
+        queryStandoff = true,
+        standoffTagFilter = Some(footnoteTagIri),
+      )
+      assertTrue(
+        actual.contains("<http://www.knora.org/ontology/standoff#StandoffFootnoteTag>"),
+        !actual.contains("targetHasOriginalXMLID"),
+      )
+    },
+    test("no standoffTagFilter - full standoff loads without type constraint (U-3)") {
+      val actual = render(queryStandoff = true)
+      assertTrue(
+        actual.contains("targetHasOriginalXMLID"),
+        !actual.contains("StandoffFootnoteTag"),
+      )
+    },
   )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceFake.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceFake.scala
@@ -39,6 +39,7 @@ final case class ReadResourcesServiceFake(readResources: Seq[ReadResourceV2]) ex
     withDeleted: Boolean = true,
     queryStandoff: Boolean = false,
     skipRetrievalChecks: Boolean = false,
+    standoffTagFilter: Option[SmartIri] = None,
   ): Task[ReadResourcesSequenceV2] = null
 
   def getResources(


### PR DESCRIPTION
[DEV-6288](https://linear.app/dasch/issue/DEV-6288/timeout-on-data-export-csv-download)

## Summary

`POST /v3/export/resources` timed out for classes with 30k+ rich-text resources. Root cause: PR #4018 introduced `queryStandoff = true` in `ExportService` unconditionally, loading all standoff markup per batch. `textValueColumn` only ever reads `StandoffFootnoteTag` nodes — all other markup was loaded and discarded. For 31k resources this caused a ~10x per-batch payload increase. Additionally, two pre-existing timeout mismatches in the triplestore layer were exposed during testing.

## Changes

**1. Narrow standoff loading to footnote tags only (`ExportService` / `GetResourcePropertiesAndValuesQuery`)**
- Add `standoffTagFilter: Option[SmartIri] = None` to `GetResourcePropertiesAndValuesQuery.build` — when `Some(tagIri)`: constrains `?standoffNode rdf:type <tagIri>` in CONSTRUCT and WHERE, drops `targetHasOriginalXMLID` join
- Thread through `ReadResourcesServiceLive.readResourcesSequencePar` (trait + impl); all existing callers keep `None` (full standoff, unchanged)
- `ExportService.exportResources` passes `standoffTagFilter = Some(footnoteTagIri)`

**2. Use maintenance timeout (120s) for standoff CONSTRUCT queries**
- `readResourcesSequence_` now passes `SparqlTimeout.Maintenance` when `queryStandoff = true`
- Only affects `ExportService.exportResources` — the only caller passing `queryStandoff = true`

**3. Align HTTP read timeout with SPARQL query timeout**
- `executeSparqlQuery` now sets `readTimeout = sparqlTimeout + 10s` on the sttp request
- sttp4 defaults to a 1-minute read timeout; Maintenance queries (120s SPARQL) were being dropped by the HTTP client at ~60s before Fuseki could respond

## Blast radius

- `standoffTagFilter` defaults to `None` — zero impact on existing callers
- Maintenance timeout: only fires for `queryStandoff = true`, only called from export
- HTTP read timeout: Standard queries go from 60s → 30s (safe: Fuseki responds within ms of its 20s kill); Maintenance/Gravsearch go from 60s → 130s (fixes latent issue)
- UPDATE queries bypass `executeSparqlQuery` — unaffected

## Tests

- `sbt "testOnly *GetResourcePropertiesAndValuesQuerySpec*"` — 14 query shape tests pass (U-2: type constraint present when filter set, no `targetHasOriginalXMLID`; U-3: full standoff and `targetHasOriginalXMLID` present when no filter)
- `sbt "testOnly *ExportServiceSpec*"` — 14 export tests pass
- `sbt check` — format + lint clean
- Manual: 31.6k resources exported successfully in ~8.8 min against dev Fuseki

## Known limitation

The full export response is buffered before being sent to the client — connections exceeding the ingress 60s idle timeout will still fail on prod for very large classes. Tracked in [DEV-6336](https://linear.app/dasch/issue/DEV-6336/improve-csv-export-performance-for-large-resource-classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)