### PR TITLE
fix(export): lower CSV export batch-size default to 100 (DEV-6336)

### DIFF
--- a/modules/test-it/src/test/scala/org/knora/webapi/slice/api/v3/export_/ExportStreamingIT.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/slice/api/v3/export_/ExportStreamingIT.scala
@@ -23,8 +23,14 @@ import org.knora.webapi.slice.ontology.repo.service.OntologyCache
  *
  * Two purposes:
  *   1. Tuning vehicle -- emits per-combo timings so we can pick production defaults from data, not guesses.
- *   2. Regression guard -- the matrix asserts that the production combo (5, 500) completes within a generous wall-time
+ *   2. Regression guard -- the matrix asserts that the production combo (5, 100) completes within a generous wall-time
  *      budget and produces the expected number of CSV rows.
+ *
+ * Caveat: this IT `runCollect`s the whole stream and measures *total throughput*. It does NOT observe the
+ * inter-flush gap that drives the real production failure mode (a single slow in-order batch going silent past the
+ * ingress 60s idle timeout). incunabula `page` is also light-text data; rich-text/standoff classes have far higher
+ * per-batch latency. Treat these timings as a throughput sanity check, not as validation of the idle-timeout fix --
+ * that lives in the conservative `app.export.batch-size` default.
  *
  * Excluded from default CI because it is multi-minute (Fuseki testcontainer startup + incunabula bulk-load + matrix).
  * Run on demand with: `sbt "test-it/testOnly *ExportStreamingIT"`.
@@ -75,7 +81,7 @@ object ExportStreamingIT extends E2EZSpec {
                     } yield (parallelism, batchSize, java.time.Duration.ofNanos(t1 - t0), lines)
 
         // Warmup: prime Fuseki query plan cache + JVM JIT for the production combo. Discarded.
-        _ <- runOnce(5, 500)
+        _ <- runOnce(5, 100)
 
         results <- ZIO.foreach(matrix) { case (p, b) => runOnce(p, b) }
 
@@ -87,8 +93,8 @@ object ExportStreamingIT extends E2EZSpec {
 
         // All combos must produce the same number of CSV lines (1 header + N data rows, deterministic order).
         lineCounts = results.map(_._4).distinct
-        // Production combo (5, 500) is the regression guard.
-        production = results.find { case (p, b, _, _) => p == 5 && b == 500 }.get
+        // Production combo (5, 100) is the regression guard.
+        production = results.find { case (p, b, _, _) => p == 5 && b == 100 }.get
       } yield assertTrue(
         lineCounts.size == 1,                                // all combos agree on row count
         lineCounts.head > 1000,                              // sanity: incunabula:page has 4024 instances

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -133,8 +133,13 @@ app {
     // Tuning knobs for the streaming CSV export (POST /v3/export/resources). Operational values, overridable per
     // deployment via env var without a code change/release/deploy.
     export {
-        // resources fetched and encoded per triplestore round-trip
-        batch-size = 500
+        // resources fetched and encoded per triplestore round-trip. The stream flushes one chunk per batch, so this
+        // also bounds the gap between bytes on the wire: a batch must complete (standoff CONSTRUCT + row encoding)
+        // before its rows are sent. Keep it small enough that even rich-text/standoff-heavy classes finish a batch
+        // well under the ingress idle timeout (60s on prod) — otherwise the connection is dropped mid-stream and the
+        // download fails with an empty body. Tuned conservatively for heavy classes (e.g. footnoted literary text),
+        // not just light ones; the env override lets ops raise it per deployment for light-resource projects.
+        batch-size = 100
         batch-size = ${?KNORA_WEBAPI_EXPORT_BATCH_SIZE}
         // number of batches fetched concurrently
         parallelism = 5


### PR DESCRIPTION
[DEV-6336](https://linear.app/dasch/issue/DEV-6336)

## Problem

Streaming CSV export (`POST /v3/export/resources`) stalls mid-download and fails with an **empty body and no error** for large rich-text classes (e.g. `ugofoscolo` `Image`) — reproducibly around a fixed point (~14%). Lighter classes (~10k light-text resources) work fine.

## Root cause

The stream flushes **one chunk per fully-materialized batch**, so `batch-size` also bounds the gap between bytes on the wire — a batch's standoff `CONSTRUCT` + row encoding must finish before its rows are sent. The default `500` was tuned on light-text data (incunabula `page`). For rich-text/standoff-heavy classes a 500-resource batch takes far longer; combined with order-preserving `mapZIOPar` (a slow in-order batch blocks all downstream flushes while later completed batches buffer), the response goes silent longer than the **ingress 60s idle timeout** → the connection is dropped → Angular's blob download discards the partial body. Because resources are label-ordered, the heavy cluster sits at a fixed position, so it fails at the same ~14% each time.

This is the **same 60s ingress idle timeout** that #4097 (DEV-6288) documented as its known limitation, explicitly deferred to DEV-6336:

> *The full export response is buffered before being sent to the client — connections exceeding the ingress 60s idle timeout will still fail on prod for very large classes. Tracked in DEV-6336.*

Streaming (the original DEV-6336 work) fixed time-to-first-byte but not the sub-60s inter-byte cadence, so the timeout still bites — just mid-transfer instead of at the start.

## Change

- **`app.export.batch-size` default `500 → 100`** so even heavy batches complete well under the idle window, keeping bytes flowing. Overridable per deployment via `KNORA_WEBAPI_EXPORT_BATCH_SIZE` (raise it for light-resource projects).
- `ExportStreamingIT`: repoint the regression-guard combo `(5, 500) → (5, 100)` and document that the IT measures total throughput, **not** the inter-flush gap that drives the production failure.

The per-batch query load is unchanged; only the on-wire flush cadence. The #4124 tuning matrix shows `bs=100` is at worst neutral vs `bs=500` on light data (and avoids Fuseki's large-`VALUES` planning cliff), so no throughput regression is expected.

## Follow-up (infra, not in this PR)

Raise `nginx.ingress.kubernetes.io/proxy-read-timeout` (and confirm `proxy-buffering` off) for the export route in ops-deploy. No batch size can guarantee <60s for a single pathologically large resource; the ingress bump is the robust backstop.

## Immediate mitigation

`KNORA_WEBAPI_EXPORT_BATCH_SIZE=100` can be set on dev/prod now — no deploy required.

## Tests

- `sbt "webapi/testOnly *ExportServiceSpec*"` — 21 pass (incl. the config fix-confirmation test asserting `batch-size` drives batching, and the streaming-shape/ordering/cross-batch tests).
- No new test added: a `batchSize == 100` assertion would be a config-mirror, and a timing test can't reproduce the ingress idle-timeout condition (no ingress in tests; `runCollect` drains the whole stream). The existing batching + streaming-shape guards cover the behavioral contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)