### PR TITLE
refactor: Remove unused dependencies from QueryTraverser

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
@@ -9,7 +9,6 @@ import zio.*
 
 import dsp.errors.GravsearchOptimizationException
 import org.knora.webapi.InternalSchema
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
@@ -18,7 +17,6 @@ import org.knora.webapi.messages.util.search.gravsearch.prequery.AbstractPrequer
 import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
 import org.knora.webapi.messages.util.search.gravsearch.transformers.WhereTransformer
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
-import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 
 /**
  * A trait for classes that visit statements and filters in WHERE clauses, accumulating some result.
@@ -61,9 +59,7 @@ case class TransformedOrderBy(
 /**
  * Assists in the transformation of CONSTRUCT queries by traversing the query, delegating work to a [[AbstractPrequeryGenerator]].
  */
-final case class QueryTraverser(private val messageRelay: MessageRelay, private val ontologyCache: OntologyCache)(
-  implicit private val stringFormatter: StringFormatter,
-) {
+final class QueryTraverser()(implicit stringFormatter: StringFormatter) {
 
   /**
    * Traverses a WHERE clause, delegating transformation tasks to a [[WhereTransformer]], and returns the transformed query patterns.


### PR DESCRIPTION
Drop the `MessageRelay` and `OntologyCache` constructor dependencies from `QueryTraverser` along with their imports. They were never referenced by the class.