### PR TITLE
refactor: Use ResourceIri and ValueIri types in value-creation flow

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ValuesEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ValuesEndpointsE2ESpec.scala
@@ -38,6 +38,7 @@ import org.knora.webapi.slice.api.v2.values.ReorderValuesRequest
 import org.knora.webapi.slice.api.v2.values.ReorderValuesResponse
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.search.repo.GetResourceWithSpecifiedPropertiesGravsearchQuery
 import org.knora.webapi.testservices.RequestsUpdates.addVersionQueryParam
 import org.knora.webapi.testservices.ResponseOps.assert200
@@ -3934,12 +3935,12 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
-          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption)
+          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption).map(ValueIri.unsafeFrom)
           _            <- ZIO.when(valueIris.size != 3)(ZIO.fail(s"Expected 3 values, got ${valueIris.size}"))
 
           // Reverse the order
           reorderRequest = ReorderValuesRequest(
-                             resourceIri = resourceIri,
+                             resourceIri = resIri,
                              propertyIri = propertyIri.toString,
                              orderedValueIris = valueIris.reverse.toList,
                            )
@@ -4014,11 +4015,11 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
-          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption)
+          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption).map(ValueIri.unsafeFrom)
 
           // Send only the first value IRI (missing the second)
           reorderRequest = ReorderValuesRequest(
-                             resourceIri = resourceIri,
+                             resourceIri = resIri,
                              propertyIri = propertyIri.toString,
                              orderedValueIris = valueIris.take(1).toList,
                            )
@@ -4062,13 +4063,14 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
-          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption)
+          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption).map(ValueIri.unsafeFrom)
 
           // Add a fake extra IRI alongside the real one
           reorderRequest = ReorderValuesRequest(
-                             resourceIri = resourceIri,
+                             resourceIri = resIri,
                              propertyIri = propertyIri.toString,
-                             orderedValueIris = valueIris.toList :+ "http://rdfh.ch/0001/a-thing/values/nonexistent",
+                             orderedValueIris =
+                               valueIris.toList :+ ValueIri.unsafeFrom("http://rdfh.ch/0001/a-thing/values/nonexistent"),
                            )
           response <- TestApiClient
                         .putJson[ReorderValuesResponse, ReorderValuesRequest](
@@ -4080,11 +4082,11 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
       },
       test("reject duplicate IRIs") {
         val reorderRequest = ReorderValuesRequest(
-          resourceIri = AThing.iri,
+          resourceIri = ResourceIri.unsafeFrom(AThing.iri),
           propertyIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasText",
           orderedValueIris = List(
-            "http://rdfh.ch/0001/a-thing/values/someValue",
-            "http://rdfh.ch/0001/a-thing/values/someValue",
+            ValueIri.unsafeFrom("http://rdfh.ch/0001/a-thing/values/someValue"),
+            ValueIri.unsafeFrom("http://rdfh.ch/0001/a-thing/values/someValue"),
           ),
         )
         TestApiClient
@@ -4097,7 +4099,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
       },
       test("reject empty list") {
         val reorderRequest = ReorderValuesRequest(
-          resourceIri = AThing.iri,
+          resourceIri = ResourceIri.unsafeFrom(AThing.iri),
           propertyIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasText",
           orderedValueIris = List.empty,
         )
@@ -4111,9 +4113,9 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
       },
       test("reject non-existent resource") {
         val reorderRequest = ReorderValuesRequest(
-          resourceIri = "http://rdfh.ch/0001/nonexistent-resource",
+          resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/nonexistent-resource"),
           propertyIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasText",
-          orderedValueIris = List("http://rdfh.ch/0001/nonexistent-resource/values/someValue"),
+          orderedValueIris = List(ValueIri.unsafeFrom("http://rdfh.ch/0001/nonexistent-resource/values/someValue")),
         )
         TestApiClient
           .putJson[ReorderValuesResponse, ReorderValuesRequest](
@@ -4156,11 +4158,11 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
-          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption)
+          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption).map(ValueIri.unsafeFrom)
 
           // Attempt reorder as incunabulaMemberUser (no modify permission on anything project resources)
           reorderRequest = ReorderValuesRequest(
-                             resourceIri = resourceIri,
+                             resourceIri = resIri,
                              propertyIri = propertyIri.toString,
                              orderedValueIris = valueIris.toList,
                            )
@@ -4205,11 +4207,11 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
-          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption)
+          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption).map(ValueIri.unsafeFrom)
 
           // Send the hasText value IRIs but claim they belong to hasInteger
           reorderRequest = ReorderValuesRequest(
-                             resourceIri = resourceIri,
+                             resourceIri = resIri,
                              propertyIri = wrongPropertyIri,
                              orderedValueIris = valueIris.toList,
                            )
@@ -4253,12 +4255,12 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
           resource     <- TestResourcesApiClient.getResource(resIri, anythingUser1).flatMap(_.assert200)
           valuesArray  <- ZIO.fromEither(resource.body.getRequiredArray(propertyIri.toString))
           valuesInOrder = valuesArray.value.collect { case obj: JsonLDObject => obj }
-          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption)
+          valueIris     = valuesInOrder.flatMap(_.getRequiredString(JsonLDKeywords.ID).toOption).map(ValueIri.unsafeFrom)
           _            <- ZIO.when(valueIris.size != 1)(ZIO.fail(s"Expected 1 value, got ${valueIris.size}"))
 
           // Reorder with the single value
           reorderRequest = ReorderValuesRequest(
-                             resourceIri = resourceIri,
+                             resourceIri = resIri,
                              propertyIri = propertyIri.toString,
                              orderedValueIris = valueIris.toList,
                            )

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -1061,7 +1061,7 @@ case class TextValueContentV2(
    * @return a list of [[CreateStandoffTagV2InTriplestore]] each representing a [[StandoffTagV2]] object
    *         along with is standoff tag class and IRI that is going to identify it in the triplestore.
    */
-  def prepareForSparqlInsert(valueIri: IRI): Seq[CreateStandoffTagV2InTriplestore] =
+  def prepareForSparqlInsert(valueIri: ValueIri): Seq[CreateStandoffTagV2InTriplestore] =
     if (standoff.nonEmpty) {
       // create an IRI for each standoff tag
       // internal references to XML ids are not resolved yet
@@ -1070,7 +1070,7 @@ case class TextValueContentV2(
           CreateStandoffTagV2InTriplestore(
             standoffNode = standoffNode,
             standoffTagInstanceIri = StandoffStringUtil.makeRandomStandoffTagIri(
-              valueIri = valueIri,
+              valueIri = valueIri.value,
               startIndex = standoffNode.startIndex,
             ), // generate IRI for new standoff node
           )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -44,7 +44,6 @@ import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.api.AuthorizationRestService
-import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.AtLeastOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
@@ -463,16 +462,14 @@ final class ValuesResponderV2(
         }
 
       dataNamedGraphInternal <- iriConverter.asInternalIri(dataNamedGraph)
-      resourceIriInternal    <- iriConverter.asInternalIri(resourceInfo.resourceIri.value)
-      newValueIriInternal    <- iriConverter.asInternalIri(newValueIri.value)
       valueCreatorInternal   <- iriConverter.asInternalIri(valueCreator)
 
       // Use repository method which handles dual validation
       _ <- valueRepo.createValue(
              dataNamedGraph = dataNamedGraphInternal,
-             resourceIri = resourceIriInternal,
+             resourceIri = resourceInfo.resourceIri,
              propertyIri = propertyIri,
-             newValueIri = newValueIriInternal,
+             newValueIri = newValueIri,
              newValueUUID = newValueUUID,
              value = value,
              linkUpdates = standoffLinkUpdates,
@@ -595,7 +592,7 @@ final class ValuesResponderV2(
 
       _ <- valueRepo.updateValuePermissions(
              projectDataGraph = ProjectService.projectDataNamedGraphV2(resourceInfo.projectADM),
-             resourceIri = InternalIri(resourceInfo.resourceIri.value),
+             resourceIri = resourceInfo.resourceIri,
              valueIri = currentValue.valueIri,
              newPermissions = newValuePermissionLiteral,
              currentTime = Instant.now,
@@ -953,19 +950,16 @@ final class ValuesResponderV2(
 
       // If no custom value creation date was provided, make a timestamp to indicate when the value
       // was updated.
-      currentTime: Instant     = valueCreationDate.getOrElse(Instant.now)
-      dataNamedGraphInternal  <- iriConverter.asInternalIri(dataNamedGraph)
-      resourceIriInternal     <- iriConverter.asInternalIri(resourceInfo.resourceIri.value)
-      currentValueIriInternal <- iriConverter.asInternalIri(currentValue.valueIri.value)
-      newValueIriInternal     <- iriConverter.asInternalIri(newValueIri.value)
-      valueCreatorInternal    <- iriConverter.asInternalIri(valueCreator)
+      currentTime: Instant    = valueCreationDate.getOrElse(Instant.now)
+      dataNamedGraphInternal <- iriConverter.asInternalIri(dataNamedGraph)
+      valueCreatorInternal   <- iriConverter.asInternalIri(valueCreator)
       // Generate a SPARQL update.
       _ <- valueRepo.updateValue(
              dataNamedGraph = dataNamedGraphInternal,
-             resourceIri = resourceIriInternal,
+             resourceIri = resourceInfo.resourceIri,
              propertyIri = propertyIri,
-             currentValueIri = currentValueIriInternal,
-             newValueIri = newValueIriInternal,
+             currentValueIri = currentValue.valueIri,
+             newValueIri = newValueIri,
              value = newValueVersion,
              valueCreator = valueCreatorInternal,
              valuePermissions = valuePermissions,
@@ -1785,7 +1779,7 @@ final class ValuesResponderV2(
               linkValueExists = true,
               linkTargetExists = true,
               newLinkValueIri = newLinkValueIri,
-              linkTargetIri = targetResourceIri.value,
+              linkTargetIri = targetResourceIri,
               currentReferenceCount = linkValueInfo.valueHasRefCount,
               newReferenceCount = linkValueInfo.valueHasRefCount + 1,
               newLinkValueCreator = valueCreator,
@@ -1803,7 +1797,7 @@ final class ValuesResponderV2(
               linkValueExists = false,
               linkTargetExists = true,
               newLinkValueIri = newLinkValueIri,
-              linkTargetIri = targetResourceIri.value,
+              linkTargetIri = targetResourceIri,
               currentReferenceCount = 0,
               newReferenceCount = 1,
               newLinkValueCreator = valueCreator,
@@ -1869,7 +1863,7 @@ final class ValuesResponderV2(
               linkValueExists = true,
               linkTargetExists = true,
               newLinkValueIri = newLinkValueIri,
-              linkTargetIri = targetResourceIri.value,
+              linkTargetIri = targetResourceIri,
               currentReferenceCount = linkValueInfo.valueHasRefCount,
               newReferenceCount = newReferenceCount,
               newLinkValueCreator = valueCreator,
@@ -1938,7 +1932,7 @@ final class ValuesResponderV2(
           linkValueExists = true,
           linkTargetExists = true,
           newLinkValueIri = newLinkValueIri,
-          linkTargetIri = targetResourceIri.value,
+          linkTargetIri = targetResourceIri,
           currentReferenceCount = linkValueInfo.valueHasRefCount,
           newReferenceCount = linkValueInfo.valueHasRefCount,
           newLinkValueCreator = valueCreator,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -497,14 +497,14 @@ final case class CreateResourceV2Handler(
                 case MovingImageFileValueContentV2(_, fileValue, _) =>
                   ZIO.succeed(OtherFileValueInfo(fileValue))
                 case LinkValueContentV2(_, referredResourceIri, _, _, _, _) =>
-                  ZIO.succeed(LinkValueInfo(InternalIri(referredResourceIri.value)))
+                  ZIO.succeed(LinkValueInfo(referredResourceIri))
                 case _: DeletedValueContentV2 => ZIO.fail(BadRequestException("Deleted values cannot be created"))
 
           } yield ValueInfo(
-            resourceIri = InternalIri(resourceIri.value),
+            resourceIri = resourceIri,
             propertyIri = InternalIri(propertyIri.toIri),
             value = valueInfo,
-            valueIri = InternalIri(newValueIri.value),
+            valueIri = newValueIri,
             valueTypeIri = InternalIri(valueToCreate.valueContent.valueType.toString),
             valueUUID = newValueUUID,
             creator = InternalIri(requestingUser.id),
@@ -528,7 +528,7 @@ final case class CreateResourceV2Handler(
 
   private def generateStandoffInfo(tv: TextValueContentV2, newValueIri: ValueIri): Seq[StandoffTagInfo] =
     tv
-      .prepareForSparqlInsert(newValueIri.value)
+      .prepareForSparqlInsert(newValueIri)
       .map(standoffTag =>
         val attributes = standoffTag.standoffNode.attributes.map { attr =>
           val v = attr match
@@ -869,11 +869,12 @@ final case class CreateResourceV2Handler(
       val standoffLinkUpdatesFutures: Seq[Task[StandoffLinkValueInfo]] = initialReferenceCounts.toSeq.map {
         case (targetIri, initialReferenceCount) =>
           for {
-            newValueIri <- makeUnusedValueIri(resourceIri)
+            newValueIri    <- makeUnusedValueIri(resourceIri)
+            targetResource <- ZIO.fromEither(ResourceIri.from(targetIri)).mapError(BadRequestException.apply)
           } yield StandoffLinkValueInfo(
             linkPropertyIri = InternalIri(OntologyConstants.KnoraBase.HasStandoffLinkTo),
-            newLinkValueIri = InternalIri(newValueIri),
-            linkTargetIri = InternalIri(targetIri),
+            newLinkValueIri = newValueIri,
+            linkTargetIri = targetResource,
             newReferenceCount = initialReferenceCount,
             newLinkValueCreator = InternalIri(KnoraUserRepo.builtIn.SystemUser.id.value),
             newLinkValuePermissions = standoffLinkValuePermissions,
@@ -892,8 +893,10 @@ final case class CreateResourceV2Handler(
    * @param resourceIri the IRI of the containing resource.
    * @return the new value IRI.
    */
-  private def makeUnusedValueIri(resourceIri: ResourceIri): Task[IRI] =
-    iriService.makeUnusedIri(ValueIri.makeNew(resourceIri).value)
+  private def makeUnusedValueIri(resourceIri: ResourceIri): Task[ValueIri] =
+    iriService
+      .makeUnusedIri(ValueIri.makeNew(resourceIri).value)
+      .flatMap(s => ZIO.fromEither(ValueIri.from(s)).mapError(BadRequestException.apply))
 
   /**
    * The permissions that are granted by every `knora-base:LinkValue` describing a standoff link.

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/metadata/MetadataEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/metadata/MetadataEndpoints.scala
@@ -16,13 +16,14 @@ import java.time.Instant
 
 import org.knora.webapi.slice.api.admin.AdminPathVariables.projectShortcode
 import org.knora.webapi.slice.api.v2.IriDto
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.api.BaseEndpoints
 import org.knora.webapi.slice.infrastructure.ColumnDef
 import org.knora.webapi.slice.infrastructure.CsvRowBuilder
 
 final case class ResourceMetadataDto(
   resourceClassIri: String,
-  resourceIri: String,
+  resourceIri: ResourceIri,
   arkUrl: String,
   arkUrlWithTimestamp: String,
   label: String,
@@ -40,7 +41,7 @@ object ResourceMetadataDto {
     ColumnDef("Resource Class", _.resourceClassIri),
     ColumnDef("ARK URL (Permalink)", _.arkUrl),
     ColumnDef("ARK with timestamp", _.arkUrlWithTimestamp),
-    ColumnDef("Resource IRI", _.resourceIri),
+    ColumnDef("Resource IRI", _.resourceIri.value),
     ColumnDef("Created by", _.resourceCreatorIri),
     ColumnDef("Creation Date", _.resourceCreationDate),
     ColumnDef("Last Modification Date (if available)", _.resourceLastModificationDate.getOrElse("")),

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/resources/info/ResourceInfoDto.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/resources/info/ResourceInfoDto.scala
@@ -9,7 +9,7 @@ import zio.json.*
 
 import java.time.Instant
 
-import org.knora.webapi.IRI
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.resources.domain.ResourceInfo
 
 final case class ListResponseDto private (resources: List[ResourceInfoDto], count: Int)
@@ -24,7 +24,7 @@ object ListResponseDto {
 }
 
 final case class ResourceInfoDto private (
-  resourceIri: IRI,
+  resourceIri: ResourceIri,
   creationDate: Instant,
   lastModificationDate: Instant,
   deleteDate: Option[Instant],
@@ -35,7 +35,7 @@ object ResourceInfoDto {
 
   def from(info: ResourceInfo): ResourceInfoDto =
     ResourceInfoDto(
-      info.iri.value,
+      info.iri,
       info.creationDate,
       info.lastModificationDate.getOrElse(info.creationDate),
       info.deleteDate,

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ReorderValuesRequest.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ReorderValuesRequest.scala
@@ -8,10 +8,13 @@ package org.knora.webapi.slice.api.v2.values
 import zio.json.DeriveJsonCodec
 import zio.json.JsonCodec
 
+import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
+
 final case class ReorderValuesRequest(
-  resourceIri: String,
+  resourceIri: ResourceIri,
   propertyIri: String,
-  orderedValueIris: List[String],
+  orderedValueIris: List[ValueIri],
 )
 
 object ReorderValuesRequest {
@@ -19,7 +22,7 @@ object ReorderValuesRequest {
 }
 
 final case class ReorderValuesResponse(
-  resourceIri: String,
+  resourceIri: ResourceIri,
   propertyIri: String,
   valuesReordered: Int,
 )

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ValuesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ValuesEndpoints.scala
@@ -13,13 +13,15 @@ import zio.ZLayer
 import org.knora.webapi.slice.api.v2.ApiV2
 import org.knora.webapi.slice.api.v2.ValueUuid
 import org.knora.webapi.slice.api.v2.VersionDate
+import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.api.BaseEndpoints
 
 final class ValuesEndpoints(baseEndpoint: BaseEndpoints) {
 
   private val base: EndpointInput[Unit] = "v2" / "values"
 
-  private val resourceIri = path[String].name("resourceIri").description("The IRI of a Resource.")
+  private val resourceIri = path[ResourceIri].name("resourceIri").description("The IRI of a Resource.")
   private val valueUuid   = path[ValueUuid].name("valueUuid").description("The UUID of a Value.")
   private val version     = query[Option[VersionDate]]("version")
 
@@ -54,10 +56,13 @@ final class ValuesEndpoints(baseEndpoint: BaseEndpoints) {
     .in(
       jsonBody[ReorderValuesRequest].example(
         ReorderValuesRequest(
-          resourceIri = "http://rdfh.ch/0001/resource-1",
+          resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/resource-1"),
           propertyIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasText",
-          orderedValueIris =
-            List("http://rdfh.ch/0001/value-3", "http://rdfh.ch/0001/value-1", "http://rdfh.ch/0001/value-2"),
+          orderedValueIris = List(
+            ValueIri.unsafeFrom("http://rdfh.ch/0001/resource-1/values/value-3"),
+            ValueIri.unsafeFrom("http://rdfh.ch/0001/resource-1/values/value-1"),
+            ValueIri.unsafeFrom("http://rdfh.ch/0001/resource-1/values/value-2"),
+          ),
         ),
       ),
     )

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ValuesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/values/ValuesRestService.scala
@@ -7,7 +7,6 @@ package org.knora.webapi.slice.api.v2.values
 
 import sttp.model.MediaType
 import zio.Clock
-import zio.IO
 import zio.Random
 import zio.Task
 import zio.ZIO
@@ -37,7 +36,6 @@ import org.knora.webapi.slice.common.api.AuthorizationRestService
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.FormatOptions
 import org.knora.webapi.slice.common.api.KnoraResponseRenderer.RenderedResponse
-import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.resources.repo.service.ValueRepo
 import org.knora.webapi.slice.resources.service.ReadResourcesService
 
@@ -53,16 +51,15 @@ final class ValuesRestService(
 )(implicit private val stringFormatter: StringFormatter) {
 
   def getValue(user: User)(
-    resourceIri: String,
+    resourceIri: ResourceIri,
     valueUuid: ValueUuid,
     versionDate: Option[VersionDate],
     formatOptions: FormatOptions,
   ): Task[(RenderedResponse, MediaType)] =
     for {
-      resIri   <- parseResourceIri(resourceIri)
       response <- render(
                     readResources.getResourcesWithDeletedResource(
-                      Seq(resIri),
+                      Seq(resourceIri),
                       None,
                       Some(valueUuid.value),
                       versionDate,
@@ -101,21 +98,20 @@ final class ValuesRestService(
 
   def reorderValues(user: User)(request: ReorderValuesRequest): Task[ReorderValuesResponse] =
     for {
-      resIri                                <- parseResourceIri(request.resourceIri)
       validated                             <- validateReorderRequest(request)
       (propertySmartIri, requestedValueIris) = validated
 
       // Fetch as system user so we see ALL values for canonical verification.
       // This is safe: only value IRIs are compared (verifyCanonicalValues), no content is leaked to the caller.
       resourcesSeq <- readResources.getResources(
-                        Seq(resIri),
+                        Seq(request.resourceIri),
                         targetSchema = ApiV2Complex,
                         schemaOptions = Set.empty,
                         requestingUser = KnoraSystemInstances.Users.SystemUser,
                       )
       resourceInfo <- ZIO
                         .fromOption(resourcesSeq.resources.headOption)
-                        .orElseFail(NotFoundException(s"Resource <$resIri> not found."))
+                        .orElseFail(NotFoundException(s"Resource <${request.resourceIri.value}> not found."))
 
       // Check that the user has modify permission on the resource
       _ <- resourceUtilV2.checkResourcePermission(resourceInfo, Permission.ObjectAccess.Modify, user)
@@ -126,9 +122,9 @@ final class ValuesRestService(
       // Derive project data graph and execute the reorder
       projectDataGraph = ProjectService.projectDataNamedGraphV2(resourceInfo.projectADM)
       now             <- Clock.instant
-      _               <- valueRepo.reorderValues(projectDataGraph, InternalIri(resIri.value), requestedValueIris, now)
+      _               <- valueRepo.reorderValues(projectDataGraph, request.resourceIri, requestedValueIris, now)
     } yield ReorderValuesResponse(
-      resourceIri = resIri.value,
+      resourceIri = request.resourceIri,
       propertyIri = request.propertyIri,
       valuesReordered = requestedValueIris.size,
     )
@@ -144,12 +140,7 @@ final class ValuesRestService(
       _ <- ZIO.when(request.orderedValueIris.distinct.size != request.orderedValueIris.size)(
              ZIO.fail(BadRequestException("Duplicate value IRIs in request.")),
            )
-      requestedValueIris <- ZIO.foreach(request.orderedValueIris) { iriStr =>
-                              ZIO
-                                .fromEither(ValueIri.from(iriStr))
-                                .mapError(e => BadRequestException(s"Invalid value IRI: $e"))
-                            }
-    } yield (propertySmartIri, requestedValueIris)
+    } yield (propertySmartIri, request.orderedValueIris)
 
   private def verifyCanonicalValues(
     request: ReorderValuesRequest,
@@ -166,7 +157,7 @@ final class ValuesRestService(
       .when(canonicalIris != requestedIris)(
         ZIO.fail(
           BadRequestException(
-            s"The provided value IRIs do not match the existing values for property <${request.propertyIri}> on resource <${request.resourceIri}>. " +
+            s"The provided value IRIs do not match the existing values for property <${request.propertyIri}> on resource <${request.resourceIri.value}>. " +
               s"Expected ${canonicalIris.size} value(s), got ${requestedIris.size}. " +
               s"Missing: ${(canonicalIris -- requestedIris).mkString(", ")}. " +
               s"Extra: ${(requestedIris -- canonicalIris).mkString(", ")}.",
@@ -205,9 +196,6 @@ final class ValuesRestService(
       knoraResponse <- valuesService.eraseValueHistory(eraseReq, user, project)
       response      <- render(knoraResponse)
     } yield response
-
-  private def parseResourceIri(iri: String): IO[BadRequestException, ResourceIri] =
-    ZIO.fromEither(ResourceIri.from(iri)).mapError(BadRequestException.apply)
 }
 
 object ValuesRestService {

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/QueryBuilderHelper.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/QueryBuilderHelper.scala
@@ -58,7 +58,8 @@ trait QueryBuilderHelper {
     case PlainStringLiteralV2(value)                => Rdf.literalOf(value)
   }
 
-  def toRdfLiteral(str: StringValue): RdfLiteral.StringLiteral = Rdf.literalOf(str.value)
+  def toRdfLiteral(str: StringValue): RdfLiteral.StringLiteral = toRdfLiteral(str.value)
+  def toRdfLiteral(str: String): RdfLiteral.StringLiteral      = Rdf.literalOfType(str, XSD.STRING)
 
   def toRdfLiteral(booleanV2: BooleanLiteralV2): RdfLiteral.StringLiteral =
     Rdf.literalOfType(booleanV2.value.toString, XSD.BOOLEAN)
@@ -69,6 +70,8 @@ trait QueryBuilderHelper {
   def toRdfLiteral(int: Int): RdfLiteral.StringLiteral            = Rdf.literalOfType(int.toString, XSD.INT)
   def toRdfLiteralNonNegative(int: Int): RdfLiteral.StringLiteral =
     Rdf.literalOfType(int.toString, XSD.NON_NEGATIVE_INTEGER)
+
+  def toRdfLiteral(bool: Boolean): RdfLiteral.StringLiteral = Rdf.literalOfType(bool.toString, XSD.BOOLEAN)
 
   def toRdfIri(iri: KnoraIri): Iri    = toRdfIri(iri.smartIri)
   def toRdfIri(iri: SmartIri): Iri    = Rdf.iri(iri.toInternalSchema.toIri)

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ResourceIri.scala
@@ -5,12 +5,19 @@
 
 package org.knora.webapi.slice.common
 
+import sttp.tapir.Codec
+import sttp.tapir.CodecFormat
+import sttp.tapir.Schema
+import zio.json.JsonCodec
+
 import java.util.UUID
 import scala.util.matching.Regex
 
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.api.admin.Codecs.TapirCodec
+import org.knora.webapi.slice.api.admin.Codecs.ZioJsonCodec
 import org.knora.webapi.slice.common.Value.StringValue
 
 final case class ResourceId private (override val value: String) extends StringValue
@@ -28,6 +35,10 @@ final case class ResourceIri private (override val value: String, shortcode: Sho
     extends StringValue
 
 object ResourceIri extends StringValueCompanion[ResourceIri] {
+
+  given JsonCodec[ResourceIri]                            = ZioJsonCodec.stringCodec[ResourceIri](from)
+  given Codec[String, ResourceIri, CodecFormat.TextPlain] = TapirCodec.stringCodec(from)
+  given Schema[ResourceIri]                               = Schema.string.description("IRI of a Knora resource.")
 
   private val ResourceIriRegex: Regex =
     """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ValueIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ValueIri.scala
@@ -5,12 +5,19 @@
 
 package org.knora.webapi.slice.common
 
+import sttp.tapir.Codec
+import sttp.tapir.CodecFormat
+import sttp.tapir.Schema
+import zio.json.JsonCodec
+
 import java.util.UUID
 import scala.util.matching.Regex
 
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.api.admin.Codecs.TapirCodec
+import org.knora.webapi.slice.api.admin.Codecs.ZioJsonCodec
 import org.knora.webapi.slice.common.Value.StringValue
 
 final case class ValueId private (override val value: String) extends StringValue
@@ -35,6 +42,10 @@ final case class ValueIri private (
 }
 
 object ValueIri extends StringValueCompanion[ValueIri] {
+
+  given JsonCodec[ValueIri]                            = ZioJsonCodec.stringCodec[ValueIri](from)
+  given Codec[String, ValueIri, CodecFormat.TextPlain] = TapirCodec.stringCodec(from)
+  given Schema[ValueIri]                               = Schema.string.description("IRI of a Knora value.")
 
   private val ValueIriRegex: Regex =
     """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)/values/([A-Za-z0-9_-]+)$""".r

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/UpdateOntologyMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/UpdateOntologyMetadataQuery.scala
@@ -87,7 +87,4 @@ object UpdateOntologyMetadataQuery extends QueryBuilderHelper {
 
     ontologyModPattern :: (labelPattern ::: commentPattern)
   }
-
-  private def toRdfLiteral(str: String): org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral =
-    org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.literalOfType(str, XSD.STRING)
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuery.scala
@@ -52,7 +52,7 @@ object ChangeLinkMetadataQuery extends QueryBuilderHelper {
       val linkSource                     = toRdfIri(linkSourceIri)
       val linkProperty                   = toRdfIri(linkUpdate.linkPropertyIri)
       val linkValueProperty              = Rdf.iri(linkUpdate.linkPropertyIri.toInternalSchema.toIri + "Value")
-      val linkTarget                     = Rdf.iri(linkUpdate.linkTargetIri)
+      val linkTarget                     = Rdf.iri(linkUpdate.linkTargetIri.value)
       val newLinkValue                   = Rdf.iri(linkUpdate.newLinkValueIri.value)
       val linkSourceClass                = variable("linkSourceClass")
       val currentLinkValue               = variable("currentLinkValue")
@@ -73,7 +73,7 @@ object ChangeLinkMetadataQuery extends QueryBuilderHelper {
         newLinkValue.has(RDF.SUBJECT, linkSource),
         newLinkValue.has(RDF.PREDICATE, linkProperty),
         newLinkValue.has(RDF.OBJECT, linkTarget),
-        newLinkValue.has(KB.valueHasString, Rdf.literalOfType(linkUpdate.linkTargetIri, XSD.STRING)),
+        newLinkValue.has(KB.valueHasString, Rdf.literalOfType(linkUpdate.linkTargetIri.value, XSD.STRING)),
         newLinkValue.has(KB.valueHasRefCount, Rdf.literalOf(linkUpdate.newReferenceCount)),
         newLinkValue.has(KB.valueCreationDate, currentTimeLiteral),
         newLinkValue.has(KB.previousValue, currentLinkValue),

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuery.scala
@@ -99,8 +99,8 @@ object ChangeLinkTargetQuery extends QueryBuilderHelper {
       val linkSource                     = toRdfIri(linkSourceIri)
       val linkProperty                   = toRdfIri(linkUpdateForCurrentLink.linkPropertyIri)
       val linkValueProperty              = Rdf.iri(linkUpdateForCurrentLink.linkPropertyIri.toInternalSchema.toIri + "Value")
-      val linkTargetForCurrentLink       = Rdf.iri(linkUpdateForCurrentLink.linkTargetIri)
-      val linkTargetForNewLink           = Rdf.iri(linkUpdateForNewLink.linkTargetIri)
+      val linkTargetForCurrentLink       = Rdf.iri(linkUpdateForCurrentLink.linkTargetIri.value)
+      val linkTargetForNewLink           = Rdf.iri(linkUpdateForNewLink.linkTargetIri.value)
       val newLinkValueForCurrentLink     = Rdf.iri(linkUpdateForCurrentLink.newLinkValueIri.value)
       val newLinkValueForNewLink         = Rdf.iri(linkUpdateForNewLink.newLinkValueIri.value)
       val linkSourceClass                = variable("linkSourceClass")
@@ -130,7 +130,7 @@ object ChangeLinkTargetQuery extends QueryBuilderHelper {
         newLinkValueForCurrentLink.has(RDF.PREDICATE, linkProperty),
         newLinkValueForCurrentLink.has(RDF.OBJECT, linkTargetForCurrentLink),
         newLinkValueForCurrentLink
-          .has(KB.valueHasString, Rdf.literalOfType(linkUpdateForCurrentLink.linkTargetIri, XSD.STRING)),
+          .has(KB.valueHasString, Rdf.literalOfType(linkUpdateForCurrentLink.linkTargetIri.value, XSD.STRING)),
         newLinkValueForCurrentLink
           .has(KB.valueHasRefCount, Rdf.literalOf(linkUpdateForCurrentLink.newReferenceCount)),
         newLinkValueForCurrentLink.has(KB.valueCreationDate, currentTimeLiteral),
@@ -157,7 +157,7 @@ object ChangeLinkTargetQuery extends QueryBuilderHelper {
         newLinkValueForNewLink.has(RDF.PREDICATE, linkProperty),
         newLinkValueForNewLink.has(RDF.OBJECT, linkTargetForNewLink),
         newLinkValueForNewLink
-          .has(KB.valueHasString, Rdf.literalOfType(linkUpdateForNewLink.linkTargetIri, XSD.STRING)),
+          .has(KB.valueHasString, Rdf.literalOfType(linkUpdateForNewLink.linkTargetIri.value, XSD.STRING)),
       )
 
       val insertComment =

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuery.scala
@@ -67,7 +67,7 @@ object CreateLinkQuery extends QueryBuilderHelper {
       val resource          = toRdfIri(resourceIri)
       val linkProperty      = toRdfIri(linkUpdate.linkPropertyIri)
       val linkValueProperty = Rdf.iri(linkUpdate.linkPropertyIri.toInternalSchema.toIri + "Value")
-      val linkTarget        = Rdf.iri(linkUpdate.linkTargetIri)
+      val linkTarget        = Rdf.iri(linkUpdate.linkTargetIri.value)
       val newLinkValue      = Rdf.iri(linkUpdate.newLinkValueIri.value)
 
       val resourceLastModificationDate = variable("resourceLastModificationDate")
@@ -90,7 +90,7 @@ object CreateLinkQuery extends QueryBuilderHelper {
         newLinkValue.has(RDF.SUBJECT, resource),
         newLinkValue.has(RDF.PREDICATE, linkProperty),
         newLinkValue.has(RDF.OBJECT, linkTarget),
-        newLinkValue.has(KB.valueHasString, Rdf.literalOfType(linkUpdate.linkTargetIri, XSD.STRING)),
+        newLinkValue.has(KB.valueHasString, Rdf.literalOfType(linkUpdate.linkTargetIri.value, XSD.STRING)),
         newLinkValue.has(KB.valueHasRefCount, literalOf(linkUpdate.newReferenceCount)),
         newLinkValue.has(KB.valueHasOrder, nextOrder),
         newLinkValue.has(KB.isDeleted, literalOf(false)),

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteLinkQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteLinkQuery.scala
@@ -62,7 +62,7 @@ object DeleteLinkQuery extends QueryBuilderHelper {
       val linkSource                     = Rdf.iri(linkSourceIri)
       val linkProperty                   = toRdfIri(linkUpdate.linkPropertyIri)
       val linkValueProperty              = Rdf.iri(linkUpdate.linkPropertyIri.toInternalSchema.toIri + "Value")
-      val linkTarget                     = Rdf.iri(linkUpdate.linkTargetIri)
+      val linkTarget                     = Rdf.iri(linkUpdate.linkTargetIri.value)
       val newLinkValue                   = Rdf.iri(linkUpdate.newLinkValueIri.value)
       val linkSourceClass                = variable("linkSourceClass")
       val currentLinkValue               = variable("currentLinkValue")
@@ -87,7 +87,7 @@ object DeleteLinkQuery extends QueryBuilderHelper {
         newLinkValue.has(RDF.SUBJECT, linkSource),
         newLinkValue.has(RDF.PREDICATE, linkProperty),
         newLinkValue.has(RDF.OBJECT, linkTarget),
-        newLinkValue.has(KB.valueHasString, Rdf.literalOfType(linkUpdate.linkTargetIri, XSD.STRING)),
+        newLinkValue.has(KB.valueHasString, Rdf.literalOfType(linkUpdate.linkTargetIri.value, XSD.STRING)),
         newLinkValue.has(KB.valueHasRefCount, Rdf.literalOf(linkUpdate.newReferenceCount)),
         newLinkValue.has(KB.valueCreationDate, toRdfLiteral(deletedAt)),
         newLinkValue.has(KB.deleteDate, toRdfLiteral(deletedAt)),

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuery.scala
@@ -89,7 +89,7 @@ object DeleteValueQuery extends QueryBuilderHelper {
         val deleteLinkPatterns = linkUpdates.zipWithIndex.flatMap { case (lu, i) =>
           val linkProperty      = toRdfIri(lu.linkPropertyIri)
           val linkValueProperty = Rdf.iri(lu.linkPropertyIri.toInternalSchema.toIri + "Value")
-          val linkTarget        = Rdf.iri(lu.linkTargetIri)
+          val linkTarget        = Rdf.iri(lu.linkTargetIri.value)
 
           // Delete direct links for standoff resource references that no longer exist
           val deleteDirectLink =
@@ -122,7 +122,7 @@ object DeleteValueQuery extends QueryBuilderHelper {
         val insertLinkPatterns = linkUpdates.zipWithIndex.flatMap { case (lu, i) =>
           val linkProperty      = toRdfIri(lu.linkPropertyIri)
           val linkValueProperty = Rdf.iri(lu.linkPropertyIri.toInternalSchema.toIri + "Value")
-          val linkTarget        = Rdf.iri(lu.linkTargetIri)
+          val linkTarget        = Rdf.iri(lu.linkTargetIri.value)
           val newLinkValue      = Rdf.iri(lu.newLinkValueIri.value)
 
           val deletedOrNot =
@@ -141,7 +141,7 @@ object DeleteValueQuery extends QueryBuilderHelper {
             newLinkValue.has(RDF.SUBJECT, resource),
             newLinkValue.has(RDF.PREDICATE, linkProperty),
             newLinkValue.has(RDF.OBJECT, linkTarget),
-            newLinkValue.has(KB.valueHasString, Rdf.literalOfType(lu.linkTargetIri, XSD.STRING)),
+            newLinkValue.has(KB.valueHasString, Rdf.literalOfType(lu.linkTargetIri.value, XSD.STRING)),
             newLinkValue.has(KB.valueHasRefCount, Rdf.literalOf(lu.newReferenceCount)),
           ) ++ deletedOrNot ++ Seq(
             newLinkValue.has(KB.valueCreationDate, currentTimeLiteral),
@@ -172,7 +172,7 @@ object DeleteValueQuery extends QueryBuilderHelper {
         val whereLinkPatterns: Seq[GraphPattern] = linkUpdates.zipWithIndex.flatMap { case (lu, i) =>
           val linkProperty      = toRdfIri(lu.linkPropertyIri)
           val linkValueProperty = Rdf.iri(lu.linkPropertyIri.toInternalSchema.toIri + "Value")
-          val linkTarget        = Rdf.iri(lu.linkTargetIri)
+          val linkTarget        = Rdf.iri(lu.linkTargetIri.value)
 
           Seq(
             // Make sure the relevant direct link exists between the two resources

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/model/ResourceCreateModels.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/model/ResourceCreateModels.scala
@@ -12,6 +12,7 @@ import org.knora.webapi.messages.util.CalendarNameV2
 import org.knora.webapi.messages.util.DatePrecisionV2
 import org.knora.webapi.messages.v2.responder.valuemessages.FileValueV2
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 
 final case class ResourceReadyToCreate(
@@ -25,9 +26,9 @@ final case class ResourceReadyToCreate(
 )
 
 final case class ValueInfo(
-  resourceIri: InternalIri,
+  resourceIri: ResourceIri,
   propertyIri: InternalIri,
-  valueIri: InternalIri,
+  valueIri: ValueIri,
   valueTypeIri: InternalIri,
   valueUUID: UUID,
   value: TypeSpecificValueInfo,
@@ -49,7 +50,7 @@ sealed trait FileValueTypeSpecificInfo {
 }
 
 enum TypeSpecificValueInfo {
-  case LinkValueInfo(referredResourceIri: InternalIri)
+  case LinkValueInfo(referredResourceIri: ResourceIri)
   case UnformattedTextValueInfo(valueHasLanguage: Option[String])
   case FormattedTextValueInfo(
     valueHasLanguage: Option[String],
@@ -95,8 +96,8 @@ enum TypeSpecificValueInfo {
 
 final case class StandoffLinkValueInfo(
   linkPropertyIri: InternalIri,
-  newLinkValueIri: InternalIri,
-  linkTargetIri: InternalIri,
+  newLinkValueIri: ValueIri,
+  linkTargetIri: ResourceIri,
   newReferenceCount: Int,
   newLinkValueCreator: InternalIri,
   newLinkValuePermissions: String,

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/model/SparqlTemplateLinkUpdate.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/model/SparqlTemplateLinkUpdate.scala
@@ -7,6 +7,7 @@ package org.knora.webapi.slice.resources.repo.model
 
 import org.knora.webapi.IRI
 import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.ValueIri
 
 /**
@@ -41,7 +42,7 @@ case class SparqlTemplateLinkUpdate(
   linkValueExists: Boolean,
   linkTargetExists: Boolean,
   newLinkValueIri: ValueIri,
-  linkTargetIri: IRI,
+  linkTargetIri: ResourceIri,
   currentReferenceCount: Int,
   newReferenceCount: Int,
   newLinkValueCreator: IRI,

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLive.scala
@@ -319,16 +319,15 @@ object ResourcesRepoLive {
     val resourcePattern = CreateResourceQueryBuilder.buildResourcePattern(resourceToCreate, projectIri, creatorIri)
     query.insertData(resourcePattern)
 
-    val resourceIriInternal = InternalIri(resourceToCreate.resourceIri.value)
-    val valuePatterns       = resourceToCreate.valueInfos.flatMap(
-      CreateResourceQueryBuilder.buildValuePattern(_, resourceIriInternal),
+    val valuePatterns = resourceToCreate.valueInfos.flatMap(
+      CreateResourceQueryBuilder.buildValuePattern(_, resourceToCreate.resourceIri),
     )
     query.insertData(valuePatterns: _*)
 
     val standoffLinkPatterns = resourceToCreate.standoffLinks.flatMap { standoffLink =>
       CreateResourceQueryBuilder.buildStandoffLinkPattern(
         standoffLink,
-        resourceIriInternal,
+        resourceToCreate.resourceIri,
         resourceToCreate.creationDate,
       )
     }
@@ -354,7 +353,7 @@ object ResourcesRepoLive {
 
     def buildStandoffLinkPattern(
       standoffLink: StandoffLinkValueInfo,
-      resourceIri: InternalIri,
+      resourceIri: ResourceIri,
       resourceCreationDate: Instant,
     ): List[TriplePattern] =
       List(
@@ -366,7 +365,7 @@ object ResourcesRepoLive {
 
     private def buildStandoffLinkPatternContent(
       standoffLink: StandoffLinkValueInfo,
-      resourceIri: InternalIri,
+      resourceIri: ResourceIri,
       resourceCreationDate: Instant,
     ): TriplePattern =
       iri(standoffLink.newLinkValueIri.value)
@@ -382,16 +381,16 @@ object ResourcesRepoLive {
         .andHas(KB.hasPermissions, literalOf(standoffLink.newLinkValuePermissions))
         .andHas(KB.valueHasUUID, literalOf(standoffLink.valueUuid))
 
-    def buildValuePattern(valueInfo: ValueInfo, resourceIri: InternalIri): List[TriplePattern] =
+    def buildValuePattern(valueInfo: ValueInfo, resourceIri: ResourceIri): List[TriplePattern] =
       List(
         iri(resourceIri.value).has(iri(valueInfo.propertyIri.value), iri(valueInfo.valueIri.value)),
         buildGeneralValuePattern(valueInfo),
       ) :::
         buildTypeSpecificValuePattern(
           valueInfo.value,
-          valueInfo.valueIri.value,
-          valueInfo.propertyIri.value,
-          resourceIri.value,
+          valueInfo.valueIri,
+          valueInfo.propertyIri,
+          resourceIri,
         )
 
     private def buildGeneralValuePattern(valueInfo: ValueInfo): TriplePattern =
@@ -408,71 +407,71 @@ object ResourcesRepoLive {
 
     private def buildTypeSpecificValuePattern(
       value: TypeSpecificValueInfo,
-      valueIri: String,
-      propertyIri: String,
-      resourceIri: String,
+      valueIri: ValueIri,
+      propertyIri: InternalIri,
+      resourceIri: ResourceIri,
     ): List[TriplePattern] =
       value match
         case v: LinkValueInfo =>
           buildLinkValuePatterns(v, valueIri, propertyIri, resourceIri)
         case UnformattedTextValueInfo(valueHasLanguage) =>
           List(
-            iri(valueIri)
+            iri(valueIri.value)
               .has(KB.hasTextValueType, KB.UnformattedText)
               .andHasOptional(KB.valueHasLanguage, valueHasLanguage.map(literalOf)),
           )
         case v: FormattedTextValueInfo =>
           buildFormattedTextValuePatterns(v, valueIri)
         case IntegerValueInfo(valueHasInteger) =>
-          List(iri(valueIri).has(KB.valueHasInteger, literalOf(valueHasInteger)))
+          List(iri(valueIri.value).has(KB.valueHasInteger, literalOf(valueHasInteger)))
         case DecimalValueInfo(valueHasDecimal) =>
-          List(iri(valueIri).has(KB.valueHasDecimal, literalOfType(valueHasDecimal.toString(), XSD.DECIMAL)))
+          List(iri(valueIri.value).has(KB.valueHasDecimal, literalOfType(valueHasDecimal.toString(), XSD.DECIMAL)))
         case BooleanValueInfo(valueHasBoolean) =>
-          List(iri(valueIri).has(KB.valueHasBoolean, literalOf(valueHasBoolean)))
+          List(iri(valueIri.value).has(KB.valueHasBoolean, literalOf(valueHasBoolean)))
         case UriValueInfo(valueHasUri) =>
-          List(iri(valueIri).has(KB.valueHasUri, literalOfType(valueHasUri, XSD.ANYURI)))
+          List(iri(valueIri.value).has(KB.valueHasUri, literalOfType(valueHasUri, XSD.ANYURI)))
         case v: DateValueInfo =>
           buildDateValuePattern(v, valueIri)
         case ColorValueInfo(valueHasColor) =>
-          List(iri(valueIri).has(KB.valueHasColor, literalOf(valueHasColor)))
+          List(iri(valueIri.value).has(KB.valueHasColor, literalOf(valueHasColor)))
         case GeomValueInfo(valueHasGeometry) =>
-          List(iri(valueIri).has(KB.valueHasGeometry, literalOf(valueHasGeometry)))
+          List(iri(valueIri.value).has(KB.valueHasGeometry, literalOf(valueHasGeometry)))
         case v: FileValueTypeSpecificInfo =>
           List(buildFileValuePattern(v, valueIri))
         case HierarchicalListValueInfo(valueHasListNode) =>
-          List(iri(valueIri).has(KB.valueHasListNode, iri(valueHasListNode.value)))
+          List(iri(valueIri.value).has(KB.valueHasListNode, iri(valueHasListNode.value)))
         case IntervalValueInfo(valueHasIntervalStart, valueHasIntervalEnd) =>
           List(
-            iri(valueIri)
+            iri(valueIri.value)
               .has(KB.valueHasIntervalStart, literalOfType(valueHasIntervalStart.toString(), XSD.DECIMAL))
               .andHas(KB.valueHasIntervalEnd, literalOfType(valueHasIntervalEnd.toString(), XSD.DECIMAL)),
           )
         case TimeValueInfo(valueHasTimeStamp) =>
-          List(iri(valueIri).has(KB.valueHasTimeStamp, literalOfType(valueHasTimeStamp.toString(), XSD.DATETIME)))
+          List(iri(valueIri.value).has(KB.valueHasTimeStamp, literalOfType(valueHasTimeStamp.toString(), XSD.DATETIME)))
         case GeonameValueInfo(valueHasGeonameCode) =>
-          List(iri(valueIri).has(KB.valueHasGeonameCode, literalOf(valueHasGeonameCode)))
+          List(iri(valueIri.value).has(KB.valueHasGeonameCode, literalOf(valueHasGeonameCode)))
 
     private def buildLinkValuePatterns(
       v: LinkValueInfo,
-      valueIri: String,
-      propertyIri: String,
-      resourceIri: String,
+      valueIri: ValueIri,
+      propertyIri: InternalIri,
+      resourceIri: ResourceIri,
     ): List[TriplePattern] =
       List(
-        iri(resourceIri).has(iri(propertyIri.stripSuffix("Value")), iri(v.referredResourceIri.value)),
-        iri(valueIri)
-          .has(RDF.SUBJECT, iri(resourceIri))
-          .andHas(RDF.PREDICATE, iri(propertyIri.stripSuffix("Value")))
+        iri(resourceIri.value).has(iri(propertyIri.value.stripSuffix("Value")), iri(v.referredResourceIri.value)),
+        iri(valueIri.value)
+          .has(RDF.SUBJECT, iri(resourceIri.value))
+          .andHas(RDF.PREDICATE, iri(propertyIri.value.stripSuffix("Value")))
           .andHas(RDF.OBJECT, iri(v.referredResourceIri.value))
           .andHas(KB.valueHasRefCount, literalOf(1)),
       )
 
-    private def buildFormattedTextValuePatterns(v: FormattedTextValueInfo, valueIri: String): List[TriplePattern] =
+    private def buildFormattedTextValuePatterns(v: FormattedTextValueInfo, valueIri: ValueIri): List[TriplePattern] =
       val txtTypeIri = v.textValueType match
         case FormattedTextValueType.StandardMapping  => KB.FormattedText
         case FormattedTextValueType.CustomMapping(_) => KB.CustomFormattedText
       val valuePattern =
-        iri(valueIri)
+        iri(valueIri.value)
           .has(KB.valueHasMapping, iri(v.mappingIri.value))
           .andHas(KB.hasTextValueType, txtTypeIri)
           .andHas(KB.valueHasMaxStandoffStartIndex, literalOf(v.maxStandoffStartIndex))
@@ -507,9 +506,9 @@ object ResourcesRepoLive {
         predicateObjectList(p, v)
       }.toList
 
-    private def buildDateValuePattern(v: DateValueInfo, valueIri: String): List[TriplePattern] =
+    private def buildDateValuePattern(v: DateValueInfo, valueIri: ValueIri): List[TriplePattern] =
       List(
-        iri(valueIri)
+        iri(valueIri.value)
           .has(KB.valueHasStartJDN, literalOf(v.valueHasStartJDN))
           .andHas(KB.valueHasEndJDN, literalOf(v.valueHasEndJDN))
           .andHas(KB.valueHasStartPrecision, literalOf(v.valueHasStartPrecision.toString()))
@@ -517,8 +516,8 @@ object ResourcesRepoLive {
           .andHas(KB.valueHasCalendar, literalOf(v.valueHasCalendar.toString())),
       )
 
-    private def buildFileValuePattern(v: FileValueTypeSpecificInfo, valueIri: String): TriplePattern = {
-      val result = iri(valueIri)
+    private def buildFileValuePattern(v: FileValueTypeSpecificInfo, valueIri: ValueIri): TriplePattern = {
+      val result = iri(valueIri.value)
         .has(KB.internalFilename, literalOf(v.fileValue.internalFilename))
         .andHas(KB.internalMimeType, literalOf(v.fileValue.internalMimeType))
         .andHasOptional(KB.originalFilename, v.fileValue.originalFilename.map(literalOf))

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueRepo.scala
@@ -26,6 +26,7 @@ import org.knora.webapi.messages.v2.responder.valuemessages.ValueContentV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.jena.JenaConversions.given_Conversion_String_Property
@@ -175,7 +176,7 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
 
   def updateValuePermissions(
     projectDataGraph: InternalIri,
-    resourceIri: InternalIri,
+    resourceIri: ResourceIri,
     valueIri: ValueIri,
     newPermissions: String,
     currentTime: Instant,
@@ -210,7 +211,7 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
   // does not support VALUES clauses with tuple bindings (?item ?newOrder) elegantly.
   def reorderValues(
     projectDataGraph: InternalIri,
-    resourceIri: InternalIri,
+    resourceIri: ResourceIri,
     orderedValueIris: List[ValueIri],
     currentTime: Instant,
   ): Task[Unit] = {
@@ -246,9 +247,9 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
 
   def createValue(
     dataNamedGraph: InternalIri,
-    resourceIri: InternalIri,
+    resourceIri: ResourceIri,
     propertyIri: SmartIri,
-    newValueIri: InternalIri,
+    newValueIri: ValueIri,
     newValueUUID: UUID,
     value: ValueContentV2,
     linkUpdates: Seq[SparqlTemplateLinkUpdate],
@@ -273,10 +274,10 @@ final case class ValueRepo(triplestore: TriplestoreService)(implicit val sf: Str
 
   def updateValue(
     dataNamedGraph: InternalIri,
-    resourceIri: InternalIri,
+    resourceIri: ResourceIri,
     propertyIri: SmartIri,
-    currentValueIri: InternalIri,
-    newValueIri: InternalIri,
+    currentValueIri: ValueIri,
+    newValueIri: ValueIri,
     value: ValueContentV2,
     valueCreator: InternalIri,
     valuePermissions: String,

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilder.scala
@@ -13,14 +13,13 @@ import org.eclipse.rdf4j.sparqlbuilder.constraint.Bind
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions
 import org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.PropertyPathBuilder
-import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.`var` as variable
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable
 import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern
 import org.eclipse.rdf4j.sparqlbuilder.rdf
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.literalOf
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.literalOfType
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfObject
@@ -37,18 +36,22 @@ import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffTagAttributeV2
 import org.knora.webapi.messages.v2.responder.valuemessages.ValueContentV2
+import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
-object InsertValueQueryBuilder {
+object InsertValueQueryBuilder extends QueryBuilderHelper {
+
   def createValueQuery(
     dataNamedGraph: InternalIri,
-    resourceIri: InternalIri,
+    resourceIri: ResourceIri,
     propertyIri: SmartIri,
-    newValueIri: InternalIri,
-    newUuidOrCurrentIri: Either[UUID, InternalIri],
+    newValueIri: ValueIri,
+    newUuidOrCurrentIri: Either[UUID, ValueIri],
     valueInitial: ValueContentV2,
     linkUpdates: Seq[SparqlTemplateLinkUpdate],
     valueCreator: InternalIri,
@@ -61,9 +64,8 @@ object InsertValueQueryBuilder {
     val resourceVar  = variable("resource")
     val currentVar   = variable("currentValue")
 
-    val resource = iri(resourceIri.value)
-    val property = iri(propertyIri.toString)
-    val valueIri = iri(newValueIri.value)
+    val resource = toRdfIri(resourceIri)
+    val property = toRdfIri(propertyIri)
 
     val currentValue     = newUuidOrCurrentIri.toOption
     val currentVarOpt    = currentValue.map(_ => currentVar)
@@ -88,7 +90,7 @@ object InsertValueQueryBuilder {
       resource,
       resourceVar,
       property,
-      valueIri,
+      newValueIri,
       newValueUUID,
       value,
       linkUpdates,
@@ -148,7 +150,7 @@ object InsertValueQueryBuilder {
 
     val linkValueDeletePatterns = linkUpdates.zipWithIndex.flatMap { case (linkUpdate, index) =>
       val deleteDirectLink = Option.when(linkUpdate.deleteDirectLink) {
-        resource.has(iri(linkUpdate.linkPropertyIri.toString), iri(linkUpdate.linkTargetIri))
+        resource.has(toRdfIri(linkUpdate.linkPropertyIri), toRdfIri(linkUpdate.linkTargetIri))
       }
 
       val linkValueExists = Option.when(linkUpdate.linkValueExists) {
@@ -157,7 +159,7 @@ object InsertValueQueryBuilder {
         val linkValuePermissions = variable(s"linkValuePermissions$index")
 
         List(
-          resource.has(iri(linkUpdate.linkPropertyIri.toString + "Value"), linkValue),
+          resource.has(Rdf.iri(linkUpdate.linkPropertyIri.toString + "Value"), linkValue),
           linkValue.has(KB.valueHasUUID, linkValueUUID),
           linkValue.has(KB.hasPermissions, linkValuePermissions),
         )
@@ -173,7 +175,7 @@ object InsertValueQueryBuilder {
     resource: rdf.Iri,
     resourceVar: Variable,
     property: rdf.Iri,
-    valueIri: rdf.Iri,
+    valueIri: ValueIri,
     valueUUID: Either[UUID, Variable],
     value: ValueContentV2,
     linkUpdates: Seq[SparqlTemplateLinkUpdate],
@@ -188,8 +190,9 @@ object InsertValueQueryBuilder {
       resourceVar.has(KB.lastModificationDate, literalOfType(creationDate.toString, XSD.DATETIME))
 
     // Basic value pattern
-    val baseValuePattern = valueIri
-      .isA(iri(value.valueType.toString))
+    val valueRdfIri      = toRdfIri(valueIri)
+    val baseValuePattern = valueRdfIri
+      .isA(toRdfIri(value.valueType))
       .andHas(KB.isDeleted, literalOf(false))
       .andHas(KB.valueHasString, literalOf(value.valueHasString))
 
@@ -199,10 +202,10 @@ object InsertValueQueryBuilder {
         variable => baseValuePattern.andHas(KB.valueHasUUID, variable),
       )
 
-    val base2 = valueIri
+    val base2 = valueRdfIri
       .hasOptional(KB.valueHasComment, value.comment.map(literalOf))
-      .fold(valueIri.has(KB.attachedToUser, iri(valueCreator.value)))(
-        _.andHas(KB.attachedToUser, iri(valueCreator.value)),
+      .fold(valueRdfIri.has(KB.attachedToUser, toRdfIri(valueCreator)))(
+        _.andHas(KB.attachedToUser, toRdfIri(valueCreator)),
       )
       .andHas(KB.hasPermissions, literalOf(valuePermissions))
       .andHas(KB.valueHasOrder, nextOrder)
@@ -215,8 +218,8 @@ object InsertValueQueryBuilder {
     val linkPatterns = buildLinkPatterns(resource, linkUpdates, creationDate, valueCreator)
 
     // Resource to value link
-    val resourceValuePattern = resource.has(property, valueIri)
-    val previousValuePattern = currentValue.toList.map(valueIri.has(KB.previousValue, _))
+    val resourceValuePattern = resource.has(property, valueRdfIri)
+    val previousValuePattern = currentValue.toList.map(valueRdfIri.has(KB.previousValue, _))
 
     List(
       List(resourceModPattern),
@@ -230,61 +233,63 @@ object InsertValueQueryBuilder {
   }
 
   private def buildTypeSpecificPatterns(
-    valueIri: rdf.Iri,
+    valueIri: ValueIri,
     value: ValueContentV2,
   ): List[TriplePattern] = {
     import org.knora.webapi.messages.v2.responder.valuemessages.*
 
+    val valueRdfIri = toRdfIri(valueIri)
     value match {
       case textValue: TextValueContentV2 =>
         buildTextValuePatterns(valueIri, textValue)
       case intValue: IntegerValueContentV2 =>
-        List(valueIri.has(KB.valueHasInteger, literalOf(intValue.valueHasInteger)))
+        List(valueRdfIri.has(KB.valueHasInteger, literalOf(intValue.valueHasInteger)))
       case decimalValue: DecimalValueContentV2 =>
-        List(valueIri.has(KB.valueHasDecimal, literalOfType(decimalValue.valueHasDecimal.toString, XSD.DECIMAL)))
+        List(valueRdfIri.has(KB.valueHasDecimal, literalOfType(decimalValue.valueHasDecimal.toString, XSD.DECIMAL)))
       case booleanValue: BooleanValueContentV2 =>
-        List(valueIri.has(KB.valueHasBoolean, literalOf(booleanValue.valueHasBoolean)))
+        List(valueRdfIri.has(KB.valueHasBoolean, literalOf(booleanValue.valueHasBoolean)))
       case uriValue: UriValueContentV2 =>
-        List(valueIri.has(KB.valueHasUri, literalOfType(uriValue.valueHasUri, XSD.ANYURI)))
+        List(valueRdfIri.has(KB.valueHasUri, literalOfType(uriValue.valueHasUri, XSD.ANYURI)))
       case dateValue: DateValueContentV2 =>
         buildDateValuePatterns(valueIri, dateValue)
       case colorValue: ColorValueContentV2 =>
-        List(valueIri.has(KB.valueHasColor, literalOf(colorValue.valueHasColor)))
+        List(valueRdfIri.has(KB.valueHasColor, literalOf(colorValue.valueHasColor)))
       case geometryValue: GeomValueContentV2 =>
-        List(valueIri.has(KB.valueHasGeometry, literalOf(geometryValue.valueHasGeometry)))
+        List(valueRdfIri.has(KB.valueHasGeometry, literalOf(geometryValue.valueHasGeometry)))
       case fileValue: FileValueContentV2 =>
         buildFileValuePatterns(valueIri, fileValue)
       case listValue: HierarchicalListValueContentV2 =>
-        List(valueIri.has(KB.valueHasListNode, iri(listValue.valueHasListNode.toString)))
+        List(valueRdfIri.has(KB.valueHasListNode, Rdf.iri(listValue.valueHasListNode)))
       case intervalValue: IntervalValueContentV2 =>
         List(
-          valueIri
+          valueRdfIri
             .has(KB.valueHasIntervalStart, literalOfType(intervalValue.valueHasIntervalStart.toString, XSD.DECIMAL))
             .andHas(KB.valueHasIntervalEnd, literalOfType(intervalValue.valueHasIntervalEnd.toString, XSD.DECIMAL)),
         )
       case timeValue: TimeValueContentV2 =>
-        List(valueIri.has(KB.valueHasTimeStamp, literalOfType(timeValue.valueHasTimeStamp.toString, XSD.DATETIME)))
+        List(valueRdfIri.has(KB.valueHasTimeStamp, literalOfType(timeValue.valueHasTimeStamp.toString, XSD.DATETIME)))
       case geonameValue: GeonameValueContentV2 =>
-        List(valueIri.has(KB.valueHasGeonameCode, literalOf(geonameValue.valueHasGeonameCode)))
+        List(valueRdfIri.has(KB.valueHasGeonameCode, literalOf(geonameValue.valueHasGeonameCode)))
       case _ => List.empty
     }
   }
 
   private def buildTextValuePatterns(
-    valueIri: rdf.Iri,
+    valueIri: ValueIri,
     textValue: org.knora.webapi.messages.v2.responder.valuemessages.TextValueContentV2,
   ): List[TriplePattern] = {
+    val valueRdfIri     = toRdfIri(valueIri)
     val languagePattern = textValue.valueHasLanguage.toList.map { lang =>
-      valueIri.has(KB.valueHasLanguage, literalOf(lang))
+      valueRdfIri.has(KB.valueHasLanguage, literalOf(lang))
     }
 
     if (textValue.standoff.nonEmpty) {
       val mappingPattern = textValue.mappingIri.map { mappingIri =>
-        valueIri.has(KB.valueHasMapping, iri(mappingIri.toString))
+        valueRdfIri.has(KB.valueHasMapping, Rdf.iri(mappingIri))
       }.toList
 
       val maxIndexPattern = textValue.computedMaxStandoffStartIndex.map { maxIndex =>
-        valueIri.has(KB.valueHasMaxStandoffStartIndex, literalOf(maxIndex))
+        valueRdfIri.has(KB.valueHasMaxStandoffStartIndex, literalOf(maxIndex))
       }.toList
 
       val standoffPatterns = buildStandoffPatterns(valueIri, textValue)
@@ -301,9 +306,9 @@ object InsertValueQueryBuilder {
     import org.knora.webapi.messages.v2.responder.standoffmessages._
 
     attr match {
-      case iriAttr: StandoffTagIriAttributeV2           => iri(iriAttr.value)
+      case iriAttr: StandoffTagIriAttributeV2           => Rdf.iri(iriAttr.value)
       case uri: StandoffTagUriAttributeV2               => literalOfType(uri.value, XSD.ANYURI)
-      case ref: StandoffTagInternalReferenceAttributeV2 => iri(ref.value)
+      case ref: StandoffTagInternalReferenceAttributeV2 => Rdf.iri(ref.value)
       case str: StandoffTagStringAttributeV2            => literalOf(str.value)
       case int: StandoffTagIntegerAttributeV2           => literalOf(int.value)
       case dec: StandoffTagDecimalAttributeV2           => literalOfType(dec.value.toString, XSD.DECIMAL)
@@ -313,24 +318,25 @@ object InsertValueQueryBuilder {
   }
 
   private def buildStandoffPatterns(
-    valueIri: rdf.Iri,
+    valueIri: ValueIri,
     textValue: org.knora.webapi.messages.v2.responder.valuemessages.TextValueContentV2,
   ): List[TriplePattern] = {
     import dsp.valueobjects.UuidUtil
 
+    val valueRdfIri = toRdfIri(valueIri)
     if (textValue.standoff.nonEmpty) {
       // Follow Twirl template lines 100-161: Create standoff nodes for each standoff tag
-      val standoffTags = textValue.prepareForSparqlInsert(valueIri.getQueryString().replaceAll("[<>]", ""))
+      val standoffTags = textValue.prepareForSparqlInsert(valueIri)
 
       standoffTags.flatMap { createStandoff =>
-        val standoffTagIri = iri(createStandoff.standoffTagInstanceIri)
+        val standoffTagIri = Rdf.iri(createStandoff.standoffTagInstanceIri)
 
         // Base pattern: valueHasStandoff connection
-        val valueHasStandoffPattern = valueIri.has(KB.valueHasStandoff, standoffTagIri)
+        val valueHasStandoffPattern = valueRdfIri.has(KB.valueHasStandoff, standoffTagIri)
 
         // Build the standoff tag properties
         val standoffPattern = standoffTagIri
-          .hasOptional(KB.standoffTagHasStartParent, createStandoff.startParentIri.map(iri))
+          .hasOptional(KB.standoffTagHasStartParent, createStandoff.startParentIri.map(Rdf.iri))
           .andHasOptional(
             standoffTagIri,
             KB.standoffTagHasOriginalXMLID,
@@ -341,15 +347,15 @@ object InsertValueQueryBuilder {
             KB.standoffTagHasEndIndex,
             createStandoff.standoffNode.endIndex.map(i => literalOf(i)),
           )
-          .andHasOptional(standoffTagIri, KB.standoffTagHasEndParent, createStandoff.endParentIri.map(iri))
+          .andHasOptional(standoffTagIri, KB.standoffTagHasEndParent, createStandoff.endParentIri.map(Rdf.iri))
           .andHasAllFn(createStandoff.standoffNode.attributes)((attr: StandoffTagAttributeV2) =>
-            (standoffTagIri, iri(attr.standoffPropertyIri.toString), standoffAttributeToRdfValue(attr)),
+            (standoffTagIri, toRdfIri(attr.standoffPropertyIri), standoffAttributeToRdfValue(attr)),
           )
           .andHas(standoffTagIri, KB.standoffTagHasStartIndex, literalOf(createStandoff.standoffNode.startIndex))
           .andHas(KB.standoffTagHasUUID, literalOf(UuidUtil.base64Encode(createStandoff.standoffNode.uuid)))
           .andHas(KB.standoffTagHasStart, literalOf(createStandoff.standoffNode.startPosition))
           .andHas(KB.standoffTagHasEnd, literalOf(createStandoff.standoffNode.endPosition))
-          .andHas(RDF.TYPE, iri(createStandoff.standoffNode.standoffTagClassIri.toString))
+          .andHas(RDF.TYPE, toRdfIri(createStandoff.standoffNode.standoffTagClassIri))
 
         List(valueHasStandoffPattern, standoffPattern)
       }.toList
@@ -359,11 +365,11 @@ object InsertValueQueryBuilder {
   }
 
   private def buildDateValuePatterns(
-    valueIri: org.eclipse.rdf4j.sparqlbuilder.rdf.Iri,
+    valueIri: ValueIri,
     dateValue: org.knora.webapi.messages.v2.responder.valuemessages.DateValueContentV2,
   ): List[TriplePattern] =
     List(
-      valueIri
+      toRdfIri(valueIri)
         .has(KB.valueHasStartJDN, literalOf(dateValue.valueHasStartJDN))
         .andHas(KB.valueHasEndJDN, literalOf(dateValue.valueHasEndJDN))
         .andHas(KB.valueHasStartPrecision, literalOf(dateValue.valueHasStartPrecision.toString))
@@ -372,10 +378,11 @@ object InsertValueQueryBuilder {
     )
 
   private def buildFileValuePatterns(
-    valueIri: org.eclipse.rdf4j.sparqlbuilder.rdf.Iri,
+    valueIri: ValueIri,
     fileValue: org.knora.webapi.messages.v2.responder.valuemessages.FileValueContentV2,
   ): List[TriplePattern] = {
-    val basePattern = valueIri
+    val valueRdfIri = toRdfIri(valueIri)
+    val basePattern = valueRdfIri
       .has(KB.internalFilename, literalOf(fileValue.fileValue.internalFilename))
       .andHas(KB.internalMimeType, literalOf(fileValue.fileValue.internalMimeType))
 
@@ -395,7 +402,7 @@ object InsertValueQueryBuilder {
     }
 
     val withLicense = fileValue.fileValue.licenseIri match {
-      case Some(licenseIri) => withCopyright.andHas(KB.hasLicense, iri(licenseIri.value))
+      case Some(licenseIri) => withCopyright.andHas(KB.hasLicense, toRdfIri(licenseIri))
       case None             => withCopyright
     }
 
@@ -439,22 +446,22 @@ object InsertValueQueryBuilder {
   ): List[TriplePattern] =
     linkUpdates.flatMap { linkUpdate =>
       val directLink = if (linkUpdate.insertDirectLink) {
-        Some(resource.has(iri(linkUpdate.linkPropertyIri.toString), iri(linkUpdate.linkTargetIri)))
+        Some(resource.has(toRdfIri(linkUpdate.linkPropertyIri), toRdfIri(linkUpdate.linkTargetIri)))
       } else None
 
       val isDeleted = linkUpdate.newReferenceCount == 0
 
-      val linkValue = iri(linkUpdate.newLinkValueIri.value)
+      val linkValue = toRdfIri(linkUpdate.newLinkValueIri)
         .isA(KB.linkValue)
         .andHas(RDF.SUBJECT, resource)
-        .andHas(RDF.PREDICATE, iri(linkUpdate.linkPropertyIri.toString))
-        .andHas(RDF.OBJECT, iri(linkUpdate.linkTargetIri))
-        .andHas(KB.valueHasString, literalOf(linkUpdate.linkTargetIri))
-        .andHas(KB.valueHasRefCount, literalOf(linkUpdate.newReferenceCount))
-        .andHas(KB.isDeleted, literalOf(isDeleted))
+        .andHas(RDF.PREDICATE, toRdfIri(linkUpdate.linkPropertyIri))
+        .andHas(RDF.OBJECT, toRdfIri(linkUpdate.linkTargetIri))
+        .andHas(KB.valueHasString, toRdfLiteral(linkUpdate.linkTargetIri))
+        .andHas(KB.valueHasRefCount, toRdfLiteral(linkUpdate.newReferenceCount))
+        .andHas(KB.isDeleted, toRdfLiteral(isDeleted))
         .andHas(KB.valueCreationDate, literalOfType(creationDate.toString, XSD.DATETIME))
-        .andHas(KB.attachedToUser, iri(linkUpdate.newLinkValueCreator))
-        .andHas(KB.hasPermissions, literalOf(linkUpdate.newLinkValuePermissions))
+        .andHas(KB.attachedToUser, Rdf.iri(linkUpdate.newLinkValueCreator))
+        .andHas(KB.hasPermissions, toRdfLiteral(linkUpdate.newLinkValuePermissions))
         .pipe { linkValue =>
           if (linkUpdate.linkValueExists) {
             val linkValueIndex    = linkUpdates.indexOf(linkUpdate)
@@ -471,14 +478,14 @@ object InsertValueQueryBuilder {
           if (isDeleted) {
             linkValue
               .andHas(KB.deleteDate, literalOfType(creationDate.toString, XSD.DATETIME))
-              .andHas(KB.deletedBy, iri(valueCreator.value))
+              .andHas(KB.deletedBy, toRdfIri(valueCreator))
           } else {
             linkValue
           }
         }
 
       val resourceToLinkValue =
-        resource.has(iri(linkUpdate.linkPropertyIri.toString + "Value"), iri(linkUpdate.newLinkValueIri.value))
+        resource.has(Rdf.iri(linkUpdate.linkPropertyIri.toString + "Value"), toRdfIri(linkUpdate.newLinkValueIri))
 
       List(directLink, Some(linkValue), Some(resourceToLinkValue)).flatten
     }.toList
@@ -492,10 +499,10 @@ object InsertValueQueryBuilder {
     linkUpdates: Seq[SparqlTemplateLinkUpdate],
     resourceLastModDate: Variable,
     nextOrder: Variable,
-    resourceIri: InternalIri,
+    resourceIri: ResourceIri,
     propertyIri: String,
     currentVar: Variable,
-    currentValue: Option[InternalIri],
+    currentValue: Option[ValueIri],
     currentValueUUID: Variable,
   ): List[GraphPattern] = {
     val resourceClass = variable("resourceClass")
@@ -529,7 +536,7 @@ object InsertValueQueryBuilder {
       Expressions.bind(Expressions.function(SparqlFunction.IRI, literalOf(value.valueType.toString)), valueType),
 
       // Property validation
-      propertyVar.has(iri(OntologyConstants.KnoraBase.ObjectClassConstraint), propertyRange),
+      propertyVar.has(Rdf.iri(OntologyConstants.KnoraBase.ObjectClassConstraint), propertyRange),
       valueType.has(subClassOfPath, propertyRange),
 
       // Cardinality validation
@@ -554,7 +561,7 @@ object InsertValueQueryBuilder {
     // List node validation for hierarchical list values
     val listNodeValidation = value match {
       case listValue: org.knora.webapi.messages.v2.responder.valuemessages.HierarchicalListValueContentV2 =>
-        List(iri(listValue.valueHasListNode.toString).isA(iri(OntologyConstants.KnoraBase.ListNode)))
+        List(Rdf.iri(listValue.valueHasListNode).isA(Rdf.iri(OntologyConstants.KnoraBase.ListNode)))
       case _ => List.empty
     }
 
@@ -569,36 +576,36 @@ object InsertValueQueryBuilder {
 
         val targetValidation = if (linkUpdate.insertDirectLink) {
           List(
-            iri(linkUpdate.linkTargetIri)
+            toRdfIri(linkUpdate.linkTargetIri)
               .isA(linkTargetClass)
               .andHas(KB.isDeleted, literalOf(false)),
             linkTargetClass.has(subClassOfPath, KB.Resource),
-            iri(linkUpdate.linkPropertyIri.toString)
-              .has(iri(OntologyConstants.KnoraBase.ObjectClassConstraint), expectedTargetClass),
+            toRdfIri(linkUpdate.linkPropertyIri)
+              .has(Rdf.iri(OntologyConstants.KnoraBase.ObjectClassConstraint), expectedTargetClass),
             linkTargetClass.has(subClassOfPath, expectedTargetClass),
           )
         } else List.empty
 
         val directLinkValidation = if (linkUpdate.directLinkExists) {
-          List(resourceVar.has(iri(linkUpdate.linkPropertyIri.toString), iri(linkUpdate.linkTargetIri)))
+          List(resourceVar.has(toRdfIri(linkUpdate.linkPropertyIri), toRdfIri(linkUpdate.linkTargetIri)))
         } else {
           // Follow Twirl template lines 471-473: Make sure there is no such direct link (MINUS clause)
           // Use MINUS pattern instead of filterNotExists for semantic equivalence
           List(
             GraphPatterns.minus(
-              resourceVar.has(iri(linkUpdate.linkPropertyIri.toString), iri(linkUpdate.linkTargetIri)),
+              resourceVar.has(toRdfIri(linkUpdate.linkPropertyIri), toRdfIri(linkUpdate.linkTargetIri)),
             ),
           )
         }
 
         val linkValueValidation = if (linkUpdate.linkValueExists) {
           List(
-            resourceVar.has(iri(linkUpdate.linkPropertyIri.toString + "Value"), linkValue),
+            resourceVar.has(Rdf.iri(linkUpdate.linkPropertyIri.toString + "Value"), linkValue),
             linkValue
               .isA(KB.linkValue)
               .andHas(RDF.SUBJECT, resourceVar)
-              .andHas(RDF.PREDICATE, iri(linkUpdate.linkPropertyIri.toString))
-              .andHas(RDF.OBJECT, iri(linkUpdate.linkTargetIri))
+              .andHas(RDF.PREDICATE, toRdfIri(linkUpdate.linkPropertyIri))
+              .andHas(RDF.OBJECT, toRdfIri(linkUpdate.linkTargetIri))
               .andHas(KB.valueHasRefCount, literalOf(linkUpdate.currentReferenceCount))
               .andHas(KB.isDeleted, literalOf(false))
               .andHas(KB.valueHasUUID, linkValueUUID)
@@ -610,13 +617,13 @@ object InsertValueQueryBuilder {
           List(
             GraphPatterns.minus(
               resourceVar
-                .has(iri(linkUpdate.linkPropertyIri.toString + "Value"), linkValue)
+                .has(Rdf.iri(linkUpdate.linkPropertyIri.toString + "Value"), linkValue)
                 .and(
                   linkValue
                     .isA(KB.linkValue)
                     .andHas(RDF.SUBJECT, resourceVar)
-                    .andHas(RDF.PREDICATE, iri(linkUpdate.linkPropertyIri.toString))
-                    .andHas(RDF.OBJECT, iri(linkUpdate.linkTargetIri))
+                    .andHas(RDF.PREDICATE, toRdfIri(linkUpdate.linkPropertyIri))
+                    .andHas(RDF.OBJECT, toRdfIri(linkUpdate.linkTargetIri))
                     .andHas(KB.isDeleted, literalOf(false)),
                 ),
             ),
@@ -660,7 +667,7 @@ object InsertValueQueryBuilder {
                 .as(nextOrder),
             )
             .where(
-              iri(resourceIri.value).has(iri(propertyIri.toString), otherValue),
+              toRdfIri(resourceIri).has(Rdf.iri(propertyIri), otherValue),
               otherValue.has(KB.valueHasOrder, order).andHas(KB.isDeleted, literalOf(false)),
             ),
         )

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/service/MetadataService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/service/MetadataService.scala
@@ -98,8 +98,10 @@ final case class MetadataService(
                 .attempt(rows.map { row =>
                   val classIri =
                     row.rowMap.getOrElse(classIriVar, throwEx(classIriVar)).toSmartIri.toComplexSchema.toIri
-                  val resourceIri         = row.rowMap.getOrElse(resourceIriVar, throwEx(resourceIriVar))
-                  val parsedResourceIri   = ResourceIri.unsafeFrom(resourceIri)
+                  val resourceIri       = row.rowMap.getOrElse(resourceIriVar, throwEx(resourceIriVar))
+                  val parsedResourceIri = ResourceIri
+                    .from(resourceIri)
+                    .fold(err => throw new InconsistentRepositoryDataException(err), identity)
                   val arkUrl              = sf.resourceIriToArkUrl(parsedResourceIri)
                   val arkUrlWithTimestamp = sf.resourceIriToArkUrl(parsedResourceIri, Some(now))
                   val label               = row.rowMap.getOrElse(labelVar, throwEx(labelVar))
@@ -110,7 +112,7 @@ final case class MetadataService(
                   val lastModAt = row.rowMap.get(lastModificationDateVar).map(Instant.parse)
                   ResourceMetadataDto(
                     classIri,
-                    resourceIri,
+                    parsedResourceIri,
                     arkUrl,
                     arkUrlWithTimestamp,
                     label,

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__BooleanValueContentV2.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__BooleanValueContentV2.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#BooleanValue" ) AS ?valueTy
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__ColorValueConte.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__ColorValueConte.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#ColorValue" ) AS ?valueType
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__DateValueContentV2.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__DateValueContentV2.txt
@@ -18,9 +18,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -33,7 +33,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#DateValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__DecimalValueContentV2_withoutComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__DecimalValueContentV2_withoutComment.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#DecimalValue" ) AS ?valueTy
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_colorValueWithTransparency.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_colorValueWithTransparency.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#ColorValue" ) AS ?valueType
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_decimalValueWithVeryHighPrecision.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_decimalValueWithVeryHighPrecision.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#DecimalValue" ) AS ?valueTy
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_decimalValueWithZero.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_decimalValueWithZero.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#DecimalValue" ) AS ?valueTy
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_integerValueWithMaximumValue.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_integerValueWithMaximumValue.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#IntValue" ) AS ?valueType )
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_integerValueWithMinimumValue.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_integerValueWithMinimumValue.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#IntValue" ) AS ?valueType )
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_intervalValueWithZeroRange.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_intervalValueWithZeroRange.txt
@@ -15,9 +15,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -30,7 +30,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#IntervalValue" ) AS ?valueT
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_textValueWithEmptyString.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_textValueWithEmptyString.txt
@@ -13,9 +13,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -28,7 +28,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_textValueWithUnicodeCharacters.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_textValueWithUnicodeCharacters.txt
@@ -15,9 +15,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -30,7 +30,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_textValueWithVeryLongString.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_textValueWithVeryLongString.txt
@@ -13,9 +13,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -28,7 +28,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_uriValueWithSpecialCharacters.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__EdgeCases_uriValueWithSpecialCharacters.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#UriValue" ) AS ?valueType )
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__GeomValueContentV2.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__GeomValueContentV2.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#GeomValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__GeonameValueContentV2.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__GeonameValueContentV2.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#GeonameValue" ) AS ?valueTy
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__HierarchicalListValueContentV2.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__HierarchicalListValueContentV2.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -30,7 +30,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#ListValue" ) AS ?valueType 
     owl:onProperty ?property .
 <http://rdfh.ch/lists/0001/treeList03> a knora-base:ListNode .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__IntegerValueContentV2_withComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__IntegerValueContentV2_withComment.txt
@@ -15,9 +15,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -30,7 +30,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#IntValue" ) AS ?valueType )
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__IntegerValueContentV2_withoutComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__IntegerValueContentV2_withoutComment.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#IntValue" ) AS ?valueType )
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__IntervalValueContentV2.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__IntervalValueContentV2.txt
@@ -15,9 +15,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -30,7 +30,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#IntervalValue" ) AS ?valueT
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_commentOrLanguage.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_commentOrLanguage.txt
@@ -13,9 +13,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -28,7 +28,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withComment.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withCommentAndLanguage.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withCommentAndLanguage.txt
@@ -15,9 +15,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -30,7 +30,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withHierarchicalStandoff.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withHierarchicalStandoff.txt
@@ -36,9 +36,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -51,7 +51,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withHierarchicalStandoffAndComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withHierarchicalStandoffAndComment.txt
@@ -37,9 +37,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -52,7 +52,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withLanguage.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withLanguage.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoff.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoff.txt
@@ -27,9 +27,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -42,7 +42,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffAndComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffAndComment.txt
@@ -28,9 +28,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -43,7 +43,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffIntegerAttribute.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffIntegerAttribute.txt
@@ -28,9 +28,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -43,7 +43,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffIntegerAttributeAndComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffIntegerAttributeAndComment.txt
@@ -29,9 +29,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -44,7 +44,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffLink.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffLink.txt
@@ -12,7 +12,7 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
 <http://rdfh.ch/0001/thing/values/value> knora-base:valueHasMapping <http://rdfh.ch/standoff/mappings/StandardMapping> .
 <http://rdfh.ch/0001/thing/values/value> knora-base:valueHasMaxStandoffStartIndex 1 .
 <http://rdfh.ch/0001/thing/values/value> knora-base:valueHasStandoff <http://rdfh.ch/0001/thing/values/value/standoff/0> .
-<http://rdfh.ch/0001/thing/values/value/standoff/0> knora-base:standoffTagHasLink <http://0.0.0.0:3333/0001/thing/linkedResource> ;
+<http://rdfh.ch/0001/thing/values/value/standoff/0> knora-base:standoffTagHasLink <http://rdfh.ch/0001/thing-linked-resource> ;
     knora-base:standoffTagHasStartIndex 0 ;
     knora-base:standoffTagHasUUID "EjRWeJCrze8SNFZ4kKvN7w" ;
     knora-base:standoffTagHasStart 0 ;
@@ -28,22 +28,22 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://0.0.0.0:3333/0001/thing/linkedResource> .
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://rdfh.ch/0001/thing-linked-resource> .
 <http://rdfh.ch/0001/thing/values/linkValue> a knora-base:LinkValue ;
-    rdf:subject <http://0.0.0.0:3333/0001/thing/resource> ;
+    rdf:subject <http://rdfh.ch/0001/thing-resource> ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
-    rdf:object <http://0.0.0.0:3333/0001/thing/linkedResource> ;
-    knora-base:valueHasString "http://0.0.0.0:3333/0001/thing/linkedResource" ;
+    rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
+    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource" ;
     knora-base:valueHasRefCount 1 ;
     knora-base:isDeleted false ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime ;
     knora-base:attachedToUser <http://0.0.0.0:3333/users/9XBCrDV3SRa7kS1WwynB4Q> ;
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasUUID "0000000000000000000000" .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> <http://rdfh.ch/0001/thing/values/linkValue> .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> <http://rdfh.ch/0001/thing/values/linkValue> .
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -55,20 +55,20 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?resourceClass rdfs:subClassOf* ?restriction .
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
-<http://0.0.0.0:3333/0001/thing/linkedResource> a ?linkTargetClass0 ;
+<http://rdfh.ch/0001/thing-linked-resource> a ?linkTargetClass0 ;
     knora-base:isDeleted false .
 ?linkTargetClass0 rdfs:subClassOf* knora-base:Resource .
 <http://www.knora.org/ontology/0001/anything#hasOtherThing> knora-base:objectClassConstraint ?expectedTargetClass0 .
 ?linkTargetClass0 rdfs:subClassOf* ?expectedTargetClass0 .
-MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://0.0.0.0:3333/0001/thing/linkedResource> . }
+MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://rdfh.ch/0001/thing-linked-resource> . }
 MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> ?linkValue0 .
 ?linkValue0 a knora-base:LinkValue ;
     rdf:subject ?resource ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
-    rdf:object <http://0.0.0.0:3333/0001/thing/linkedResource> ;
+    rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
     knora-base:isDeleted false . }
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffLink.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffLink.txt
@@ -12,7 +12,7 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
 <http://rdfh.ch/0001/thing/values/value> knora-base:valueHasMapping <http://rdfh.ch/standoff/mappings/StandardMapping> .
 <http://rdfh.ch/0001/thing/values/value> knora-base:valueHasMaxStandoffStartIndex 1 .
 <http://rdfh.ch/0001/thing/values/value> knora-base:valueHasStandoff <http://rdfh.ch/0001/thing/values/value/standoff/0> .
-<http://rdfh.ch/0001/thing/values/value/standoff/0> knora-base:standoffTagHasLink <http://rdfh.ch/0001/thing-linked-resource> ;
+<http://rdfh.ch/0001/thing/values/value/standoff/0> knora-base:standoffTagHasLink <http://0.0.0.0:3333/0001/thing/linkedResource> ;
     knora-base:standoffTagHasStartIndex 0 ;
     knora-base:standoffTagHasUUID "EjRWeJCrze8SNFZ4kKvN7w" ;
     knora-base:standoffTagHasStart 0 ;
@@ -33,12 +33,12 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     rdf:subject <http://rdfh.ch/0001/thing-resource> ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
     rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
-    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource" ;
-    knora-base:valueHasRefCount 1 ;
-    knora-base:isDeleted false ;
+    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource"^^xsd:string ;
+    knora-base:valueHasRefCount "1"^^xsd:int ;
+    knora-base:isDeleted "false"^^xsd:boolean ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime ;
     knora-base:attachedToUser <http://0.0.0.0:3333/users/9XBCrDV3SRa7kS1WwynB4Q> ;
-    knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
+    knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser"^^xsd:string ;
     knora-base:valueHasUUID "0000000000000000000000" .
 <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> <http://rdfh.ch/0001/thing/values/linkValue> .
 <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffTimeAttribute.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffTimeAttribute.txt
@@ -28,9 +28,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -43,7 +43,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffTimeAttributeAndComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withStandoffTimeAttributeAndComment.txt
@@ -29,9 +29,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -44,7 +44,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withVirtualHierarchyStandoff.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withVirtualHierarchyStandoff.txt
@@ -35,9 +35,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -50,7 +50,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withVirtualHierarchyStandoffAndComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withVirtualHierarchyStandoffAndComment.txt
@@ -36,9 +36,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -51,7 +51,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withXmlIdStandoff.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withXmlIdStandoff.txt
@@ -36,9 +36,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -51,7 +51,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withXmlIdStandoffAndComment.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TextValueContentV2_withXmlIdStandoffAndComment.txt
@@ -37,9 +37,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -52,7 +52,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TimeValueContentV2.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__TimeValueContentV2.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TimeValue" ) AS ?valueType 
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__UriValueContentV2.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__UriValueContentV2.txt
@@ -14,9 +14,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -29,7 +29,7 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#UriValue" ) AS ?valueType )
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__commentOrLanguage.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__commentOrLanguage.txt
@@ -13,9 +13,9 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -28,7 +28,7 @@ BIND( IRI( "http://api.knora.org/ontology/knora-api/v2#TextValue" ) AS ?valueTyp
 ?restriction a owl:Restriction ;
     owl:onProperty ?property .
 { SELECT ( MAX( ?order ) AS ?maxOrder ) ( IF( BOUND( ?maxOrder ), ( ?maxOrder + 1 ), 0 ) AS ?nextOrder )
-WHERE { <http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
+WHERE { <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> ?otherValue .
 ?otherValue knora-base:valueHasOrder ?order ;
     knora-base:isDeleted false . }
  } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue.txt
@@ -17,10 +17,10 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
-BIND( IRI( "http://rdfh.ch/0803/861b5644b302" ) AS ?currentValue )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0803/861b5644b302/values/current" ) AS ?currentValue )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue__withLinkUpdates.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue__withLinkUpdates.txt
@@ -17,23 +17,23 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://0.0.0.0:3333/0001/thing/linkedResource> .
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://rdfh.ch/0001/thing-linked-resource> .
 <http://rdfh.ch/0001/thing/values/linkValue> a knora-base:LinkValue ;
-    rdf:subject <http://0.0.0.0:3333/0001/thing/resource> ;
+    rdf:subject <http://rdfh.ch/0001/thing-resource> ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
-    rdf:object <http://0.0.0.0:3333/0001/thing/linkedResource> ;
-    knora-base:valueHasString "http://0.0.0.0:3333/0001/thing/linkedResource" ;
+    rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
+    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource" ;
     knora-base:valueHasRefCount 1 ;
     knora-base:isDeleted false ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime ;
     knora-base:attachedToUser <http://0.0.0.0:3333/users/9XBCrDV3SRa7kS1WwynB4Q> ;
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasUUID "0000000000000000000000" .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> <http://rdfh.ch/0001/thing/values/linkValue> .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> <http://rdfh.ch/0001/thing/values/linkValue> .
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
-BIND( IRI( "http://rdfh.ch/0803/861b5644b302" ) AS ?currentValue )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0803/861b5644b302/values/current" ) AS ?currentValue )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -51,17 +51,17 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?currentValue knora-base:isDeleted false .
 ?currentValue knora-base:valueHasUUID ?currentValueUuid .
 ?currentValue knora-base:hasPermissions ?currentValuePermissions .
-<http://0.0.0.0:3333/0001/thing/linkedResource> a ?linkTargetClass0 ;
+<http://rdfh.ch/0001/thing-linked-resource> a ?linkTargetClass0 ;
     knora-base:isDeleted false .
 ?linkTargetClass0 rdfs:subClassOf* knora-base:Resource .
 <http://www.knora.org/ontology/0001/anything#hasOtherThing> knora-base:objectClassConstraint ?expectedTargetClass0 .
 ?linkTargetClass0 rdfs:subClassOf* ?expectedTargetClass0 .
-MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://0.0.0.0:3333/0001/thing/linkedResource> . }
+MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://rdfh.ch/0001/thing-linked-resource> . }
 MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> ?linkValue0 .
 ?linkValue0 a knora-base:LinkValue ;
     rdf:subject ?resource ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
-    rdf:object <http://0.0.0.0:3333/0001/thing/linkedResource> ;
+    rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
     knora-base:isDeleted false . }
 OPTIONAL { ?currentValue knora-base:valueHasOrder ?existingOrder . }
 BIND( IF( BOUND( ?existingOrder ), ?existingOrder, 0 ) AS ?nextOrder ) }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue__withLinkUpdates.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue__withLinkUpdates.txt
@@ -22,12 +22,12 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     rdf:subject <http://rdfh.ch/0001/thing-resource> ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
     rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
-    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource" ;
-    knora-base:valueHasRefCount 1 ;
-    knora-base:isDeleted false ;
+    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource"^^xsd:string ;
+    knora-base:valueHasRefCount "1"^^xsd:int ;
+    knora-base:isDeleted "false"^^xsd:boolean ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime ;
     knora-base:attachedToUser <http://0.0.0.0:3333/users/9XBCrDV3SRa7kS1WwynB4Q> ;
-    knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
+    knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser"^^xsd:string ;
     knora-base:valueHasUUID "0000000000000000000000" .
 <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> <http://rdfh.ch/0001/thing/values/linkValue> .
 <http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue__withLinkUpdatesDeleted.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue__withLinkUpdatesDeleted.txt
@@ -17,12 +17,12 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
     knora-base:valueHasOrder ?nextOrder ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://0.0.0.0:3333/0001/thing/linkedResource> .
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://rdfh.ch/0001/thing-linked-resource> .
 <http://rdfh.ch/0001/thing/values/linkValue> a knora-base:LinkValue ;
-    rdf:subject <http://0.0.0.0:3333/0001/thing/resource> ;
+    rdf:subject <http://rdfh.ch/0001/thing-resource> ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
-    rdf:object <http://0.0.0.0:3333/0001/thing/linkedResource> ;
-    knora-base:valueHasString "http://0.0.0.0:3333/0001/thing/linkedResource" ;
+    rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
+    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource" ;
     knora-base:valueHasRefCount 0 ;
     knora-base:isDeleted true ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime ;
@@ -31,11 +31,11 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     knora-base:valueHasUUID "0000000000000000000000" .
     knora-base:deleteDate "2023-08-01T10:30:00Z"^^xsd:dateTime ;
     knora-base:deletedBy <http://0.0.0.0:3333/users/9XBCrDV3SRa7kS1WwynB4Q> .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> <http://rdfh.ch/0001/thing/values/linkValue> .
-<http://0.0.0.0:3333/0001/thing/resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> <http://rdfh.ch/0001/thing/values/linkValue> .
+<http://rdfh.ch/0001/thing-resource> <http://www.knora.org/ontology/0001/anything#hasText> <http://rdfh.ch/0001/thing/values/value> . } }
 WHERE { BIND( IRI( "http://0.0.0.0:3333/data/0001/thing" ) AS ?dataNamedGraph )
-BIND( IRI( "http://0.0.0.0:3333/0001/thing/resource" ) AS ?resource )
-BIND( IRI( "http://rdfh.ch/0803/861b5644b302" ) AS ?currentValue )
+BIND( IRI( "http://rdfh.ch/0001/thing-resource" ) AS ?resource )
+BIND( IRI( "http://rdfh.ch/0803/861b5644b302/values/current" ) AS ?currentValue )
 ?resource a ?resourceClass ;
     knora-base:isDeleted false .
 ?resourceClass rdfs:subClassOf* knora-base:Resource .
@@ -53,17 +53,17 @@ BIND( IRI( "http://www.knora.org/ontology/knora-base#TextValue" ) AS ?valueType 
 ?currentValue knora-base:isDeleted false .
 ?currentValue knora-base:valueHasUUID ?currentValueUuid .
 ?currentValue knora-base:hasPermissions ?currentValuePermissions .
-<http://0.0.0.0:3333/0001/thing/linkedResource> a ?linkTargetClass0 ;
+<http://rdfh.ch/0001/thing-linked-resource> a ?linkTargetClass0 ;
     knora-base:isDeleted false .
 ?linkTargetClass0 rdfs:subClassOf* knora-base:Resource .
 <http://www.knora.org/ontology/0001/anything#hasOtherThing> knora-base:objectClassConstraint ?expectedTargetClass0 .
 ?linkTargetClass0 rdfs:subClassOf* ?expectedTargetClass0 .
-MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://0.0.0.0:3333/0001/thing/linkedResource> . }
+MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThing> <http://rdfh.ch/0001/thing-linked-resource> . }
 MINUS { ?resource <http://www.knora.org/ontology/0001/anything#hasOtherThingValue> ?linkValue0 .
 ?linkValue0 a knora-base:LinkValue ;
     rdf:subject ?resource ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
-    rdf:object <http://0.0.0.0:3333/0001/thing/linkedResource> ;
+    rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
     knora-base:isDeleted false . }
 OPTIONAL { ?currentValue knora-base:valueHasOrder ?existingOrder . }
 BIND( IF( BOUND( ?existingOrder ), ?existingOrder, 0 ) AS ?nextOrder ) }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue__withLinkUpdatesDeleted.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec__currentValue__withLinkUpdatesDeleted.txt
@@ -22,12 +22,12 @@ INSERT { GRAPH ?dataNamedGraph { ?resource knora-base:lastModificationDate "2023
     rdf:subject <http://rdfh.ch/0001/thing-resource> ;
     rdf:predicate <http://www.knora.org/ontology/0001/anything#hasOtherThing> ;
     rdf:object <http://rdfh.ch/0001/thing-linked-resource> ;
-    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource" ;
-    knora-base:valueHasRefCount 0 ;
-    knora-base:isDeleted true ;
+    knora-base:valueHasString "http://rdfh.ch/0001/thing-linked-resource"^^xsd:string ;
+    knora-base:valueHasRefCount "0"^^xsd:int ;
+    knora-base:isDeleted "true"^^xsd:boolean ;
     knora-base:valueCreationDate "2023-08-01T10:30:00Z"^^xsd:dateTime ;
     knora-base:attachedToUser <http://0.0.0.0:3333/users/9XBCrDV3SRa7kS1WwynB4Q> ;
-    knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser" ;
+    knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser"^^xsd:string ;
     knora-base:valueHasUUID "0000000000000000000000" .
     knora-base:deleteDate "2023-08-01T10:30:00Z"^^xsd:dateTime ;
     knora-base:deletedBy <http://0.0.0.0:3333/users/9XBCrDV3SRa7kS1WwynB4Q> .

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkMetadataQuerySpec.scala
@@ -40,7 +40,7 @@ object ChangeLinkMetadataQuerySpec extends ZIOSpecDefault {
   )
   private val testLinkSourceIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
-  private val testLinkTargetIri   = "http://rdfh.ch/0001/thing2"
+  private val testLinkTargetIri   = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing2")
   private val testNewLinkValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/newLinkValue")
   private val testRefCount        = 1
   private val testNewLinkCreator  = "http://rdfh.ch/users/creator1"

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeLinkTargetQuerySpec.scala
@@ -43,8 +43,8 @@ object ChangeLinkTargetQuerySpec extends ZIOSpecDefault {
   )
   private val testLinkSourceIri             = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri           = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
-  private val testCurrentLinkTargetIri      = "http://rdfh.ch/0001/thing2"
-  private val testNewLinkTargetIri          = "http://rdfh.ch/0001/thing3"
+  private val testCurrentLinkTargetIri      = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing2")
+  private val testNewLinkTargetIri          = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing3")
   private val testNewLinkValueIriForCurrent =
     ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/currentLinkValueNew")
   private val testNewLinkValueIriForNew =
@@ -57,7 +57,7 @@ object ChangeLinkTargetQuerySpec extends ZIOSpecDefault {
 
   private def createCurrentLinkUpdate(
     linkPropertyIri: SmartIri = testLinkPropertyIri,
-    linkTargetIri: String = testCurrentLinkTargetIri,
+    linkTargetIri: ResourceIri = testCurrentLinkTargetIri,
     newLinkValueIri: ValueIri = testNewLinkValueIriForCurrent,
     currentReferenceCount: Int = testCurrentReferenceCount,
     newLinkValueCreator: String = testNewLinkValueCreator,
@@ -79,7 +79,7 @@ object ChangeLinkTargetQuerySpec extends ZIOSpecDefault {
 
   private def createNewLinkUpdate(
     linkPropertyIri: SmartIri = testLinkPropertyIri,
-    linkTargetIri: String = testNewLinkTargetIri,
+    linkTargetIri: ResourceIri = testNewLinkTargetIri,
     newLinkValueIri: ValueIri = testNewLinkValueIriForNew,
     newReferenceCount: Int = 1,
     newLinkValueCreator: String = testNewLinkValueCreator,

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/CreateLinkQuerySpec.scala
@@ -43,7 +43,7 @@ object CreateLinkQuerySpec extends ZIOSpecDefault {
 
   private val testResourceIri         = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing1")
   private val testLinkPropertyIri     = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
-  private val testLinkTargetIri       = "http://rdfh.ch/0001/thing2"
+  private val testLinkTargetIri       = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing2")
   private val testNewLinkValueIri     = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/newLinkValue")
   private val testNewLinkValueCreator = "http://rdfh.ch/users/creator1"
   private val testNewLinkValuePerms   = "CR knora-admin:Creator"

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteLinkQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteLinkQuerySpec.scala
@@ -15,6 +15,7 @@ import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.domain.model.UserIri
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
@@ -25,7 +26,7 @@ object DeleteLinkQuerySpec extends ZIOSpecDefault {
   private val testDataNamedGraph        = "http://www.knora.org/data/0001/anything"
   private val testLinkSourceIri         = "http://rdfh.ch/0001/thing1"
   private val testLinkPropertyIri       = "http://www.knora.org/ontology/0001/anything#hasOtherThing".toSmartIri
-  private val testLinkTargetIri         = "http://rdfh.ch/0001/thing2"
+  private val testLinkTargetIri         = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing2")
   private val testNewLinkValueIri       = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/newLinkValue")
   private val testCurrentReferenceCount = 1
   private val testNewLinkValueCreator   = "http://rdfh.ch/users/creator1"
@@ -35,7 +36,7 @@ object DeleteLinkQuerySpec extends ZIOSpecDefault {
 
   private def createValidSparqlTemplateLinkUpdate(
     linkPropertyIri: SmartIri = testLinkPropertyIri,
-    linkTargetIri: String = testLinkTargetIri,
+    linkTargetIri: ResourceIri = testLinkTargetIri,
     newLinkValueIri: ValueIri = testNewLinkValueIri,
     currentReferenceCount: Int = testCurrentReferenceCount,
     newLinkValueCreator: String = testNewLinkValueCreator,
@@ -168,7 +169,7 @@ object DeleteLinkQuerySpec extends ZIOSpecDefault {
                      "http://rdfh.ch/0803/page123",
                      createValidSparqlTemplateLinkUpdate(
                        linkPropertyIri = differentLinkProperty,
-                       linkTargetIri = "http://rdfh.ch/0803/book456",
+                       linkTargetIri = ResourceIri.unsafeFrom("http://rdfh.ch/0803/book456"),
                        newLinkValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0803/page123/values/deletedLink"),
                        currentReferenceCount = 1,
                        newLinkValueCreator = "http://rdfh.ch/users/incunabulaUser",

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteValueQuerySpec.scala
@@ -48,14 +48,14 @@ object DeleteValueQuerySpec extends ZIOSpecDefault {
   private val testRequestingUser = UserIri.unsafeFrom("http://rdfh.ch/users/root")
 
   private val testLinkPropertyIri     = "http://www.knora.org/ontology/knora-base#hasStandoffLinkTo".toSmartIri
-  private val testLinkTargetIri       = "http://rdfh.ch/0001/thing2"
+  private val testLinkTargetIri       = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing2")
   private val testNewLinkValueIri     = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing1/values/newLinkValue")
   private val testNewLinkValueCreator = "http://rdfh.ch/users/systemUser"
   private val testNewLinkValuePerms   = "CR knora-admin:Creator"
 
   private def createValidLinkUpdate(
     linkPropertyIri: SmartIri = testLinkPropertyIri,
-    linkTargetIri: String = testLinkTargetIri,
+    linkTargetIri: ResourceIri = testLinkTargetIri,
     newLinkValueIri: ValueIri = testNewLinkValueIri,
     currentReferenceCount: Int = 2,
     newReferenceCount: Int = 1,

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLiveSpec.scala
@@ -22,6 +22,7 @@ import org.knora.webapi.messages.v2.responder.valuemessages.FileValueV2
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.resources.repo.model.FormattedTextValueType
 import org.knora.webapi.slice.resources.repo.model.ResourceReadyToCreate
@@ -61,24 +62,24 @@ object TestData {
   )
 
   val linkValueDefinition = ValueInfo(
-    resourceIri = resourceIriInt,
+    resourceIri = resourceIri,
     propertyIri = InternalIri("foo:hasLinkToValue"),
-    valueIri = InternalIri("foo:LinkValueIri"),
+    valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/LinkValueIri"),
     valueTypeIri = InternalIri(OntologyConstants.KnoraBase.LinkValue),
     valueUUID = UUID.randomUUID(),
-    value = TypeSpecificValueInfo.LinkValueInfo(InternalIri("foo:LinkTargetIri")),
+    value = TypeSpecificValueInfo.LinkValueInfo(ResourceIri.unsafeFrom("http://rdfh.ch/0001/LinkTargetIri")),
     permissions = valuePermissions,
     creator = valueCreator,
     creationDate = valueCreationDate,
     valueHasOrder = 1,
-    valueHasString = "foo:LinkValueIri",
+    valueHasString = "http://rdfh.ch/0001/foo-resource/values/LinkValueIri",
     comment = None,
   )
 
   val unformattedTextValueDefinition = ValueInfo(
-    resourceIri = resourceIriInt,
+    resourceIri = resourceIri,
     propertyIri = InternalIri("foo:hasUnformattedTextValue"),
-    valueIri = InternalIri("foo:UnformattedTextValueIri"),
+    valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/UnformattedTextValueIri"),
     valueTypeIri = InternalIri(OntologyConstants.KnoraBase.TextValue),
     valueUUID = UUID.randomUUID(),
     value = TypeSpecificValueInfo.UnformattedTextValueInfo(Some("en")),
@@ -92,9 +93,9 @@ object TestData {
 
   val standoffTagUuid              = UUID.randomUUID()
   val formattedTextValueDefinition = ValueInfo(
-    resourceIri = resourceIriInt,
+    resourceIri = resourceIri,
     propertyIri = InternalIri("foo:hasFormattedTextValue"),
-    valueIri = InternalIri("foo:FormattedTextValueIri"),
+    valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/FormattedTextValueIri"),
     valueTypeIri = InternalIri(OntologyConstants.KnoraBase.TextValue),
     valueUUID = UUID.randomUUID(),
     value = TypeSpecificValueInfo.FormattedTextValueInfo(
@@ -155,9 +156,9 @@ object TestData {
 
   val intValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasInt"),
-      valueIri = InternalIri("foo:IntValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/IntValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.IntValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.IntegerValueInfo(42),
@@ -171,9 +172,9 @@ object TestData {
 
   val boolValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasBoolean"),
-      valueIri = InternalIri("foo:BooleanValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/BooleanValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.BooleanValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.BooleanValueInfo(true),
@@ -187,9 +188,9 @@ object TestData {
 
   val decimalValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasDecimal"),
-      valueIri = InternalIri("foo:DecimalValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/DecimalValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.DecimalValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.DecimalValueInfo(BigDecimal(42.42)),
@@ -203,9 +204,9 @@ object TestData {
 
   val uriValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasUri"),
-      valueIri = InternalIri("foo:UriValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/UriValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.UriValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.UriValueInfo("http://example.com"),
@@ -219,9 +220,9 @@ object TestData {
 
   val dateValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasDate"),
-      valueIri = InternalIri("foo:DateValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/DateValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.DateValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.DateValueInfo(0, 0, DatePrecisionDay, DatePrecisionDay, CalendarNameGregorian),
@@ -235,9 +236,9 @@ object TestData {
 
   val colorValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasColor"),
-      valueIri = InternalIri("foo:ColorValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/ColorValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.ColorValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.ColorValueInfo("#ff0000"),
@@ -251,9 +252,9 @@ object TestData {
 
   val geometryValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasGeom"),
-      valueIri = InternalIri("foo:GeomValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/GeomValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.GeomValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.GeomValueInfo(
@@ -270,9 +271,9 @@ object TestData {
 
   val stillImageFileValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasStillImage"),
-      valueIri = InternalIri("foo:StillImageFileValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/StillImageFileValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.StillImageFileValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.StillImageFileValueInfo(
@@ -295,9 +296,9 @@ object TestData {
 
   val stillImageExternalFileValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasStillImageExternal"),
-      valueIri = InternalIri("foo:StillImageExternalFileValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/StillImageExternalFileValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.StillImageFileValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.StillImageExternalFileValueInfo(
@@ -317,9 +318,9 @@ object TestData {
 
   val documentFileValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasDocument"),
-      valueIri = InternalIri("foo:DocumentFileValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/DocumentFileValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.DocumentFileValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.DocumentFileValueInfo(
@@ -343,9 +344,9 @@ object TestData {
 
   val otherFileValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasOtherFile"),
-      valueIri = InternalIri("foo:OtherFileValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/OtherFileValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.ArchiveFileValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.OtherFileValueInfo(
@@ -366,9 +367,9 @@ object TestData {
 
   val hierarchicalListValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasList"),
-      valueIri = InternalIri("foo:ListNodeIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/ListValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.ListValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.HierarchicalListValueInfo(InternalIri("foo:ListNodeIri")),
@@ -382,9 +383,9 @@ object TestData {
 
   val intervalValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasInterval"),
-      valueIri = InternalIri("foo:IntervalValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/IntervalValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.IntervalValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.IntervalValueInfo(
@@ -401,9 +402,9 @@ object TestData {
 
   val timeValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasTime"),
-      valueIri = InternalIri("foo:TimeValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/TimeValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.TimeValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.TimeValueInfo(Instant.parse("1024-01-01T10:00:00.673298Z")),
@@ -417,9 +418,9 @@ object TestData {
 
   val geonameValueDefinition =
     ValueInfo(
-      resourceIri = resourceIriInt,
+      resourceIri = resourceIri,
       propertyIri = InternalIri("foo:hasGeoname"),
-      valueIri = InternalIri("foo:GeonameValueIri"),
+      valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/GeonameValueIri"),
       valueTypeIri = InternalIri(OntologyConstants.KnoraBase.GeonameValue),
       valueUUID = UUID.randomUUID(),
       value = TypeSpecificValueInfo.GeonameValueInfo("geoname_code"),
@@ -434,8 +435,8 @@ object TestData {
   val standoffLinkValue =
     StandoffLinkValueInfo(
       linkPropertyIri = InternalIri("foo:hasStandoffLinkTo"),
-      newLinkValueIri = InternalIri("foo:StandoffLinkValueIri"),
-      linkTargetIri = InternalIri("foo:StandoffLinkTargetIri"),
+      newLinkValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/foo-resource/values/StandoffLinkValueIri"),
+      linkTargetIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/StandoffLinkTargetIri"),
       newReferenceCount = 2,
       newLinkValueCreator = valueCreator,
       newLinkValuePermissions = valuePermissions,
@@ -507,19 +508,19 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasLinkToValue> <foo:LinkValueIri> .
-            |        <foo:LinkValueIri> rdf:type <http://www.knora.org/ontology/knora-base#LinkValue> ;
+            |            <foo:hasLinkToValue> <http://rdfh.ch/0001/foo-resource/values/LinkValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/LinkValueIri> rdf:type <http://www.knora.org/ontology/knora-base#LinkValue> ;
             |            knora-base:isDeleted false  ;
-            |            knora-base:valueHasString "foo:LinkValueIri" ;
+            |            knora-base:valueHasString "http://rdfh.ch/0001/foo-resource/values/LinkValueIri" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(linkValueDefinition.valueUUID)}" ;
             |            knora-base:attachedToUser <${valueCreator.value}> ;
             |            knora-base:hasPermissions "$valuePermissions" ;
             |            knora-base:valueHasOrder 1 ;
             |            knora-base:valueCreationDate "$valueCreationDate"^^xsd:dateTime .
-            |        <${resourceIri.value}> <foo:hasLinkTo> <foo:LinkTargetIri> .
-            |        <foo:LinkValueIri> rdf:subject <${resourceIri.value}> ;
+            |        <${resourceIri.value}> <foo:hasLinkTo> <http://rdfh.ch/0001/LinkTargetIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/LinkValueIri> rdf:subject <${resourceIri.value}> ;
             |            rdf:predicate <foo:hasLinkTo> ;
-            |            rdf:object <foo:LinkTargetIri> ;
+            |            rdf:object <http://rdfh.ch/0001/LinkTargetIri> ;
             |            knora-base:valueHasRefCount 1 .
             |    }
             |}
@@ -546,8 +547,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasUnformattedTextValue> <foo:UnformattedTextValueIri> .
-            |        <foo:UnformattedTextValueIri> rdf:type <http://www.knora.org/ontology/knora-base#TextValue> ;
+            |            <foo:hasUnformattedTextValue> <http://rdfh.ch/0001/foo-resource/values/UnformattedTextValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/UnformattedTextValueIri> rdf:type <http://www.knora.org/ontology/knora-base#TextValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "this is a text without formatting" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(unformattedTextValueDefinition.valueUUID)}" ;
@@ -582,8 +583,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasFormattedTextValue> <foo:FormattedTextValueIri> .
-            |        <foo:FormattedTextValueIri> rdf:type <http://www.knora.org/ontology/knora-base#TextValue> ;
+            |            <foo:hasFormattedTextValue> <http://rdfh.ch/0001/foo-resource/values/FormattedTextValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/FormattedTextValueIri> rdf:type <http://www.knora.org/ontology/knora-base#TextValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "this is a text with formatting" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(formattedTextValueDefinition.valueUUID)}" ;
@@ -638,8 +639,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasInt> <foo:IntValueIri> .
-            |        <foo:IntValueIri> rdf:type <http://www.knora.org/ontology/knora-base#IntValue> ;
+            |            <foo:hasInt> <http://rdfh.ch/0001/foo-resource/values/IntValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/IntValueIri> rdf:type <http://www.knora.org/ontology/knora-base#IntValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "42" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(intValueDefinition.valueUUID)}" ;
@@ -673,8 +674,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasBoolean> <foo:BooleanValueIri> .
-            |        <foo:BooleanValueIri> rdf:type <http://www.knora.org/ontology/knora-base#BooleanValue> ;
+            |            <foo:hasBoolean> <http://rdfh.ch/0001/foo-resource/values/BooleanValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/BooleanValueIri> rdf:type <http://www.knora.org/ontology/knora-base#BooleanValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "true" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(boolValueDefinition.valueUUID)}" ;
@@ -708,8 +709,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasDecimal> <foo:DecimalValueIri> .
-            |        <foo:DecimalValueIri> rdf:type <http://www.knora.org/ontology/knora-base#DecimalValue> ;
+            |            <foo:hasDecimal> <http://rdfh.ch/0001/foo-resource/values/DecimalValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/DecimalValueIri> rdf:type <http://www.knora.org/ontology/knora-base#DecimalValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "42.42" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(decimalValueDefinition.valueUUID)}" ;
@@ -743,8 +744,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasUri> <foo:UriValueIri> .
-            |        <foo:UriValueIri> rdf:type <http://www.knora.org/ontology/knora-base#UriValue> ;
+            |            <foo:hasUri> <http://rdfh.ch/0001/foo-resource/values/UriValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/UriValueIri> rdf:type <http://www.knora.org/ontology/knora-base#UriValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "http://example.com" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(uriValueDefinition.valueUUID)}" ;
@@ -778,8 +779,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasDate> <foo:DateValueIri> .
-            |        <foo:DateValueIri> rdf:type <http://www.knora.org/ontology/knora-base#DateValue> ;
+            |            <foo:hasDate> <http://rdfh.ch/0001/foo-resource/values/DateValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/DateValueIri> rdf:type <http://www.knora.org/ontology/knora-base#DateValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "2024-01-01" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(dateValueDefinition.valueUUID)}" ;
@@ -817,8 +818,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasColor> <foo:ColorValueIri> .
-            |        <foo:ColorValueIri> rdf:type <http://www.knora.org/ontology/knora-base#ColorValue> ;
+            |            <foo:hasColor> <http://rdfh.ch/0001/foo-resource/values/ColorValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/ColorValueIri> rdf:type <http://www.knora.org/ontology/knora-base#ColorValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "#ff0000" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(colorValueDefinition.valueUUID)}" ;
@@ -853,8 +854,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasGeom> <foo:GeomValueIri> .
-            |        <foo:GeomValueIri> rdf:type <http://www.knora.org/ontology/knora-base#GeomValue> ;
+            |            <foo:hasGeom> <http://rdfh.ch/0001/foo-resource/values/GeomValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/GeomValueIri> rdf:type <http://www.knora.org/ontology/knora-base#GeomValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "{\\"status\\":\\"active\\",\\"lineColor\\":\\"#33ff33\\",\\"lineWidth\\":2,\\"points\\":[{\\"x\\":0.20226843100189035,\\"y\\":0.3090909090909091},{\\"x\\":0.6389413988657845,\\"y\\":0.3594405594405594}],\\"type\\":\\"rectangle\\",\\"original_index\\":0}" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(geometryValueDefinition.valueUUID)}" ;
@@ -888,8 +889,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasStillImage> <foo:StillImageFileValueIri> .
-            |        <foo:StillImageFileValueIri> rdf:type <http://www.knora.org/ontology/knora-base#StillImageFileValue> ;
+            |            <foo:hasStillImage> <http://rdfh.ch/0001/foo-resource/values/StillImageFileValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/StillImageFileValueIri> rdf:type <http://www.knora.org/ontology/knora-base#StillImageFileValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "foo.jpg" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(stillImageFileValueDefinition.valueUUID)}" ;
@@ -929,8 +930,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasStillImageExternal> <foo:StillImageExternalFileValueIri> .
-            |        <foo:StillImageExternalFileValueIri> rdf:type <http://www.knora.org/ontology/knora-base#StillImageFileValue> ;
+            |            <foo:hasStillImageExternal> <http://rdfh.ch/0001/foo-resource/values/StillImageExternalFileValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/StillImageExternalFileValueIri> rdf:type <http://www.knora.org/ontology/knora-base#StillImageFileValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "foo.jpg" ;
             |            knora-base:valueHasUUID "$uuidEncoded" ;
@@ -966,8 +967,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasDocument> <foo:DocumentFileValueIri> .
-            |        <foo:DocumentFileValueIri> rdf:type <http://www.knora.org/ontology/knora-base#DocumentFileValue> ;
+            |            <foo:hasDocument> <http://rdfh.ch/0001/foo-resource/values/DocumentFileValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/DocumentFileValueIri> rdf:type <http://www.knora.org/ontology/knora-base#DocumentFileValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "foo.pdf" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(documentFileValueDefinition.valueUUID)}" ;
@@ -1007,8 +1008,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasOtherFile> <foo:OtherFileValueIri> .
-            |        <foo:OtherFileValueIri> rdf:type <http://www.knora.org/ontology/knora-base#ArchiveFileValue> ;
+            |            <foo:hasOtherFile> <http://rdfh.ch/0001/foo-resource/values/OtherFileValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/OtherFileValueIri> rdf:type <http://www.knora.org/ontology/knora-base#ArchiveFileValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "foo.zip" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(otherFileValueDefinition.valueUUID)}" ;
@@ -1045,8 +1046,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasList> <foo:ListNodeIri> .
-            |        <foo:ListNodeIri> rdf:type <http://www.knora.org/ontology/knora-base#ListValue> ;
+            |            <foo:hasList> <http://rdfh.ch/0001/foo-resource/values/ListValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/ListValueIri> rdf:type <http://www.knora.org/ontology/knora-base#ListValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "foo list" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(hierarchicalListValueDefinition.valueUUID)}" ;
@@ -1080,8 +1081,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasInterval> <foo:IntervalValueIri> .
-            |        <foo:IntervalValueIri> rdf:type <http://www.knora.org/ontology/knora-base#IntervalValue> ;
+            |            <foo:hasInterval> <http://rdfh.ch/0001/foo-resource/values/IntervalValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/IntervalValueIri> rdf:type <http://www.knora.org/ontology/knora-base#IntervalValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "0.0 - 100.0" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(intervalValueDefinition.valueUUID)}" ;
@@ -1117,8 +1118,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasTime> <foo:TimeValueIri> .
-            |        <foo:TimeValueIri> rdf:type <http://www.knora.org/ontology/knora-base#TimeValue> ;
+            |            <foo:hasTime> <http://rdfh.ch/0001/foo-resource/values/TimeValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/TimeValueIri> rdf:type <http://www.knora.org/ontology/knora-base#TimeValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "1024-01-01T10:00:00.673298Z" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(timeValueDefinition.valueUUID)}" ;
@@ -1153,8 +1154,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasGeoname> <foo:GeonameValueIri> .
-            |        <foo:GeonameValueIri> rdf:type <http://www.knora.org/ontology/knora-base#GeonameValue> ;
+            |            <foo:hasGeoname> <http://rdfh.ch/0001/foo-resource/values/GeonameValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/GeonameValueIri> rdf:type <http://www.knora.org/ontology/knora-base#GeonameValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "geoname_code" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(geonameValueDefinition.valueUUID)}" ;
@@ -1191,8 +1192,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
           |            knora-base:attachedToProject <${projectIri.value}> ;
           |            knora-base:hasPermissions "$permissions" ;
           |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-          |            <foo:hasInt> <foo:IntValueIri> .
-          |        <foo:IntValueIri> rdf:type <http://www.knora.org/ontology/knora-base#IntValue> ;
+          |            <foo:hasInt> <http://rdfh.ch/0001/foo-resource/values/IntValueIri> .
+          |        <http://rdfh.ch/0001/foo-resource/values/IntValueIri> rdf:type <http://www.knora.org/ontology/knora-base#IntValue> ;
           |            knora-base:isDeleted false  ;
           |            knora-base:valueHasString "42" ;
           |            knora-base:valueHasUUID "${UuidUtil.base64Encode(intValueDefinition.valueUUID)}" ;
@@ -1201,8 +1202,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
           |            knora-base:valueHasOrder 1 ;
           |            knora-base:valueCreationDate "$valueCreationDate"^^xsd:dateTime ;
           |            knora-base:valueHasInteger 42 .
-          |        <${resourceIri.value}> <foo:hasBoolean> <foo:BooleanValueIri> .
-          |        <foo:BooleanValueIri> rdf:type <http://www.knora.org/ontology/knora-base#BooleanValue> ;
+          |        <${resourceIri.value}> <foo:hasBoolean> <http://rdfh.ch/0001/foo-resource/values/BooleanValueIri> .
+          |        <http://rdfh.ch/0001/foo-resource/values/BooleanValueIri> rdf:type <http://www.knora.org/ontology/knora-base#BooleanValue> ;
           |            knora-base:isDeleted false  ;
           |            knora-base:valueHasString "true" ;
           |            knora-base:valueHasUUID "${UuidUtil.base64Encode(boolValueDefinition.valueUUID)}" ;
@@ -1238,13 +1239,13 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
           |            knora-base:attachedToProject <${projectIri.value}> ;
           |            knora-base:hasPermissions "$permissions" ;
           |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-          |            <foo:hasStandoffLinkTo> <foo:StandoffLinkTargetIri> ;
-          |            <foo:hasStandoffLinkToValue> <foo:StandoffLinkValueIri> .
-          |        <foo:StandoffLinkValueIri> rdf:type <http://www.knora.org/ontology/knora-base#LinkValue> ;
+          |            <foo:hasStandoffLinkTo> <http://rdfh.ch/0001/StandoffLinkTargetIri> ;
+          |            <foo:hasStandoffLinkToValue> <http://rdfh.ch/0001/foo-resource/values/StandoffLinkValueIri> .
+          |        <http://rdfh.ch/0001/foo-resource/values/StandoffLinkValueIri> rdf:type <http://www.knora.org/ontology/knora-base#LinkValue> ;
           |            rdf:subject <${resourceIri.value}> ;
           |            rdf:predicate <foo:hasStandoffLinkTo> ;
-          |            rdf:object <foo:StandoffLinkTargetIri> ;
-          |            knora-base:valueHasString "foo:StandoffLinkTargetIri" ;
+          |            rdf:object <http://rdfh.ch/0001/StandoffLinkTargetIri> ;
+          |            knora-base:valueHasString "http://rdfh.ch/0001/StandoffLinkTargetIri" ;
           |            knora-base:valueHasRefCount 2;
           |            knora-base:isDeleted false  ;
           |            knora-base:valueCreationDate "$creationDate"^^xsd:dateTime ;
@@ -1281,8 +1282,8 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:attachedToProject <${projectIri.value}> ;
             |            knora-base:hasPermissions "$permissions" ;
             |            knora-base:creationDate "$creationDate"^^xsd:dateTime ;
-            |            <foo:hasInt> <foo:IntValueIri> .
-            |        <foo:IntValueIri> rdf:type <http://www.knora.org/ontology/knora-base#IntValue> ;
+            |            <foo:hasInt> <http://rdfh.ch/0001/foo-resource/values/IntValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/IntValueIri> rdf:type <http://www.knora.org/ontology/knora-base#IntValue> ;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueHasString "42" ;
             |            knora-base:valueHasUUID "${UuidUtil.base64Encode(intValueDefinition.valueUUID)}" ;
@@ -1291,13 +1292,13 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:valueHasOrder 1 ;
             |            knora-base:valueCreationDate "$valueCreationDate"^^xsd:dateTime ;
             |            knora-base:valueHasInteger 42 .
-            |        <${resourceIri.value}> <foo:hasStandoffLinkTo> <foo:StandoffLinkTargetIri> ;
-            |            <foo:hasStandoffLinkToValue> <foo:StandoffLinkValueIri> .
-            |        <foo:StandoffLinkValueIri> rdf:type <http://www.knora.org/ontology/knora-base#LinkValue> ;
+            |        <${resourceIri.value}> <foo:hasStandoffLinkTo> <http://rdfh.ch/0001/StandoffLinkTargetIri> ;
+            |            <foo:hasStandoffLinkToValue> <http://rdfh.ch/0001/foo-resource/values/StandoffLinkValueIri> .
+            |        <http://rdfh.ch/0001/foo-resource/values/StandoffLinkValueIri> rdf:type <http://www.knora.org/ontology/knora-base#LinkValue> ;
             |            rdf:subject <${resourceIri.value}> ;
             |            rdf:predicate <foo:hasStandoffLinkTo> ;
-            |            rdf:object <foo:StandoffLinkTargetIri> ;
-            |            knora-base:valueHasString "foo:StandoffLinkTargetIri" ;
+            |            rdf:object <http://rdfh.ch/0001/StandoffLinkTargetIri> ;
+            |            knora-base:valueHasString "http://rdfh.ch/0001/StandoffLinkTargetIri" ;
             |            knora-base:valueHasRefCount 2;
             |            knora-base:isDeleted false  ;
             |            knora-base:valueCreationDate "$creationDate"^^xsd:dateTime ;

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec.scala
@@ -30,9 +30,9 @@ import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffTagIriAtt
 import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffTagTimeAttributeV2
 import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffTagV2
 import org.knora.webapi.messages.v2.responder.valuemessages.*
+import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
-import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.resources.repo.model.SparqlTemplateLinkUpdate
 
@@ -41,9 +41,9 @@ object InsertValueQueryBuilderTestSupport {
 
   object TestDataFactory {
     val testDataGraph   = InternalIri("http://0.0.0.0:3333/data/0001/thing")
-    val testResourceIri = InternalIri("http://0.0.0.0:3333/0001/thing/resource")
+    val testResourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-resource")
     val testPropertyIri = SmartIri("http://www.knora.org/ontology/0001/anything#hasText")
-    val testValueIri    = InternalIri("http://rdfh.ch/0001/thing/values/value")
+    val testValueIri    = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing/values/value")
     val testValueUUID   = UUID.fromString("12345678-90ab-cdef-1234-567890abcdef")
     val testUserIri     = InternalIri("http://0.0.0.0:3333/users/9XBCrDV3SRa7kS1WwynB4Q")
     val testPermissions =
@@ -53,7 +53,7 @@ object InsertValueQueryBuilderTestSupport {
     def createBuilderQuery(
       value: ValueContentV2,
       linkUpdates: Seq[SparqlTemplateLinkUpdate] = Seq.empty,
-      newUuidOrCurrentIri: Either[UUID, InternalIri] = Left(testValueUUID),
+      newUuidOrCurrentIri: Either[UUID, ValueIri] = Left(testValueUUID),
     ): String =
       InsertValueQueryBuilder
         .createValueQuery(
@@ -247,7 +247,7 @@ object InsertValueQueryBuilderTestSupport {
         linkValueExists = false,
         linkTargetExists = true,
         newLinkValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/thing/values/linkValue"),
-        linkTargetIri = "http://0.0.0.0:3333/0001/thing/linkedResource",
+        linkTargetIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/thing-linked-resource"),
         currentReferenceCount = 0,
         newReferenceCount = newReferenceCount,
         newLinkValueCreator = testUserIri.value,
@@ -1071,9 +1071,9 @@ object InsertValueQueryBuilderSpec extends ZIOSpecDefault with GoldenTest {
     suite("With currentValue")(
       test("Basic case") {
         for {
-          testValue       <- ZIO.succeed(TestDataFactory.createTextValue())
-          currentValueIri <- ZIO.serviceWithZIO[IriConverter](_.asInternalIri("http://rdfh.ch/0803/861b5644b302"))
-          builderQuery    <- ZIO.attempt(
+          testValue      <- ZIO.succeed(TestDataFactory.createTextValue())
+          currentValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0803/861b5644b302/values/current")
+          builderQuery   <- ZIO.attempt(
                             TestDataFactory.createBuilderQuery(
                               testValue,
                               newUuidOrCurrentIri = Right(currentValueIri),
@@ -1083,10 +1083,10 @@ object InsertValueQueryBuilderSpec extends ZIOSpecDefault with GoldenTest {
       },
       test("With link updates") {
         for {
-          testValue       <- ZIO.succeed(TestDataFactory.createTextValue())
-          linkUpdates     <- ZIO.succeed(Seq(TestDataFactory.createSparqlTemplateLinkUpdate()))
-          currentValueIri <- ZIO.serviceWithZIO[IriConverter](_.asInternalIri("http://rdfh.ch/0803/861b5644b302"))
-          builderQuery    <- ZIO.attempt(
+          testValue      <- ZIO.succeed(TestDataFactory.createTextValue())
+          linkUpdates    <- ZIO.succeed(Seq(TestDataFactory.createSparqlTemplateLinkUpdate()))
+          currentValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0803/861b5644b302/values/current")
+          builderQuery   <- ZIO.attempt(
                             TestDataFactory.createBuilderQuery(
                               testValue,
                               linkUpdates = linkUpdates,
@@ -1097,10 +1097,10 @@ object InsertValueQueryBuilderSpec extends ZIOSpecDefault with GoldenTest {
       },
       test("With a deleted link update") {
         for {
-          testValue       <- ZIO.succeed(TestDataFactory.createTextValue())
-          linkUpdates     <- ZIO.succeed(Seq(TestDataFactory.createSparqlTemplateLinkUpdate(newReferenceCount = 0)))
-          currentValueIri <- ZIO.serviceWithZIO[IriConverter](_.asInternalIri("http://rdfh.ch/0803/861b5644b302"))
-          builderQuery    <- ZIO.attempt(
+          testValue      <- ZIO.succeed(TestDataFactory.createTextValue())
+          linkUpdates    <- ZIO.succeed(Seq(TestDataFactory.createSparqlTemplateLinkUpdate(newReferenceCount = 0)))
+          currentValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0803/861b5644b302/values/current")
+          builderQuery   <- ZIO.attempt(
                             TestDataFactory.createBuilderQuery(
                               testValue,
                               linkUpdates = linkUpdates,
@@ -1113,9 +1113,9 @@ object InsertValueQueryBuilderSpec extends ZIOSpecDefault with GoldenTest {
     suite("Cross-type update")(
       test("WHERE clause uses ?currentValueType (not ?valueType) for current value type check") {
         for {
-          testValue       <- ZIO.succeed(TestDataFactory.createStillImageExternalFileValue())
-          currentValueIri <- ZIO.serviceWithZIO[IriConverter](_.asInternalIri("http://rdfh.ch/0803/861b5644b302"))
-          builderQuery    <- ZIO.attempt(
+          testValue      <- ZIO.succeed(TestDataFactory.createStillImageExternalFileValue())
+          currentValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0803/861b5644b302/values/current")
+          builderQuery   <- ZIO.attempt(
                             TestDataFactory.createBuilderQuery(
                               testValue,
                               newUuidOrCurrentIri = Right(currentValueIri),
@@ -1130,9 +1130,9 @@ object InsertValueQueryBuilderSpec extends ZIOSpecDefault with GoldenTest {
     suite("Order preservation")(
       test("Update query reads order from current value instead of MAX + 1") {
         for {
-          testValue       <- ZIO.succeed(TestDataFactory.createTextValue())
-          currentValueIri <- ZIO.serviceWithZIO[IriConverter](_.asInternalIri("http://rdfh.ch/0803/861b5644b302"))
-          builderQuery    <- ZIO.attempt(
+          testValue      <- ZIO.succeed(TestDataFactory.createTextValue())
+          currentValueIri = ValueIri.unsafeFrom("http://rdfh.ch/0803/861b5644b302/values/current")
+          builderQuery   <- ZIO.attempt(
                             TestDataFactory.createBuilderQuery(
                               testValue,
                               newUuidOrCurrentIri = Right(currentValueIri),
@@ -1155,5 +1155,5 @@ object InsertValueQueryBuilderSpec extends ZIOSpecDefault with GoldenTest {
         )
       },
     ),
-  ).provide(IriConverter.layer, StringFormatter.test)
+  )
 }


### PR DESCRIPTION
Pushes typed `ResourceIri`/`ValueIri` further through the value create/update/reorder flow so resource and value IRIs are no longer represented as raw `String`, `IRI`, `SmartIri`, or generic `InternalIri` once they have crossed the API boundary.

Affects `ValuesResponderV2`, `ValueRepo`, `InsertValueQueryBuilder`, the link-update queries, `SparqlTemplateLinkUpdate`, `ResourceCreateModels`, the values endpoints/DTOs, and the metadata service. Removes redundant `iriConverter.asInternalIri` round-trips for IRIs that are already typed, and replaces a few bare `iri(...)` and `InternalIri(...)` call sites with `QueryBuilderHelper.toRdfIri` so the SPARQL builders consume the value object directly.

Tests and golden SPARQL fixtures are updated to use valid `http://rdfh.ch/...` IRIs that satisfy the `ResourceIri`/`ValueIri` regex.