### PR TITLE
refactor: Extract StandoffMappingService and remove MessageRelay usage

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ValuesEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ValuesEndpointsE2ESpec.scala
@@ -38,6 +38,7 @@ import org.knora.webapi.slice.api.v2.values.ReorderValuesRequest
 import org.knora.webapi.slice.api.v2.values.ReorderValuesResponse
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.search.repo.GetResourceWithSpecifiedPropertiesGravsearchQuery
 import org.knora.webapi.testservices.RequestsUpdates.addVersionQueryParam
 import org.knora.webapi.testservices.ResponseOps.assert200
@@ -228,12 +229,14 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
       |   And this <strong id="link_id">strong value</strong> is linked by this <a class="internal-link" href="#link_id">link</a>
       |</text>""".stripMargin
 
-  private val standardMappingIri: IRI = "http://rdfh.ch/standoff/mappings/StandardMapping"
-
   private val geometryValue1 =
     """{"status":"active","lineColor":"#ff3333","lineWidth":2,"points":[{"x":0.08098591549295775,"y":0.16741071428571427},{"x":0.7394366197183099,"y":0.7299107142857143}],"type":"rectangle","original_index":0}"""
 
-  private def createTextValueWithStandoffRequest(resourceIri: IRI, textValueAsXml: String, mappingIri: String): String =
+  private def createTextValueWithStandoffRequest(
+    resourceIri: IRI,
+    textValueAsXml: String,
+    mappingIri: StandoffMappingIri,
+  ): String =
     s"""{
        |  "@id" : "$resourceIri",
        |  "@type" : "anything:Thing",
@@ -1077,7 +1080,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
         jsonLd                    = createTextValueWithStandoffRequest(
                    resourceIri = resourceIri,
                    textValueAsXml = textValue1AsXmlWithStandardMapping,
-                   mappingIri = standardMappingIri,
+                   mappingIri = StandoffMappingIri.StandardMapping,
                  )
         responseJsonDoc <- TestApiClient.postJsonLdDocument(uri"/v2/values", jsonLd, anythingUser1).flatMap(_.assert200)
         valueIri        <- ZIO.fromEither(responseJsonDoc.body.getRequiredString(JsonLDKeywords.ID))
@@ -1120,7 +1123,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
         jsonLd                    = createTextValueWithStandoffRequest(
                    resourceIri = resourceIri,
                    textValueAsXml = textValueAsXml,
-                   mappingIri = standardMappingIri,
+                   mappingIri = StandoffMappingIri.StandardMapping,
                  )
         responseJsonDoc <- TestApiClient.postJsonLdDocument(uri"/v2/values", jsonLd, anythingUser1).flatMap(_.assert200)
         valueIri        <- ZIO.fromEither(responseJsonDoc.body.getRequiredString(JsonLDKeywords.ID))
@@ -1154,7 +1157,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
         jsonLd                    = createTextValueWithStandoffRequest(
                    resourceIri = resourceIri,
                    textValueAsXml = textValueAsXml,
-                   mappingIri = standardMappingIri,
+                   mappingIri = StandoffMappingIri.StandardMapping,
                  )
         responseJsonDoc <- TestApiClient.postJsonLdDocument(uri"/v2/values", jsonLd, anythingUser1).flatMap(_.assert200)
         valueIri        <- ZIO.fromEither(responseJsonDoc.body.getRequiredString(JsonLDKeywords.ID))
@@ -1210,7 +1213,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
         jsonLd                    = createTextValueWithStandoffRequest(
                    resourceIri = resourceIri,
                    textValueAsXml = textValueAsXml,
-                   mappingIri = standardMappingIri,
+                   mappingIri = StandoffMappingIri.StandardMapping,
                  )
         responseJsonDoc <- TestApiClient.postJsonLdDocument(uri"/v2/values", jsonLd, anythingUser1).flatMap(_.assert200)
         valueIri        <- ZIO.fromEither(responseJsonDoc.body.getRequiredString(JsonLDKeywords.ID))
@@ -1238,7 +1241,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
       val jsonLd = createTextValueWithStandoffRequest(
         resourceIri = resourceIri,
         textValueAsXml = textValueAsXml,
-        mappingIri = standardMappingIri,
+        mappingIri = StandoffMappingIri.StandardMapping,
       )
       TestApiClient.postJsonLd(uri"/v2/values", jsonLd, anythingUser1).flatMap(_.assert400).as(assertCompletes)
     },
@@ -1276,7 +1279,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
         jsonLd = createTextValueWithStandoffRequest(
                    resourceIri = resourceIri,
                    textValueAsXml = textValueAsXml,
-                   mappingIri = s"$anythingProjectIri/mappings/HTMLMapping",
+                   mappingIri = StandoffMappingIri.unsafeFrom(s"$anythingProjectIri/mappings/HTMLMapping"),
                  )
         _               <- TestApiClient.postMultiPart[Json](uri"/v2/mapping", multipartBody, anythingUser1).flatMap(_.assert200)
         responseJsonDoc <- TestApiClient.postJsonLdDocument(uri"/v2/values", jsonLd, anythingUser1).flatMap(_.assert200)
@@ -1583,7 +1586,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
         jsonLd = createTextValueWithStandoffRequest(
                    resourceIri = resourceIri,
                    textValueAsXml = textValueAsXml,
-                   mappingIri = standardMappingIri,
+                   mappingIri = StandoffMappingIri.StandardMapping,
                  )
 
         responseJsonDoc <- TestApiClient.postJsonLdDocument(uri"/v2/values", jsonLd, anythingUser1).flatMap(_.assert200)
@@ -2535,7 +2538,7 @@ object ValuesEndpointsE2ESpec extends E2EZSpec { self =>
            |    "@type" : "knora-api:TextValue",
            |    "knora-api:textValueAsXml" : ${textValue2AsXmlWithStandardMapping.toJson},
            |    "knora-api:textValueHasMapping" : {
-           |      "@id": "$standardMappingIri"
+           |      "@id": "${StandoffMappingIri.StandardMapping}"
            |    }
            |  },
            |  "@context" : {

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/ConstructResponseUtilV2SpecFullData.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/ConstructResponseUtilV2SpecFullData.scala
@@ -20,6 +20,7 @@ import org.knora.webapi.messages.v2.responder.valuemessages.*
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.admin.domain.model.Permission
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
 
 object ConstructResponseUtilV2SpecFullData {
@@ -274,7 +275,7 @@ object ConstructResponseUtilV2SpecFullData {
                 maybeValueHasString = Some("Ich liebe die Dinge, sie sind alles f\u00FCr mich."),
                 comment = None,
                 xslt = None,
-                mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+                mappingIri = Some(StandoffMappingIri.StandardMapping),
                 textValueType = TextValueType.FormattedText,
               ),
               valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-values/values/1"),
@@ -329,7 +330,7 @@ object ConstructResponseUtilV2SpecFullData {
                 maybeValueHasString = Some("Na ja, die Dinge sind OK."),
                 comment = None,
                 xslt = None,
-                mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+                mappingIri = Some(StandoffMappingIri.StandardMapping),
                 textValueType = TextValueType.FormattedText,
               ),
               valueIri = ValueIri.unsafeFrom("http://rdfh.ch/0001/a-thing-with-text-values/values/2"),

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -44,9 +44,11 @@ import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.resources.repo.GetStandoffTagByUUIDQuery
+import org.knora.webapi.slice.standoff.service.StandoffMappingService
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 import org.knora.webapi.util.*
@@ -516,7 +518,9 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
   override val e2eSpec = suite("ResourceResponserV2")(
     test("Load test data") {
       ZIO
-        .serviceWithZIO[StandoffResponderV2](_.getMappingV2("http://rdfh.ch/standoff/mappings/StandardMapping"))
+        .serviceWithZIO[StandoffMappingService](
+          _.getMappingV2(StandoffMappingIri.unsafeFrom("http://rdfh.ch/standoff/mappings/StandardMapping")),
+        )
         .tap(r => ZIO.succeed(self.standardMapping = Some(r.mapping)))
         .as(assertCompletes)
     },

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -519,7 +519,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
     test("Load test data") {
       ZIO
         .serviceWithZIO[StandoffMappingService](
-          _.getMappingV2(StandoffMappingIri.unsafeFrom("http://rdfh.ch/standoff/mappings/StandardMapping")),
+          _.getMappingV2(StandoffMappingIri.StandardMapping),
         )
         .tap(r => ZIO.succeed(self.standardMapping = Some(r.mapping)))
         .as(assertCompletes)
@@ -956,7 +956,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
                 ontologySchema = ApiV2Complex,
                 maybeValueHasString = Some("this is text with standoff"),
                 standoff = sampleStandoff,
-                mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+                mappingIri = Some(StandoffMappingIri.StandardMapping),
                 mapping = standardMapping,
                 textValueType = TextValueType.FormattedText,
               ),
@@ -1344,7 +1344,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
                 ontologySchema = ApiV2Complex,
                 maybeValueHasString = Some("this is text with standoff"),
                 standoff = standoffWithInvalidLink,
-                mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+                mappingIri = Some(StandoffMappingIri.StandardMapping),
                 mapping = standardMapping,
                 textValueType = TextValueType.FormattedText,
               ),
@@ -1862,7 +1862,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
                 ontologySchema = ApiV2Complex,
                 maybeValueHasString = Some("this is text with standoff"),
                 standoff = sampleStandoffForErasingResource,
-                mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+                mappingIri = Some(StandoffMappingIri.StandardMapping),
                 mapping = standardMapping,
                 textValueType = TextValueType.FormattedText,
               ),
@@ -1897,7 +1897,7 @@ object ResourcesResponderV2Spec extends E2EZSpec { self =>
                                          ontologySchema = ApiV2Complex,
                                          maybeValueHasString = Some("this is some other text with standoff"),
                                          standoff = Vector(sampleStandoffForErasingResource.head),
-                                         mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+                                         mappingIri = Some(StandoffMappingIri.StandardMapping),
                                          mapping = standardMapping,
                                          textValueType = TextValueType.FormattedText,
                                        ),

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/StandoffResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/StandoffResponderV2Spec.scala
@@ -77,7 +77,7 @@ object StandoffResponderV2Spec extends E2EZSpec {
 
       for {
         response <- ZIO.serviceWithZIO[StandoffResponderV2](
-                      _.createMappingV2(createRequest, rootUser, UUID.randomUUID()),
+                      _.createMappingV2(createRequest, UUID.randomUUID()),
                     )
         expectedMappingIRI = f"${anythingProjectIri.value}/mappings/$mappingName"
         mappingFromDB     <- ZIO.serviceWithZIO[TriplestoreService](

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -1211,7 +1211,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
     test("Load test data") {
       ZIO
         .serviceWithZIO[StandoffMappingService](
-          _.getMappingV2(StandoffMappingIri.unsafeFrom("http://rdfh.ch/standoff/mappings/StandardMapping")),
+          _.getMappingV2(StandoffMappingIri.StandardMapping),
         )
         .tap(r => ZIO.succeed(self.standardMapping = Some(r.mapping)))
         .as(assertCompletes)
@@ -1290,7 +1290,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           ontologySchema = ApiV2Complex,
           maybeValueHasString = Some(valueHasString),
           standoff = sampleStandoff,
-          mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+          mappingIri = Some(StandoffMappingIri.StandardMapping),
           mapping = standardMapping,
           textValueType = TextValueType.FormattedText,
         ),
@@ -1312,7 +1312,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       } yield assertTrue(
         savedValue.valueHasString.contains(valueHasString),
         savedValue.standoff == sampleStandoff,
-        savedValue.mappingIri.contains("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        savedValue.mappingIri.contains(StandoffMappingIri.StandardMapping),
         savedValue.mapping == standardMapping,
       )
     },
@@ -1840,7 +1840,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           ontologySchema = ApiV2Complex,
           maybeValueHasString = Some(valueHasString),
           standoff = standoff,
-          mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+          mappingIri = Some(StandoffMappingIri.StandardMapping),
           mapping = standardMapping,
           textValueType = TextValueType.FormattedText,
         ),
@@ -1874,7 +1874,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
         savedTextValue.valueHasString.contains(valueHasString),
         savedTextValue.standoff == standoff,
         savedTextValue.mapping == standardMapping,
-        savedTextValue.mappingIri.contains("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        savedTextValue.mappingIri.contains(StandoffMappingIri.StandardMapping),
         linkValuesFromTriplestore.size == 1,
         linkValueFromTriplestore.previousValueIri.isEmpty,
         linkValueFromTriplestore.valueHasRefCount == 1,
@@ -1914,7 +1914,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           ontologySchema = ApiV2Complex,
           maybeValueHasString = Some(valueHasString),
           standoff = standoff,
-          mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+          mappingIri = Some(StandoffMappingIri.StandardMapping),
           mapping = standardMapping,
           textValueType = TextValueType.FormattedText,
         ),
@@ -1952,7 +1952,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       } yield assertTrue(
         savedTextValue.valueHasString.contains(valueHasString),
         savedTextValue.standoff == (standoff),
-        savedTextValue.mappingIri.contains("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        savedTextValue.mappingIri.contains(StandoffMappingIri.StandardMapping),
         savedTextValue.mapping == (standardMapping),
         linkValuesFromTriplestore.size == 1,
         linkValueFromTriplestore.previousValueIri.contains(previousStandoffLinkValueIri),
@@ -2002,7 +2002,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           ontologySchema = ApiV2Complex,
           maybeValueHasString = Some("ignored"),
           standoff = standoffTags,
-          mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+          mappingIri = Some(StandoffMappingIri.StandardMapping),
           mapping = standardMapping,
           textValueType = TextValueType.FormattedText,
         ),
@@ -2029,7 +2029,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           ontologySchema = ApiV2Complex,
           maybeValueHasString = Some(valueHasString),
           standoff = standoffTags,
-          mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+          mappingIri = Some(StandoffMappingIri.StandardMapping),
           mapping = standardMapping,
           textValueType = TextValueType.FormattedText,
         ),
@@ -2064,7 +2064,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       } yield assertTrue(
         savedValue.valueHasString.contains(valueHasString),
         savedValue.standoff == standoffTags,
-        savedValue.mappingIri.contains("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        savedValue.mappingIri.contains(StandoffMappingIri.StandardMapping),
         savedValue.mapping == standardMapping,
         standoffLinkValues.size == 1,
         linkValueContentV2.referredResourceIri == generationeIri,
@@ -2083,7 +2083,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           ontologySchema = ApiV2Complex,
           maybeValueHasString = Some(valueHasString),
           standoff = sampleStandoff,
-          mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+          mappingIri = Some(StandoffMappingIri.StandardMapping),
           mapping = standardMapping,
           textValueType = TextValueType.FormattedText,
         ),
@@ -2104,7 +2104,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       } yield assertTrue(
         savedValue.valueHasString.contains(valueHasString),
         savedValue.standoff == (sampleStandoff),
-        savedValue.mappingIri.contains("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        savedValue.mappingIri.contains(StandoffMappingIri.StandardMapping),
         savedValue.mapping == (standardMapping),
       )
     },
@@ -2121,7 +2121,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           ontologySchema = ApiV2Complex,
           maybeValueHasString = Some(valueHasString),
           standoff = sampleStandoffModified,
-          mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+          mappingIri = Some(StandoffMappingIri.StandardMapping),
           mapping = standardMapping,
           textValueType = TextValueType.FormattedText,
         ),
@@ -2142,7 +2142,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
       } yield assertTrue(
         savedValue.valueHasString.contains(valueHasString),
         savedValue.standoff == sampleStandoffModified,
-        savedValue.mappingIri.contains("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        savedValue.mappingIri.contains(StandoffMappingIri.StandardMapping),
         savedValue.mapping == standardMapping,
       )
     },
@@ -3089,7 +3089,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
           ontologySchema = ApiV2Complex,
           maybeValueHasString = Some("Comment 1 for UUID checking"),
           standoff = sampleStandoffWithLink(aThingIri.value),
-          mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+          mappingIri = Some(StandoffMappingIri.StandardMapping),
           mapping = standardMapping,
           textValueType = TextValueType.FormattedText,
         ),
@@ -3121,7 +3121,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
                   ontologySchema = ApiV2Complex,
                   maybeValueHasString = Some("Comment 2 for UUID checking"),
                   standoff = sampleStandoffWithLink(aThingIri.value),
-                  mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+                  mappingIri = Some(StandoffMappingIri.StandardMapping),
                   mapping = standardMapping,
                   textValueType = TextValueType.FormattedText,
                 ),
@@ -3162,7 +3162,7 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
                   ontologySchema = ApiV2Complex,
                   maybeValueHasString = Some("Comment 3 for UUID checking"),
                   standoff = sampleStandoffWithLink(aThingIri.value),
-                  mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+                  mappingIri = Some(StandoffMappingIri.StandardMapping),
                   mapping = standardMapping,
                   textValueType = TextValueType.FormattedText,
                 ),

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -35,9 +35,11 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.KnoraIris.*
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
 import org.knora.webapi.slice.search.repo.GetResourceWithSpecifiedPropertiesGravsearchQuery
+import org.knora.webapi.slice.standoff.service.StandoffMappingService
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 import org.knora.webapi.util.MutableTestIri
@@ -1208,7 +1210,9 @@ object ValuesResponderV2Spec extends E2EZSpec { self =>
   override val e2eSpec = suite("ValuesResponderV2")(
     test("Load test data") {
       ZIO
-        .serviceWithZIO[StandoffResponderV2](_.getMappingV2("http://rdfh.ch/standoff/mappings/StandardMapping"))
+        .serviceWithZIO[StandoffMappingService](
+          _.getMappingV2(StandoffMappingIri.unsafeFrom("http://rdfh.ch/standoff/mappings/StandardMapping")),
+        )
         .tap(r => ZIO.succeed(self.standardMapping = Some(r.mapping)))
         .as(assertCompletes)
     },

--- a/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -43,6 +43,8 @@ import org.knora.webapi.slice.resources.repo.service.ResourcesRepoLive
 import org.knora.webapi.slice.resources.service.ReadResourcesService
 import org.knora.webapi.slice.resources.service.ReadResourcesServiceLive
 import org.knora.webapi.slice.security.SecurityModule
+import org.knora.webapi.slice.standoff.service.StandoffMappingService
+import org.knora.webapi.slice.standoff.service.StandoffMappingServiceLive
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.store.iiif.impl.SipiServiceLive
 import org.knora.webapi.store.triplestore.upgrade.RepositoryUpdater
@@ -86,6 +88,7 @@ object LayersLive { self =>
     SearchResponderV2Module.Provided &
     SecurityModule.Provided &
     SipiService &
+    StandoffMappingService &
     StandoffResponderV2 &
     StandoffTagUtilV2 &
     State &
@@ -133,6 +136,7 @@ object LayersLive { self =>
       SearchResponderV2Module.layer,
       SecurityModule.layer,
       SipiServiceLive.layer,
+      StandoffMappingServiceLive.layer,
       StandoffResponderV2.layer,
       StandoffTagUtilV2Live.layer,
       State.layer,

--- a/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
@@ -1440,31 +1440,6 @@ class StringFormatter private (
       maybeTimestamp = maybeTimestamp,
     )
 
-  /**
-   * Creates a mapping IRI based on a project IRI and a mapping name.
-   *
-   * @param projectIri the IRI of the project the mapping will belong to.
-   * @return a mapping IRI.
-   */
-  def makeProjectMappingIri(projectIri: IRI, mappingName: String): IRI = {
-    val mappingIri = s"$projectIri/mappings/$mappingName"
-    // check that the mapping IRI is valid (mappingName is user input)
-    Iri
-      .validateAndEscapeIri(mappingIri)
-      .getOrElse(throw BadRequestException(s"the created mapping IRI $mappingIri is invalid"))
-  }
-
-  /**
-   * Creates a random IRI for an element of a mapping based on a mapping IRI.
-   *
-   * @param mappingIri the IRI of the mapping the element belongs to.
-   * @return a new mapping element IRI.
-   */
-  def makeRandomMappingElementIri(mappingIri: IRI): IRI = {
-    val knoraMappingElementUuid = UuidUtil.makeRandomBase64EncodedUuid
-    s"$mappingIri/elements/$knoraMappingElementUuid"
-  }
-
   def unescapeStringLiteralSeq(stringLiteralSeq: StringLiteralSequenceV2): StringLiteralSequenceV2 =
     StringLiteralSequenceV2(
       stringLiterals = stringLiteralSeq.stringLiterals.map(stringLiteral =>

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/ConstructResponseUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/ConstructResponseUtilV2.scala
@@ -647,16 +647,19 @@ final class ConstructResponseUtilV2(
       valueObject.maybeStringObject(OntologyConstants.KnoraBase.ValueHasLanguage.toSmartIri)
 
     if (valueObject.standoff.nonEmpty) {
-      val mappingIri: Option[IRI]                                           = valueObject.maybeIriObject(OntologyConstants.KnoraBase.ValueHasMapping.toSmartIri)
-      val mappingAndXsltTransformation: Option[MappingAndXSLTransformation] =
-        mappingIri.flatMap(s => StandoffMappingIri.from(s).toOption).flatMap(mappings.get)
-
       for {
-        standoff <- standoffTagUtilV2.createStandoffTagsV2FromConstructResults(
+        mappingIri <- ZIO.foreach(valueObject.maybeIriObject(OntologyConstants.KnoraBase.ValueHasMapping.toSmartIri)) {
+                        iri =>
+                          ZIO
+                            .fromEither(StandoffMappingIri.from(iri))
+                            .mapBoth(_ => InconsistentRepositoryDataException(s"Invalid mapping IRI $iri"), identity)
+                      }
+        mappingAndXsltTransformation = mappingIri.flatMap(mappings.get)
+        standoff                    <- standoffTagUtilV2.createStandoffTagsV2FromConstructResults(
                       standoffAssertions = valueObject.standoff,
                       requestingUser = requestingUser,
                     )
-        textTypeInferred = mappingIri match
+        textTypeInferred = mappingIri.map(_.value) match
                              case None                                              => TextValueType.UnformattedText
                              case Some(OntologyConstants.KnoraBase.StandardMapping) => TextValueType.FormattedText
                              case Some(iri)                                         => TextValueType.CustomFormattedText(InternalIri(iri))
@@ -666,7 +669,7 @@ final class ConstructResponseUtilV2(
                        case OntologyConstants.KnoraBase.UnformattedText     => Some(TextValueType.UnformattedText)
                        case OntologyConstants.KnoraBase.FormattedText       => Some(TextValueType.FormattedText)
                        case OntologyConstants.KnoraBase.CustomFormattedText =>
-                         mappingIri.map(iri => TextValueType.CustomFormattedText(InternalIri(iri)))
+                         mappingIri.map(iri => TextValueType.CustomFormattedText(InternalIri(iri.value)))
                        case OntologyConstants.KnoraBase.UndefinedTextType => None
                        case _                                             => None
                      }

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/ConstructResponseUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/ConstructResponseUtilV2.scala
@@ -18,7 +18,6 @@ import dsp.errors.NotImplementedException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
@@ -43,10 +42,7 @@ import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.StandoffEntityInfoGetResponseV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.ReadResourceV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.ReadResourcesSequenceV2
-import org.knora.webapi.messages.v2.responder.standoffmessages.GetMappingRequestV2
 import org.knora.webapi.messages.v2.responder.standoffmessages.GetMappingResponseV2
-import org.knora.webapi.messages.v2.responder.standoffmessages.GetXSLTransformationRequestV2
-import org.knora.webapi.messages.v2.responder.standoffmessages.GetXSLTransformationResponseV2
 import org.knora.webapi.messages.v2.responder.standoffmessages.MappingXMLtoStandoff
 import org.knora.webapi.messages.v2.responder.valuemessages.*
 import org.knora.webapi.responders.admin.ListsResponder
@@ -59,18 +55,20 @@ import org.knora.webapi.slice.admin.domain.model.Permission
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
+import org.knora.webapi.slice.standoff.service.StandoffMappingService
 import org.knora.webapi.store.iiif.errors.SipiException
 import org.knora.webapi.util.ZioHelper
 
-final case class ConstructResponseUtilV2(
-  private val appConfig: AppConfig,
-  private val messageRelay: MessageRelay,
-  private val listsResponder: ListsResponder,
-  private val standoffTagUtilV2: StandoffTagUtilV2,
-  private val projectService: ProjectService,
+final class ConstructResponseUtilV2(
+  appConfig: AppConfig,
+  standoffMappingService: StandoffMappingService,
+  listsResponder: ListsResponder,
+  standoffTagUtilV2: StandoffTagUtilV2,
+  projectService: ProjectService,
 )(implicit val stringFormatter: StringFormatter) {
 
   private val inferredPredicates = Set(
@@ -601,7 +599,7 @@ final case class ConstructResponseUtilV2(
    * @param valuePropertyAssertions the given assertions (property -> value object).
    * @return a set of mapping Iris.
    */
-  def getMappingIrisFromValuePropertyAssertions(valuePropertyAssertions: RdfPropertyValues): Set[IRI] =
+  private def getMappingIrisFromValuePropertyAssertions(valuePropertyAssertions: RdfPropertyValues): Set[IRI] =
     valuePropertyAssertions.foldLeft(Set.empty[IRI]) {
       case (acc: Set[IRI], (_: SmartIri, valObjs: Seq[ValueRdfData])) =>
         val mappings: Seq[String] = valObjs.filter { (valObj: ValueRdfData) =>
@@ -641,7 +639,7 @@ final case class ConstructResponseUtilV2(
     valueObject: ValueRdfData,
     valueObjectValueHasString: Option[String],
     valueCommentOption: Option[String],
-    mappings: Map[IRI, MappingAndXSLTransformation],
+    mappings: Map[StandoffMappingIri, MappingAndXSLTransformation],
     requestingUser: User,
   ): Task[TextValueContentV2] = {
     // Any knora-base:TextValue may have a language
@@ -651,7 +649,7 @@ final case class ConstructResponseUtilV2(
     if (valueObject.standoff.nonEmpty) {
       val mappingIri: Option[IRI]                                           = valueObject.maybeIriObject(OntologyConstants.KnoraBase.ValueHasMapping.toSmartIri)
       val mappingAndXsltTransformation: Option[MappingAndXSLTransformation] =
-        mappingIri.flatMap(definedMappingIri => mappings.get(definedMappingIri))
+        mappingIri.flatMap(s => StandoffMappingIri.from(s).toOption).flatMap(mappings.get)
 
       for {
         standoff <- standoffTagUtilV2.createStandoffTagsV2FromConstructResults(
@@ -823,7 +821,7 @@ final case class ConstructResponseUtilV2(
   private def makeLinkValueContentV2(
     valueObject: ValueRdfData,
     valueCommentOption: Option[IRI],
-    mappings: Map[IRI, MappingAndXSLTransformation],
+    mappings: Map[StandoffMappingIri, MappingAndXSLTransformation],
     queryStandoff: Boolean,
     versionDate: Option[Instant],
     targetSchema: ApiV2Schema,
@@ -878,7 +876,7 @@ final case class ConstructResponseUtilV2(
    */
   private def createValueContentV2FromValueRdfData(
     valueObject: ValueRdfData,
-    mappings: Map[IRI, MappingAndXSLTransformation],
+    mappings: Map[StandoffMappingIri, MappingAndXSLTransformation],
     queryStandoff: Boolean,
     versionDate: Option[Instant] = None,
     targetSchema: ApiV2Schema,
@@ -1084,7 +1082,7 @@ final case class ConstructResponseUtilV2(
   private def constructReadResourceV2(
     resourceIri: IRI,
     resourceWithValueRdfData: ResourceWithValueRdfData,
-    mappings: Map[IRI, MappingAndXSLTransformation],
+    mappings: Map[StandoffMappingIri, MappingAndXSLTransformation],
     queryStandoff: Boolean,
     versionDate: Option[Instant],
     targetSchema: ApiV2Schema,
@@ -1269,7 +1267,8 @@ final case class ConstructResponseUtilV2(
     mainResourcesAndValueRdfData: MainResourcesAndValueRdfData,
     orderByResourceIri: Seq[IRI],
     pageSizeBeforeFiltering: Int,
-    mappings: Map[IRI, MappingAndXSLTransformation] = Map.empty[IRI, MappingAndXSLTransformation],
+    mappings: Map[StandoffMappingIri, MappingAndXSLTransformation] =
+      Map.empty[StandoffMappingIri, MappingAndXSLTransformation],
     queryStandoff: Boolean,
     calculateMayHaveMoreResults: Boolean,
     versionDate: Option[Instant],
@@ -1317,27 +1316,24 @@ final case class ConstructResponseUtilV2(
    * Gets mappings referred to in query results [[Map[IRI, ResourceWithValueRdfData]]].
    *
    * @param queryResultsSeparated query results referring to mappings.
-   *
-   * @param requestingUser        the user making the request.
    * @return the referred mappings.
    */
   def mappingsFromQueryResults(
-    queryResultsSeparated: Map[IRI, ResourceWithValueRdfData],
-    requestingUser: User,
-  ): Task[Map[IRI, MappingAndXSLTransformation]] = {
+    queryResultsSeparated: RdfResources,
+  ): Task[Map[StandoffMappingIri, MappingAndXSLTransformation]] = {
 
     // collect the Iris of the mappings referred to in the resources' text values
     val mappingIris = queryResultsSeparated.flatMap { case (_, assertions: ResourceWithValueRdfData) =>
       getMappingIrisFromValuePropertyAssertions(assertions.valuePropertyAssertions)
     }.toSet
 
-    // get all the mappings
-    val mappingResponsesFuture = mappingIris.map { (mappingIri: IRI) =>
-      messageRelay.ask[GetMappingResponseV2](GetMappingRequestV2(mappingIri))
-    }
-
     for {
-      mappingResponses <- ZIO.collectAll(mappingResponsesFuture)
+      mappingResponses <- ZIO.foreach(mappingIris)(iri =>
+                            ZIO
+                              .fromEither(StandoffMappingIri.from(iri))
+                              .mapError(BadRequestException.apply)
+                              .flatMap(standoffMappingService.getMappingV2),
+                          )
 
       // get the default XSL transformations
       mappingsWithFuture =
@@ -1345,23 +1341,14 @@ final case class ConstructResponseUtilV2(
           for {
             // if given, get the default XSL transformation
             xsltOption <-
-              if (mapping.mapping.defaultXSLTransformation.nonEmpty) {
-                val xslTransformationFuture = for {
-                  xslTransformation <- messageRelay.ask[GetXSLTransformationResponseV2](
-                                         GetXSLTransformationRequestV2(
-                                           mapping.mapping.defaultXSLTransformation.get,
-                                           requestingUser = requestingUser,
-                                         ),
-                                       )
-                } yield Some(xslTransformation.xslt)
-
-                xslTransformationFuture.mapError { case notFound: NotFoundException =>
-                  throw SipiException(
-                    s"Default XSL transformation <${mapping.mapping.defaultXSLTransformation.get}> not found for mapping <${mapping.mappingIri}>: ${notFound.message}",
-                  )
-                }
-              } else {
-                ZIO.none
+              ZIO.foreach(mapping.mapping.defaultXSLTransformation) { transformationIri =>
+                standoffMappingService
+                  .getXSLTransformation(transformationIri)
+                  .mapError { case notFound: NotFoundException =>
+                    SipiException(
+                      s"Default XSL transformation <$transformationIri> not found for mapping <${mapping.mappingIri}>: ${notFound.message}",
+                    )
+                  }
               }
           } yield mapping.mappingIri -> MappingAndXSLTransformation(
             mapping = mapping.mapping,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/standoffmessages/StandoffMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/standoffmessages/StandoffMessagesV2.scala
@@ -13,10 +13,8 @@ import dsp.errors.AssertionException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.RelayedMessage
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants
-import org.knora.webapi.messages.ResponderRequest.KnoraRequestV2
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.rdf.*
@@ -24,12 +22,7 @@ import org.knora.webapi.messages.v2.responder.KnoraContentV2
 import org.knora.webapi.messages.v2.responder.KnoraJsonLDResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.StandoffEntityInfoGetResponseV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
-import org.knora.webapi.slice.admin.domain.model.User
-
-/**
- * An abstract trait representing a Knora v2 API request message that can be sent to `StandoffResponderV2`.
- */
-sealed trait StandoffResponderRequestV2 extends KnoraRequestV2 with RelayedMessage
+import org.knora.webapi.slice.common.StandoffMappingIri
 
 /**
  * Provides the IRI of the created mapping.
@@ -76,43 +69,17 @@ case class CreateMappingResponseV2(mappingIri: IRI, label: String, projectIri: P
 }
 
 /**
- * Represents a request to get a mapping from XML elements and attributes to standoff entities.
- *
- * @param mappingIri           the IRI of the mapping.
- * @param requestingUser       the the user making the request.
- */
-case class GetMappingRequestV2(mappingIri: IRI) extends StandoffResponderRequestV2
-
-/**
- * Represents a response to a [[GetMappingRequestV2]].
+ * Bundles a mapping with the standoff entities it references.
  *
  * @param mappingIri       the IRI of the requested mapping.
  * @param mapping          the requested mapping.
  * @param standoffEntities the standoff entities referred to in the mapping.
  */
 case class GetMappingResponseV2(
-  mappingIri: IRI,
+  mappingIri: StandoffMappingIri,
   mapping: MappingXMLtoStandoff,
   standoffEntities: StandoffEntityInfoGetResponseV2,
 )
-
-/**
- * Represents a request that gets an XSL Transformation represented by a `knora-base:XSLTransformation`.
- *
- * @param xsltTextRepresentationIri the IRI of the `knora-base:XSLTransformation`.
- * @param requestingUser            the the user making the request.
- */
-case class GetXSLTransformationRequestV2(
-  xsltTextRepresentationIri: IRI,
-  requestingUser: User,
-) extends StandoffResponderRequestV2
-
-/**
- * Represents a response to a [[GetXSLTransformationRequestV2]].
- *
- * @param xslt the XSLT to be applied to the XML created from standoff.
- */
-case class GetXSLTransformationResponseV2(xslt: String)
 
 /**
  * Represents a mapping between XML tags and standoff entities (classes and properties).

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -22,7 +22,6 @@ import dsp.valueobjects.Iri
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.*
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Complex.*
@@ -48,6 +47,7 @@ import org.knora.webapi.slice.api.admin.model.Project
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
@@ -55,6 +55,7 @@ import org.knora.webapi.slice.common.jena.JenaConversions.given
 import org.knora.webapi.slice.common.jena.ResourceOps.*
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
+import org.knora.webapi.slice.standoff.service.StandoffMappingService
 import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.util.WithAsIs
@@ -1179,10 +1180,10 @@ object TextValueContentV2 {
                                   )
 
           textType =
-            if (mappingResponse.mappingIri == OntologyConstants.KnoraBase.StandardMapping) {
+            if (mappingResponse.mappingIri.value == OntologyConstants.KnoraBase.StandardMapping) {
               TextValueType.FormattedText
             } else {
-              TextValueType.CustomFormattedText(InternalIri(mappingResponse.mappingIri))
+              TextValueType.CustomFormattedText(InternalIri(mappingResponse.mappingIri.value))
             }
         } yield TextValueContentV2(
           ontologySchema = ApiV2Complex,
@@ -1190,7 +1191,7 @@ object TextValueContentV2 {
           textValueType = textType,
           valueHasLanguage = maybeValueHasLanguage,
           standoff = textWithStandoffTags.standoffTagV2,
-          mappingIri = Some(mappingResponse.mappingIri),
+          mappingIri = Some(mappingResponse.mappingIri.value),
           mapping = Some(mappingResponse.mapping),
           comment = comment,
         )
@@ -1211,17 +1212,16 @@ object TextValueContentV2 {
              case Some(s)                    => Right(Some(s))
   } yield iri
 
-  def from(r: Resource): ZIO[MessageRelay, IRI, TextValueContentV2] = for {
-    messageRelay          <- ZIO.service[MessageRelay]
-    maybeValueAsString    <- ZIO.fromEither(objectSparqlStringOption(r, ValueAsString))
-    maybeValueHasLanguage <- ZIO.fromEither(objectSparqlStringOption(r, TextValueHasLanguage))
-    maybeTextValueAsXml   <- ZIO.fromEither(r.objectStringOption(TextValueAsXml))
-    comment               <- ZIO.fromEither(objectCommentOption(r))
-    mappingIriOption      <- ZIO.fromEither(r.objectUriOption(TextValueHasMapping))
-    maybeMappingResponse  <- ZIO
-                              .foreach(mappingIriOption) { mappingIri =>
-                                messageRelay.ask[GetMappingResponseV2](GetMappingRequestV2(mappingIri))
-                              }
+  def from(r: Resource): ZIO[StandoffMappingService, IRI, TextValueContentV2] = for {
+    standoffMappingService <- ZIO.service[StandoffMappingService]
+    maybeValueAsString     <- ZIO.fromEither(objectSparqlStringOption(r, ValueAsString))
+    maybeValueHasLanguage  <- ZIO.fromEither(objectSparqlStringOption(r, TextValueHasLanguage))
+    maybeTextValueAsXml    <- ZIO.fromEither(r.objectStringOption(TextValueAsXml))
+    comment                <- ZIO.fromEither(objectCommentOption(r))
+    mappingIriOption       <- ZIO.fromEither(r.objectUriOption(TextValueHasMapping))
+    maybeMappingIri        <- ZIO.foreach(mappingIriOption)(s => ZIO.fromEither(StandoffMappingIri.from(s)))
+    maybeMappingResponse   <- ZIO
+                              .foreach(maybeMappingIri)(standoffMappingService.getMappingV2)
                               .mapError(_.getMessage)
     textValue <-
       getTextValue(maybeValueAsString, maybeTextValueAsXml, maybeValueHasLanguage, maybeMappingResponse, comment)

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -912,7 +912,7 @@ case class TextValueContentV2(
   textValueType: TextValueType,
   valueHasLanguage: Option[String] = None,
   standoff: Seq[StandoffTagV2] = Vector.empty,
-  mappingIri: Option[IRI] = None,
+  mappingIri: Option[StandoffMappingIri] = None,
   mapping: Option[MappingXMLtoStandoff] = None,
   xslt: Option[String] = None,
   comment: Option[String] = None,
@@ -1191,7 +1191,7 @@ object TextValueContentV2 {
           textValueType = textType,
           valueHasLanguage = maybeValueHasLanguage,
           standoff = textWithStandoffTags.standoffTagV2,
-          mappingIri = Some(mappingResponse.mappingIri.value),
+          mappingIri = Some(mappingResponse.mappingIri),
           mapping = Some(mappingResponse.mapping),
           comment = comment,
         )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -33,10 +33,6 @@ import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
 import org.knora.webapi.messages.v2.responder.CanDoResponseV2
 import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.*
-import org.knora.webapi.messages.v2.responder.standoffmessages.GetMappingRequestV2
-import org.knora.webapi.messages.v2.responder.standoffmessages.GetMappingResponseV2
-import org.knora.webapi.messages.v2.responder.standoffmessages.GetXSLTransformationRequestV2
-import org.knora.webapi.messages.v2.responder.standoffmessages.GetXSLTransformationResponseV2
 import org.knora.webapi.messages.v2.responder.valuemessages.*
 import org.knora.webapi.responders.IriLocker
 import org.knora.webapi.responders.IriService
@@ -51,6 +47,7 @@ import org.knora.webapi.slice.api.v2.GraphDirection
 import org.knora.webapi.slice.api.v2.VersionDate
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.resources.repo.ChangeResourceMetadataQuery
@@ -61,6 +58,7 @@ import org.knora.webapi.slice.resources.repo.GetGraphDataQuery
 import org.knora.webapi.slice.resources.repo.GetResourceValueVersionHistoryQuery
 import org.knora.webapi.slice.resources.service.ReadResourcesService
 import org.knora.webapi.slice.search.repo.GetIncomingImageLinksGravsearchQuery
+import org.knora.webapi.slice.standoff.service.StandoffMappingService
 import org.knora.webapi.store.iiif.api.SipiService
 import org.knora.webapi.store.iiif.errors.SipiException
 import org.knora.webapi.store.triplestore.api.TriplestoreService
@@ -72,11 +70,11 @@ final class ResourcesResponderV2(
   appConfig: AppConfig,
   iriConverter: IriConverter,
   iriService: IriService,
-  messageRelay: MessageRelay,
   projectService: KnoraProjectService,
   resourceUtilV2: ResourceUtilV2,
   searchResponderV2: SearchResponderV2,
   sipiService: SipiService,
+  standoffMappingService: StandoffMappingService,
   triplestore: TriplestoreService,
   readResources: ReadResourcesService,
   createHandler: CreateResourceV2Handler,
@@ -709,25 +707,29 @@ final class ResourcesResponderV2(
       // get the XSL transformation for the TEI header
       headerXSLT <- headerXSLTIri match {
                       case Some(headerIri) =>
-                        messageRelay
-                          .ask[GetXSLTransformationResponseV2](GetXSLTransformationRequestV2(headerIri, requestingUser))
+                        standoffMappingService
+                          .getXSLTransformation(headerIri)
                           .mapBoth(
                             { case e: NotFoundException =>
                               SipiException(s"TEI header XSL transformation <$headerIri> not found: ${e.message}")
                             },
-                            resp => Some(resp.xslt),
+                            Some(_),
                           )
                       case _ => ZIO.none
                     }
 
       // get the Iri of the mapping to convert standoff markup to TEI/XML
-      mappingToBeApplied = mappingIri.getOrElse(OntologyConstants.KnoraBase.TEIMapping)
+      mappingToBeApplied <- ZIO
+                              .fromEither(
+                                StandoffMappingIri.from(mappingIri.getOrElse(OntologyConstants.KnoraBase.TEIMapping)),
+                              )
+                              .mapError(BadRequestException.apply)
 
       // get mapping to convert standoff markup to TEI/XML
-      teiMapping <- messageRelay.ask[GetMappingResponseV2](GetMappingRequestV2(mappingToBeApplied))
+      teiMapping <- standoffMappingService.getMappingV2(mappingToBeApplied)
 
       // get XSLT from mapping for the TEI body
-      bodyXslt <- teiMapping.mappingIri match {
+      bodyXslt <- teiMapping.mappingIri.value match {
                     case OntologyConstants.KnoraBase.TEIMapping =>
                       // standard standoff to TEI conversion
 
@@ -743,18 +745,13 @@ final class ResourcesResponderV2(
 
                         case Some(xslTransformationIri) =>
                           // get XSLT for the TEI body.
-                          messageRelay
-                            .ask[GetXSLTransformationResponseV2](
-                              GetXSLTransformationRequestV2(xslTransformationIri, requestingUser),
-                            )
-                            .mapBoth(
-                              { case notFound: NotFoundException =>
-                                val msg =
-                                  s"Default XSL transformation <${teiMapping.mapping.defaultXSLTransformation.get}> not found for mapping <${teiMapping.mappingIri}>: ${notFound.message}"
-                                SipiException(msg)
-                              },
-                              _.xslt,
-                            )
+                          standoffMappingService
+                            .getXSLTransformation(xslTransformationIri)
+                            .mapError { case notFound: NotFoundException =>
+                              val msg =
+                                s"Default XSL transformation <${teiMapping.mapping.defaultXSLTransformation.get}> not found for mapping <${teiMapping.mappingIri}>: ${notFound.message}"
+                              SipiException(msg)
+                            }
                         case None =>
                           val msg = s"Default XSL Transformation expected for mapping $otherMapping"
                           ZIO.fail(BadRequestException(msg))
@@ -1775,6 +1772,7 @@ object ResourcesResponderV2 {
       resourceUtilV2          <- ZIO.service[ResourceUtilV2]
       searchResponderV2       <- ZIO.service[SearchResponderV2]
       sipiService             <- ZIO.service[SipiService]
+      standoffMappingService  <- ZIO.service[StandoffMappingService]
       stringFormatter         <- ZIO.service[StringFormatter]
       triplestoreService      <- ZIO.service[TriplestoreService]
       readResources           <- ZIO.service[ReadResourcesService]
@@ -1783,11 +1781,11 @@ object ResourcesResponderV2 {
                     appConfig,
                     iriConverter,
                     iriService,
-                    messageRelay,
                     projectService,
                     resourceUtilV2,
                     searchResponderV2,
                     sipiService,
+                    standoffMappingService,
                     triplestoreService,
                     readResources,
                     createResourceV2Handler,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -47,6 +47,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
@@ -638,12 +639,9 @@ final class SearchResponderV2Live(
       // If we're querying standoff, get XML-to standoff mappings.
       mappingsAsMap <-
         if (queryStandoff) {
-          constructResponseUtilV2.mappingsFromQueryResults(
-            mainResourcesAndValueRdfData.resources,
-            requestingUser,
-          )
+          constructResponseUtilV2.mappingsFromQueryResults(mainResourcesAndValueRdfData.resources)
         } else {
-          ZIO.succeed(Map.empty[IRI, MappingAndXSLTransformation])
+          ZIO.succeed(Map.empty[StandoffMappingIri, MappingAndXSLTransformation])
         }
 
       apiResponse <-
@@ -914,9 +912,9 @@ final class SearchResponderV2Live(
       // If we're querying standoff, get XML-to standoff mappings.
       mappingsAsMap <-
         if (queryStandoff) {
-          constructResponseUtilV2.mappingsFromQueryResults(mainQueryResults.resources, user)
+          constructResponseUtilV2.mappingsFromQueryResults(mainQueryResults.resources)
         } else {
-          ZIO.succeed(Map.empty[IRI, MappingAndXSLTransformation])
+          ZIO.succeed(Map.empty[StandoffMappingIri, MappingAndXSLTransformation])
         }
 
       apiResponse <-
@@ -1083,12 +1081,9 @@ final class SearchResponderV2Live(
             // If we're querying standoff, get XML-to standoff mappings.
             mappings <-
               if (queryStandoff) {
-                constructResponseUtilV2.mappingsFromQueryResults(
-                  mainResourcesAndValueRdfData.resources,
-                  requestingUser,
-                )
+                constructResponseUtilV2.mappingsFromQueryResults(mainResourcesAndValueRdfData.resources)
               } else {
-                ZIO.succeed(Map.empty[IRI, MappingAndXSLTransformation])
+                ZIO.succeed(Map.empty[StandoffMappingIri, MappingAndXSLTransformation])
               }
 
             // Construct a ReadResourceV2 for each resource that the user has permission to see.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
@@ -20,172 +20,41 @@ import scala.xml.XML
 import dsp.errors.*
 import dsp.valueobjects.Iri
 import org.knora.webapi.*
-import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageHandler
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.*
-import org.knora.webapi.messages.IriConversions.*
-import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
-import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2.XMLTagItem
-import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.*
-import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
-import org.knora.webapi.messages.v2.responder.ontologymessages.StandoffEntityInfoGetResponseV2
-import org.knora.webapi.messages.v2.responder.resourcemessages.*
 import org.knora.webapi.messages.v2.responder.standoffmessages.*
-import org.knora.webapi.messages.v2.responder.valuemessages.*
 import org.knora.webapi.responders.IriLocker
-import org.knora.webapi.responders.Responder
-import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.CreateMappingRequestV2
-import org.knora.webapi.slice.common.ResourceIri
-import org.knora.webapi.slice.infrastructure.CacheManager
-import org.knora.webapi.slice.infrastructure.EhCache
-import org.knora.webapi.slice.ontology.domain.model.Cardinality.AtLeastOne
-import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
+import org.knora.webapi.slice.common.StandoffMappingElementIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.resources.repo.CreateNewMappingQuery
 import org.knora.webapi.slice.resources.repo.GetMappingQuery
 import org.knora.webapi.slice.resources.repo.model.MappingElement
 import org.knora.webapi.slice.resources.repo.model.MappingStandoffDatatypeClass
 import org.knora.webapi.slice.resources.repo.model.MappingXMLAttribute
-import org.knora.webapi.store.iiif.api.SipiService
+import org.knora.webapi.slice.standoff.service.StandoffMappingService
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.util.FileUtil
 
 /**
- * Responds to requests relating to the creation of mappings from XML elements
- * and attributes to standoff classes and properties.
+ * Handles creation of mappings from XML elements and attributes to standoff classes and properties.
  */
 final class StandoffResponderV2(
-  appConfig: AppConfig,
-  messageRelay: MessageRelay,
-  ontologyResponder: OntologyResponderV2,
   triplestore: TriplestoreService,
   projectService: ProjectService,
-  xsltCache: EhCache[String, String],
-  mappingCache: EhCache[String, MappingXMLtoStandoff],
-  sipiService: SipiService,
-)(implicit val stringFormatter: StringFormatter)
-    extends MessageHandler {
-
-  private val xmlMimeTypes = Set("text/xml", "application/xml", "application/xslt+xml")
-
-  override def isResponsibleFor(message: ResponderRequest): Boolean = message.isInstanceOf[StandoffResponderRequestV2]
-
-  /**
-   * Receives a message of type [[StandoffResponderRequestV2]], and returns an appropriate response message.
-   */
-  override def handle(msg: ResponderRequest): Task[Any] = msg match {
-    case GetMappingRequestV2(mappingIri)                                => getMappingV2(mappingIri)
-    case GetXSLTransformationRequestV2(xsltTextReprIri, requestingUser) =>
-      getXSLTransformation(xsltTextReprIri, requestingUser)
-    case other => Responder.handleUnexpectedMessage(other, this.getClass.getName)
-  }
-
-  /**
-   * If not already in the cache, retrieves a `knora-base:XSLTransformation` in the triplestore and requests the corresponding XSL transformation file from Sipi.
-   *
-   * @param xslTransformationIri the IRI of the resource representing the XSL Transformation (a [[OntologyConstants.KnoraBase.XSLTransformation]]).
-   * @param requestingUser       the user making the request.
-   * @return a [[GetXSLTransformationResponseV2]].
-   */
-  private def getXSLTransformation(
-    xslTransformationIri: IRI,
-    requestingUser: User,
-  ): Task[GetXSLTransformationResponseV2] = {
-
-    val xsltUrlFuture = for {
-      xslResIri <- ZIO.fromEither(ResourceIri.from(xslTransformationIri)).mapError(BadRequestException.apply)
-
-      textRepresentationResponseV2 <-
-        messageRelay
-          .ask[ReadResourcesSequenceV2](
-            ResourcesGetRequestV2(
-              resourceIris = Vector(xslResIri),
-              targetSchema = ApiV2Complex,
-              requestingUser = requestingUser,
-            ),
-          )
-
-      resource <- textRepresentationResponseV2.toResource(xslResIri)
-
-      _ = if (resource.resourceClassIri.toString != OntologyConstants.KnoraBase.XSLTransformation) {
-            throw BadRequestException(
-              s"Resource $xslTransformationIri is not a ${OntologyConstants.KnoraBase.XSLTransformation}",
-            )
-          }
-
-      (fileValueIri, xsltFileValueContent) =
-        resource.values.get(
-          OntologyConstants.KnoraBase.HasTextFileValue.toSmartIri,
-        ) match {
-          case Some(values: Seq[ReadValueV2]) if values.size == 1 =>
-            values.head match {
-              case value: ReadValueV2 =>
-                value.valueContent match {
-                  case textRepr: TextFileValueContentV2 => (value.valueIri, textRepr)
-                  case _                                =>
-                    throw InconsistentRepositoryDataException(
-                      s"${OntologyConstants.KnoraBase.XSLTransformation} $xslTransformationIri is supposed to have exactly one value of type ${OntologyConstants.KnoraBase.TextFileValue}",
-                    )
-                }
-            }
-
-          case _ =>
-            throw InconsistentRepositoryDataException(
-              s"${OntologyConstants.KnoraBase.XSLTransformation} has no or more than one property ${OntologyConstants.KnoraBase.HasTextFileValue}",
-            )
-        }
-
-      // check if xsltFileValueContent represents an XSL transformation
-      _ = if (!xmlMimeTypes.contains(xsltFileValueContent.fileValue.internalMimeType)) {
-            throw BadRequestException(
-              s"Expected $fileValueIri to be an XML file referring to an XSL transformation, but it has MIME type ${xsltFileValueContent.fileValue.internalMimeType}",
-            )
-          }
-
-      xsltUrl: String =
-        s"${appConfig.sipi.internalBaseUrl}/${resource.projectADM.shortcode}/${xsltFileValueContent.fileValue.internalFilename}/file"
-
-    } yield xsltUrl
-
-    val recoveredXsltUrlFuture = xsltUrlFuture.mapError { case notFound: NotFoundException =>
-      BadRequestException(s"XSL transformation $xslTransformationIri not found: ${notFound.message}")
-    }
-
-    for {
-
-      // check if the XSL transformation is in the cache
-      xsltFileUrl <- recoveredXsltUrlFuture
-
-      xsltMaybe: Option[String] = xsltCache.get(xsltFileUrl)
-
-      xslt <-
-        if (xsltMaybe.nonEmpty) {
-          // XSL transformation is cached
-          ZIO.attempt(xsltMaybe.get)
-        } else {
-          for {
-            content <- sipiService.getTextFileRequest(xsltFileUrl, this.getClass.getName)
-            _        = xsltCache.put(xsltFileUrl, content)
-          } yield content
-        }
-
-    } yield GetXSLTransformationResponseV2(xslt)
-  }
+  standoffMappingService: StandoffMappingService,
+)(implicit val stringFormatter: StringFormatter) {
 
   /**
    * Creates a mapping between XML elements and attributes to standoff classes and properties.
    * The mapping is used to convert XML documents to texts with standoff and back.
    *
-   * @param request               the mapping creation request.
-   * @param requestingUser        the client that made the request.
+   * @param request the mapping creation request.
    */
   def createMappingV2(
     request: CreateMappingRequestV2,
-    requestingUser: User,
     uuid: UUID,
   ): Task[CreateMappingResponseV2] = {
     val createMappingAndCheck: Task[CreateMappingResponseV2] = (for {
@@ -195,7 +64,9 @@ final class StandoffResponderV2(
                    .someOrFail(BadRequestException(s"Project with Iri ${request.projectIri.toString} does not exist"))
 
       // create the mapping IRI from the project IRI and the name provided by the user
-      mappingIri = stringFormatter.makeProjectMappingIri(request.projectIri.toString, request.mappingName)
+      mappingIri <- ZIO
+                      .fromEither(StandoffMappingIri.from(request.projectIri, request.mappingName))
+                      .mapError(BadRequestException.apply)
       // put the mapping into the named graph of the project
       namedGraph = ProjectService.projectDataNamedGraphV2(project).value
 
@@ -233,10 +104,7 @@ final class StandoffResponderV2(
 
             // try to obtain the XSL transformation to make sure that it really exists
             for {
-              _ <- getXSLTransformation(
-                     xslTransformationIri = transIri,
-                     requestingUser = requestingUser,
-                   )
+              _ <- standoffMappingService.getXSLTransformation(transIri)
             } yield Some(transIri)
           case _ => ZIO.none
         }
@@ -317,7 +185,7 @@ final class StandoffResponderV2(
                 .getOrElse(
                   throw BadRequestException(s"standoff class IRI $standoffClassIri is not a valid IRI"),
                 ),
-              mappingXMLAttributeElementIri = stringFormatter.makeRandomMappingElementIri(mappingIri),
+              mappingXMLAttributeElementIri = StandoffMappingElementIri.makeNew(mappingIri),
             )
 
           }
@@ -353,7 +221,7 @@ final class StandoffResponderV2(
                     .getOrElse(
                       throw BadRequestException(s"tagname $dataTypeAttribute contains invalid characters"),
                     ),
-                  mappingStandoffDataTypeClassElementIri = stringFormatter.makeRandomMappingElementIri(mappingIri),
+                  mappingStandoffDataTypeClassElementIri = StandoffMappingElementIri.makeNew(mappingIri),
                 ),
               )
             } else {
@@ -391,7 +259,7 @@ final class StandoffResponderV2(
               ),
             attributes = attributes,
             standoffDataTypeClass = standoffDataTypeOption,
-            mappingElementIri = stringFormatter.makeRandomMappingElementIri(mappingIri),
+            mappingElementIri = StandoffMappingElementIri.makeNew(mappingIri),
             separatorRequired = separatorRequired,
           )
 
@@ -399,19 +267,17 @@ final class StandoffResponderV2(
 
       // transform mappingElements to the structure that is used internally to convert to or from standoff
       // in order to check for duplicates (checks are done during transformation)
-      mappingXMLToStandoff: MappingXMLtoStandoff = transformMappingElementsToMappingXMLtoStandoff(
-                                                     mappingElements,
-                                                     None,
-                                                   )
+      mappingXMLToStandoff: MappingXMLtoStandoff =
+        StandoffMappingService.transformMappingElementsToMappingXMLtoStandoff(mappingElements, None)
 
       // get the standoff entities used in the mapping
       // checks if the standoff classes exist in the ontology
       // checks if the standoff properties exist in the ontology
       // checks if the attributes defined for XML elements have cardinalities for the standoff properties defined on the standoff class
-      _ <- getStandoffEntitiesFromMappingV2(mappingXMLToStandoff)
+      _ <- standoffMappingService.getStandoffEntitiesFromMappingV2(mappingXMLToStandoff)
 
       // check if the mapping IRI already exists
-      getExistingMappingQuery  = GetMappingQuery.build(mappingIri)
+      getExistingMappingQuery  = GetMappingQuery.build(mappingIri.value)
       existingMappingResponse <- triplestore.query(Construct(getExistingMappingQuery))
 
       _ = if (existingMappingResponse.statements.nonEmpty) {
@@ -420,7 +286,7 @@ final class StandoffResponderV2(
 
       createNewMappingSparql = CreateNewMappingQuery.build(
                                  dataNamedGraph = namedGraph,
-                                 mappingIri = mappingIri,
+                                 mappingIri = mappingIri.value,
                                  label = request.label,
                                  defaultXSLTransformation = defaultXSLTransformation,
                                  mappingElements = mappingElements,
@@ -436,9 +302,9 @@ final class StandoffResponderV2(
             )
           }
 
-      // get the mapping from the triplestore and cache it thereby
-      _ <- getMappingFromTriplestore(mappingIri)
-    } yield CreateMappingResponseV2(mappingIri, request.label, request.projectIri)).mapError {
+      // populate the mapping cache by reading it back through the service
+      _ <- standoffMappingService.getMappingV2(mappingIri)
+    } yield CreateMappingResponseV2(mappingIri.value, request.label, request.projectIri)).mapError {
       case validationException: SAXException =>
         BadRequestException(s"the provided mapping is invalid: ${validationException.getMessage}")
 
@@ -450,458 +316,8 @@ final class StandoffResponderV2(
 
     IriLocker.runWithIriLock(uuid, s"${request.projectIri.value}/mappings")(createMappingAndCheck)
   }
-
-  /**
-   * Transforms a mapping represented as a Seq of [[MappingElement]] to a [[MappingXMLtoStandoff]].
-   * This method is called when reading a mapping back from the triplestore.
-   *
-   * @param mappingElements the Seq of MappingElement to be transformed.
-   * @return a [[MappingXMLtoStandoff]].
-   */
-  private def transformMappingElementsToMappingXMLtoStandoff(
-    mappingElements: Seq[MappingElement],
-    defaultXSLTransformation: Option[IRI],
-  ): MappingXMLtoStandoff = {
-
-    val mappingXMLToStandoff = mappingElements.foldLeft(
-      MappingXMLtoStandoff(
-        namespace = Map.empty[String, Map[String, Map[String, XMLTag]]],
-        defaultXSLTransformation = None,
-      ),
-    ) { case (acc: MappingXMLtoStandoff, curEle: MappingElement) =>
-      // get the name of the XML tag
-      val tagname = curEle.tagName
-
-      // get the namespace the tag is defined in
-      val namespace = curEle.namespace
-
-      // get the class the tag is combined with
-      val classname = curEle.className
-
-      // get tags from this namespace if already existent, otherwise create an empty map
-      val namespaceMap: Map[String, Map[String, XMLTag]] =
-        acc.namespace.getOrElse(namespace, Map.empty[String, Map[String, XMLTag]])
-
-      // get the standoff class IRI
-      val standoffClassIri = curEle.standoffClass
-
-      // get a collection containing all the attributes
-      val attributeNodes: Seq[MappingXMLAttribute] = curEle.attributes
-
-      // group attributes by their namespace
-      val attributeNodesByNamespace: Map[String, Seq[MappingXMLAttribute]] = attributeNodes.groupBy {
-        (attr: MappingXMLAttribute) => attr.namespace
-      }
-
-      // create attribute entries for each given namespace
-      val attributes: Map[String, Map[String, IRI]] = attributeNodesByNamespace.map {
-        case (namespace: String, attrNodes: Seq[MappingXMLAttribute]) =>
-          // collect all the attributes for the current namespace
-          val attributesInNamespace: Map[String, IRI] = attrNodes.foldLeft(Map.empty[String, IRI]) {
-            case (acc: Map[String, IRI], attrEle: MappingXMLAttribute) =>
-              // get the current attribute's name
-              val attrName = attrEle.attributeName
-
-              // check if the current attribute already exists in this namespace
-              if (acc.contains(attrName)) {
-                throw BadRequestException("Duplicate attribute name in namespace")
-              }
-
-              // get the standoff property IRI for the current attribute
-              val propIri = attrEle.standoffProperty
-
-              // add the current attribute to the collection
-              acc + (attrName -> propIri)
-          }
-
-          namespace -> attributesInNamespace
-      }
-
-      // if "datatype" is given, create a `XMLStandoffDataTypeClass`
-      val dataTypeOption: Option[XMLStandoffDataTypeClass] = curEle.standoffDataTypeClass match {
-
-        case Some(dataTypeClass: MappingStandoffDatatypeClass) =>
-          val dataType =
-            StandoffDataTypeClasses.lookup(
-              dataTypeClass.datatype,
-              throw BadRequestException(s"Invalid data type provided for $tagname"),
-            )
-
-          val dataTypeAttribute = dataTypeClass.attributeName
-
-          Some(
-            XMLStandoffDataTypeClass(
-              standoffDataTypeClass = dataType,
-              dataTypeXMLAttribute = dataTypeAttribute,
-            ),
-          )
-
-        case None => None
-      }
-
-      // add the current tag to the map
-      val newNamespaceMap: Map[String, Map[String, XMLTag]] = namespaceMap.get(tagname) match {
-        case Some(tagMap: Map[String, XMLTag]) =>
-          tagMap.get(classname) match {
-            case Some(_) => throw BadRequestException("Duplicate tag and classname combination in the same namespace")
-            case None    =>
-              // create the definition for the current element
-              val xmlElementDef = XMLTag(
-                name = tagname,
-                mapping = XMLTagToStandoffClass(
-                  standoffClassIri = standoffClassIri,
-                  attributesToProps = attributes,
-                  dataType = dataTypeOption,
-                ),
-                separatorRequired = curEle.separatorRequired,
-              )
-
-              // combine the definition for the this classname with the existing definitions beloning to the same element
-              val combinedClassDef: Map[String, XMLTag] = namespaceMap(tagname) + (classname -> xmlElementDef)
-
-              // combine all elements for this namespace
-              namespaceMap + (tagname -> combinedClassDef)
-
-          }
-        case None =>
-          namespaceMap + (tagname -> Map(
-            classname -> XMLTag(
-              name = tagname,
-              mapping = XMLTagToStandoffClass(
-                standoffClassIri = standoffClassIri,
-                attributesToProps = attributes,
-                dataType = dataTypeOption,
-              ),
-              separatorRequired = curEle.separatorRequired,
-            ),
-          ))
-      }
-
-      // recreate the whole structure for all namespaces
-      MappingXMLtoStandoff(
-        namespace = acc.namespace + (namespace -> newNamespaceMap),
-        defaultXSLTransformation = defaultXSLTransformation,
-      )
-
-    }
-
-    // invert mapping in order to run checks for duplicate use of
-    // standoff class Iris and property Iris in the attributes for a standoff class
-    StandoffTagUtilV2.invertXMLToStandoffMapping(mappingXMLToStandoff)
-
-    mappingXMLToStandoff
-
-  }
-
-  /**
-   * Gets a mapping either from the cache or by making a request to the triplestore.
-   *
-   * @param mappingIri           the IRI of the mapping to retrieve.
-   * @return a [[MappingXMLtoStandoff]].
-   */
-  def getMappingV2(mappingIri: IRI): Task[GetMappingResponseV2] = {
-
-    val mappingFuture: Task[GetMappingResponseV2] =
-      mappingCache.get(mappingIri) match {
-        case Some(mapping: MappingXMLtoStandoff) =>
-          for {
-            entities <- getStandoffEntitiesFromMappingV2(mapping)
-          } yield GetMappingResponseV2(
-            mappingIri = mappingIri,
-            mapping = mapping,
-            standoffEntities = entities,
-          )
-
-        case None =>
-          for {
-            mapping  <- getMappingFromTriplestore(mappingIri = mappingIri)
-            entities <- getStandoffEntitiesFromMappingV2(mapping)
-          } yield GetMappingResponseV2(
-            mappingIri = mappingIri,
-            mapping = mapping,
-            standoffEntities = entities,
-          )
-      }
-
-    val mappingRecovered: Task[GetMappingResponseV2] = mappingFuture.mapError { case e: Exception =>
-      BadRequestException(s"An error occurred when requesting mapping $mappingIri: ${e.getMessage}")
-    }
-
-    for {
-      mapping <- mappingRecovered
-    } yield mapping
-
-  }
-
-  /**
-   * Gets a mapping from the triplestore.
-   *
-   * @param mappingIri           the IRI of the mapping to retrieve.
-   * @return a [[MappingXMLtoStandoff]].
-   */
-  private def getMappingFromTriplestore(mappingIri: IRI) =
-    for {
-      mappingResponse <- triplestore.query(Construct(GetMappingQuery.build(mappingIri)))
-
-      // if the result is empty, the mapping does not exist
-      _ = if (mappingResponse.statements.isEmpty) {
-            throw BadRequestException(s"mapping $mappingIri does not exist in triplestore")
-          }
-
-      // separate MappingElements from other statements (attributes and datatypes)
-      (mappingElementStatements, otherStatements) =
-        mappingResponse.statements.partition { case (_: IRI, assertions: Seq[(IRI, String)]) =>
-          assertions.contains((OntologyConstants.Rdf.Type, OntologyConstants.KnoraBase.MappingElement))
-        }
-
-      mappingElements =
-        mappingElementStatements.map { case (subjectIri: IRI, assertions: Seq[(IRI, String)]) =>
-          // for convenience (works only for props with cardinality one)
-          val assertionsAsMap: Map[IRI, String] = assertions.toMap
-
-          // check for attributes
-          val attributes: Seq[MappingXMLAttribute] = assertions.filter { case (propIri, _) =>
-            propIri == OntologyConstants.KnoraBase.MappingHasXMLAttribute
-          }.map { case (_: IRI, attributeElementIri: String) =>
-            val attributeStatementsAsMap: Map[IRI, String] =
-              otherStatements(attributeElementIri).toMap
-
-            MappingXMLAttribute(
-              attributeName = attributeStatementsAsMap(
-                OntologyConstants.KnoraBase.MappingHasXMLAttributename,
-              ),
-              namespace = attributeStatementsAsMap(
-                OntologyConstants.KnoraBase.MappingHasXMLNamespace,
-              ),
-              standoffProperty = attributeStatementsAsMap(
-                OntologyConstants.KnoraBase.MappingHasStandoffProperty,
-              ),
-              mappingXMLAttributeElementIri = attributeElementIri,
-            )
-          }
-
-          // check for standoff data type class
-          val dataTypeOption: Option[IRI] =
-            assertionsAsMap.get(
-              OntologyConstants.KnoraBase.MappingHasStandoffDataTypeClass,
-            )
-
-          MappingElement(
-            tagName = assertionsAsMap(OntologyConstants.KnoraBase.MappingHasXMLTagname),
-            namespace = assertionsAsMap(
-              OntologyConstants.KnoraBase.MappingHasXMLNamespace,
-            ),
-            className = assertionsAsMap(OntologyConstants.KnoraBase.MappingHasXMLClass),
-            standoffClass = assertionsAsMap(
-              OntologyConstants.KnoraBase.MappingHasStandoffClass,
-            ),
-            mappingElementIri = subjectIri,
-            standoffDataTypeClass = dataTypeOption match {
-              case Some(dataTypeElementIri: IRI) =>
-                val dataTypeAssertionsAsMap: Map[IRI, String] =
-                  otherStatements(dataTypeElementIri).toMap
-
-                Some(
-                  MappingStandoffDatatypeClass(
-                    datatype = dataTypeAssertionsAsMap(
-                      OntologyConstants.KnoraBase.MappingHasStandoffClass,
-                    ),
-                    attributeName = dataTypeAssertionsAsMap(
-                      OntologyConstants.KnoraBase.MappingHasXMLAttributename,
-                    ),
-                    mappingStandoffDataTypeClassElementIri = dataTypeElementIri,
-                  ),
-                )
-              case None => None
-            },
-            attributes = attributes,
-            separatorRequired = assertionsAsMap(
-              OntologyConstants.KnoraBase.MappingElementRequiresSeparator,
-            ).toBoolean,
-          )
-
-        }.toSeq
-
-      // check if there is a default XSL transformation
-      defaultXSLTransformationOption =
-        otherStatements(mappingIri).find { case (pred: IRI, _: String) =>
-          pred == OntologyConstants.KnoraBase.MappingHasDefaultXSLTransformation
-        }.map { case (_: IRI, xslTransformationIri: IRI) =>
-          xslTransformationIri
-        }
-
-      mappingXMLToStandoff =
-        transformMappingElementsToMappingXMLtoStandoff(
-          mappingElements,
-          defaultXSLTransformationOption,
-        )
-
-      // add the mapping to the cache
-      _ = mappingCache.put(mappingIri, mappingXMLToStandoff)
-
-    } yield mappingXMLToStandoff
-
-  /**
-   * Gets the required standoff entities (classes and properties) from the mapping and requests information about these entities from the ontology responder.
-   *
-   * @param mappingXMLtoStandoff the mapping to be used.
-   * @return a [[StandoffEntityInfoGetResponseV2]] holding information about standoff classes and properties.
-   */
-  private def getStandoffEntitiesFromMappingV2(
-    mappingXMLtoStandoff: MappingXMLtoStandoff,
-  ): Task[StandoffEntityInfoGetResponseV2] = {
-
-    implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
-
-    // invert the mapping so standoff class Iris become keys
-    val mappingStandoffToXML: Map[IRI, XMLTagItem] = StandoffTagUtilV2.invertXMLToStandoffMapping(mappingXMLtoStandoff)
-
-    // collect standoff class Iris from the mapping
-    val standoffTagIrisFromMapping: Set[IRI] = mappingStandoffToXML.keySet
-
-    // collect all the standoff property Iris from the mapping
-    val standoffPropertyIrisFromMapping: Set[IRI] = mappingStandoffToXML.values.foldLeft(Set.empty[IRI]) {
-      (acc: Set[IRI], xmlTag: XMLTagItem) =>
-        acc ++ xmlTag.attributes.keySet
-    }
-
-    // make sure that the mapping does not contain system or data type standoff properties as attributes
-    // these standoff properties can only be used via the standoff base tag and standoff data type classes
-    val systemOrDatatypePropsAsAttr: Set[IRI] = standoffPropertyIrisFromMapping.intersect(
-      StandoffProperties.systemProperties ++ StandoffProperties.dataTypeProperties,
-    )
-    if (systemOrDatatypePropsAsAttr.nonEmpty)
-      throw InvalidStandoffException(
-        s"attempt to define attributes for system or data type properties: ${systemOrDatatypePropsAsAttr.mkString(", ")}",
-      )
-
-    for {
-
-      // request information about standoff classes that should be created
-      standoffClassEntities <-
-        ontologyResponder.getStandoffEntityInfoResponseV2(
-          standoffClassIris = standoffTagIrisFromMapping.map(_.toSmartIri),
-        )
-
-      // check that the ontology responder returned the information for all the standoff classes it was asked for
-      // if the ontology responder does not return a standoff class it was asked for, then this standoff class does not exist
-      _ = if (standoffTagIrisFromMapping.map(_.toSmartIri) != standoffClassEntities.standoffClassInfoMap.keySet) {
-            throw NotFoundException(
-              s"the ontology responder could not find information about these standoff classes: ${(standoffTagIrisFromMapping
-                  .map(_.toSmartIri) -- standoffClassEntities.standoffClassInfoMap.keySet).mkString(", ")}",
-            )
-          }
-
-      // get the property Iris that are defined on the standoff classes returned by the ontology responder
-      standoffPropertyIrisFromOntologyResponder: Set[SmartIri] =
-        standoffClassEntities.standoffClassInfoMap.foldLeft(
-          Set.empty[SmartIri],
-        ) { case (acc, (_, standoffClassEntity: ReadClassInfoV2)) =>
-          val props = standoffClassEntity.allCardinalities.keySet
-          acc ++ props
-        }
-
-      // request information about the standoff properties
-      standoffPropertyEntities <-
-        ontologyResponder.getStandoffEntityInfoResponseV2(
-          standoffPropertyIris = standoffPropertyIrisFromOntologyResponder,
-        )
-
-      // check that the ontology responder returned the information for all the standoff properties it was asked for
-      // if the ontology responder does not return a standoff property it was asked for, then this standoff property does not exist
-      propertyDefinitionsFromMappingFoundInOntology: Set[SmartIri] =
-        standoffPropertyEntities.standoffPropertyInfoMap.keySet
-          .intersect(standoffPropertyIrisFromMapping.map(_.toSmartIri))
-
-      _ <-
-        ZIO.fail {
-          NotFoundException(
-            s"the ontology responder could not find information about these standoff properties: " +
-              s"${(standoffPropertyIrisFromMapping.map(_.toSmartIri) -- propertyDefinitionsFromMappingFoundInOntology)
-                  .mkString(", ")}",
-          )
-        }.when(standoffPropertyIrisFromMapping.map(_.toSmartIri) != propertyDefinitionsFromMappingFoundInOntology)
-
-      // check that for each standoff property defined in the mapping element for a standoff class, a corresponding cardinality exists in the ontology
-      _ <- ZIO.attempt {
-             mappingStandoffToXML.foreach { case (standoffClass: IRI, xmlTag: XMLTagItem) =>
-               // collect all the standoff properties defined for this standoff class
-               val standoffPropertiesForStandoffClass: Set[SmartIri] = xmlTag.attributes.keySet.map(_.toSmartIri)
-
-               // check that the current standoff class has cardinalities for all the properties defined
-               val cardinalitiesFound = standoffClassEntities
-                 .standoffClassInfoMap(standoffClass.toSmartIri)
-                 .allCardinalities
-                 .keySet
-                 .intersect(standoffPropertiesForStandoffClass)
-
-               if (standoffPropertiesForStandoffClass != cardinalitiesFound) {
-                 throw NotFoundException(
-                   s"the following standoff properties have no cardinality for $standoffClass: ${(standoffPropertiesForStandoffClass -- cardinalitiesFound)
-                       .mkString(", ")}",
-                 )
-               }
-
-               // collect the required standoff properties for the standoff class
-               val requiredPropsForClass: Set[SmartIri] = standoffClassEntities
-                 .standoffClassInfoMap(standoffClass.toSmartIri)
-                 .allCardinalities
-                 .filter { case (_: SmartIri, card: KnoraCardinalityInfo) =>
-                   card.cardinality == ExactlyOne || card.cardinality == AtLeastOne
-                 }
-                 .keySet -- StandoffProperties.systemProperties.map(
-                 _.toSmartIri,
-               ) -- StandoffProperties.dataTypeProperties
-                 .map(_.toSmartIri)
-
-               // check that all the required standoff properties exist in the mapping
-               if (standoffPropertiesForStandoffClass.intersect(requiredPropsForClass) != requiredPropsForClass) {
-                 throw NotFoundException(
-                   s"the following required standoff properties are not defined for the standoff class $standoffClass: ${(requiredPropsForClass -- standoffPropertiesForStandoffClass)
-                       .mkString(", ")}",
-                 )
-               }
-
-               // check if the standoff class's data type is correct in the mapping
-               standoffClassEntities.standoffClassInfoMap(standoffClass.toSmartIri).standoffDataType match {
-                 case Some(dataType: StandoffDataTypeClasses.Value) =>
-                   // check if this corresponds to the datatype in the mapping
-                   val dataTypeFromMapping: XMLStandoffDataTypeClass = xmlTag.tagItem.mapping.dataType.getOrElse(
-                     throw InvalidStandoffException(s"no data type provided for $standoffClass, but $dataType required"),
-                   )
-                   if (dataTypeFromMapping.standoffDataTypeClass != dataType) {
-                     throw InvalidStandoffException(
-                       s"wrong data type ${dataTypeFromMapping.standoffDataTypeClass} provided for $standoffClass, but $dataType required",
-                     )
-                   }
-                 case None =>
-                   if (xmlTag.tagItem.mapping.dataType.nonEmpty) {
-                     throw InvalidStandoffException(
-                       s"no data type expected for $standoffClass, but ${xmlTag.tagItem.mapping.dataType.get.standoffDataTypeClass} given",
-                     )
-                   }
-               }
-             }
-           }
-
-    } yield StandoffEntityInfoGetResponseV2(
-      standoffClassInfoMap = standoffClassEntities.standoffClassInfoMap,
-      standoffPropertyInfoMap = standoffPropertyEntities.standoffPropertyInfoMap,
-    )
-  }
 }
 
 object StandoffResponderV2 {
-  private val cachesLayer: URLayer[CacheManager, EhCache[String, String] & EhCache[String, MappingXMLtoStandoff]] =
-    ZLayer.fromZIO(ZIO.serviceWithZIO[CacheManager](_.createCache[String, String]("xsltCache"))) ++
-      ZLayer.fromZIO(
-        ZIO.serviceWithZIO[CacheManager](_.createCache[String, MappingXMLtoStandoff]("mappingCache")),
-      )
-
-  val layer = cachesLayer >>> ZLayer.derive[StandoffResponderV2].flatMap { env =>
-    ZLayer.fromZIO {
-      val handler = env.get[StandoffResponderV2]
-      ZIO.serviceWithZIO[MessageRelay](_.subscribe(handler))
-    }
-  }
+  val layer = ZLayer.derive[StandoffResponderV2]
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CreateResourceV2Handler.scala
@@ -39,6 +39,7 @@ import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.admin.model.*
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
@@ -557,7 +558,7 @@ final class CreateResourceV2Handler(
     maxStandoffStartIndex: Option[Int],
     textType: TextValueType,
     valueHasLanguage: Option[String],
-    mappingIri: String,
+    mappingIri: StandoffMappingIri,
   ): IO[StandoffInternalException, TypeSpecificValueInfo] =
     ZIO
       .whenCase(textType) {
@@ -572,13 +573,7 @@ final class CreateResourceV2Handler(
           .mapBoth(
             _ => StandoffInternalException("Max standoff start index not computed"),
             standoffStartIndex =>
-              FormattedTextValueInfo(
-                valueHasLanguage,
-                InternalIri(mappingIri),
-                standoffStartIndex,
-                standoffInfo,
-                textType,
-              ),
+              FormattedTextValueInfo(valueHasLanguage, mappingIri, standoffStartIndex, standoffInfo, textType),
           )
       }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/mapping/StandoffRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/mapping/StandoffRestService.scala
@@ -33,7 +33,7 @@ final class StandoffRestService(
                          .createMappingRequestMetadataV2(mappingForm)
                          .mapError(BadRequestException.apply)
       uuid     <- Random.nextUUID
-      result   <- standoffResponder.createMappingV2(createRequest, user, uuid)
+      result   <- standoffResponder.createMappingV2(createRequest, uuid)
       response <- renderer.render(result, opts)
     } yield response
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -19,7 +19,6 @@ import scala.jdk.CollectionConverters.*
 import scala.language.implicitConversions
 
 import org.knora.webapi.config.Sipi
-import org.knora.webapi.core.MessageRelay
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Complex as KA
 import org.knora.webapi.messages.OntologyConstants.KnoraApiV2Complex.*
 import org.knora.webapi.messages.OntologyConstants.Rdfs
@@ -48,13 +47,14 @@ import org.knora.webapi.slice.common.jena.ModelOps.*
 import org.knora.webapi.slice.common.jena.ResourceOps.*
 import org.knora.webapi.slice.common.jena.StatementOps.*
 import org.knora.webapi.slice.common.service.IriConverter
+import org.knora.webapi.slice.standoff.service.StandoffMappingService
 import org.knora.webapi.store.iiif.api.SipiService
 
 case class CreateMappingRequestV2(label: String, projectIri: ProjectIri, mappingName: String, xml: String)
 
 final case class ApiComplexV2JsonLdRequestParser(
   converter: IriConverter,
-  messageRelay: MessageRelay,
+  standoffMappingService: StandoffMappingService,
   sipiService: SipiService,
   projectService: ProjectService,
   userService: UserService,
@@ -573,7 +573,7 @@ final case class ApiComplexV2JsonLdRequestParser(
           case StillImageExternalFileValue => ZIO.fromEither(StillImageExternalFileValueContentV2.from(v.r))
           case StillImageFileValue         => withFileInfo(v, StillImageFileValueContentV2.from)
           case StillImageVectorFileValue   => withFileInfo(v, StillImageVectorFileValueContentV2.from)
-          case TextValue                   => TextValueContentV2.from(v.r).provide(ZLayer.succeed(messageRelay))
+          case TextValue                   => TextValueContentV2.from(v.r).provide(ZLayer.succeed(standoffMappingService))
           case TextFileValue               => withFileInfo(v, TextFileValueContentV2.from)
           case TimeValue                   => ZIO.fromEither(TimeValueContentV2.from(v.r))
           case UriValue                    => ZIO.fromEither(UriValueContentV2.from(v.r))

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/StandoffMappingElementIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/StandoffMappingElementIri.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import scala.util.matching.Regex
+
+import dsp.valueobjects.UuidUtil
+import org.knora.webapi.slice.common.Value.StringValue
+
+/**
+ * IRI of an element of a standoff (XML→standoff) mapping — for example a tag,
+ * an attribute, or a data type sub-node. Produced by
+ * [[StandoffMappingElementIri.makeNew]] and persisted as the subject of the
+ * mapping element triples. Has the form
+ * `<mappingIri>/elements/<base64uuid>` where `<mappingIri>` is a valid
+ * [[StandoffMappingIri]] and `<base64uuid>` is a 22-char URL-safe Base64
+ * encoding of a random UUID.
+ */
+final case class StandoffMappingElementIri private (override val value: String) extends StringValue
+
+object StandoffMappingElementIri extends StringValueCompanion[StandoffMappingElementIri] {
+
+  // Any non-empty path-segment characters after `/elements/`. In production the
+  // segment is a 22-char URL-safe Base64 encoded UUID (see `makeNew`), but
+  // mappings read back from the triplestore may carry legacy / hand-written
+  // segments containing additional `/`-separated path parts.
+  private val ElementSuffix: String = "[A-Za-z0-9_/-]+"
+
+  private val BuiltInElementIriRegex: Regex =
+    s"""^http://rdfh\\.ch/standoff/mappings/[A-Za-z0-9_-]+/elements/$ElementSuffix$$""".r
+
+  private val ProjectElementIriRegex: Regex =
+    s"""^http://rdfh\\.ch/projects/[a-zA-Z0-9_-]{4,40}/mappings/[A-Za-z0-9_-]+/elements/$ElementSuffix$$""".r
+
+  def from(value: String): Either[String, StandoffMappingElementIri] = value match {
+    case BuiltInElementIriRegex() | ProjectElementIriRegex() => Right(StandoffMappingElementIri(value))
+    case _                                                   => Left(s"<$value> is not a standoff mapping element IRI")
+  }
+
+  def makeNew(mappingIri: StandoffMappingIri): StandoffMappingElementIri =
+    StandoffMappingElementIri(s"$mappingIri/elements/${UuidUtil.makeRandomBase64EncodedUuid}")
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/StandoffMappingIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/StandoffMappingIri.scala
@@ -7,6 +7,7 @@ package org.knora.webapi.slice.common
 
 import scala.util.matching.Regex
 
+import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.common.Value.StringValue
 
@@ -36,6 +37,9 @@ object StandoffMappingIri extends StringValueCompanion[StandoffMappingIri] {
 
   private val ProjectMappingIriRegex: Regex =
     """^(http://rdfh\.ch/projects/[a-zA-Z0-9_-]{4,40})/mappings/([A-Za-z0-9_-]+)$""".r
+
+  val StandardMapping: StandoffMappingIri = StandoffMappingIri.unsafeFrom(OntologyConstants.KnoraBase.StandardMapping)
+  val TEIMapping: StandoffMappingIri      = StandoffMappingIri.unsafeFrom(OntologyConstants.KnoraBase.TEIMapping)
 
   def from(value: String): Either[String, StandoffMappingIri] = value match {
     case BuiltInMappingIriRegex(name) =>

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/StandoffMappingIri.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/StandoffMappingIri.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import scala.util.matching.Regex
+
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.common.Value.StringValue
+
+/**
+ * IRI of a standoff (XML→standoff) mapping.
+ *
+ * Two forms exist:
+ *   - project-scoped: `http://rdfh.ch/projects/<projectId>/mappings/<name>`,
+ *     created via `StringFormatter.makeProjectMappingIri`.
+ *   - built-in: `http://rdfh.ch/standoff/mappings/<name>` — the only instances
+ *     are `StandardMapping` and `TEIMapping` (see `OntologyConstants.KnoraBase`).
+ */
+final case class StandoffMappingIri private (
+  override val value: String,
+  projectIri: Option[ProjectIri],
+  mappingName: String,
+) extends StringValue {
+  def isBuiltIn: Boolean = projectIri.isEmpty
+}
+
+object StandoffMappingIri extends StringValueCompanion[StandoffMappingIri] {
+
+  private val MappingNameRegex: Regex = """[A-Za-z0-9_-]+""".r
+
+  private val BuiltInMappingIriRegex: Regex =
+    """^http://rdfh\.ch/standoff/mappings/([A-Za-z0-9_-]+)$""".r
+
+  private val ProjectMappingIriRegex: Regex =
+    """^(http://rdfh\.ch/projects/[a-zA-Z0-9_-]{4,40})/mappings/([A-Za-z0-9_-]+)$""".r
+
+  def from(value: String): Either[String, StandoffMappingIri] = value match {
+    case BuiltInMappingIriRegex(name) =>
+      Right(StandoffMappingIri(value, None, name))
+    case ProjectMappingIriRegex(projectIri, name) =>
+      // safe: the regex above already ensures the project IRI segment is well-formed
+      Right(StandoffMappingIri(value, Some(ProjectIri.unsafeFrom(projectIri)), name))
+    case _ =>
+      Left(s"<$value> is not a standoff mapping IRI")
+  }
+
+  def from(projectIri: ProjectIri, mappingName: String): Either[String, StandoffMappingIri] =
+    mappingName match {
+      case MappingNameRegex() => from(s"$projectIri/mappings/$mappingName")
+      case _                  => Left(s"<$mappingName> is not a valid mapping name")
+    }
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateNewMappingQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/CreateNewMappingQuery.scala
@@ -37,7 +37,7 @@ object CreateNewMappingQuery extends QueryBuilderHelper {
     }
 
     val elementPatterns: Seq[TriplePattern] = mappingElements.flatMap { ele =>
-      val eleIri = Rdf.iri(ele.mappingElementIri)
+      val eleIri = Rdf.iri(ele.mappingElementIri.value)
 
       val hasMappingEle = mappingIRI.has(KnoraBase.hasMappingElement, eleIri)
 
@@ -50,7 +50,7 @@ object CreateNewMappingQuery extends QueryBuilderHelper {
         .andHas(KnoraBase.mappingElementRequiresSeparator, ele.separatorRequired)
 
       val attrPatterns = ele.attributes.flatMap { attr =>
-        val attrIri = Rdf.iri(attr.mappingXMLAttributeElementIri)
+        val attrIri = Rdf.iri(attr.mappingXMLAttributeElementIri.value)
         Seq(
           eleIri.has(KnoraBase.mappingHasXMLAttribute, attrIri),
           attrIri
@@ -62,7 +62,7 @@ object CreateNewMappingQuery extends QueryBuilderHelper {
       }
 
       val dtcPatterns = ele.standoffDataTypeClass.toSeq.flatMap { dtc =>
-        val dtcIri = Rdf.iri(dtc.mappingStandoffDataTypeClassElementIri)
+        val dtcIri = Rdf.iri(dtc.mappingStandoffDataTypeClassElementIri.value)
         Seq(
           eleIri.has(KnoraBase.mappingHasStandoffDataTypeClass, dtcIri),
           dtcIri

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/model/Mapping.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/model/Mapping.scala
@@ -6,6 +6,7 @@
 package org.knora.webapi.slice.resources.repo.model
 
 import org.knora.webapi.IRI
+import org.knora.webapi.slice.common.StandoffMappingElementIri
 
 /**
  * Represents a standoff datatype class of an XML tag.
@@ -17,7 +18,7 @@ import org.knora.webapi.IRI
 case class MappingStandoffDatatypeClass(
   datatype: IRI,
   attributeName: String,
-  mappingStandoffDataTypeClassElementIri: IRI,
+  mappingStandoffDataTypeClassElementIri: StandoffMappingElementIri,
 )
 
 /**
@@ -32,7 +33,7 @@ case class MappingXMLAttribute(
   attributeName: String,
   namespace: String,
   standoffProperty: IRI,
-  mappingXMLAttributeElementIri: IRI,
+  mappingXMLAttributeElementIri: StandoffMappingElementIri,
 )
 
 /**
@@ -53,6 +54,6 @@ case class MappingElement(
   standoffClass: IRI,
   attributes: Seq[MappingXMLAttribute] = Seq.empty[MappingXMLAttribute],
   standoffDataTypeClass: Option[MappingStandoffDatatypeClass] = None,
-  mappingElementIri: IRI,
+  mappingElementIri: StandoffMappingElementIri,
   separatorRequired: Boolean,
 )

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/model/ResourceCreateModels.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/model/ResourceCreateModels.scala
@@ -12,6 +12,7 @@ import org.knora.webapi.messages.util.CalendarNameV2
 import org.knora.webapi.messages.util.DatePrecisionV2
 import org.knora.webapi.messages.v2.responder.valuemessages.FileValueV2
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.domain.InternalIri
 
 final case class ResourceReadyToCreate(
@@ -53,7 +54,7 @@ enum TypeSpecificValueInfo {
   case UnformattedTextValueInfo(valueHasLanguage: Option[String])
   case FormattedTextValueInfo(
     valueHasLanguage: Option[String],
-    mappingIri: InternalIri,
+    mappingIri: StandoffMappingIri,
     maxStandoffStartIndex: Int,
     standoff: Seq[StandoffTagInfo],
     textValueType: FormattedTextValueType,

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceLive.scala
@@ -132,7 +132,7 @@ final case class ReadResourcesServiceLive(
 
       mappings <-
         ZIO.when(queryStandoff) {
-          constructResponseUtilV2.mappingsFromQueryResults(resourcesWithValues.resources, requestingUser)
+          constructResponseUtilV2.mappingsFromQueryResults(resourcesWithValues.resources)
         }
 
       readSequence <-

--- a/webapi/src/main/scala/org/knora/webapi/slice/standoff/repo/GetXslTransformationMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/standoff/repo/GetXslTransformationMetadataQuery.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.standoff.repo
+
+import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
+import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
+
+import org.knora.webapi.IRI
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
+
+/**
+ * Builds a SELECT query that returns the metadata of a `knora-base:XSLTransformation`
+ * resource needed to construct its Sipi file URL: the resource class, the file
+ * value IRI, the internal filename and MIME type, and the project IRI.
+ *
+ * Used by `StandoffMappingService.getXSLTransformation` instead of a full
+ * `ReadResourcesService` round-trip — the latter would form a layer cycle
+ * through `ConstructResponseUtilV2`.
+ */
+object GetXslTransformationMetadataQuery extends QueryBuilderHelper {
+
+  val resourceClass: String    = "resourceClass"
+  val fileValueIri: String     = "fileValueIri"
+  val internalFilename: String = "internalFilename"
+  val internalMimeType: String = "internalMimeType"
+  val projectIri: String       = "projectIri"
+
+  def build(xslIri: IRI): SelectQuery = {
+    val res                 = Rdf.iri(xslIri)
+    val resourceClassVar    = variable(resourceClass)
+    val fileValueIriVar     = variable(fileValueIri)
+    val internalFilenameVar = variable(internalFilename)
+    val internalMimeTypeVar = variable(internalMimeType)
+    val projectIriVar       = variable(projectIri)
+    val hasTextFileValue    = Rdf.iri(OntologyConstants.KnoraBase.HasTextFileValue)
+    val rdfType             = Rdf.iri(RDF.TYPE.stringValue)
+
+    Queries
+      .SELECT(
+        resourceClassVar,
+        fileValueIriVar,
+        internalFilenameVar,
+        internalMimeTypeVar,
+        projectIriVar,
+      )
+      .where(
+        res
+          .has(rdfType, resourceClassVar)
+          .andHas(KnoraBase.attachedToProject, projectIriVar)
+          .andHas(hasTextFileValue, fileValueIriVar),
+        fileValueIriVar
+          .has(KnoraBase.internalFilename, internalFilenameVar)
+          .andHas(KnoraBase.internalMimeType, internalMimeTypeVar),
+      )
+      .prefix(KnoraBase.NS, RDF.NS)
+  }
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/standoff/service/StandoffMappingService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/standoff/service/StandoffMappingService.scala
@@ -1,0 +1,458 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.standoff.service
+
+import zio.*
+
+import dsp.errors.*
+import org.knora.webapi.*
+import org.knora.webapi.config.AppConfig
+import org.knora.webapi.messages.IriConversions.*
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
+import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2.XMLTagItem
+import org.knora.webapi.messages.v2.responder.ontologymessages.OwlCardinality.*
+import org.knora.webapi.messages.v2.responder.ontologymessages.ReadClassInfoV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.StandoffEntityInfoGetResponseV2
+import org.knora.webapi.messages.v2.responder.standoffmessages.*
+import org.knora.webapi.responders.v2.OntologyResponderV2
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
+import org.knora.webapi.slice.common.StandoffMappingElementIri
+import org.knora.webapi.slice.common.StandoffMappingIri
+import org.knora.webapi.slice.infrastructure.CacheManager
+import org.knora.webapi.slice.infrastructure.EhCache
+import org.knora.webapi.slice.ontology.domain.model.Cardinality.AtLeastOne
+import org.knora.webapi.slice.ontology.domain.model.Cardinality.ExactlyOne
+import org.knora.webapi.slice.resources.repo.GetMappingQuery
+import org.knora.webapi.slice.resources.repo.model.MappingElement
+import org.knora.webapi.slice.resources.repo.model.MappingStandoffDatatypeClass
+import org.knora.webapi.slice.resources.repo.model.MappingXMLAttribute
+import org.knora.webapi.slice.standoff.repo.GetXslTransformationMetadataQuery
+import org.knora.webapi.store.iiif.api.SipiService
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
+
+/**
+ * Looks up XML→standoff mappings and the XSL transformations they reference.
+ *
+ * Extracted from `StandoffResponderV2` so that callers can invoke these read
+ * operations directly instead of via `MessageRelay`. Mapping creation
+ * (`createMappingV2`) remains on `StandoffResponderV2` and uses this service
+ * for the XSL transformation lookup it needs internally.
+ */
+trait StandoffMappingService {
+
+  /**
+   * Loads a mapping from the cache or, on miss, from the triplestore. Validates
+   * the standoff classes/properties referenced by the mapping against the
+   * ontology.
+   */
+  def getMappingV2(mappingIri: StandoffMappingIri): Task[GetMappingResponseV2]
+
+  /**
+   * Resolves the URL of the XSL transformation file in Sipi and fetches its
+   * contents (cached after the first request).
+   */
+  def getXSLTransformation(xslTransformationIri: IRI): Task[String]
+
+  /**
+   * Validates the standoff classes/properties referenced by `mappingXMLtoStandoff`
+   * against the ontology and returns the resolved entities. Used by mapping
+   * creation to fail fast before persisting an invalid mapping.
+   */
+  def getStandoffEntitiesFromMappingV2(
+    mappingXMLtoStandoff: MappingXMLtoStandoff,
+  ): Task[StandoffEntityInfoGetResponseV2]
+}
+
+final class StandoffMappingServiceLive(
+  appConfig: AppConfig,
+  triplestore: TriplestoreService,
+  ontologyResponder: OntologyResponderV2,
+  sipiService: SipiService,
+  projectService: KnoraProjectService,
+  xsltCache: EhCache[String, String],
+  mappingCache: EhCache[String, MappingXMLtoStandoff],
+) extends StandoffMappingService {
+
+  private val xmlMimeTypes = Set("text/xml", "application/xml", "application/xslt+xml")
+
+  override def getMappingV2(mappingIri: StandoffMappingIri): Task[GetMappingResponseV2] = {
+    val mapping: Task[GetMappingResponseV2] =
+      mappingCache.get(mappingIri.value) match {
+        case Some(m) => getStandoffEntitiesFromMappingV2(m).map(GetMappingResponseV2(mappingIri, m, _))
+        case None    =>
+          for {
+            m        <- getMappingFromTriplestore(mappingIri)
+            entities <- getStandoffEntitiesFromMappingV2(m)
+          } yield GetMappingResponseV2(mappingIri, m, entities)
+      }
+    mapping.mapError { case e: Exception =>
+      BadRequestException(s"An error occurred when requesting mapping $mappingIri: ${e.getMessage}")
+    }
+  }
+
+  override def getXSLTransformation(
+    xslTransformationIri: IRI,
+  ): Task[String] = {
+    val Q       = GetXslTransformationMetadataQuery
+    val xsltUrl = (for {
+      result <- triplestore.select(Q.build(xslTransformationIri))
+
+      row <- result.results.bindings match {
+               case head +: Nil => ZIO.succeed(head.rowMap)
+               case Nil         =>
+                 ZIO.fail(NotFoundException(s"XSL transformation $xslTransformationIri not found"))
+               case _ =>
+                 ZIO.fail(
+                   InconsistentRepositoryDataException(
+                     s"${OntologyConstants.KnoraBase.XSLTransformation} $xslTransformationIri is supposed to have exactly one value of type ${OntologyConstants.KnoraBase.TextFileValue}",
+                   ),
+                 )
+             }
+
+      _ <- ZIO
+             .fail(
+               BadRequestException(
+                 s"Resource $xslTransformationIri is not a ${OntologyConstants.KnoraBase.XSLTransformation}",
+               ),
+             )
+             .when(row(Q.resourceClass) != OntologyConstants.KnoraBase.XSLTransformation)
+
+      mimeType     = row(Q.internalMimeType)
+      fileValueIri = row(Q.fileValueIri)
+      _           <-
+        ZIO
+          .fail(
+            BadRequestException(
+              s"Expected $fileValueIri to be an XML file referring to an XSL transformation, but it has MIME type $mimeType",
+            ),
+          )
+          .when(!xmlMimeTypes.contains(mimeType))
+
+      projectIri <- ZIO.fromEither(ProjectIri.from(row(Q.projectIri))).mapError(BadRequestException.apply)
+      project    <- projectService
+                   .findById(projectIri)
+                   .someOrFail(InconsistentRepositoryDataException(s"Project $projectIri not found"))
+    } yield s"${appConfig.sipi.internalBaseUrl}/${project.shortcode.value}/${row(Q.internalFilename)}/file").mapError {
+      case notFound: NotFoundException =>
+        BadRequestException(s"XSL transformation $xslTransformationIri not found: ${notFound.message}")
+    }
+
+    for {
+      url  <- xsltUrl
+      xslt <- xsltCache.get(url) match {
+                case Some(cached) => ZIO.succeed(cached)
+                case None         =>
+                  sipiService
+                    .getTextFileRequest(url, this.getClass.getName)
+                    .tap(c => ZIO.succeed(xsltCache.put(url, c)))
+              }
+    } yield xslt
+  }
+
+  /**
+   * Reads a mapping from the triplestore and parses it into a `MappingXMLtoStandoff`.
+   * Caches the result.
+   */
+  private def getMappingFromTriplestore(mappingIri: StandoffMappingIri): Task[MappingXMLtoStandoff] =
+    for {
+      mappingResponse <- triplestore.query(Construct(GetMappingQuery.build(mappingIri.value)))
+
+      _ = if (mappingResponse.statements.isEmpty) {
+            throw BadRequestException(s"mapping $mappingIri does not exist in triplestore")
+          }
+
+      (mappingElementStatements, otherStatements) =
+        mappingResponse.statements.partition { case (_: IRI, assertions: Seq[(IRI, String)]) =>
+          assertions.contains((OntologyConstants.Rdf.Type, OntologyConstants.KnoraBase.MappingElement))
+        }
+
+      mappingElements =
+        mappingElementStatements.map { case (subjectIri: IRI, assertions: Seq[(IRI, String)]) =>
+          val assertionsAsMap: Map[IRI, String] = assertions.toMap
+
+          val attributes: Seq[MappingXMLAttribute] = assertions.filter { case (propIri, _) =>
+            propIri == OntologyConstants.KnoraBase.MappingHasXMLAttribute
+          }.map { case (_: IRI, attributeElementIri: String) =>
+            val attributeStatementsAsMap: Map[IRI, String] = otherStatements(attributeElementIri).toMap
+            MappingXMLAttribute(
+              attributeName = attributeStatementsAsMap(OntologyConstants.KnoraBase.MappingHasXMLAttributename),
+              namespace = attributeStatementsAsMap(OntologyConstants.KnoraBase.MappingHasXMLNamespace),
+              standoffProperty = attributeStatementsAsMap(OntologyConstants.KnoraBase.MappingHasStandoffProperty),
+              mappingXMLAttributeElementIri = StandoffMappingElementIri.unsafeFrom(attributeElementIri),
+            )
+          }
+
+          val dataTypeOption: Option[IRI] =
+            assertionsAsMap.get(OntologyConstants.KnoraBase.MappingHasStandoffDataTypeClass)
+
+          MappingElement(
+            tagName = assertionsAsMap(OntologyConstants.KnoraBase.MappingHasXMLTagname),
+            namespace = assertionsAsMap(OntologyConstants.KnoraBase.MappingHasXMLNamespace),
+            className = assertionsAsMap(OntologyConstants.KnoraBase.MappingHasXMLClass),
+            standoffClass = assertionsAsMap(OntologyConstants.KnoraBase.MappingHasStandoffClass),
+            mappingElementIri = StandoffMappingElementIri.unsafeFrom(subjectIri),
+            standoffDataTypeClass = dataTypeOption match {
+              case Some(dataTypeElementIri: IRI) =>
+                val dataTypeAssertionsAsMap: Map[IRI, String] = otherStatements(dataTypeElementIri).toMap
+                Some(
+                  MappingStandoffDatatypeClass(
+                    datatype = dataTypeAssertionsAsMap(OntologyConstants.KnoraBase.MappingHasStandoffClass),
+                    attributeName = dataTypeAssertionsAsMap(OntologyConstants.KnoraBase.MappingHasXMLAttributename),
+                    mappingStandoffDataTypeClassElementIri = StandoffMappingElementIri.unsafeFrom(dataTypeElementIri),
+                  ),
+                )
+              case None => None
+            },
+            attributes = attributes,
+            separatorRequired = assertionsAsMap(OntologyConstants.KnoraBase.MappingElementRequiresSeparator).toBoolean,
+          )
+        }.toSeq
+
+      defaultXSLTransformationOption =
+        otherStatements(mappingIri.value).find { case (pred: IRI, _: String) =>
+          pred == OntologyConstants.KnoraBase.MappingHasDefaultXSLTransformation
+        }.map { case (_: IRI, xslTransformationIri: IRI) => xslTransformationIri }
+
+      mappingXMLToStandoff =
+        StandoffMappingService.transformMappingElementsToMappingXMLtoStandoff(
+          mappingElements,
+          defaultXSLTransformationOption,
+        )
+
+      _ = mappingCache.put(mappingIri.value, mappingXMLToStandoff)
+    } yield mappingXMLToStandoff
+
+  override def getStandoffEntitiesFromMappingV2(
+    mappingXMLtoStandoff: MappingXMLtoStandoff,
+  ): Task[StandoffEntityInfoGetResponseV2] = {
+    implicit val sf: StringFormatter = StringFormatter.getGeneralInstance
+
+    val mappingStandoffToXML: Map[IRI, XMLTagItem] = StandoffTagUtilV2.invertXMLToStandoffMapping(mappingXMLtoStandoff)
+    val standoffTagIrisFromMapping: Set[IRI]       = mappingStandoffToXML.keySet
+    val standoffPropertyIrisFromMapping: Set[IRI]  = mappingStandoffToXML.values.foldLeft(Set.empty[IRI]) {
+      (acc, xmlTag) => acc ++ xmlTag.attributes.keySet
+    }
+
+    val systemOrDatatypePropsAsAttr: Set[IRI] = standoffPropertyIrisFromMapping.intersect(
+      StandoffProperties.systemProperties ++ StandoffProperties.dataTypeProperties,
+    )
+    if (systemOrDatatypePropsAsAttr.nonEmpty)
+      throw InvalidStandoffException(
+        s"attempt to define attributes for system or data type properties: ${systemOrDatatypePropsAsAttr.mkString(", ")}",
+      )
+
+    for {
+      standoffClassEntities <- ontologyResponder.getStandoffEntityInfoResponseV2(
+                                 standoffClassIris = standoffTagIrisFromMapping.map(_.toSmartIri),
+                               )
+
+      _ = if (standoffTagIrisFromMapping.map(_.toSmartIri) != standoffClassEntities.standoffClassInfoMap.keySet) {
+            throw NotFoundException(
+              s"the ontology responder could not find information about these standoff classes: ${(standoffTagIrisFromMapping
+                  .map(_.toSmartIri) -- standoffClassEntities.standoffClassInfoMap.keySet).mkString(", ")}",
+            )
+          }
+
+      standoffPropertyIrisFromOntologyResponder: Set[SmartIri] =
+        standoffClassEntities.standoffClassInfoMap.foldLeft(Set.empty[SmartIri]) {
+          case (acc, (_, standoffClassEntity: ReadClassInfoV2)) =>
+            acc ++ standoffClassEntity.allCardinalities.keySet
+        }
+
+      standoffPropertyEntities <- ontologyResponder.getStandoffEntityInfoResponseV2(
+                                    standoffPropertyIris = standoffPropertyIrisFromOntologyResponder,
+                                  )
+
+      propertyDefinitionsFromMappingFoundInOntology: Set[SmartIri] =
+        standoffPropertyEntities.standoffPropertyInfoMap.keySet
+          .intersect(standoffPropertyIrisFromMapping.map(_.toSmartIri))
+
+      _ <-
+        ZIO.fail {
+          NotFoundException(
+            s"the ontology responder could not find information about these standoff properties: " +
+              s"${(standoffPropertyIrisFromMapping.map(_.toSmartIri) -- propertyDefinitionsFromMappingFoundInOntology)
+                  .mkString(", ")}",
+          )
+        }.when(standoffPropertyIrisFromMapping.map(_.toSmartIri) != propertyDefinitionsFromMappingFoundInOntology)
+
+      _ <- ZIO.attempt {
+             mappingStandoffToXML.foreach { case (standoffClass: IRI, xmlTag: XMLTagItem) =>
+               val standoffPropertiesForStandoffClass: Set[SmartIri] = xmlTag.attributes.keySet.map(_.toSmartIri)
+
+               val cardinalitiesFound = standoffClassEntities
+                 .standoffClassInfoMap(standoffClass.toSmartIri)
+                 .allCardinalities
+                 .keySet
+                 .intersect(standoffPropertiesForStandoffClass)
+
+               if (standoffPropertiesForStandoffClass != cardinalitiesFound) {
+                 throw NotFoundException(
+                   s"the following standoff properties have no cardinality for $standoffClass: ${(standoffPropertiesForStandoffClass -- cardinalitiesFound)
+                       .mkString(", ")}",
+                 )
+               }
+
+               val requiredPropsForClass: Set[SmartIri] = standoffClassEntities
+                 .standoffClassInfoMap(standoffClass.toSmartIri)
+                 .allCardinalities
+                 .filter { case (_: SmartIri, card: KnoraCardinalityInfo) =>
+                   card.cardinality == ExactlyOne || card.cardinality == AtLeastOne
+                 }
+                 .keySet -- StandoffProperties.systemProperties.map(
+                 _.toSmartIri,
+               ) -- StandoffProperties.dataTypeProperties.map(_.toSmartIri)
+
+               if (standoffPropertiesForStandoffClass.intersect(requiredPropsForClass) != requiredPropsForClass) {
+                 throw NotFoundException(
+                   s"the following required standoff properties are not defined for the standoff class $standoffClass: ${(requiredPropsForClass -- standoffPropertiesForStandoffClass)
+                       .mkString(", ")}",
+                 )
+               }
+
+               standoffClassEntities.standoffClassInfoMap(standoffClass.toSmartIri).standoffDataType match {
+                 case Some(dataType: StandoffDataTypeClasses.Value) =>
+                   val dataTypeFromMapping: XMLStandoffDataTypeClass = xmlTag.tagItem.mapping.dataType.getOrElse(
+                     throw InvalidStandoffException(s"no data type provided for $standoffClass, but $dataType required"),
+                   )
+                   if (dataTypeFromMapping.standoffDataTypeClass != dataType) {
+                     throw InvalidStandoffException(
+                       s"wrong data type ${dataTypeFromMapping.standoffDataTypeClass} provided for $standoffClass, but $dataType required",
+                     )
+                   }
+                 case None =>
+                   if (xmlTag.tagItem.mapping.dataType.nonEmpty) {
+                     throw InvalidStandoffException(
+                       s"no data type expected for $standoffClass, but ${xmlTag.tagItem.mapping.dataType.get.standoffDataTypeClass} given",
+                     )
+                   }
+               }
+             }
+           }
+    } yield StandoffEntityInfoGetResponseV2(
+      standoffClassInfoMap = standoffClassEntities.standoffClassInfoMap,
+      standoffPropertyInfoMap = standoffPropertyEntities.standoffPropertyInfoMap,
+    )
+  }
+}
+
+object StandoffMappingService {
+
+  /**
+   * Pure transformation used both during mapping creation (in
+   * `StandoffResponderV2.createMappingV2`) and when reading a mapping back from
+   * the triplestore.
+   */
+  def transformMappingElementsToMappingXMLtoStandoff(
+    mappingElements: Seq[MappingElement],
+    defaultXSLTransformation: Option[IRI],
+  ): MappingXMLtoStandoff = {
+    val mappingXMLToStandoff = mappingElements.foldLeft(
+      MappingXMLtoStandoff(
+        namespace = Map.empty[String, Map[String, Map[String, XMLTag]]],
+        defaultXSLTransformation = None,
+      ),
+    ) { case (acc, curEle) =>
+      val tagname   = curEle.tagName
+      val namespace = curEle.namespace
+      val classname = curEle.className
+
+      val namespaceMap: Map[String, Map[String, XMLTag]] =
+        acc.namespace.getOrElse(namespace, Map.empty[String, Map[String, XMLTag]])
+
+      val standoffClassIri = curEle.standoffClass
+
+      val attributeNodes: Seq[MappingXMLAttribute]                         = curEle.attributes
+      val attributeNodesByNamespace: Map[String, Seq[MappingXMLAttribute]] = attributeNodes.groupBy(_.namespace)
+
+      val attributes: Map[String, Map[String, IRI]] = attributeNodesByNamespace.map { case (ns, attrNodes) =>
+        val attributesInNamespace: Map[String, IRI] = attrNodes.foldLeft(Map.empty[String, IRI]) {
+          case (acc, attrEle) =>
+            val attrName = attrEle.attributeName
+            if (acc.contains(attrName)) {
+              throw BadRequestException("Duplicate attribute name in namespace")
+            }
+            acc + (attrName -> attrEle.standoffProperty)
+        }
+        ns -> attributesInNamespace
+      }
+
+      val dataTypeOption: Option[XMLStandoffDataTypeClass] = curEle.standoffDataTypeClass match {
+        case Some(dataTypeClass: MappingStandoffDatatypeClass) =>
+          val dataType = StandoffDataTypeClasses.lookup(
+            dataTypeClass.datatype,
+            throw BadRequestException(s"Invalid data type provided for $tagname"),
+          )
+          Some(
+            XMLStandoffDataTypeClass(
+              standoffDataTypeClass = dataType,
+              dataTypeXMLAttribute = dataTypeClass.attributeName,
+            ),
+          )
+        case None => None
+      }
+
+      val newNamespaceMap: Map[String, Map[String, XMLTag]] = namespaceMap.get(tagname) match {
+        case Some(tagMap: Map[String, XMLTag]) =>
+          tagMap.get(classname) match {
+            case Some(_) => throw BadRequestException("Duplicate tag and classname combination in the same namespace")
+            case None    =>
+              val xmlElementDef = XMLTag(
+                name = tagname,
+                mapping = XMLTagToStandoffClass(
+                  standoffClassIri = standoffClassIri,
+                  attributesToProps = attributes,
+                  dataType = dataTypeOption,
+                ),
+                separatorRequired = curEle.separatorRequired,
+              )
+              val combinedClassDef: Map[String, XMLTag] = namespaceMap(tagname) + (classname -> xmlElementDef)
+              namespaceMap + (tagname -> combinedClassDef)
+          }
+        case None =>
+          namespaceMap + (tagname -> Map(
+            classname -> XMLTag(
+              name = tagname,
+              mapping = XMLTagToStandoffClass(
+                standoffClassIri = standoffClassIri,
+                attributesToProps = attributes,
+                dataType = dataTypeOption,
+              ),
+              separatorRequired = curEle.separatorRequired,
+            ),
+          ))
+      }
+
+      MappingXMLtoStandoff(
+        namespace = acc.namespace + (namespace -> newNamespaceMap),
+        defaultXSLTransformation = defaultXSLTransformation,
+      )
+    }
+
+    // run inversion checks for duplicate use of standoff class IRIs and property IRIs
+    StandoffTagUtilV2.invertXMLToStandoffMapping(mappingXMLToStandoff)
+    mappingXMLToStandoff
+  }
+}
+
+object StandoffMappingServiceLive {
+  private val cachesLayer: URLayer[CacheManager, EhCache[String, String] & EhCache[String, MappingXMLtoStandoff]] =
+    ZLayer.fromZIO(ZIO.serviceWithZIO[CacheManager](_.createCache[String, String]("xsltCache"))) ++
+      ZLayer.fromZIO(
+        ZIO.serviceWithZIO[CacheManager](_.createCache[String, MappingXMLtoStandoff]("mappingCache")),
+      )
+
+  val layer: URLayer[
+    AppConfig & TriplestoreService & OntologyResponderV2 & SipiService & KnoraProjectService & CacheManager,
+    StandoffMappingService,
+  ] =
+    cachesLayer >>> ZLayer.derive[StandoffMappingServiceLive]
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
@@ -16,7 +16,6 @@ import java.time.Instant
 
 import org.knora.webapi.ApiV2Complex
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageRelayLive
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.CalendarNameGregorian
@@ -57,6 +56,7 @@ import org.knora.webapi.slice.common.JsonLdTestUtil.JsonLdTransformations
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoInMemory
 import org.knora.webapi.slice.resources.IiifImageRequestUrl
+import org.knora.webapi.slice.standoff.service.StandoffMappingServiceFake
 import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
 import org.knora.webapi.store.iiif.impl.SipiServiceMock
 import org.knora.webapi.store.iiif.impl.SipiServiceMock.SipiMockMethodName.GetFileMetadataFromDspIngest
@@ -865,7 +865,7 @@ object ApiComplexV2JsonLdRequestParserSpec extends ZIOSpecDefault {
     KnoraUserService.layer,
     KnoraUserToUserConverter.layer,
     LicenseRepo.layer,
-    MessageRelayLive.layer,
+    StandoffMappingServiceFake.layer,
     OntologyRepoInMemory.emptyLayer,
     PasswordService.layer,
     ProjectService.layer,

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/StandoffMappingIriSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/StandoffMappingIriSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.common
+
+import zio.test.*
+
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+
+object StandoffMappingIriSpec extends ZIOSpecDefault {
+
+  private val projectIri        = ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001")
+  private val projectMappingIri = "http://rdfh.ch/projects/0001/mappings/MyMapping"
+  private val standardMapping   = "http://rdfh.ch/standoff/mappings/StandardMapping"
+  private val teiMapping        = "http://rdfh.ch/standoff/mappings/TEIMapping"
+
+  val spec = suite("StandoffMappingIri")(
+    suite("from(String)")(
+      test("should return a StandoffMappingIri for a project-scoped IRI") {
+        val actual = StandoffMappingIri.from(projectMappingIri)
+        assertTrue(
+          actual.isRight,
+          actual.toOption.get.value == projectMappingIri,
+          actual.toOption.get.projectIri.contains(projectIri),
+          actual.toOption.get.mappingName == "MyMapping",
+          !actual.toOption.get.isBuiltIn,
+        )
+      },
+      test("should return a StandoffMappingIri for the built-in StandardMapping") {
+        val actual = StandoffMappingIri.from(standardMapping)
+        assertTrue(
+          actual.isRight,
+          actual.toOption.get.value == standardMapping,
+          actual.toOption.get.projectIri.isEmpty,
+          actual.toOption.get.mappingName == "StandardMapping",
+          actual.toOption.get.isBuiltIn,
+        )
+      },
+      test("should return a StandoffMappingIri for the built-in TEIMapping") {
+        val actual = StandoffMappingIri.from(teiMapping)
+        assertTrue(
+          actual.isRight,
+          actual.toOption.get.mappingName == "TEIMapping",
+          actual.toOption.get.isBuiltIn,
+        )
+      },
+      test("should fail for an invalid mapping IRI") {
+        val invalidIris = Seq(
+          "",
+          "not-an-iri",
+          "http://example.com/ontology#Foo",
+          "http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A",
+          "http://rdfh.ch/standoff/mappings/",
+          "http://rdfh.ch/standoff/mappings/Has Space",
+          "http://rdfh.ch/projects/0001/mappings/",
+          "http://rdfh.ch/projects/0001/mappings/Bad Name",
+          "http://rdfh.ch/projects/abc/mappings/MyMapping",
+        )
+        check(Gen.fromIterable(invalidIris)) { iri =>
+          val actual = StandoffMappingIri.from(iri)
+          assertTrue(actual == Left(s"<$iri> is not a standoff mapping IRI"))
+        }
+      },
+    ),
+    suite("from(ProjectIri, String)")(
+      test("should assemble a project-scoped mapping IRI") {
+        val actual = StandoffMappingIri.from(projectIri, "MyMapping")
+        assertTrue(
+          actual.isRight,
+          actual.toOption.get.value == projectMappingIri,
+          actual.toOption.get.projectIri.contains(projectIri),
+          actual.toOption.get.mappingName == "MyMapping",
+        )
+      },
+      test("should fail for an invalid mapping name") {
+        val invalidNames = Seq("", "Has Space", "with/slash", "with#hash")
+        check(Gen.fromIterable(invalidNames)) { name =>
+          val actual = StandoffMappingIri.from(projectIri, name)
+          assertTrue(actual == Left(s"<$name> is not a valid mapping name"))
+        }
+      },
+    ),
+  )
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ValueOrderingSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ValueOrderingSpec.scala
@@ -15,7 +15,6 @@ import scala.jdk.CollectionConverters.*
 import scala.language.implicitConversions
 
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageRelayLive
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.responders.IriService
 import org.knora.webapi.slice.admin.domain.model.AdministrativePermissionRepoInMemory
@@ -30,6 +29,7 @@ import org.knora.webapi.slice.common.jena.ModelOps.*
 import org.knora.webapi.slice.common.jena.ResourceOps.*
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoInMemory
+import org.knora.webapi.slice.standoff.service.StandoffMappingServiceFake
 import org.knora.webapi.store.iiif.impl.SipiServiceMock
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory
 
@@ -753,7 +753,7 @@ object ValueOrderingSpec extends ZIOSpecDefault {
     KnoraUserService.layer,
     KnoraUserToUserConverter.layer,
     LicenseRepo.layer,
-    MessageRelayLive.layer,
+    StandoffMappingServiceFake.layer,
     OntologyRepoInMemory.emptyLayer,
     PasswordService.layer,
     ProjectService.layer,

--- a/webapi/src/test/scala/org/knora/webapi/slice/export/api/service/ExportServiceSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/export/api/service/ExportServiceSpec.scala
@@ -14,7 +14,6 @@ import zio.test.*
 import org.knora.webapi.GoldenTest
 import org.knora.webapi.TestDataFactory
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.core.MessageRelayLive
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.messages.util.ConstructResponseUtilV2
@@ -48,6 +47,7 @@ import org.knora.webapi.slice.ontology.repo.service.OntologyCacheLive
 import org.knora.webapi.slice.ontology.repo.service.OntologyRepoLive
 import org.knora.webapi.slice.ontology.repo.service.PredicateRepositoryLive
 import org.knora.webapi.slice.resources.service.ReadResourcesServiceLive
+import org.knora.webapi.slice.standoff.service.StandoffMappingServiceFake
 import org.knora.webapi.store.triplestore.TestDatasetBuilder.emptyDataset
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory
@@ -222,7 +222,6 @@ object ExportServiceSpec extends ZIOSpecDefault with GoldenTest {
       KnoraProjectRepoLive.layer,
       KnoraProjectService.layer,
       LicenseRepo.layer,
-      MessageRelayLive.layer,
       CardinalityHandler.layer,
       CardinalityService.layer,
       OntologyCacheHelpers.layer,
@@ -233,6 +232,7 @@ object ExportServiceSpec extends ZIOSpecDefault with GoldenTest {
       PredicateRepositoryLive.layer,
       ProjectService.layer,
       ReadResourcesServiceLive.layer,
+      StandoffMappingServiceFake.layer,
       StandoffTagUtilV2Live.layer,
       StringFormatter.test,
       TriplestoreServiceInMemory.layer,

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/CreateNewMappingQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/CreateNewMappingQuerySpec.scala
@@ -7,6 +7,7 @@ package org.knora.webapi.slice.resources.repo
 
 import zio.test.*
 
+import org.knora.webapi.slice.common.StandoffMappingElementIri
 import org.knora.webapi.slice.resources.repo.model.MappingElement
 import org.knora.webapi.slice.resources.repo.model.MappingStandoffDatatypeClass
 import org.knora.webapi.slice.resources.repo.model.MappingXMLAttribute
@@ -24,7 +25,8 @@ object CreateNewMappingQuerySpec extends ZIOSpecDefault {
     standoffClass = "http://www.knora.org/ontology/standoff#StandoffParagraphTag",
     attributes = Seq.empty,
     standoffDataTypeClass = None,
-    mappingElementIri = "http://rdfh.ch/projects/0001/mappings/testMapping/elements/1",
+    mappingElementIri =
+      StandoffMappingElementIri.unsafeFrom("http://rdfh.ch/projects/0001/mappings/testMapping/elements/1"),
     separatorRequired = true,
   )
 
@@ -38,18 +40,22 @@ object CreateNewMappingQuerySpec extends ZIOSpecDefault {
         attributeName = "href",
         namespace = "noNamespace",
         standoffProperty = "http://www.knora.org/ontology/knora-base#valueHasUri",
-        mappingXMLAttributeElementIri = "http://rdfh.ch/projects/0001/mappings/testMapping/elements/2/attributes/1",
+        mappingXMLAttributeElementIri = StandoffMappingElementIri.unsafeFrom(
+          "http://rdfh.ch/projects/0001/mappings/testMapping/elements/2/attributes/1",
+        ),
       ),
     ),
     standoffDataTypeClass = Some(
       MappingStandoffDatatypeClass(
         datatype = "http://www.knora.org/ontology/knora-base#StandoffUriTag",
         attributeName = "href",
-        mappingStandoffDataTypeClassElementIri =
+        mappingStandoffDataTypeClassElementIri = StandoffMappingElementIri.unsafeFrom(
           "http://rdfh.ch/projects/0001/mappings/testMapping/elements/2/datatypeclass/1",
+        ),
       ),
     ),
-    mappingElementIri = "http://rdfh.ch/projects/0001/mappings/testMapping/elements/2",
+    mappingElementIri =
+      StandoffMappingElementIri.unsafeFrom("http://rdfh.ch/projects/0001/mappings/testMapping/elements/2"),
     separatorRequired = false,
   )
 

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLiveSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/service/ResourcesRepoLiveSpec.scala
@@ -22,6 +22,7 @@ import org.knora.webapi.messages.v2.responder.valuemessages.FileValueV2
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.resources.repo.model.FormattedTextValueType
 import org.knora.webapi.slice.resources.repo.model.ResourceReadyToCreate
@@ -99,7 +100,7 @@ object TestData {
     valueUUID = UUID.randomUUID(),
     value = TypeSpecificValueInfo.FormattedTextValueInfo(
       valueHasLanguage = Some("en"),
-      mappingIri = InternalIri("foo:MappingIri"),
+      mappingIri = StandoffMappingIri.StandardMapping,
       maxStandoffStartIndex = 0,
       standoff = List(
         StandoffTagInfo(
@@ -591,7 +592,7 @@ object ResourcesRepoLiveSpec extends ZIOSpecDefault {
             |            knora-base:hasPermissions "$valuePermissions" ;
             |            knora-base:valueHasOrder 1 ;
             |            knora-base:valueCreationDate "$valueCreationDate"^^xsd:dateTime ;
-            |            knora-base:valueHasMapping <foo:MappingIri> ;
+            |            knora-base:valueHasMapping <http://rdfh.ch/standoff/mappings/StandardMapping> ;
             |            knora-base:hasTextValueType knora-base:FormattedText ;
             |            knora-base:valueHasMaxStandoffStartIndex 0 ;
             |            knora-base:valueHasLanguage "en" ;

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/service/value/queries/InsertValueQueryBuilderSpec.scala
@@ -30,6 +30,7 @@ import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffTagIriAtt
 import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffTagTimeAttributeV2
 import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffTagV2
 import org.knora.webapi.messages.v2.responder.valuemessages.*
+import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.domain.InternalIri
 import org.knora.webapi.slice.common.service.IriConverter
@@ -193,7 +194,7 @@ object InsertValueQueryBuilderTestSupport {
         textValueType = TextValueType.FormattedText,
         valueHasLanguage = None,
         standoff = standoffTags,
-        mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        mappingIri = Some(StandoffMappingIri.StandardMapping),
         comment = Option.when(withComment)("Test standoff comment"),
       )
     }
@@ -231,7 +232,7 @@ object InsertValueQueryBuilderTestSupport {
         textValueType = TextValueType.FormattedText,
         valueHasLanguage = None,
         standoff = standoffTags,
-        mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        mappingIri = Some(StandoffMappingIri.StandardMapping),
         comment = Option.when(withComment)("Test standoff link comment"),
       )
     }
@@ -289,7 +290,7 @@ object InsertValueQueryBuilderTestSupport {
         textValueType = TextValueType.FormattedText,
         valueHasLanguage = None,
         standoff = standoffTags,
-        mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        mappingIri = Some(StandoffMappingIri.StandardMapping),
         comment = Option.when(withComment)("Virtual hierarchy standoff comment"),
       )
     }
@@ -330,7 +331,7 @@ object InsertValueQueryBuilderTestSupport {
         textValueType = TextValueType.FormattedText,
         valueHasLanguage = None,
         standoff = standoffTags,
-        mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        mappingIri = Some(StandoffMappingIri.StandardMapping),
         comment = Option.when(withComment)("Hierarchical standoff comment"),
       )
     }
@@ -368,7 +369,7 @@ object InsertValueQueryBuilderTestSupport {
         textValueType = TextValueType.FormattedText,
         valueHasLanguage = None,
         standoff = standoffTags,
-        mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        mappingIri = Some(StandoffMappingIri.StandardMapping),
         comment = Option.when(withComment)("XML ID standoff comment"),
       )
     }
@@ -405,7 +406,7 @@ object InsertValueQueryBuilderTestSupport {
         textValueType = TextValueType.FormattedText,
         valueHasLanguage = None,
         standoff = standoffTags,
-        mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        mappingIri = Some(StandoffMappingIri.StandardMapping),
         comment = Option.when(withComment)("Standoff integer attribute comment"),
       )
     }
@@ -442,7 +443,7 @@ object InsertValueQueryBuilderTestSupport {
         textValueType = TextValueType.FormattedText,
         valueHasLanguage = None,
         standoff = standoffTags,
-        mappingIri = Some("http://rdfh.ch/standoff/mappings/StandardMapping"),
+        mappingIri = Some(StandoffMappingIri.StandardMapping),
         comment = Option.when(withComment)("Standoff time attribute comment"),
       )
     }

--- a/webapi/src/test/scala/org/knora/webapi/slice/standoff/service/StandoffMappingServiceFake.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/standoff/service/StandoffMappingServiceFake.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.standoff.service
+
+import zio.*
+
+import org.knora.webapi.IRI
+import org.knora.webapi.messages.v2.responder.ontologymessages.StandoffEntityInfoGetResponseV2
+import org.knora.webapi.messages.v2.responder.standoffmessages.GetMappingResponseV2
+import org.knora.webapi.messages.v2.responder.standoffmessages.MappingXMLtoStandoff
+import org.knora.webapi.slice.common.StandoffMappingIri
+
+/**
+ * No-op `StandoffMappingService` stub for specs that wire the layer graph but
+ * never exercise the mapping/XSLT code paths at runtime.
+ */
+final class StandoffMappingServiceFake extends StandoffMappingService {
+  override def getMappingV2(mappingIri: StandoffMappingIri): Task[GetMappingResponseV2] =
+    ZIO.die(new UnsupportedOperationException("StandoffMappingServiceFake.getMappingV2"))
+
+  override def getXSLTransformation(xslTransformationIri: IRI): Task[String] =
+    ZIO.die(new UnsupportedOperationException("StandoffMappingServiceFake.getXSLTransformation"))
+
+  override def getStandoffEntitiesFromMappingV2(
+    mappingXMLtoStandoff: MappingXMLtoStandoff,
+  ): Task[StandoffEntityInfoGetResponseV2] =
+    ZIO.die(new UnsupportedOperationException("StandoffMappingServiceFake.getStandoffEntitiesFromMappingV2"))
+}
+
+object StandoffMappingServiceFake {
+  val layer: ULayer[StandoffMappingService] = ZLayer.succeed(new StandoffMappingServiceFake)
+}


### PR DESCRIPTION
Extract a dedicated `StandoffMappingService` for XML→standoff mapping and XSL transformation lookups so callers can invoke these operations directly instead of routing through `MessageRelay`. The service owns mapping caching, triplestore queries, ontology validation, and Sipi file access.

Replace raw mapping IRI strings with `StandoffMappingIri` and `StandoffMappingElementIri` value types for type safety and validation at API boundaries. A separate `GetXslTransformationMetadataQuery` avoids the layer cycle that previously kept the lookup inside the responder.