### PR TITLE
chore: Add .worktreeinclude for Claude Code worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+.claude/settings.local.json
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

Adds a `.worktreeinclude` file at the repo root so that local config files are auto-copied into worktrees created by Claude Code (via `claude --worktree`, subagent isolation, or parallel desktop sessions).

The file uses `.gitignore` syntax. Only files that match a pattern **and** are also gitignored are copied — tracked files are never duplicated.

Patterns included:

- `.env` — carries `DEV_DB_PASSWORD` for `just run-with-dev-db` (per `CLAUDE.md`)
- `.claude/settings.local.json` — per-user Claude Code settings/permissions
- `CLAUDE.local.md` — per-user Claude project instructions

If a teammate does not have one of these files locally, nothing is copied for that pattern — no harm done.

Reference: https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees

## Test plan

- [ ] Run `claude --worktree test-wt` in this repo and verify `.env` (if present) and `CLAUDE.local.md` (if present) appear inside `.claude/worktrees/test-wt/`