### PR TITLE
chore: Upgrade Apache Jena Fuseki to 6.1.0 (DEV-5935)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   db:
     # should be the same version as in Dependencies.scala,
     # make sure to use the same version in ops-deploy repository when deploying new DSP releases!
-    image: daschswiss/apache-jena-fuseki:5.5.0-3
+    image: daschswiss/apache-jena-fuseki:6.1.0-0
     build:
       context: ./fuseki
     ports:

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM eclipse-temurin:21-jre-jammy
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 # hadolint ignore=DL3008
 RUN set -eux; \
     apt-get update; \
@@ -29,32 +29,32 @@ RUN set -eux; \
 
 # Update below according to https://jena.apache.org/download/
 # and checksum for apache-jena-fuseki-<version>.tar.gz.sha512
-ARG IMAGE_VERSION=5.5.0-3
-ARG FUSEKI_VERSION=5.5.0
-ARG FUSEKI_SHA512=bfbf59eac731b71bcf8e148f2abeda9b4adca215639eef3bba61243b308572b23a9a70a43c1483247f9894bfb23d69b59e0e64e1da47cb3cfc592aa979084d5c
+ARG IMAGE_VERSION=6.1.0-0
+ARG FUSEKI_VERSION=6.1.0
+ARG FUSEKI_SHA512=75457f45d14397876a41ed51abe7ae5d2f1e708dfe1315765f858158bc5c6813bc036ec1539ddc4dffd26201f5cc31fadec299ca5c3dc2548b723513ed31d326
 ENV IMAGE_VERSION=$IMAGE_VERSION
 ENV FUSEKI_VERSION=$FUSEKI_VERSION
 ENV FUSEKI_SHA512=$FUSEKI_SHA512
 # No need for https due to sha512 checksums below
-ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
-ENV ASF_ARCHIVE http://archive.apache.org/dist/
+ENV ASF_MIRROR=http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
+ENV ASF_ARCHIVE=http://archive.apache.org/dist/
 
-LABEL org.opencontainers.image.url https://github.com/dasch-swiss/dsp-api/tree/main/fuseki
-LABEL org.opencontainers.image.source https://github.com/dasch-swiss/dsp-api
-LABEL org.opencontainers.image.documentation https://jena.apache.org/documentation/fuseki2/
-LABEL org.opencontainers.image.title "Apache Jena Fuseki"
-LABEL org.opencontainers.image.description "Fuseki is a SPARQL 1.1 server with a web interface, backed by the Apache Jena TDB RDF triple store."
-LABEL org.opencontainers.image.version ${IMAGE_VERSION}
-LABEL org.opencontainers.image.licenses "(Apache-2.0 AND (GPL-2.0 WITH Classpath-exception-2.0) AND GPL-3.0)"
-LABEL org.opencontainers.image.authors "DaSCH — https://dasch.swiss"
+LABEL org.opencontainers.image.url=https://github.com/dasch-swiss/dsp-api/tree/main/fuseki
+LABEL org.opencontainers.image.source=https://github.com/dasch-swiss/dsp-api
+LABEL org.opencontainers.image.documentation=https://jena.apache.org/documentation/fuseki2/
+LABEL org.opencontainers.image.title="Apache Jena Fuseki"
+LABEL org.opencontainers.image.description="Fuseki is a SPARQL 1.1 server with a web interface, backed by the Apache Jena TDB RDF triple store."
+LABEL org.opencontainers.image.version=${IMAGE_VERSION}
+LABEL org.opencontainers.image.licenses="(Apache-2.0 AND (GPL-2.0 WITH Classpath-exception-2.0) AND GPL-3.0)"
+LABEL org.opencontainers.image.authors="DaSCH — https://dasch.swiss"
 
 # Config and data
 VOLUME /fuseki
-ENV FUSEKI_BASE /fuseki
-ENV INDEX_BASE $FUSEKI_BASE/lucene
+ENV FUSEKI_BASE=/fuseki
+ENV INDEX_BASE=$FUSEKI_BASE/lucene
 
 # Installation folder
-ENV FUSEKI_HOME /jena-fuseki
+ENV FUSEKI_HOME=/jena-fuseki
 
 WORKDIR /tmp
 # published sha512 checksum

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ import sbt._
 object Dependencies {
   // should be the same version as in docker-compose.yml,
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
-  val fusekiImage = "daschswiss/apache-jena-fuseki:5.5.0-3"
+  val fusekiImage = "daschswiss/apache-jena-fuseki:6.1.0-0"
   // base image the knora-sipi image is created from
   val sipiImage = "daschswiss/sipi:v4.1.1"
 

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -529,7 +529,11 @@ case class TriplestoreServiceLive(
           (response.code.code, response.body.merge) match {
             case (404, _) =>
               ZIO.fail(NotFoundException.notFound)
-            case (400, response) if response.contains("Text search parse error") =>
+            // Jena/Fuseki reports invalid Lucene text-search input either as a parse-time
+            // error (HTTP 400) for top-level text:query usage, or as an evaluation-time
+            // TextIndexParseException (HTTP 500) when the same query is embedded in a
+            // sub-select/OPTIONAL. Both indicate bad user input, not a triplestore fault.
+            case (400 | 500, response) if response.contains("Text search parse error") =>
               ZIO.fail(BadRequestException(s"$response"))
             case (503, response) if response.contains("Query timed out") =>
               ZIO.fail(TriplestoreTimeoutException(s"$statusResponseMsg: $response"))


### PR DESCRIPTION
Bump the DaSCH Fuseki image to Apache Jena Fuseki 6.1.0 (`daschswiss/apache-jena-fuseki:6.1.0-0`) to stay on the supported upstream release line.

Jena 6.1 changed how invalid Lucene input in `text:query` surfaces: when embedded in a sub-select or OPTIONAL it is now raised at evaluation time as `TextIndexParseException` and returned as HTTP 500 instead of the previous parse-time HTTP 400. Both still indicate bad user input, so the triplestore client maps either status (when the body contains `Text search parse error`) to `BadRequestException`, preserving the public API contract.

Also cleans up the long-standing Dockerfile `LegacyKeyValueFormat` warnings while the file is being touched.