### PR TITLE
refactor: Remove MessageRelay from OntologyResponderV2

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/ProjectEraseIT.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/ProjectEraseIT.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.messages.util.KnoraSystemInstances
-import org.knora.webapi.messages.v2.responder.ontologymessages.CreateOntologyRequestV2
 import org.knora.webapi.responders.v2.OntologyResponderV2
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.rootUser
 import org.knora.webapi.slice.admin.domain.model.AdministrativePermissionPart
@@ -53,6 +52,7 @@ import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.admin.GroupsRequests.GroupCreateRequest
 import org.knora.webapi.slice.api.admin.UsersEndpoints.Requests.UserCreateRequest
 import org.knora.webapi.slice.api.admin.model.ProjectsEndpointsRequestsAndResponses.ProjectCreateRequest
+import org.knora.webapi.slice.api.v2.ontologies.CreateOntologyRequestV2
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.domain.LanguageCode
 import org.knora.webapi.store.triplestore.api.TriplestoreService

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -39,9 +39,15 @@ import org.knora.webapi.messages.v2.responder.resourcemessages.CreateValueInNewR
 import org.knora.webapi.messages.v2.responder.valuemessages.IntegerValueContentV2
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.api.v2.ontologies.AddCardinalitiesToClassRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.CanDeleteCardinalitiesFromClassRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.ChangeClassLabelsOrCommentsRequestV2
 import org.knora.webapi.slice.api.v2.ontologies.ChangeGuiOrderRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.ChangePropertyGuiElementRequest
 import org.knora.webapi.slice.api.v2.ontologies.ChangePropertyLabelsOrCommentsRequestV2
 import org.knora.webapi.slice.api.v2.ontologies.CreateClassRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.CreateOntologyRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.DeleteCardinalitiesFromClassRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.LabelOrComment
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.api.v2.ontologies.ReplaceClassCardinalitiesRequestV2
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
@@ -20,7 +20,6 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.search.*
 import org.knora.webapi.messages.v2.responder.KnoraReadV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV2
@@ -873,15 +872,9 @@ final case class InferringGravsearchTypeInspector(
       usageIndex <- ZIO.attempt(makeUsageIndex(whereClause))
 
       // Ask the ontology responder about all the Knora class and property IRIs mentioned in the query.
-
-      initialEntityInfoRequest = EntityInfoGetRequestV2(
-                                   classIris = usageIndex.knoraClassIris,
-                                   propertyIris = usageIndex.knoraPropertyIris,
-                                 )
-
       initialEntityInfo <- ontologyCacheHelpers.getEntityInfoResponseV2(
-                             initialEntityInfoRequest.classIris,
-                             initialEntityInfoRequest.propertyIris,
+                             classIris = usageIndex.knoraClassIris,
+                             propertyIris = usageIndex.knoraPropertyIris,
                            )
 
       // The ontology responder may return the requested information in the internal schema. Convert each entity
@@ -928,12 +921,7 @@ final case class InferringGravsearchTypeInspector(
                                                acc ++ maybeSubjectType ++ maybeObjectType
                                              }
 
-      additionalEntityInfoRequest = EntityInfoGetRequestV2(classIris = subjectAndObjectTypes)
-
-      additionalEntityInfo <- ontologyCacheHelpers.getEntityInfoResponseV2(
-                                additionalEntityInfoRequest.classIris,
-                                additionalEntityInfoRequest.propertyIris,
-                              )
+      additionalEntityInfo <- ontologyCacheHelpers.getEntityInfoResponseV2(classIris = subjectAndObjectTypes)
 
       // Add the additional classes to the usage index.
       usageIndexWithAdditionalClasses = usageIndex.copy(

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
@@ -29,9 +29,9 @@ import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 /**
  * A Gravsearch type inspector that infers types, relying on information from the relevant ontologies.
  */
-final case class InferringGravsearchTypeInspector(
-  private val ontologyCacheHelpers: OntologyCacheHelpers,
-  private val queryTraverser: QueryTraverser,
+final class InferringGravsearchTypeInspector(
+  ontologyCacheHelpers: OntologyCacheHelpers,
+  queryTraverser: QueryTraverser,
 )(private implicit val sf: StringFormatter) {
 
   // The maximum number of type inference iterations.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/standoff/StandoffTagUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/standoff/StandoffTagUtilV2.scala
@@ -15,7 +15,6 @@ import dsp.errors.*
 import dsp.valueobjects.Iri
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.IRI
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
@@ -30,6 +29,7 @@ import org.knora.webapi.messages.util.KnoraCalendarType
 import org.knora.webapi.messages.v2.responder.ontologymessages.*
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.*
 import org.knora.webapi.messages.v2.responder.standoffmessages.*
+import org.knora.webapi.responders.v2.OntologyResponderV2
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.AtLeastOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
@@ -60,8 +60,9 @@ trait StandoffTagUtilV2 {
   ): Task[Vector[StandoffTagV2]]
 }
 
-final case class StandoffTagUtilV2Live(messageRelay: MessageRelay)(implicit val stringFormatter: StringFormatter)
-    extends StandoffTagUtilV2 {
+final class StandoffTagUtilV2Live(ontologyResponder: OntologyResponderV2)(implicit
+  stringFormatter: StringFormatter,
+) extends StandoffTagUtilV2 {
 
   /**
    * Creates a sequence of [[StandoffTagV2]] from the given standoff nodes resulting from a SPARQL CONSTRUCT query.
@@ -103,13 +104,10 @@ final case class StandoffTagUtilV2Live(messageRelay: MessageRelay)(implicit val 
     }.toSet
 
     for {
-      standoffEntities <- messageRelay
-                            .ask[StandoffEntityInfoGetResponseV2](
-                              StandoffEntityInfoGetRequestV2(
-                                standoffClassIris = standoffClassIris,
-                                standoffPropertyIris = standoffPropertyIris,
-                              ),
-                            )
+      standoffEntities <- ontologyResponder.getStandoffEntityInfoResponseV2(
+                            standoffClassIris = standoffClassIris,
+                            standoffPropertyIris = standoffPropertyIris,
+                          )
 
       standoffTags = standoffAssertions.map { case (standoffTagIri: IRI, standoffTagAssertions: Map[IRI, String]) =>
                        val standoffTagSmartIri: SmartIri = standoffTagIri.toSmartIri

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -15,7 +15,6 @@ import org.eclipse.rdf4j.model.vocabulary.XSD
 import zio.prelude.Validation
 
 import java.time.Instant
-import java.util.UUID
 
 import dsp.constants.SalsahGui
 import dsp.errors.AssertionException
@@ -23,16 +22,13 @@ import dsp.errors.BadRequestException
 import dsp.errors.DataConversionException
 import dsp.errors.InconsistentRepositoryDataException
 import dsp.valueobjects.Iri
-import dsp.valueobjects.Schema
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.RelayedMessage
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Complex
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Simple
 import org.knora.webapi.messages.OntologyConstants.Rdfs
-import org.knora.webapi.messages.ResponderRequest.KnoraRequestV2
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.*
@@ -41,137 +37,12 @@ import org.knora.webapi.messages.v2.responder.*
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.KnoraCardinalityInfo
 import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffDataTypeClasses
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
-import org.knora.webapi.slice.admin.domain.model.User
-import org.knora.webapi.slice.common.KnoraIris
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.domain.LanguageCode
 import org.knora.webapi.slice.common.domain.LanguageCode.EN
 import org.knora.webapi.slice.ontology.domain.model.Cardinality
-
-/**
- * An abstract trait for messages that can be sent to `ResourcesResponderV2`.
- */
-sealed trait OntologiesResponderRequestV2 extends KnoraRequestV2 with RelayedMessage
-
-/**
- * Requests the creation of an empty ontology. A successful response will be a [[ReadOntologyV2]].
- *
- * @param ontologyName   the name of the ontology to be created.
- * @param projectIri     the IRI of the project that the ontology will belong to.
- * @param isShared       the flag that shows if an ontology is a shared one.
- * @param label          the label of the ontology.
- * @param comment        the optional comment that described the ontology to be created.
- * @param apiRequestID   the ID of the API request.
- * @param requestingUser the user making the request.
- */
-case class CreateOntologyRequestV2(
-  ontologyName: String,
-  projectIri: ProjectIri,
-  isShared: Boolean,
-  label: String,
-  comment: Option[NonEmptyString],
-  apiRequestID: UUID,
-  requestingUser: User,
-)
-
-/**
- * Requests the addition of a property to an ontology. A successful response will be a [[ReadOntologyV2]].
- *
- * @param propertyInfoContent  an [[PropertyInfoContentV2]] containing the property definition.
- * @param lastModificationDate the ontology's last modification date.
- * @param apiRequestID         the ID of the API request.
- * @param requestingUser       the user making the request.
- */
-case class CreatePropertyRequestV2(
-  propertyInfoContent: PropertyInfoContentV2,
-  lastModificationDate: Instant,
-  apiRequestID: UUID,
-  requestingUser: User,
-) extends OntologiesResponderRequestV2
-
-/**
- * FIXME(DSP-1856): Can only remove one single cardinality at a time.
- * Requests a check if the user can remove class's cardinalities. A successful response will be a [[CanDoResponseV2]].
- *
- * @param classInfoContent     a [[ClassInfoContentV2]] containing the cardinalities to be removed.
- * @param lastModificationDate the ontology's last modification date.
- * @param apiRequestID         the ID of the API request.
- * @param requestingUser       the user making the request.
- */
-final case class CanDeleteCardinalitiesFromClassRequestV2(
-  classInfoContent: ClassInfoContentV2,
-  lastModificationDate: Instant,
-  apiRequestID: UUID,
-  requestingUser: User,
-) extends OntologiesResponderRequestV2
-
-/**
- * FIXME(DSP-1856): Can only remove one single cardinality at a time.
- * Requests the removal of a class's cardinalities. A successful response will be a [[ReadOntologyV2]].
- *
- * @param classInfoContent     a [[ClassInfoContentV2]] containing the cardinalities to be removed.
- * @param lastModificationDate the ontology's last modification date.
- * @param apiRequestID         the ID of the API request.
- * @param requestingUser       the user making the request.
- */
-final case class DeleteCardinalitiesFromClassRequestV2(
-  classInfoContent: ClassInfoContentV2,
-  lastModificationDate: Instant,
-  apiRequestID: UUID,
-  requestingUser: User,
-) extends OntologiesResponderRequestV2
-
-/**
- * Requests that the `salsah-gui:guiElement` and `salsah-gui:guiAttribute` of a property are changed.
- *
- * @param propertyIri          the IRI of the property to be changed.
- * @param newGuiObject         the GUI object with the new GUI element and/or GUI attributes.
- * @param lastModificationDate the ontology's last modification date.
- * @param apiRequestID         the ID of the API request.
- * @param requestingUser       the user making the request.
- */
-case class ChangePropertyGuiElementRequest(
-  propertyIri: KnoraIris.PropertyIri,
-  newGuiObject: Schema.GuiObject,
-  lastModificationDate: Instant,
-  apiRequestID: UUID,
-  requestingUser: User,
-) extends OntologiesResponderRequestV2
-
-/**
- * Requests that a class's labels or comments are changed. A successful response will be a [[ReadOntologyV2]].
- *
- * @param classIri             the IRI of the property.
- * @param predicateToUpdate    `rdfs:label` or `rdfs:comment`.
- * @param newObjects           the class's new labels or comments.
- * @param lastModificationDate the ontology's last modification date.
- * @param apiRequestID         the ID of the API request.
- * @param requestingUser       the user making the request.
- */
-case class ChangeClassLabelsOrCommentsRequestV2(
-  classIri: ResourceClassIri,
-  predicateToUpdate: LabelOrComment,
-  newObjects: Seq[LanguageTaggedStringLiteralV2],
-  lastModificationDate: Instant,
-  apiRequestID: UUID,
-  requestingUser: User,
-) extends OntologiesResponderRequestV2
-
-enum LabelOrComment {
-  case Label
-  case Comment
-
-  override def toString: String = this match {
-    case Label   => RDFS.LABEL.toString
-    case Comment => RDFS.COMMENT.toString
-  }
-}
-object LabelOrComment {
-  def fromString(str: String): Option[LabelOrComment] =
-    LabelOrComment.values.find(_.toString == str)
-}
 
 /**
  * Represents assertions about one or more ontology entities (resource classes and/or properties).

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -124,21 +124,6 @@ final case class DeleteCardinalitiesFromClassRequestV2(
 ) extends OntologiesResponderRequestV2
 
 /**
- * Requests the deletion of a class. A successful response will be a [[ReadOntologyMetadataV2]].
- *
- * @param classIri             the IRI of the class to be deleted.
- * @param lastModificationDate the ontology's last modification date.
- * @param apiRequestID         the ID of the API request.
- * @param requestingUser       the user making the request.
- */
-case class DeleteClassRequestV2(
-  classIri: SmartIri,
-  lastModificationDate: Instant,
-  apiRequestID: UUID,
-  requestingUser: User,
-) extends OntologiesResponderRequestV2
-
-/**
  * Requests that the `salsah-gui:guiElement` and `salsah-gui:guiAttribute` of a property are changed.
  *
  * @param propertyIri          the IRI of the property to be changed.
@@ -189,18 +174,6 @@ object LabelOrComment {
 }
 
 /**
- * Requests all available information about a list of ontology entities (classes and/or properties). A successful response will be an
- * [[EntityInfoGetResponseV2]].
- *
- * @param classIris      the IRIs of the class entities to be queried.
- * @param propertyIris   the IRIs of the property entities to be queried.
- */
-case class EntityInfoGetRequestV2(
-  classIris: Set[SmartIri] = Set.empty[SmartIri],
-  propertyIris: Set[SmartIri] = Set.empty[SmartIri],
-) extends OntologiesResponderRequestV2
-
-/**
  * Represents assertions about one or more ontology entities (resource classes and/or properties).
  *
  * @param classInfoMap    a [[Map]] of class entity IRIs to [[ReadClassInfoV2]] objects.
@@ -210,18 +183,6 @@ case class EntityInfoGetResponseV2(
   classInfoMap: Map[SmartIri, ReadClassInfoV2],
   propertyInfoMap: Map[SmartIri, ReadPropertyInfoV2],
 )
-
-/**
- * Requests all available information about a list of ontology entities (standoff classes and/or properties). A successful response will be an
- * [[StandoffEntityInfoGetResponseV2]].
- *
- * @param standoffClassIris    the IRIs of the resource entities to be queried.
- * @param standoffPropertyIris the IRIs of the property entities to be queried.
- */
-case class StandoffEntityInfoGetRequestV2(
-  standoffClassIris: Set[SmartIri] = Set.empty,
-  standoffPropertyIris: Set[SmartIri] = Set.empty,
-) extends OntologiesResponderRequestV2
 
 /**
  * Represents assertions about one or more ontology entities (resource classes and/or properties).
@@ -235,62 +196,11 @@ case class StandoffEntityInfoGetResponseV2(
 )
 
 /**
- * Requests information about all standoff classes that are a subclass of a data type standoff class. A successful response will be an
- * [[StandoffClassesWithDataTypeGetResponseV2]].
- *
- * @param requestingUser the user making the request.
- */
-case class StandoffClassesWithDataTypeGetRequestV2(requestingUser: User) extends OntologiesResponderRequestV2
-
-/**
- * Represents assertions about all standoff classes that are a subclass of a data type standoff class.
- *
- * @param standoffClassInfoMap a [[Map]] of standoff class entity IRIs to [[ReadClassInfoV2]] objects.
- */
-case class StandoffClassesWithDataTypeGetResponseV2(standoffClassInfoMap: Map[SmartIri, ReadClassInfoV2])
-
-/**
- * Requests information about all standoff property entities. A successful response will be an
- * [[StandoffAllPropertyEntitiesGetResponseV2]].
- *
- * @param requestingUser the user making the request.
- */
-case class StandoffAllPropertyEntitiesGetRequestV2(requestingUser: User) extends OntologiesResponderRequestV2
-
-/**
- * Represents assertions about all standoff all standoff property entities.
- *
- * @param standoffAllPropertiesEntityInfoMap a [[Map]] of standoff property IRIs to [[ReadPropertyInfoV2]] objects.
- */
-case class StandoffAllPropertyEntitiesGetResponseV2(
-  standoffAllPropertiesEntityInfoMap: Map[SmartIri, ReadPropertyInfoV2],
-)
-
-/**
- * Checks whether a Knora resource or value class is a subclass of (or identical to) another class.
- * A successful response will be a [[CheckSubClassResponseV2]].
- *
- * @param subClassIri   the IRI of the subclass.
- * @param superClassIri the IRI of the superclass.
- */
-case class CheckSubClassRequestV2(subClassIri: SmartIri, superClassIri: SmartIri, requestingUser: User)
-    extends OntologiesResponderRequestV2
-
-/**
- * Represents a response to a [[CheckSubClassRequestV2]].
+ * Represents the response to a sub-class check.
  *
  * @param isSubClass `true` if the requested inheritance relationship exists.
  */
 case class CheckSubClassResponseV2(isSubClass: Boolean)
-
-/**
- * Requests information about the subclasses of a Knora resource class. A successful response will be
- * a [[SubClassesGetResponseV2]].
- *
- * @param resourceClassIri the IRI of the given resource class.
- * @param requestingUser   the user making the request.
- */
-case class SubClassesGetRequestV2(resourceClassIri: SmartIri, requestingUser: User) extends OntologiesResponderRequestV2
 
 /**
  * Provides information about the subclasses of a Knora resource class.
@@ -298,45 +208,6 @@ case class SubClassesGetRequestV2(resourceClassIri: SmartIri, requestingUser: Us
  * @param subClasses a list of [[SubClassInfoV2]] representing the subclasses of the specified class.
  */
 case class SubClassesGetResponseV2(subClasses: Seq[SubClassInfoV2])
-
-/**
- * Requests metadata about ontologies by ontology IRI.
- *
- * @param ontologyIris   the IRIs of the ontologies to be queried. If this set is empty, information
- *                       about all ontologies is returned.
- */
-case class OntologyMetadataGetByIriRequestV2(ontologyIris: Set[SmartIri] = Set.empty[SmartIri])
-    extends OntologiesResponderRequestV2
-
-/**
- * Requests entity definitions for the given ontology.
- *
- * @param ontologyIri    the ontology to query for.
- * @param allLanguages   true if information in all available languages should be returned.
- * @param requestingUser the user making the request.
- */
-case class OntologyEntitiesGetRequestV2(ontologyIri: OntologyIri, allLanguages: Boolean, requestingUser: User)
-    extends OntologiesResponderRequestV2
-
-/**
- * Requests the entity definitions for the given class IRIs. A successful response will be a [[ReadOntologyV2]].
- *
- * @param classIris      the IRIs of the classes to be queried.
- * @param allLanguages   true if information in all available languages should be returned.
- * @param requestingUser the user making the request.
- */
-case class ClassesGetRequestV2(classIris: Set[SmartIri], allLanguages: Boolean, requestingUser: User)
-    extends OntologiesResponderRequestV2
-
-/**
- * Requests the definitions of the specified properties. A successful response will be a [[ReadOntologyV2]].
- *
- * @param propertyIris   the IRIs of the properties to be queried.
- * @param allLanguages   true if information in all available languages should be returned.
- * @param requestingUser the user making the request.
- */
-case class PropertiesGetRequestV2(propertyIris: Set[SmartIri], allLanguages: Boolean, requestingUser: User)
-    extends OntologiesResponderRequestV2
 
 /**
  * Represents the contents of an ontology to be returned in an API response.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -14,7 +14,6 @@ import java.util.UUID
 
 import dsp.errors.*
 import org.knora.webapi.*
-import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.*
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants.Rdfs
@@ -85,8 +84,7 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
  *
  * The API v1 ontology responder, which is read-only, delegates most of its work to this responder.
  */
-final case class OntologyResponderV2(
-  appConfig: AppConfig,
+final class OntologyResponderV2(
   cardinalityHandler: CardinalityHandler,
   cardinalityService: CardinalityService,
   iriService: IriService,
@@ -1727,23 +1725,5 @@ final case class OntologyResponderV2(
 }
 
 object OntologyResponderV2 {
-  val layer: URLayer[
-    AppConfig & CardinalityHandler & CardinalityService & IriService & KnoraProjectService & OntologyCache &
-      OntologyTriplestoreHelpers & OntologyCacheHelpers & OntologyRepo & StringFormatter & TriplestoreService,
-    OntologyResponderV2,
-  ] = ZLayer.fromZIO {
-    for {
-      ac  <- ZIO.service[AppConfig]
-      ch  <- ZIO.service[CardinalityHandler]
-      cs  <- ZIO.service[CardinalityService]
-      is  <- ZIO.service[IriService]
-      kr  <- ZIO.service[KnoraProjectService]
-      oc  <- ZIO.service[OntologyCache]
-      oth <- ZIO.service[OntologyTriplestoreHelpers]
-      och <- ZIO.service[OntologyCacheHelpers]
-      or  <- ZIO.service[OntologyRepo]
-      sf  <- ZIO.service[StringFormatter]
-      ts  <- ZIO.service[TriplestoreService]
-    } yield OntologyResponderV2(ac, ch, cs, is, oc, och, oth, or, kr, ts)(sf)
-  }
+  val layer = ZLayer.derive[OntologyResponderV2]
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -30,9 +30,15 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.api.v2.ontologies.AddCardinalitiesToClassRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.CanDeleteCardinalitiesFromClassRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.ChangeClassLabelsOrCommentsRequestV2
 import org.knora.webapi.slice.api.v2.ontologies.ChangeGuiOrderRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.ChangePropertyGuiElementRequest
 import org.knora.webapi.slice.api.v2.ontologies.ChangePropertyLabelsOrCommentsRequestV2
 import org.knora.webapi.slice.api.v2.ontologies.CreateClassRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.CreateOntologyRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.CreatePropertyRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.DeleteCardinalitiesFromClassRequestV2
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.api.v2.ontologies.ReplaceClassCardinalitiesRequestV2
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -15,8 +15,6 @@ import java.util.UUID
 import dsp.errors.*
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageHandler
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.*
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants.Rdfs
@@ -27,7 +25,6 @@ import org.knora.webapi.messages.v2.responder.ontologymessages.*
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.KnoraCardinalityInfo
 import org.knora.webapi.responders.IriLocker
 import org.knora.webapi.responders.IriService
-import org.knora.webapi.responders.Responder
 import org.knora.webapi.responders.v2.ontology.CardinalityHandler
 import org.knora.webapi.responders.v2.ontology.OntologyHelpers
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
@@ -99,56 +96,7 @@ final case class OntologyResponderV2(
   ontologyRepo: OntologyRepo,
   knoraProjectService: KnoraProjectService,
   triplestoreService: TriplestoreService,
-)(implicit val stringFormatter: StringFormatter)
-    extends MessageHandler {
-
-  override def isResponsibleFor(message: ResponderRequest): Boolean = message.isInstanceOf[OntologiesResponderRequestV2]
-
-  override def handle(msg: ResponderRequest): Task[Any] = msg match {
-    case EntityInfoGetRequestV2(classIris, propertyIris) =>
-      getEntityInfoResponseV2(classIris, propertyIris)
-    case StandoffEntityInfoGetRequestV2(standoffClassIris, standoffPropertyIris) =>
-      getStandoffEntityInfoResponseV2(standoffClassIris, standoffPropertyIris)
-    case StandoffClassesWithDataTypeGetRequestV2(_) =>
-      getStandoffStandoffClassesWithDataTypeV2
-    case StandoffAllPropertyEntitiesGetRequestV2(_)            => getAllStandoffPropertyEntitiesV2
-    case CheckSubClassRequestV2(subClassIri, superClassIri, _) =>
-      checkSubClassV2(subClassIri, superClassIri)
-    case SubClassesGetRequestV2(resourceClassIri, requestingUser) =>
-      getSubClassesV2(resourceClassIri, requestingUser)
-    case OntologyEntitiesGetRequestV2(ontologyIri, allLanguages, requestingUser) =>
-      getOntologyEntitiesV2(ontologyIri, allLanguages, requestingUser)
-    case ClassesGetRequestV2(resourceClassIris, allLanguages, requestingUser) =>
-      ontologyCacheHelpers.getClassDefinitionsFromOntologyV2(resourceClassIris, allLanguages, requestingUser)
-    case PropertiesGetRequestV2(propertyIris, allLanguages, requestingUser) =>
-      getPropertyDefinitionsFromOntologyV2(propertyIris, allLanguages, requestingUser)
-    case OntologyMetadataGetByIriRequestV2(ontologyIris) =>
-      getOntologyMetadataByIriV2(ontologyIris)
-    case createOntologyRequest: CreateOntologyRequestV2                           => createOntology(createOntologyRequest)
-    case changeClassLabelsOrCommentsRequest: ChangeClassLabelsOrCommentsRequestV2 =>
-      changeClassLabelsOrComments(changeClassLabelsOrCommentsRequest)
-    case canDeleteCardinalitiesFromClassRequestV2: CanDeleteCardinalitiesFromClassRequestV2 =>
-      canDeleteCardinalitiesFromClass(canDeleteCardinalitiesFromClassRequestV2)
-    case deleteCardinalitiesFromClassRequest: DeleteCardinalitiesFromClassRequestV2 =>
-      deleteCardinalitiesFromClass(deleteCardinalitiesFromClassRequest)
-    case deleteClassRequest: DeleteClassRequestV2       => deleteClass(deleteClassRequest)
-    case createPropertyRequest: CreatePropertyRequestV2 => createProperty(createPropertyRequest)
-    case req: ChangePropertyGuiElementRequest           => changePropertyGuiElement(req)
-    case other                                          => Responder.handleUnexpectedMessage(other, this.getClass.getName)
-  }
-
-  /**
-   * Given a list of resource IRIs and a list of property IRIs (ontology entities), returns an [[EntityInfoGetResponseV2]] describing both resource and property entities.
-   *
-   * @param classIris      the IRIs of the resource entities to be queried.
-   * @param propertyIris   the IRIs of the property entities to be queried.
-   * @return an [[EntityInfoGetResponseV2]].
-   */
-  private def getEntityInfoResponseV2(
-    classIris: Set[SmartIri] = Set.empty[SmartIri],
-    propertyIris: Set[SmartIri],
-  ): Task[EntityInfoGetResponseV2] =
-    ontologyCacheHelpers.getEntityInfoResponseV2(classIris, propertyIris)
+)(implicit val stringFormatter: StringFormatter) {
 
   /**
    * Given a list of standoff class IRIs and a list of property IRIs (ontology entities), returns an [[StandoffEntityInfoGetResponseV2]] describing both resource and property entities.
@@ -157,9 +105,9 @@ final case class OntologyResponderV2(
    * @param standoffPropertyIris the IRIs of the property entities to be queried.
    * @return a [[StandoffEntityInfoGetResponseV2]].
    */
-  private def getStandoffEntityInfoResponseV2(
-    standoffClassIris: Set[SmartIri],
-    standoffPropertyIris: Set[SmartIri],
+  def getStandoffEntityInfoResponseV2(
+    standoffClassIris: Set[SmartIri] = Set.empty[SmartIri],
+    standoffPropertyIris: Set[SmartIri] = Set.empty[SmartIri],
   ): Task[StandoffEntityInfoGetResponseV2] =
     for {
       cacheData <- ontologyCache.getCacheData
@@ -216,74 +164,19 @@ final case class OntologyResponderV2(
     } yield response
 
   /**
-   * Gets information about all standoff classes that are a subclass of a data type standoff class.
-   *
-   * @return a [[StandoffClassesWithDataTypeGetResponseV2]]
-   */
-  private def getStandoffStandoffClassesWithDataTypeV2: Task[StandoffClassesWithDataTypeGetResponseV2] =
-    for {
-      cacheData <- ontologyCache.getCacheData
-    } yield StandoffClassesWithDataTypeGetResponseV2(
-      standoffClassInfoMap = cacheData.ontologies.values.flatMap { ontology =>
-        ontology.classes.filter { case (_, classDef) =>
-          classDef.isStandoffClass && classDef.standoffDataType.isDefined
-        }
-      }.toMap,
-    )
-
-  /**
-   * Gets all standoff property entities.
-   *
-   * @return a [[StandoffAllPropertyEntitiesGetResponseV2]].
-   */
-  private def getAllStandoffPropertyEntitiesV2: Task[StandoffAllPropertyEntitiesGetResponseV2] =
-    ontologyCache.getCacheData.map { data =>
-      val ontologies: Iterable[ReadOntologyV2] = data.ontologies.values
-      ontologies.flatMap(_.properties.view.filterKeys(data.standoffProperties)).toMap
-    }.map(StandoffAllPropertyEntitiesGetResponseV2.apply)
-
-  /**
    * Checks whether a certain Knora resource or value class is a subclass of another class.
    *
    * @param subClassIri   the IRI of the resource or value class whose subclassOf relations have to be checked.
    * @param superClassIri the IRI of the resource or value class to check for (whether it is a super class of `subClassIri` or not).
    * @return a [[CheckSubClassResponseV2]].
    */
-  private def checkSubClassV2(subClassIri: SmartIri, superClassIri: SmartIri): Task[CheckSubClassResponseV2] =
+  def checkSubClassV2(subClassIri: SmartIri, superClassIri: SmartIri): Task[CheckSubClassResponseV2] =
     for {
       cacheData  <- ontologyCache.getCacheData
       isSubClass <- ZIO
                       .fromOption(cacheData.classToSuperClassLookup.get(subClassIri))
                       .mapBoth(_ => BadRequestException(s"Class $subClassIri not found"), _.contains(superClassIri))
     } yield CheckSubClassResponseV2(isSubClass)
-
-  /**
-   * Gets the IRIs of the subclasses of a class.
-   *
-   * @param classIri the IRI of the class whose subclasses should be returned.
-   * @return a [[SubClassesGetResponseV2]].
-   */
-  private def getSubClassesV2(classIri: SmartIri, requestingUser: User): Task[SubClassesGetResponseV2] =
-    for {
-      cacheData  <- ontologyCache.getCacheData
-      subClasses <-
-        ZIO.foreach(cacheData.classToSubclassLookup(classIri).toVector.sorted) { subClassIri =>
-          val labelValueMaybe = cacheData
-            .ontologies(subClassIri.getOntologyFromEntity)
-            .classes(subClassIri)
-            .entityInfoContent
-            .getPredicateStringLiteralObject(
-              OntologyConstants.Rdfs.Label.toSmartIri,
-              Some(requestingUser.lang, appConfig.fallbackLanguage),
-            )
-          ZIO
-            .fromOption(labelValueMaybe)
-            .mapBoth(
-              _ => InconsistentRepositoryDataException(s"Resource class $subClassIri has no rdfs:label"),
-              SubClassInfoV2(subClassIri, _),
-            )
-        }
-    } yield SubClassesGetResponseV2(subClasses)
 
   /**
    * Gets the metadata describing the ontologies that belong to selected projects, or to all projects.
@@ -301,36 +194,6 @@ final case class OntologyResponderV2(
 
   def getOntologyMetadataForAllProjects: Task[ReadOntologyMetadataV2] =
     ontologyRepo.findAll().map(_.map(_.ontologyMetadata).toSet).map(ReadOntologyMetadataV2.apply)
-
-  /**
-   * Gets the metadata describing the specified ontologies, or all ontologies.
-   *
-   * @param ontologyIris   the IRIs of the ontologies selected, or an empty set if all ontologies are selected.
-   * @return a [[ReadOntologyMetadataV2]].
-   */
-  private def getOntologyMetadataByIriV2(ontologyIris: Set[SmartIri]): Task[ReadOntologyMetadataV2] =
-    for {
-      cacheData          <- ontologyCache.getCacheData
-      returnAllOntologies = ontologyIris.isEmpty
-      ontologyMetadata   <-
-        if (returnAllOntologies) { ZIO.succeed(cacheData.ontologies.values.map(_.ontologyMetadata).toSet) }
-        else {
-          val ontologyIrisForCache = ontologyIris.map(_.toOntologySchema(InternalSchema))
-          val missingOntologies    = ontologyIrisForCache -- cacheData.ontologies.keySet
-          if (missingOntologies.nonEmpty) {
-            val msg = s"One or more requested ontologies were not found: ${missingOntologies.mkString(", ")}"
-            ZIO.fail(BadRequestException(msg))
-          } else {
-            ZIO.succeed(
-              cacheData.ontologies.view
-                .filterKeys(ontologyIrisForCache)
-                .values
-                .map(ontology => ontology.ontologyMetadata)
-                .toSet,
-            )
-          }
-        }
-    } yield ReadOntologyMetadataV2(ontologyMetadata)
 
   /**
    * Requests the entities defined in the given ontology.
@@ -377,7 +240,7 @@ final case class OntologyResponderV2(
   ): Task[ReadOntologyV2] =
     getPropertyDefinitionsFromOntologyV2(propertyIris.map(_.smartIri), allLanguages, requestingUser)
 
-  private def getPropertyDefinitionsFromOntologyV2(
+  def getPropertyDefinitionsFromOntologyV2(
     propertyIris: Set[SmartIri],
     allLanguages: Boolean,
     requestingUser: User,
@@ -388,7 +251,7 @@ final case class OntologyResponderV2(
                        .filterOrFail(_.size == 1)(BadRequestException(s"Only one ontology may be queried per request"))
                        .map(_.head)
       ontology             <- getOntologyOrFailNotFound(ontologyIri)
-      propertyInfoResponse <- getEntityInfoResponseV2(propertyIris = propertyIris)
+      propertyInfoResponse <- ontologyCacheHelpers.getEntityInfoResponseV2(propertyIris = propertyIris)
       userLang              = if allLanguages then None else Some(requestingUser.lang)
     } yield ReadOntologyV2(
       ontologyMetadata = ontology.ontologyMetadata,
@@ -1194,20 +1057,6 @@ final case class OntologyResponderV2(
     classIsUsed           <- iriService.isEntityUsed(classIri.toInternalSchema)
   } yield CanDoResponseV2.of(userCanUpdateOntology && !classIsUsed)
 
-  /**
-   * Deletes a class.
-   *
-   * @param deleteClassRequest the request to delete the class.
-   * @return a [[SuccessResponseV2]].
-   */
-  private def deleteClass(deleteClassRequest: DeleteClassRequestV2): Task[ReadOntologyMetadataV2] =
-    deleteClass(
-      ResourceClassIri.unsafeFrom(deleteClassRequest.classIri),
-      deleteClassRequest.lastModificationDate,
-      deleteClassRequest.apiRequestID,
-      deleteClassRequest.requestingUser,
-    )
-
   def deleteClass(
     classIri: ResourceClassIri,
     lastModificationDate: Instant,
@@ -1879,25 +1728,22 @@ final case class OntologyResponderV2(
 
 object OntologyResponderV2 {
   val layer: URLayer[
-    AppConfig & CardinalityHandler & CardinalityService & IriService & KnoraProjectService & MessageRelay &
-      OntologyCache & OntologyTriplestoreHelpers & OntologyCacheHelpers & OntologyRepo & StringFormatter &
-      TriplestoreService,
+    AppConfig & CardinalityHandler & CardinalityService & IriService & KnoraProjectService & OntologyCache &
+      OntologyTriplestoreHelpers & OntologyCacheHelpers & OntologyRepo & StringFormatter & TriplestoreService,
     OntologyResponderV2,
   ] = ZLayer.fromZIO {
     for {
-      ac       <- ZIO.service[AppConfig]
-      ch       <- ZIO.service[CardinalityHandler]
-      cs       <- ZIO.service[CardinalityService]
-      is       <- ZIO.service[IriService]
-      kr       <- ZIO.service[KnoraProjectService]
-      oc       <- ZIO.service[OntologyCache]
-      oth      <- ZIO.service[OntologyTriplestoreHelpers]
-      och      <- ZIO.service[OntologyCacheHelpers]
-      or       <- ZIO.service[OntologyRepo]
-      sf       <- ZIO.service[StringFormatter]
-      ts       <- ZIO.service[TriplestoreService]
-      responder = OntologyResponderV2(ac, ch, cs, is, oc, och, oth, or, kr, ts)(sf)
-      _        <- ZIO.serviceWithZIO[MessageRelay](_.subscribe(responder))
-    } yield responder
+      ac  <- ZIO.service[AppConfig]
+      ch  <- ZIO.service[CardinalityHandler]
+      cs  <- ZIO.service[CardinalityService]
+      is  <- ZIO.service[IriService]
+      kr  <- ZIO.service[KnoraProjectService]
+      oc  <- ZIO.service[OntologyCache]
+      oth <- ZIO.service[OntologyTriplestoreHelpers]
+      och <- ZIO.service[OntologyCacheHelpers]
+      or  <- ZIO.service[OntologyRepo]
+      sf  <- ZIO.service[StringFormatter]
+      ts  <- ZIO.service[TriplestoreService]
+    } yield OntologyResponderV2(ac, ch, cs, is, oc, och, oth, or, kr, ts)(sf)
   }
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -13,7 +13,6 @@ import dsp.errors.GravsearchException
 import dsp.errors.InconsistentRepositoryDataException
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
@@ -42,8 +41,6 @@ import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTrans
 import org.knora.webapi.messages.util.search.gravsearch.types.*
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.messages.v2.responder.KnoraJsonLDResponseV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.*
@@ -52,6 +49,7 @@ import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.service.IriConverter
+import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resources.repo.GetResourcePropertiesAndValuesQuery
@@ -292,9 +290,9 @@ trait SearchResponderV2 {
 final case class SearchResponderV2Live(
   private val appConfig: AppConfig,
   private val triplestore: TriplestoreService,
-  private val messageRelay: MessageRelay,
   private val constructResponseUtilV2: ConstructResponseUtilV2,
   private val ontologyCache: OntologyCache,
+  private val ontologyCacheHelpers: OntologyCacheHelpers,
   private val standoffTagUtilV2: StandoffTagUtilV2,
   private val queryTraverser: QueryTraverser,
   private val sparqlTransformerLive: OntologyInferencer,
@@ -965,11 +963,9 @@ final case class SearchResponderV2Live(
 
     for {
       // Get information about the resource class, and about the ORDER BY property if specified.
-      entityInfoResponse <- messageRelay.ask[EntityInfoGetResponseV2](
-                              EntityInfoGetRequestV2(
-                                classIris = Set(internalClassIri),
-                                propertyIris = maybeInternalOrderByPropertyIri.toSet,
-                              ),
+      entityInfoResponse <- ontologyCacheHelpers.getEntityInfoResponseV2(
+                              classIris = Set(internalClassIri),
+                              propertyIris = maybeInternalOrderByPropertyIri.toSet,
                             )
 
       classDef: ReadClassInfoV2 = entityInfoResponse.classInfoMap(internalClassIri)

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -39,7 +39,6 @@ import org.knora.webapi.messages.util.search.gravsearch.transformers.ConstructTr
 import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
 import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
 import org.knora.webapi.messages.util.search.gravsearch.types.*
-import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.messages.v2.responder.KnoraJsonLDResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV2
@@ -51,7 +50,6 @@ import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
-import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.slice.resources.repo.GetResourcePropertiesAndValuesQuery
 import org.knora.webapi.slice.resources.repo.GetResourcesByClassInProjectPrequery
 import org.knora.webapi.slice.search.repo.SearchFulltextQuery
@@ -287,21 +285,19 @@ trait SearchResponderV2 {
   ): Task[ReadResourcesSequenceV2]
 }
 
-final case class SearchResponderV2Live(
-  private val appConfig: AppConfig,
-  private val triplestore: TriplestoreService,
-  private val constructResponseUtilV2: ConstructResponseUtilV2,
-  private val ontologyCache: OntologyCache,
-  private val ontologyCacheHelpers: OntologyCacheHelpers,
-  private val standoffTagUtilV2: StandoffTagUtilV2,
-  private val queryTraverser: QueryTraverser,
-  private val sparqlTransformerLive: OntologyInferencer,
-  private val gravsearchTypeInspectionRunner: GravsearchTypeInspectionRunner,
-  private val inferenceOptimizationService: InferenceOptimizationService,
-  private val stringFormatter: StringFormatter,
-  private val iriConverter: IriConverter,
-  private val constructTransformer: ConstructTransformer,
-  private val ontologyRepo: OntologyRepo,
+final class SearchResponderV2Live(
+  appConfig: AppConfig,
+  triplestore: TriplestoreService,
+  constructResponseUtilV2: ConstructResponseUtilV2,
+  ontologyCacheHelpers: OntologyCacheHelpers,
+  queryTraverser: QueryTraverser,
+  sparqlTransformerLive: OntologyInferencer,
+  gravsearchTypeInspectionRunner: GravsearchTypeInspectionRunner,
+  inferenceOptimizationService: InferenceOptimizationService,
+  stringFormatter: StringFormatter,
+  iriConverter: IriConverter,
+  constructTransformer: ConstructTransformer,
+  ontologyRepo: OntologyRepo,
 ) extends SearchResponderV2 {
 
   private implicit val sf: StringFormatter = stringFormatter

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2Module.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2Module.scala
@@ -9,7 +9,6 @@ import zio.*
 
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.ConstructResponseUtilV2
 import org.knora.webapi.messages.util.search.*
@@ -27,7 +26,7 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService
 
 object SearchResponderV2Module {
   type Dependencies = StandoffTagUtilV2 & AppConfig & TriplestoreService & ConstructResponseUtilV2 & OntologyCache &
-    OntologyCacheHelpers & OntologyRepo & IriConverter & MessageRelay & StringFormatter & ProjectService
+    OntologyCacheHelpers & OntologyRepo & IriConverter & StringFormatter & ProjectService
 
   type Provided = GravsearchTypeInspectionRunner & InferringGravsearchTypeInspector & OntologyInferencer &
     QueryTraverser & SearchResponderV2Live

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
@@ -25,7 +25,6 @@ import org.knora.webapi.core.MessageHandler
 import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.*
 import org.knora.webapi.messages.IriConversions.*
-import org.knora.webapi.messages.util.ConstructResponseUtilV2
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2.XMLTagItem
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.*
@@ -59,13 +58,11 @@ import org.knora.webapi.util.FileUtil
  * Responds to requests relating to the creation of mappings from XML elements
  * and attributes to standoff classes and properties.
  */
-final case class StandoffResponderV2(
+final class StandoffResponderV2(
   appConfig: AppConfig,
   messageRelay: MessageRelay,
   ontologyResponder: OntologyResponderV2,
   triplestore: TriplestoreService,
-  constructResponseUtilV2: ConstructResponseUtilV2,
-  standoffTagUtilV2: StandoffTagUtilV2,
   projectService: ProjectService,
   xsltCache: EhCache[String, String],
   mappingCache: EhCache[String, MappingXMLtoStandoff],
@@ -895,21 +892,16 @@ final case class StandoffResponderV2(
 }
 
 object StandoffResponderV2 {
-  val layer =
+  private val cachesLayer: URLayer[CacheManager, EhCache[String, String] & EhCache[String, MappingXMLtoStandoff]] =
+    ZLayer.fromZIO(ZIO.serviceWithZIO[CacheManager](_.createCache[String, String]("xsltCache"))) ++
+      ZLayer.fromZIO(
+        ZIO.serviceWithZIO[CacheManager](_.createCache[String, MappingXMLtoStandoff]("mappingCache")),
+      )
+
+  val layer = cachesLayer >>> ZLayer.derive[StandoffResponderV2].flatMap { env =>
     ZLayer.fromZIO {
-      for {
-        ac      <- ZIO.service[AppConfig]
-        mr      <- ZIO.service[MessageRelay]
-        or      <- ZIO.service[OntologyResponderV2]
-        ts      <- ZIO.service[TriplestoreService]
-        cru     <- ZIO.service[ConstructResponseUtilV2]
-        stu     <- ZIO.service[StandoffTagUtilV2]
-        ps      <- ZIO.service[ProjectService]
-        xc      <- ZIO.serviceWithZIO[CacheManager](_.createCache[String, String]("xsltCache"))
-        mc      <- ZIO.serviceWithZIO[CacheManager](_.createCache[String, MappingXMLtoStandoff]("mappingCache"))
-        sf      <- ZIO.service[StringFormatter]
-        ssl     <- ZIO.service[SipiService]
-        handler <- mr.subscribe(StandoffResponderV2(ac, mr, or, ts, cru, stu, ps, xc, mc, ssl)(sf))
-      } yield handler
+      val handler = env.get[StandoffResponderV2]
+      ZIO.serviceWithZIO[MessageRelay](_.subscribe(handler))
     }
+  }
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
@@ -30,7 +30,6 @@ import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2.XMLTagItem
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.*
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.StandoffEntityInfoGetRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.StandoffEntityInfoGetResponseV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.*
 import org.knora.webapi.messages.v2.responder.standoffmessages.*
@@ -63,6 +62,7 @@ import org.knora.webapi.util.FileUtil
 final case class StandoffResponderV2(
   appConfig: AppConfig,
   messageRelay: MessageRelay,
+  ontologyResponder: OntologyResponderV2,
   triplestore: TriplestoreService,
   constructResponseUtilV2: ConstructResponseUtilV2,
   standoffTagUtilV2: StandoffTagUtilV2,
@@ -782,12 +782,9 @@ final case class StandoffResponderV2(
 
       // request information about standoff classes that should be created
       standoffClassEntities <-
-        messageRelay
-          .ask[StandoffEntityInfoGetResponseV2](
-            StandoffEntityInfoGetRequestV2(
-              standoffClassIris = standoffTagIrisFromMapping.map(_.toSmartIri),
-            ),
-          )
+        ontologyResponder.getStandoffEntityInfoResponseV2(
+          standoffClassIris = standoffTagIrisFromMapping.map(_.toSmartIri),
+        )
 
       // check that the ontology responder returned the information for all the standoff classes it was asked for
       // if the ontology responder does not return a standoff class it was asked for, then this standoff class does not exist
@@ -809,12 +806,9 @@ final case class StandoffResponderV2(
 
       // request information about the standoff properties
       standoffPropertyEntities <-
-        messageRelay
-          .ask[StandoffEntityInfoGetResponseV2](
-            StandoffEntityInfoGetRequestV2(
-              standoffPropertyIris = standoffPropertyIrisFromOntologyResponder,
-            ),
-          )
+        ontologyResponder.getStandoffEntityInfoResponseV2(
+          standoffPropertyIris = standoffPropertyIrisFromOntologyResponder,
+        )
 
       // check that the ontology responder returned the information for all the standoff properties it was asked for
       // if the ontology responder does not return a standoff property it was asked for, then this standoff property does not exist
@@ -906,6 +900,7 @@ object StandoffResponderV2 {
       for {
         ac      <- ZIO.service[AppConfig]
         mr      <- ZIO.service[MessageRelay]
+        or      <- ZIO.service[OntologyResponderV2]
         ts      <- ZIO.service[TriplestoreService]
         cru     <- ZIO.service[ConstructResponseUtilV2]
         stu     <- ZIO.service[StandoffTagUtilV2]
@@ -914,7 +909,7 @@ object StandoffResponderV2 {
         mc      <- ZIO.serviceWithZIO[CacheManager](_.createCache[String, MappingXMLtoStandoff]("mappingCache"))
         sf      <- ZIO.service[StringFormatter]
         ssl     <- ZIO.service[SipiService]
-        handler <- mr.subscribe(StandoffResponderV2(ac, mr, ts, cru, stu, ps, xc, mc, ssl)(sf))
+        handler <- mr.subscribe(StandoffResponderV2(ac, mr, or, ts, cru, stu, ps, xc, mc, ssl)(sf))
       } yield handler
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -49,6 +49,7 @@ import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.AtLeastOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
+import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.resources.repo.ChangeLinkMetadataQuery
 import org.knora.webapi.slice.resources.repo.ChangeLinkTargetQuery
@@ -69,7 +70,9 @@ final class ValuesResponderV2(
   iriConverter: IriConverter,
   iriService: IriService,
   messageRelay: MessageRelay,
+  ontologyCacheHelpers: OntologyCacheHelpers,
   ontologyRepo: OntologyRepo,
+  ontologyResponder: OntologyResponderV2,
   permissionUtilADM: PermissionUtilADM,
   permissionsResponder: PermissionsResponder,
   resourceUtilV2: ResourceUtilV2,
@@ -102,15 +105,12 @@ final class ValuesResponderV2(
       submittedInternalValueContent = valueToCreate.valueContent.toOntologySchema(InternalSchema)
 
       // Get ontology information about the submitted property.
-      propertyInfoRequestForSubmittedProperty =
-        PropertiesGetRequestV2(
+      propertyInfoResponseForSubmittedProperty <-
+        ontologyResponder.getPropertyDefinitionsFromOntologyV2(
           propertyIris = Set(submittedInternalPropertyIri),
           allLanguages = false,
           requestingUser = requestingUser,
         )
-
-      propertyInfoResponseForSubmittedProperty <-
-        messageRelay.ask[ReadOntologyV2](propertyInfoRequestForSubmittedProperty)
 
       propertyInfoForSubmittedProperty: ReadPropertyInfoV2 =
         propertyInfoResponseForSubmittedProperty.properties(
@@ -173,14 +173,12 @@ final class ValuesResponderV2(
            )
 
       // Get the definition of the resource class.
-      classInfoRequest =
-        ClassesGetRequestV2(
+      classInfoResponse <-
+        ontologyCacheHelpers.getClassDefinitionsFromOntologyV2(
           classIris = Set(resourceInfo.resourceClassIri),
           allLanguages = false,
           requestingUser = requestingUser,
         )
-
-      classInfoResponse <- messageRelay.ask[ReadOntologyV2](classInfoRequest)
 
       // Check that the resource class has a cardinality for the submitted property.
       cardinalityInfo <-
@@ -768,15 +766,12 @@ final class ValuesResponderV2(
       submittedInternalValueType   <- ZIO.attempt(updateValue.valueType.toInternalSchema)
 
       // Get ontology information about the submitted property.
-      propertyInfoRequestForSubmittedProperty =
-        PropertiesGetRequestV2(
+      propertyInfoResponseForSubmittedProperty <-
+        ontologyResponder.getPropertyDefinitionsFromOntologyV2(
           propertyIris = Set(submittedInternalPropertyIri),
           allLanguages = false,
           requestingUser = requestingUser,
         )
-
-      propertyInfoResponseForSubmittedProperty <-
-        messageRelay.ask[ReadOntologyV2](propertyInfoRequestForSubmittedProperty)
 
       propertyInfoForSubmittedProperty: ReadPropertyInfoV2 =
         propertyInfoResponseForSubmittedProperty.properties(submittedInternalPropertyIri)
@@ -1590,13 +1585,10 @@ final class ValuesResponderV2(
       resource <- resourcePreviewResponse.toResource(linkValueContent.referredResourceIri)
 
       // Ask the ontology responder whether the resource's class is a subclass of the link property's object class constraint.
-      subClassRequest = CheckSubClassRequestV2(
-                          subClassIri = resource.resourceClassIri,
-                          superClassIri = objectClassConstraint,
-                          requestingUser = requestingUser,
-                        )
-
-      subClassResponse <- messageRelay.ask[CheckSubClassResponseV2](subClassRequest)
+      subClassResponse <- ontologyResponder.checkSubClassV2(
+                            subClassIri = resource.resourceClassIri,
+                            superClassIri = objectClassConstraint,
+                          )
 
       // If it isn't, fail with an exception.
       _ <-
@@ -1615,27 +1607,20 @@ final class ValuesResponderV2(
    * @param propertyIri           the IRI of the property that should point to the value.
    * @param objectClassConstraint the property's object class constraint.
    * @param valueContent          the value.
-   * @param requestingUser        the user making the request.
    */
   private def checkNonLinkPropertyObjectClassConstraint(
     propertyIri: SmartIri,
     objectClassConstraint: SmartIri,
     valueContent: ValueContentV2,
-    requestingUser: User,
   ): Task[Unit] =
     // Is the value type the same as the property's object class constraint?
     ZIO
       .unless(objectClassConstraint == valueContent.valueType) {
         for {
-          subClassRequest <- ZIO.succeed(
-                               CheckSubClassRequestV2(
-                                 subClassIri = valueContent.valueType,
-                                 superClassIri = objectClassConstraint,
-                                 requestingUser = requestingUser,
-                               ),
-                             )
-
-          subClassResponse <- messageRelay.ask[CheckSubClassResponseV2](subClassRequest)
+          subClassResponse <- ontologyResponder.checkSubClassV2(
+                                subClassIri = valueContent.valueType,
+                                superClassIri = objectClassConstraint,
+                              )
 
           // If it isn't, fail with an exception.
           _ <-
@@ -1695,7 +1680,7 @@ final class ValuesResponderV2(
           // We're creating an ordinary value.
           case otherValue =>
             // Check that its type is valid for the property's object class constraint.
-            checkNonLinkPropertyObjectClassConstraint(propertyIri, objectClassConstraint, otherValue, requestingUser)
+            checkNonLinkPropertyObjectClassConstraint(propertyIri, objectClassConstraint, otherValue)
         }
     } yield result
   }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ontology/CardinalityHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ontology/CardinalityHandler.scala
@@ -17,6 +17,8 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.v2.responder.CanDoResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.*
+import org.knora.webapi.slice.api.v2.ontologies.CanDeleteCardinalitiesFromClassRequestV2
+import org.knora.webapi.slice.api.v2.ontologies.DeleteCardinalitiesFromClassRequestV2
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -59,16 +59,16 @@ import org.knora.webapi.slice.resources.service.ReadResourcesService
 import org.knora.webapi.slice.resources.service.ValueContentValidator
 import org.knora.webapi.util.ZioHelper
 
-final case class CreateResourceV2Handler(
-  private val iriService: IriService,
-  private val ontologyCacheHelpers: OntologyCacheHelpers,
-  private val resourcesRepo: ResourcesRepo,
-  private val resourceUtilV2: ResourceUtilV2,
-  private val permissionUtilADM: PermissionUtilADM,
-  private val ontologyRepo: OntologyRepo,
-  private val permissionsResponder: PermissionsResponder,
-  private val valueValidator: ValueContentValidator,
-  private val readResources: ReadResourcesService,
+final class CreateResourceV2Handler(
+  iriService: IriService,
+  ontologyCacheHelpers: OntologyCacheHelpers,
+  resourcesRepo: ResourcesRepo,
+  resourceUtilV2: ResourceUtilV2,
+  permissionUtilADM: PermissionUtilADM,
+  ontologyRepo: OntologyRepo,
+  permissionsResponder: PermissionsResponder,
+  valueValidator: ValueContentValidator,
+  readResources: ReadResourcesService,
 )(implicit val stringFormatter: StringFormatter) {
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -13,7 +13,6 @@ import scala.language.postfixOps
 import dsp.errors.*
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.*
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.*
 import org.knora.webapi.messages.admin.responder.permissionsmessages.PermissionADM
 import org.knora.webapi.messages.admin.responder.permissionsmessages.PermissionType
@@ -21,7 +20,6 @@ import org.knora.webapi.messages.admin.responder.permissionsmessages.ResourceCre
 import org.knora.webapi.messages.util.*
 import org.knora.webapi.messages.util.PermissionUtilADM.AGreaterThanB
 import org.knora.webapi.messages.util.PermissionUtilADM.PermissionComparisonResult
-import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.EntityInfoGetResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.*
 import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
@@ -45,6 +43,7 @@ import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ZeroOrOne
+import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.resources.repo.model.FormattedTextValueType
 import org.knora.webapi.slice.resources.repo.model.ResourceReadyToCreate
@@ -62,7 +61,7 @@ import org.knora.webapi.util.ZioHelper
 
 final case class CreateResourceV2Handler(
   private val iriService: IriService,
-  private val messageRelay: MessageRelay,
+  private val ontologyCacheHelpers: OntologyCacheHelpers,
   private val resourcesRepo: ResourcesRepo,
   private val resourceUtilV2: ResourceUtilV2,
   private val permissionUtilADM: PermissionUtilADM,
@@ -183,24 +182,18 @@ final case class CreateResourceV2Handler(
       // Get the definitions of the resource class and its properties, as well as of the classes of all
       // resources that are link targets.
       resourceClassEntityInfoResponse <-
-        messageRelay
-          .ask[EntityInfoGetResponseV2](
-            EntityInfoGetRequestV2(
-              classIris = linkTargetClasses.values.toSet + internalCreateResource.resourceClassIri,
-            ),
-          )
+        ontologyCacheHelpers.getEntityInfoResponseV2(
+          classIris = linkTargetClasses.values.toSet + internalCreateResource.resourceClassIri,
+        )
 
       resourceClassInfo: ReadClassInfoV2 = resourceClassEntityInfoResponse.classInfoMap(
                                              internalCreateResource.resourceClassIri,
                                            )
 
       propertyEntityInfoResponse <-
-        messageRelay
-          .ask[EntityInfoGetResponseV2](
-            EntityInfoGetRequestV2(
-              propertyIris = resourceClassInfo.knoraResourceProperties,
-            ),
-          )
+        ontologyCacheHelpers.getEntityInfoResponseV2(
+          propertyIris = resourceClassInfo.knoraResourceProperties,
+        )
 
       allEntityInfo = EntityInfoGetResponseV2(
                         classInfoMap = resourceClassEntityInfoResponse.classInfoMap,

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyRequests.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyRequests.scala
@@ -1,0 +1,133 @@
+package org.knora.webapi.slice.api.v2.ontologies
+
+import eu.timepit.refined.types.string.NonEmptyString
+import org.eclipse.rdf4j.model.vocabulary.RDFS
+
+import java.time.Instant
+import java.util.UUID
+
+import dsp.valueobjects.Schema
+import org.knora.webapi.messages.store.triplestoremessages.LanguageTaggedStringLiteralV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.ClassInfoContentV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.PropertyInfoContentV2
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.common.KnoraIris
+import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+
+/**
+ * Requests a check if the user can remove class's cardinalities. A successful response will be a [[CanDoResponseV2]].
+ *
+ * @param classInfoContent     a [[ClassInfoContentV2]] containing the cardinalities to be removed.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
+final case class CanDeleteCardinalitiesFromClassRequestV2(
+  classInfoContent: ClassInfoContentV2,
+  lastModificationDate: Instant,
+  apiRequestID: UUID,
+  requestingUser: User,
+)
+
+/**
+ * Requests that a class's labels or comments are changed. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param classIri             the IRI of the property.
+ * @param predicateToUpdate    `rdfs:label` or `rdfs:comment`.
+ * @param newObjects           the class's new labels or comments.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
+case class ChangeClassLabelsOrCommentsRequestV2(
+  classIri: ResourceClassIri,
+  predicateToUpdate: LabelOrComment,
+  newObjects: Seq[LanguageTaggedStringLiteralV2],
+  lastModificationDate: Instant,
+  apiRequestID: UUID,
+  requestingUser: User,
+)
+
+/**
+ * Requests that the `salsah-gui:guiElement` and `salsah-gui:guiAttribute` of a property are changed.
+ *
+ * @param propertyIri          the IRI of the property to be changed.
+ * @param newGuiObject         the GUI object with the new GUI element and/or GUI attributes.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
+case class ChangePropertyGuiElementRequest(
+  propertyIri: KnoraIris.PropertyIri,
+  newGuiObject: Schema.GuiObject,
+  lastModificationDate: Instant,
+  apiRequestID: UUID,
+  requestingUser: User,
+)
+
+/**
+ * Requests the creation of an empty ontology. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param ontologyName   the name of the ontology to be created.
+ * @param projectIri     the IRI of the project that the ontology will belong to.
+ * @param isShared       the flag that shows if an ontology is a shared one.
+ * @param label          the label of the ontology.
+ * @param comment        the optional comment that described the ontology to be created.
+ * @param apiRequestID   the ID of the API request.
+ * @param requestingUser the user making the request.
+ */
+case class CreateOntologyRequestV2(
+  ontologyName: String,
+  projectIri: ProjectIri,
+  isShared: Boolean,
+  label: String,
+  comment: Option[NonEmptyString],
+  apiRequestID: UUID,
+  requestingUser: User,
+)
+
+/**
+ * Requests the addition of a property to an ontology. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param propertyInfoContent  an [[PropertyInfoContentV2]] containing the property definition.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
+case class CreatePropertyRequestV2(
+  propertyInfoContent: PropertyInfoContentV2,
+  lastModificationDate: Instant,
+  apiRequestID: UUID,
+  requestingUser: User,
+)
+
+/**
+ * Requests the removal of a class's cardinalities. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param classInfoContent     a [[ClassInfoContentV2]] containing the cardinalities to be removed.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
+final case class DeleteCardinalitiesFromClassRequestV2(
+  classInfoContent: ClassInfoContentV2,
+  lastModificationDate: Instant,
+  apiRequestID: UUID,
+  requestingUser: User,
+)
+
+enum LabelOrComment {
+  case Label
+  case Comment
+
+  override def toString: String = this match {
+    case Label   => RDFS.LABEL.toString
+    case Comment => RDFS.COMMENT.toString
+  }
+}
+
+object LabelOrComment {
+  def fromString(str: String): Option[LabelOrComment] =
+    LabelOrComment.values.find(_.toString == str)
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyRequests.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyRequests.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.knora.webapi.slice.api.v2.ontologies
 
 import eu.timepit.refined.types.string.NonEmptyString

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyV2RequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyV2RequestParser.scala
@@ -31,14 +31,7 @@ import org.knora.webapi.messages.store.triplestoremessages.OntologyLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.PlainStringLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.SmartIriLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.CanDeleteCardinalitiesFromClassRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.ChangeClassLabelsOrCommentsRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.ChangePropertyGuiElementRequest
 import org.knora.webapi.messages.v2.responder.ontologymessages.ClassInfoContentV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.CreateOntologyRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.CreatePropertyRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.DeleteCardinalitiesFromClassRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.LabelOrComment
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.KnoraCardinalityInfo
 import org.knora.webapi.messages.v2.responder.ontologymessages.PredicateInfoV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.PropertyInfoContentV2

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyV2Requests.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyV2Requests.scala
@@ -14,7 +14,6 @@ import scala.language.implicitConversions
 
 import org.knora.webapi.messages.store.triplestoremessages.LanguageTaggedStringLiteralV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ClassInfoContentV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.LabelOrComment
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/QueryBuilderHelper.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/QueryBuilderHelper.scala
@@ -30,11 +30,11 @@ import org.knora.webapi.messages.store.triplestoremessages.OntologyLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.PlainStringLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.SmartIriLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.LabelOrComment
 import org.knora.webapi.messages.v2.responder.ontologymessages.PredicateInfoV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.admin.model.Project
+import org.knora.webapi.slice.api.v2.ontologies.LabelOrComment
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.KnoraIri
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangeClassLabelsOrCommentsQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangeClassLabelsOrCommentsQuery.scala
@@ -15,7 +15,7 @@ import zio.*
 
 import org.knora.webapi.messages.store.triplestoremessages.LanguageTaggedStringLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.LabelOrComment
+import org.knora.webapi.slice.api.v2.ontologies.LabelOrComment
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.QueryBuilderHelper

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyLabelsOrCommentsQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyLabelsOrCommentsQuery.scala
@@ -15,7 +15,7 @@ import zio.*
 
 import org.knora.webapi.messages.store.triplestoremessages.LanguageTaggedStringLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.LabelOrComment
+import org.knora.webapi.slice.api.v2.ontologies.LabelOrComment
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.QueryBuilderHelper

--- a/webapi/src/test/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyV2RequestParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/api/v2/ontologies/OntologyV2RequestParserSpec.scala
@@ -18,11 +18,7 @@ import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.SmartIriLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.ChangeClassLabelsOrCommentsRequestV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.ClassInfoContentV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.CreateOntologyRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.CreatePropertyRequestV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.LabelOrComment
 import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.KnoraCardinalityInfo
 import org.knora.webapi.messages.v2.responder.ontologymessages.PredicateInfoV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.PropertyInfoContentV2

--- a/webapi/src/test/scala/org/knora/webapi/slice/export/api/service/ExportServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/export/api/service/ExportServiceSpec.scala
@@ -183,8 +183,6 @@ object ExportServiceSpec extends ZIOSpecDefault with GoldenTest {
       },
       test("with footnotes in text value") {
         for {
-          // OntologyResponderV2 must be initialized so it subscribes to MessageRelay (handles StandoffEntityInfoGetRequestV2)
-          _             <- ZIO.serviceWithZIO[OntologyResponderV2](_ => ZIO.unit)
           _             <- ZIO.serviceWithZIO[TriplestoreService](_.insertDataIntoTriplestore(dataSets.toList, false))
           _             <- ZIO.serviceWithZIO[OntologyCache](_.refreshCache())
           project       <- ZIO.serviceWithZIO[KnoraProjectService](_.findById(projectIri)).map(_.get)

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/ChangeClassLabelsOrCommentsQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/ChangeClassLabelsOrCommentsQuerySpec.scala
@@ -13,7 +13,7 @@ import java.time.Instant
 import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.LabelOrComment
+import org.knora.webapi.slice.api.v2.ontologies.LabelOrComment
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.domain.LanguageCode.*

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyLabelsOrCommentsQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyLabelsOrCommentsQuerySpec.scala
@@ -13,7 +13,7 @@ import java.time.Instant
 import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.LabelOrComment
+import org.knora.webapi.slice.api.v2.ontologies.LabelOrComment
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.domain.LanguageCode.*


### PR DESCRIPTION
Remove `MessageRelay` from `OntologyResponderV2` and migrate former callers to now call `OntologyCacheHelpers` or `OntologyResponderV2` directly .

`OntologyResponderV2` no longer extends `MessageHandler`, no longer subscribes to `MessageRelay`, and the layer no longer requires it. Unused request case classes that existed only as relay envelopes are deleted, along with the dispatch methods in the responder.
