### PR TITLE
fix(project-migration): Use the mounted storage for unzipping the bagit zip (DEV-6334)

### DIFF
--- a/ingest/src/main/scala/swiss/dasch/domain/ImportService.scala
+++ b/ingest/src/main/scala/swiss/dasch/domain/ImportService.scala
@@ -62,9 +62,12 @@ final class ImportServiceLive(
     val shortcode  = projectPath.shortcode
     val importPath = projectPath.path
     for {
-      _      <- ZIO.logInfo(s"Importing project $shortcode from $zipFile to $importPath")
+      _        <- ZIO.logInfo(s"Importing project $shortcode from $zipFile to $importPath")
+      bagItDir <- storageService
+                    .createTempDirectoryScoped(s"bagit-$shortcode", Some("import"))
+                    .mapError(IoError.apply)
       result <- BagIt
-                  .readAndValidateZip(zipFile)
+                  .readAndValidateZip(zipFile, Some(bagItDir))
                   .tapError(e => ZIO.logError(s"BagIt validation failed for project $shortcode: $e"))
                   .mapError {
                     case e: java.io.IOException => IoError(e)


### PR DESCRIPTION
On `rdu-28` the ingest container's filesystem ran full during a Migration v2 import: the BagIt ZIP (~15 GB) was being unpacked into the container-local `/tmp`, which is not mounted and far smaller than the NFS volumes where the final assets live (`/opt/tmp`, `/opt/img`).

Unpack the BagIt archive into a scoped temp directory under the mounted import storage instead, so extraction has the same headroom as the rest of the import pipeline and no longer depends on container disk size.

Resolves [DEV-6334](https://linear.app/dasch/issue/DEV-6334).