### PR TITLE
refactor: Upgrade Jena to 6.1.0 and TopBraid SHACL to 1.5.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val MonocleVersion = "3.3.0"
 
   val Rdf4jVersion = "5.2.2"
-  val JenaVersion  = "5.2.0"
+  val JenaVersion  = "6.1.0"
 
   val ZioConfigVersion            = "4.0.7"
   val ZioLoggingVersion           = "2.5.3"
@@ -172,7 +172,7 @@ object Dependencies {
   val bagitDependencies     = Seq(zio, "dev.zio" %% "zio-streams" % ZioVersion, zioNio)
   val bagitTestDependencies = Seq(zioTest, zioTestSbt).map(_ % Test)
 
-  val TopbraidShaclVersion = "1.4.4"
+  val TopbraidShaclVersion = "1.5.0"
   val topbraidShacl        = "org.topbraid" % "shacl" % TopbraidShaclVersion
 
   val shaclValidatorDependencies     = Seq(topbraidShacl, zio)

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/JenaModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/JenaModel.scala
@@ -380,7 +380,7 @@ object JenaNodeFactory {
    */
   def makeStatement(subj: RdfResource, pred: IriNode, obj: RdfNode, context: Option[IRI] = None): Statement =
     JenaStatement(
-      new jena.sparql.core.Quad(
+      jena.sparql.core.Quad.create(
         JenaContextFactory.contextNodeOrDefaultGraph(context),
         JenaConversions.asJenaNode(subj),
         JenaConversions.asJenaNode(pred),

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/JenaModel.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/JenaModel.scala
@@ -335,6 +335,9 @@ object JenaNodeFactory {
   }
 
   // Jena's registry of datatypes.
+  // Force full Jena initialization before touching TypeMapper; under Jena 6.1.0
+  // `TypeMapper.getInstance` returns null if `JenaSystem.init()` has not run yet.
+  org.apache.jena.sys.JenaSystem.init()
   private val typeMapper = jena.datatypes.TypeMapper.getInstance
 
   // Register Knora's custom datatypes.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfFormatUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/rdf/RdfFormatUtil.scala
@@ -321,7 +321,7 @@ object RdfFormatUtil {
       )
       def processStatement(statement: JenaStatement): Unit =
         inner.quad(
-          new jena.sparql.core.Quad(
+          jena.sparql.core.Quad.create(
             jena.graph.NodeFactory.createURI(graphIri),
             JenaConversions.asJenaNode(statement.subj),
             JenaConversions.asJenaNode(statement.pred),
@@ -331,6 +331,7 @@ object RdfFormatUtil {
       override def start(): Unit                                      = inner.start()
       override def base(s: String): Unit                              = {}
       override def prefix(prefixStr: String, namespace: String): Unit = inner.prefix(prefixStr, namespace)
+      override def version(s: String): Unit                           = {}
       override def finish(): Unit                                     = inner.finish()
       override def triple(triple: jena.graph.Triple): Unit            =
         quad(jena.sparql.core.Quad.create(jena.sparql.core.Quad.defaultGraphIRI, triple))

--- a/webapi/src/main/scala/org/knora/webapi/slice/security/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/security/Authenticator.scala
@@ -115,7 +115,7 @@ final case class AuthenticatorLive(
   } yield ()
 
   override def calculateCookieName(): String = {
-    val base32 = new Base32('9'.toByte)
+    val base32 = Base32.builder().setPadding('9'.toByte).get()
     "KnoraAuthentication" + base32.encodeAsString(appConfig.knoraApi.externalKnoraApiHostPort.getBytes())
   }
 

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/api/TriplestoreServiceInMemory.scala
@@ -10,7 +10,7 @@ import org.apache.jena.rdf.model
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.riot.Lang
 import org.apache.jena.riot.RDFDataMgr
-import org.apache.jena.tdb.TDB
+import org.apache.jena.tdb2.TDB2
 import org.apache.jena.tdb2.TDB2Factory
 import org.apache.jena.update.UpdateExecutionFactory
 import org.apache.jena.update.UpdateFactory
@@ -280,7 +280,7 @@ final case class TriplestoreServiceInMemory(datasetRef: Ref[Dataset])(implicit v
 
   override def printDataset(prefix: String = ""): UIO[Unit] =
     for {
-//      _  <- Console.printLine(s"TDB Context:\n${TDB.getContext}\n").orDie
+//      _  <- Console.printLine(s"TDB Context:\n${TDB2.getContext}\n").orDie
       ds <- getDataset
       _  <- Console.printLine(s"${prefix}TriplestoreServiceInMemory.printDataset:").orDie
       _   = printDatasetContents(ds)
@@ -334,6 +334,11 @@ object TriplestoreServiceInMemory {
     .datasetFromTriG(triG)
     .flatMap(TriplestoreServiceInMemory.setDataset)
 
+  // Force full Jena initialization once, lazily, before any TDB2 static symbol is referenced.
+  // Touching TDB2's symbol fields directly re-enters TDB2.<clinit> via InitTDB2 → TDB2.init,
+  // which fails with NPE on the not-yet-assigned TDB2.initLock (Jena 6.1.0 static-init bug).
+  private lazy val jenaInitialized: Unit = org.apache.jena.sys.JenaSystem.init()
+
   /**
    * Creates an empty TBD2 [[Dataset]].
    *
@@ -341,9 +346,11 @@ object TriplestoreServiceInMemory {
    * TODO: https://jena.apache.org/documentation/query/text-query.html#configuration-by-code
    */
   val createEmptyDataset: UIO[Dataset] =
-    ZIO
-      .succeed(TDB.getContext.set(TDB.symUnionDefaultGraph, true))
-      .as(TDB2Factory.createDataset())
+    ZIO.succeed {
+      jenaInitialized
+      TDB2.getContext.set(TDB2.symUnionDefaultGraph, true)
+      TDB2Factory.createDataset()
+    }
 
   val emptyDatasetRefLayer: ULayer[Ref[Dataset]] = ZLayer.fromZIO(createEmptyDataset.flatMap(Ref.make(_)))
 


### PR DESCRIPTION
Brings Jena to the current 6.x line and TopBraid SHACL to 1.5.0 so the RDF stack stays on supported releases.

Jena 6 reshuffles the TDB1 package (`org.apache.jena.tdb` → `org.apache.jena.tdb1`), deprecates the `Quad(...)` and `Base32(...)` constructors in favour of factory/builder APIs, and adds `StreamRDF.version`. Beyond adopting those APIs, the upgrade exposes two static-initialisation ordering bugs in Jena 6.1.0 that we work around by forcing `JenaSystem.init()` before:

- reading `TDB2`'s context symbols in the in-memory test triplestore (touching `TDB2.symUnionDefaultGraph` re-enters `TDB2.<clinit>` and NPEs on the not-yet-assigned `initLock`);
- calling `TypeMapper.getInstance` in `JenaNodeFactory`, which otherwise returns `null` and caused the production API container to fail on startup during repository upgrade.