### PR TITLE
feat(ontology): Synthesise valueHasString and convert dates to JDN in transformer

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/util/CalendarDateUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/CalendarDateUtilV2.scala
@@ -8,6 +8,7 @@ package org.knora.webapi.messages.util
 import com.ibm.icu.util.*
 
 import java.util.Date
+import scala.util.Try
 
 import dsp.errors.AssertionException
 import dsp.errors.BadRequestException
@@ -550,6 +551,32 @@ object CalendarDateRangeV2 {
       )
     }
   }
+
+  /**
+   * Builds a [[CalendarDateRangeV2]] from its individual start/end components. A single date is expressed as equal
+   * start and end components. The component constraints enforced by [[CalendarDateV2]] and [[CalendarDateRangeV2]]
+   * (e.g. a day requires a month, Gregorian/Julian dates require an era) are returned as a `Left` rather than thrown.
+   * This does not check that the dates are valid in their calendar; call `toJulianDayRange` on the result for that.
+   *
+   * @return the date range, or a `Left` describing why the components are invalid.
+   */
+  def fromComponents(
+    calendarName: CalendarNameV2,
+    startYear: Int,
+    startMonth: Option[Int],
+    startDay: Option[Int],
+    startEra: Option[DateEraV2],
+    endYear: Int,
+    endMonth: Option[Int],
+    endDay: Option[Int],
+    endEra: Option[DateEraV2],
+  ): Either[String, CalendarDateRangeV2] =
+    Try(
+      CalendarDateRangeV2(
+        CalendarDateV2(calendarName, startYear, startMonth, startDay, startEra),
+        CalendarDateV2(calendarName, endYear, endMonth, endDay, endEra),
+      ),
+    ).toEither.left.map(_.getMessage)
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -875,16 +875,17 @@ object DateValueContentV2 {
 
       calendarName <- r.objectString(DateValueHasCalendar, CalendarNameV2.fromString)
 
-      // validate the combination of start/end dates and calendarName
-      _ <- if (startMonth.isEmpty && startDay.isDefined) Left(s"Start day defined, missing start month") else Right(())
-      _ <- if (endMonth.isEmpty && endDay.isDefined) Left(s"End day defined, missing end month") else Right(())
-      _ <- if (calendarName.isInstanceOf[CalendarNameGregorianOrJulian] && (startEra.isEmpty || endEra.isEmpty))
-             Left(s"Era is required in calendar $calendarName")
-           else Right(())
-
-      startDate          = CalendarDateV2(calendarName, startYear, startMonth, startDay, startEra)
-      endDate            = CalendarDateV2(calendarName, endYear, endMonth, endDay, endEra)
-      dateRange          = CalendarDateRangeV2(startDate, endDate)
+      dateRange <- CalendarDateRangeV2.fromComponents(
+                     calendarName,
+                     startYear,
+                     startMonth,
+                     startDay,
+                     startEra,
+                     endYear,
+                     endMonth,
+                     endDay,
+                     endEra,
+                   )
       startEnd          <- Try(dateRange.toJulianDayRange).toEither.left.map(_.getMessage)
       (startJdn, endJdn) = startEnd
 
@@ -893,8 +894,8 @@ object DateValueContentV2 {
       ApiV2Complex,
       startJdn,
       endJdn,
-      startDate.precision,
-      endDate.precision,
+      dateRange.startCalendarDate.precision,
+      dateRange.endCalendarDate.precision,
       calendarName,
       comment,
     )

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -38,7 +38,6 @@ import org.knora.webapi.messages.OntologyConstants.KnoraBase
 import org.knora.webapi.messages.OntologyConstants.Rdf
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.CalendarDateRangeV2
-import org.knora.webapi.messages.util.CalendarDateV2
 import org.knora.webapi.messages.util.CalendarNameV2
 import org.knora.webapi.messages.util.DateEraV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
@@ -238,32 +237,35 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
       Option(s.getProperty(rdfType)).map(_.getObject).exists(n => n.isURIResource && n.asResource.getURI == dateValue)
     }
 
+    def required[A](opt: Option[A], what: String, v: Resource): A =
+      opt.getOrElse(throw new IllegalArgumentException(s"DateValue $v has no $what"))
+
     dateValues.foreach { v =>
-      val calendarStr =
-        stringOf(v, srcCalendar).getOrElse(throw new IllegalArgumentException(s"DateValue $v has no calendar"))
+      val calendarStr  = required(stringOf(v, srcCalendar), "calendar", v)
       val calendarName =
         CalendarNameV2.fromString(calendarStr).fold(msg => throw new IllegalArgumentException(msg), identity)
-      val startYear =
-        intOf(v, srcStartYear).getOrElse(throw new IllegalArgumentException(s"DateValue $v has no start year"))
 
-      val start =
-        CalendarDateV2(calendarName, startYear, intOf(v, srcStartMonth), intOf(v, srcStartDay), eraOf(v, srcStartEra))
-      val end = CalendarDateV2(
-        calendarName,
-        intOf(v, srcEndYear).getOrElse(startYear),
-        intOf(v, srcEndMonth).orElse(intOf(v, srcStartMonth)),
-        intOf(v, srcEndDay).orElse(intOf(v, srcStartDay)),
-        eraOf(v, srcEndEra).orElse(eraOf(v, srcStartEra)),
-      )
-      val range              = CalendarDateRangeV2(start, end)
+      val range = CalendarDateRangeV2
+        .fromComponents(
+          calendarName,
+          required(intOf(v, srcStartYear), "start year", v),
+          intOf(v, srcStartMonth),
+          intOf(v, srcStartDay),
+          eraOf(v, srcStartEra),
+          required(intOf(v, srcEndYear), "end year", v),
+          intOf(v, srcEndMonth),
+          intOf(v, srcEndDay),
+          eraOf(v, srcEndEra),
+        )
+        .fold(msg => throw new IllegalArgumentException(msg), identity)
       val (startJDN, endJDN) = range.toJulianDayRange
 
       srcProps.foreach(v.removeAll)
       v.addProperty(valueHasCalendar, calendarStr)
       v.addProperty(valueHasStartJDN, model.createTypedLiteral(startJDN.toString, XSDDatatype.XSDinteger))
       v.addProperty(valueHasEndJDN, model.createTypedLiteral(endJDN.toString, XSDDatatype.XSDinteger))
-      v.addProperty(valueHasStartPrecision, start.precision.toString)
-      v.addProperty(valueHasEndPrecision, end.precision.toString)
+      v.addProperty(valueHasStartPrecision, range.startCalendarDate.precision.toString)
+      v.addProperty(valueHasEndPrecision, range.endCalendarDate.precision.toString)
       v.addProperty(valueHasString, range.toString)
     }
   }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -10,7 +10,9 @@ import org.apache.jena.graph.Node
 import org.apache.jena.graph.NodeFactory
 import org.apache.jena.graph.Triple
 import org.apache.jena.rdf.model.Model
+import org.apache.jena.rdf.model.Property
 import org.apache.jena.rdf.model.RDFNode
+import org.apache.jena.rdf.model.Resource
 import org.apache.jena.riot.Lang
 import org.apache.jena.riot.RDFParser
 import org.apache.jena.riot.system.StreamRDF
@@ -33,6 +35,7 @@ import scala.jdk.CollectionConverters.*
 
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.OntologyConstants.KnoraBase
+import org.knora.webapi.messages.OntologyConstants.Rdf
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.UserIri
@@ -98,6 +101,7 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
       model <- RdfDataMgr.loadModel(nq, Lang.NTRIPLES)
       _     <- ZIO.attempt(addResourceMetadata(model, ctx, now))
       _     <- ZIO.attempt(addValueMetadata(model, ctx, now))
+      _     <- ZIO.attempt(addValueHasString(model))
       kb    <- tempFile("onto-transformer-kb-", ".nq")
       _     <- RdfDataMgr.write(model, kb, Lang.NTRIPLES)
     } yield kb)
@@ -163,9 +167,6 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
     val creationDateLit = model.createTypedLiteral(now.toString, XSDDatatype.XSDdateTimeStamp)
     val falseLit        = model.createTypedLiteral("false", XSDDatatype.XSDboolean)
 
-    def asValueIri(n: RDFNode): Option[ValueIri] =
-      Option.when(n.isURIResource)(n.asResource.getURI).flatMap(ValueIri.from(_).toOption)
-
     model.listSubjects().asScala.toList.flatMap(s => asValueIri(s).map((s, _))).foreach { case (v, iri) =>
       v.removeAll(attachedToUser)
         .removeAll(hasPermissions)
@@ -179,6 +180,52 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
       v.addProperty(isDeleted, falseLit)
     }
   }
+
+  /**
+   * Step 2 (`valueHasString`) — derive the plain-text `knora-base:valueHasString` from each value's content. Scalar
+   * values use the lexical form of their content literal; `ListValue` falls back to the list-node IRI. `TextValue`
+   * already carries `valueHasString` from the stage-1 rename and is left untouched. `DateValue` (step 3), `LinkValue`
+   * (step 4), rich text (step 5) and file values (step 6) are handled where those structures are built.
+   */
+  private def addValueHasString(model: Model): Unit = {
+    val rdfType          = model.createProperty(Rdf.Type)
+    val valueHasString   = model.createProperty(KnoraBase.ValueHasString)
+    val valueHasListNode = model.createProperty(KnoraBase.ValueHasListNode)
+
+    val literalContent: Map[String, Property] = Map(
+      KnoraBase.BooleanValue -> KnoraBase.ValueHasBoolean,
+      KnoraBase.IntValue     -> KnoraBase.ValueHasInteger,
+      KnoraBase.DecimalValue -> KnoraBase.ValueHasDecimal,
+      KnoraBase.ColorValue   -> KnoraBase.ValueHasColor,
+      KnoraBase.UriValue     -> KnoraBase.ValueHasUri,
+      KnoraBase.GeonameValue -> KnoraBase.ValueHasGeonameCode,
+      KnoraBase.TimeValue    -> KnoraBase.ValueHasTimeStamp,
+    ).map { case (cls, prop) => cls -> model.createProperty(prop) }
+
+    def iriOf(v: Resource, p: Property): Option[String] =
+      Option(v.getProperty(p)).map(_.getObject).collect { case n if n.isURIResource => n.asResource.getURI }
+
+    def typeOf(v: Resource): Option[String] = iriOf(v, rdfType)
+
+    def lexicalOf(v: Resource, p: Property): Option[String] =
+      Option(v.getProperty(p)).map(_.getObject).collect { case n if n.isLiteral => n.asLiteral.getLexicalForm }
+
+    model.listSubjects().asScala.toList.filter(isValue).foreach { v =>
+      if (!v.hasProperty(valueHasString)) {
+        val string = typeOf(v).flatMap {
+          case cls if literalContent.contains(cls) => lexicalOf(v, literalContent(cls))
+          case KnoraBase.ListValue                 => iriOf(v, valueHasListNode)
+          case _                                   => None
+        }
+        string.foreach(v.addProperty(valueHasString, _))
+      }
+    }
+  }
+
+  private def asValueIri(n: RDFNode): Option[ValueIri] =
+    Option.when(n.isURIResource)(n.asResource.getURI).flatMap(ValueIri.from(_).toOption)
+
+  private def isValue(n: RDFNode): Boolean = asValueIri(n).isDefined
 
   private def rewritingSink(downstream: StreamRDF): StreamRDF = {
     def rewriteUri(uri: String): String =

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -37,6 +37,10 @@ import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.OntologyConstants.KnoraBase
 import org.knora.webapi.messages.OntologyConstants.Rdf
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.util.CalendarDateRangeV2
+import org.knora.webapi.messages.util.CalendarDateV2
+import org.knora.webapi.messages.util.CalendarNameV2
+import org.knora.webapi.messages.util.DateEraV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.common.ResourceIri
@@ -101,6 +105,7 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
       model <- RdfDataMgr.loadModel(nq, Lang.NTRIPLES)
       _     <- ZIO.attempt(addResourceMetadata(model, ctx, now))
       _     <- ZIO.attempt(addValueMetadata(model, ctx, now))
+      _     <- ZIO.attempt(convertDateValues(model))
       _     <- ZIO.attempt(addValueHasString(model))
       kb    <- tempFile("onto-transformer-kb-", ".nq")
       _     <- RdfDataMgr.write(model, kb, Lang.NTRIPLES)
@@ -178,6 +183,88 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
       v.addProperty(valueCreationDate, creationDateLit)
       v.addProperty(valueHasUUID, iri.valueId.value)
       v.addProperty(isDeleted, falseLit)
+    }
+  }
+
+  /**
+   * Step 3 — collapse the v2 `dateValueHas{Calendar,Start*,End*}` properties of every `DateValue` into the
+   * `knora-base` JDN form: `valueHasCalendar`, `valueHasStart/EndJDN`, `valueHasStart/EndPrecision`, plus a
+   * `valueHasString` rendering of the date range. Eras are not stored in `knora-base`; they only feed the JDN math.
+   * JDN computation and the date-range string are delegated to [[CalendarDateRangeV2]].
+   */
+  private def convertDateValues(model: Model): Unit = {
+    val rdfType   = model.createProperty(Rdf.Type)
+    val dateValue = KnoraBase.DateValue
+
+    // The v2 date properties, renamed into the knora-base namespace by stage 1.
+    val srcCalendar   = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasCalendar")
+    val srcStartYear  = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasStartYear")
+    val srcStartMonth = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasStartMonth")
+    val srcStartDay   = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasStartDay")
+    val srcStartEra   = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasStartEra")
+    val srcEndYear    = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasEndYear")
+    val srcEndMonth   = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasEndMonth")
+    val srcEndDay     = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasEndDay")
+    val srcEndEra     = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "dateValueHasEndEra")
+    val srcProps      =
+      List(
+        srcCalendar,
+        srcStartYear,
+        srcStartMonth,
+        srcStartDay,
+        srcStartEra,
+        srcEndYear,
+        srcEndMonth,
+        srcEndDay,
+        srcEndEra,
+      )
+
+    val valueHasCalendar       = model.createProperty(KnoraBase.ValueHasCalendar)
+    val valueHasStartJDN       = model.createProperty(KnoraBase.ValueHasStartJDN)
+    val valueHasEndJDN         = model.createProperty(KnoraBase.ValueHasEndJDN)
+    val valueHasStartPrecision = model.createProperty(KnoraBase.ValueHasStartPrecision)
+    val valueHasEndPrecision   = model.createProperty(KnoraBase.ValueHasEndPrecision)
+    val valueHasString         = model.createProperty(KnoraBase.ValueHasString)
+
+    def stringOf(v: Resource, p: Property): Option[String] =
+      Option(v.getProperty(p)).map(_.getObject).collect { case n if n.isLiteral => n.asLiteral.getLexicalForm }
+    def intOf(v: Resource, p: Property): Option[Int] =
+      Option(v.getProperty(p)).map(_.getObject).collect { case n if n.isLiteral => n.asLiteral.getInt }
+    def eraOf(v: Resource, p: Property): Option[DateEraV2] =
+      stringOf(v, p).flatMap(DateEraV2.fromString(_).toOption)
+
+    val dateValues = model.listSubjects().asScala.toList.filter { s =>
+      asValueIri(s).isDefined &&
+      Option(s.getProperty(rdfType)).map(_.getObject).exists(n => n.isURIResource && n.asResource.getURI == dateValue)
+    }
+
+    dateValues.foreach { v =>
+      val calendarStr =
+        stringOf(v, srcCalendar).getOrElse(throw new IllegalArgumentException(s"DateValue $v has no calendar"))
+      val calendarName =
+        CalendarNameV2.fromString(calendarStr).fold(msg => throw new IllegalArgumentException(msg), identity)
+      val startYear =
+        intOf(v, srcStartYear).getOrElse(throw new IllegalArgumentException(s"DateValue $v has no start year"))
+
+      val start =
+        CalendarDateV2(calendarName, startYear, intOf(v, srcStartMonth), intOf(v, srcStartDay), eraOf(v, srcStartEra))
+      val end = CalendarDateV2(
+        calendarName,
+        intOf(v, srcEndYear).getOrElse(startYear),
+        intOf(v, srcEndMonth).orElse(intOf(v, srcStartMonth)),
+        intOf(v, srcEndDay).orElse(intOf(v, srcStartDay)),
+        eraOf(v, srcEndEra).orElse(eraOf(v, srcStartEra)),
+      )
+      val range              = CalendarDateRangeV2(start, end)
+      val (startJDN, endJDN) = range.toJulianDayRange
+
+      srcProps.foreach(v.removeAll)
+      v.addProperty(valueHasCalendar, calendarStr)
+      v.addProperty(valueHasStartJDN, model.createTypedLiteral(startJDN.toString, XSDDatatype.XSDinteger))
+      v.addProperty(valueHasEndJDN, model.createTypedLiteral(endJDN.toString, XSDDatatype.XSDinteger))
+      v.addProperty(valueHasStartPrecision, start.precision.toString)
+      v.addProperty(valueHasEndPrecision, end.precision.toString)
+      v.addProperty(valueHasString, range.toString)
     }
   }
 

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/CalendarDateUtilV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/CalendarDateUtilV2Spec.scala
@@ -320,5 +320,142 @@ object CalendarDateUtilV2Spec extends ZIOSpecDefault {
 
       assertTrue(ok1, ok2)
     },
+    suite("fromComponents")(
+      test("builds a Gregorian day-precision range") {
+        val result = CalendarDateRangeV2.fromComponents(
+          CalendarNameGregorian,
+          1800,
+          Some(1),
+          Some(2),
+          Some(DateEraCE),
+          1900,
+          Some(3),
+          Some(4),
+          Some(DateEraCE),
+        )
+        val range = result.toOption.get
+        assertTrue(
+          result.isRight,
+          range.startCalendarDate == CalendarDateV2(CalendarNameGregorian, 1800, Some(1), Some(2), Some(DateEraCE)),
+          range.endCalendarDate == CalendarDateV2(CalendarNameGregorian, 1900, Some(3), Some(4), Some(DateEraCE)),
+          range.toJulianDayRange == (2378498, 2415083),
+        )
+      },
+      test("infers precision from the components (year, month, day)") {
+        val year = CalendarDateRangeV2.fromComponents(
+          CalendarNameGregorian,
+          1800,
+          None,
+          None,
+          Some(DateEraCE),
+          1900,
+          None,
+          None,
+          Some(DateEraCE),
+        )
+        val month = CalendarDateRangeV2.fromComponents(
+          CalendarNameGregorian,
+          1800,
+          Some(3),
+          None,
+          Some(DateEraCE),
+          1900,
+          Some(5),
+          None,
+          Some(DateEraCE),
+        )
+        val day = CalendarDateRangeV2.fromComponents(
+          CalendarNameGregorian,
+          1800,
+          Some(1),
+          Some(2),
+          Some(DateEraCE),
+          1900,
+          Some(3),
+          Some(4),
+          Some(DateEraCE),
+        )
+        assertTrue(
+          year.toOption.get.startCalendarDate.precision == DatePrecisionYear,
+          month.toOption.get.startCalendarDate.precision == DatePrecisionMonth,
+          day.toOption.get.startCalendarDate.precision == DatePrecisionDay,
+        )
+      },
+      test("allows an absent era for the ISLAMIC calendar") {
+        val result =
+          CalendarDateRangeV2.fromComponents(
+            CalendarNameIslamic,
+            1432,
+            Some(8),
+            Some(29),
+            None,
+            1436,
+            Some(9),
+            Some(14),
+            None,
+          )
+        assertTrue(result.isRight)
+      },
+      test("returns a Left when a start day is given without a start month") {
+        val result =
+          CalendarDateRangeV2.fromComponents(
+            CalendarNameGregorian,
+            1800,
+            None,
+            Some(2),
+            Some(DateEraCE),
+            1900,
+            Some(3),
+            Some(4),
+            Some(DateEraCE),
+          )
+        assertTrue(result.isLeft)
+      },
+      test("returns a Left when an end day is given without an end month") {
+        val result =
+          CalendarDateRangeV2.fromComponents(
+            CalendarNameGregorian,
+            1800,
+            Some(1),
+            Some(2),
+            Some(DateEraCE),
+            1900,
+            None,
+            Some(4),
+            Some(DateEraCE),
+          )
+        assertTrue(result.isLeft)
+      },
+      test("returns a Left when a Gregorian start date has no era") {
+        val result =
+          CalendarDateRangeV2.fromComponents(
+            CalendarNameGregorian,
+            1800,
+            Some(1),
+            Some(2),
+            None,
+            1900,
+            Some(3),
+            Some(4),
+            Some(DateEraCE),
+          )
+        assertTrue(result.isLeft)
+      },
+      test("returns a Left when a Julian end date has no era") {
+        val result =
+          CalendarDateRangeV2.fromComponents(
+            CalendarNameJulian,
+            1800,
+            Some(1),
+            Some(2),
+            Some(DateEraCE),
+            1900,
+            Some(3),
+            Some(4),
+            None,
+          )
+        assertTrue(result.isLeft)
+      },
+    ),
   )
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -689,13 +689,17 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
         dateString = "GREGORIAN:1800 CE:1900 CE",
       )
     },
-    test("single date (only start fields) collapses to one date") {
+    test("single date (equal start and end) collapses to one date") {
       runDateStage2(
         inner = s""""${knoraApi}dateValueHasCalendar":  { "@type": "${xsd}string",  "@value": "GREGORIAN" },
                    |    "${knoraApi}dateValueHasStartYear":  { "@type": "${xsd}integer", "@value": 1800 },
                    |    "${knoraApi}dateValueHasStartMonth": { "@type": "${xsd}integer", "@value": 1 },
                    |    "${knoraApi}dateValueHasStartDay":   { "@type": "${xsd}integer", "@value": 2 },
-                   |    "${knoraApi}dateValueHasStartEra":   { "@type": "${xsd}string",  "@value": "CE" }""".stripMargin,
+                   |    "${knoraApi}dateValueHasStartEra":   { "@type": "${xsd}string",  "@value": "CE" },
+                   |    "${knoraApi}dateValueHasEndYear":    { "@type": "${xsd}integer", "@value": 1800 },
+                   |    "${knoraApi}dateValueHasEndMonth":   { "@type": "${xsd}integer", "@value": 1 },
+                   |    "${knoraApi}dateValueHasEndDay":     { "@type": "${xsd}integer", "@value": 2 },
+                   |    "${knoraApi}dateValueHasEndEra":     { "@type": "${xsd}string",  "@value": "CE" }""".stripMargin,
         startJDN = 2378498,
         endJDN = 2378498,
         startPrecision = "DAY",

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -416,6 +416,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
                             |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
                             |     knora-base:valueHasUUID      "${valueIri.valueId.value}" ;
+                            |     knora-base:valueHasString    "true" ;
                             |     knora-base:isDeleted         false .
                             |""".stripMargin,
       )
@@ -459,6 +460,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
                             |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
                             |     knora-base:valueHasUUID      "${valueIri.valueId.value}" ;
+                            |     knora-base:valueHasString    "1" ;
                             |     knora-base:isDeleted         false .
                             |
                             | <$valueIri2>
@@ -468,8 +470,128 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
                             |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
                             |     knora-base:valueHasUUID      "${valueIri2.valueId.value}" ;
+                            |     knora-base:valueHasString    "2" ;
                             |     knora-base:isDeleted         false .
                             |""".stripMargin,
+      )
+    },
+  )
+
+  /** Full expected `knora-base` graph for a single-value resource, including synthesised resource + value metadata. */
+  private def expectedStage2SingleValue(
+    propLocalName: String,
+    valueClass: String,
+    valueContent: String,
+    valueHasString: String,
+  ): String =
+    s"""
+       | PREFIX rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+       | PREFIX rdfs:       <http://www.w3.org/2000/01/rdf-schema#>
+       | PREFIX xsd:        <http://www.w3.org/2001/XMLSchema#>
+       | PREFIX onto:       <http://www.knora.org/ontology/9999/onto#>
+       | PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+       |
+       | <$resourceIri>
+       |     a                            onto:Example ;
+       |     rdfs:label                   "test" ;
+       |     onto:$propLocalName          <$valueIri> ;
+       |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
+       |     knora-base:attachedToProject <${ctx.attachedToProject.value}> ;
+       |     knora-base:hasPermissions    "${ctx.permissions}" ;
+       |     knora-base:creationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+       |     knora-base:isDeleted         false .
+       |
+       | <$valueIri>
+       |     a                            knora-base:$valueClass ;
+       |     $valueContent ;
+       |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
+       |     knora-base:hasPermissions    "${ctx.permissions}" ;
+       |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
+       |     knora-base:valueHasUUID      "${valueIri.valueId.value}" ;
+       |     knora-base:valueHasString    "$valueHasString" ;
+       |     knora-base:isDeleted         false .
+       |""".stripMargin
+
+  private val valueHasString = suite("Stage 2 — valueHasString")(
+    test("ColorValue uses the hex string") {
+      runTransformStage2(
+        resourceWithValueJsonLd(
+          s"${onto}testColor",
+          s"${knoraApi}ColorValue",
+          s""""${knoraApi}colorValueAsColor": { "@type": "${xsd}string", "@value": "#00ff00" }""",
+        ),
+        expectedStage2SingleValue("testColor", "ColorValue", """knora-base:valueHasColor "#00ff00"""", "#00ff00"),
+      )
+    },
+    test("DecimalValue uses the decimal lexical form") {
+      runTransformStage2(
+        resourceWithValueJsonLd(
+          s"${onto}testDecimal",
+          s"${knoraApi}DecimalValue",
+          s""""${knoraApi}decimalValueAsDecimal": { "@type": "${xsd}decimal", "@value": "2.71" }""",
+        ),
+        expectedStage2SingleValue(
+          "testDecimal",
+          "DecimalValue",
+          """knora-base:valueHasDecimal "2.71"^^xsd:decimal""",
+          "2.71",
+        ),
+      )
+    },
+    test("GeonameValue uses the geoname code") {
+      runTransformStage2(
+        resourceWithValueJsonLd(
+          s"${onto}testGeoname",
+          s"${knoraApi}GeonameValue",
+          s""""${knoraApi}geonameValueAsGeonameCode": { "@type": "${xsd}string", "@value": "1111111" }""",
+        ),
+        expectedStage2SingleValue(
+          "testGeoname",
+          "GeonameValue",
+          """knora-base:valueHasGeonameCode "1111111"""",
+          "1111111",
+        ),
+      )
+    },
+    test("TimeValue uses the timestamp lexical form") {
+      runTransformStage2(
+        resourceWithValueJsonLd(
+          s"${onto}testTimeValue",
+          s"${knoraApi}TimeValue",
+          s""""${knoraApi}timeValueAsTimeStamp": { "@type": "${xsd}dateTimeStamp", "@value": "2019-10-23T13:45:12.01-14:00" }""",
+        ),
+        expectedStage2SingleValue(
+          "testTimeValue",
+          "TimeValue",
+          """knora-base:valueHasTimeStamp "2019-10-23T13:45:12.01-14:00"^^xsd:dateTimeStamp""",
+          "2019-10-23T13:45:12.01-14:00",
+        ),
+      )
+    },
+    test("UriValue uses the URI") {
+      runTransformStage2(
+        resourceWithValueJsonLd(
+          s"${onto}testUriValue",
+          s"${knoraApi}UriValue",
+          s""""${knoraApi}uriValueAsUri": { "@type": "${xsd}anyURI", "@value": "https://dasch.swiss" }""",
+        ),
+        expectedStage2SingleValue(
+          "testUriValue",
+          "UriValue",
+          """knora-base:valueHasUri "https://dasch.swiss"^^xsd:anyURI""",
+          "https://dasch.swiss",
+        ),
+      )
+    },
+    test("ListValue falls back to the list-node IRI") {
+      val node = "http://rdfh.ch/lists/9999/WF8qwFbGQg228GJUlqOLzw"
+      runTransformStage2(
+        resourceWithValueJsonLd(
+          s"${onto}testListProp",
+          s"${knoraApi}ListValue",
+          s""""${knoraApi}listValueAsListNode": { "@id": "$node" }""",
+        ),
+        expectedStage2SingleValue("testListProp", "ListValue", s"knora-base:valueHasListNode <$node>", node),
       )
     },
   )
@@ -480,6 +602,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
     textValues,
     dateValues,
     resourceMetadata,
+    valueHasString,
   ).provide(OntologyTransformer.layer, StringFormatter.test, TestAppConfig.layer())
 
 }

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -596,6 +596,115 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
     },
   )
 
+  /** Drives a GREGORIAN `DateValue` through stage 2 and asserts the collapsed JDN form. */
+  private def runDateStage2(
+    inner: String,
+    startJDN: Int,
+    endJDN: Int,
+    startPrecision: String,
+    endPrecision: String,
+    dateString: String,
+  ) =
+    runTransformStage2(
+      jsonLd = resourceWithValueJsonLd(s"${onto}testSubDate1", s"${knoraApi}DateValue", inner),
+      expectedTurtle = s"""
+                          | PREFIX rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                          | PREFIX rdfs:       <http://www.w3.org/2000/01/rdf-schema#>
+                          | PREFIX xsd:        <http://www.w3.org/2001/XMLSchema#>
+                          | PREFIX onto:       <http://www.knora.org/ontology/9999/onto#>
+                          | PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                          |
+                          | <$resourceIri>
+                          |     a                            onto:Example ;
+                          |     rdfs:label                   "test" ;
+                          |     onto:testSubDate1            <$valueIri> ;
+                          |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
+                          |     knora-base:attachedToProject <${ctx.attachedToProject.value}> ;
+                          |     knora-base:hasPermissions    "${ctx.permissions}" ;
+                          |     knora-base:creationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+                          |     knora-base:isDeleted         false .
+                          |
+                          | <$valueIri>
+                          |     a                                 knora-base:DateValue ;
+                          |     knora-base:valueHasCalendar       "GREGORIAN" ;
+                          |     knora-base:valueHasStartJDN       $startJDN ;
+                          |     knora-base:valueHasEndJDN         $endJDN ;
+                          |     knora-base:valueHasStartPrecision "$startPrecision" ;
+                          |     knora-base:valueHasEndPrecision   "$endPrecision" ;
+                          |     knora-base:valueHasString         "$dateString" ;
+                          |     knora-base:attachedToUser         <${ctx.attachedToUser}> ;
+                          |     knora-base:hasPermissions         "${ctx.permissions}" ;
+                          |     knora-base:valueCreationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+                          |     knora-base:valueHasUUID           "${valueIri.valueId.value}" ;
+                          |     knora-base:isDeleted              false .
+                          |""".stripMargin,
+    )
+
+  private val dateValuesStage2 = suite("Stage 2 — DateValue → JDN")(
+    test("day-precision range") {
+      runDateStage2(
+        inner = s""""${knoraApi}dateValueHasCalendar":  { "@type": "${xsd}string",  "@value": "GREGORIAN" },
+                   |    "${knoraApi}dateValueHasStartYear":  { "@type": "${xsd}integer", "@value": 1800 },
+                   |    "${knoraApi}dateValueHasStartMonth": { "@type": "${xsd}integer", "@value": 1 },
+                   |    "${knoraApi}dateValueHasStartDay":   { "@type": "${xsd}integer", "@value": 2 },
+                   |    "${knoraApi}dateValueHasStartEra":   { "@type": "${xsd}string",  "@value": "CE" },
+                   |    "${knoraApi}dateValueHasEndYear":    { "@type": "${xsd}integer", "@value": 1900 },
+                   |    "${knoraApi}dateValueHasEndMonth":   { "@type": "${xsd}integer", "@value": 3 },
+                   |    "${knoraApi}dateValueHasEndDay":     { "@type": "${xsd}integer", "@value": 4 },
+                   |    "${knoraApi}dateValueHasEndEra":     { "@type": "${xsd}string",  "@value": "CE" }""".stripMargin,
+        startJDN = 2378498,
+        endJDN = 2415083,
+        startPrecision = "DAY",
+        endPrecision = "DAY",
+        dateString = "GREGORIAN:1800-01-02 CE:1900-03-04 CE",
+      )
+    },
+    test("month-precision range (no day fields)") {
+      runDateStage2(
+        inner = s""""${knoraApi}dateValueHasCalendar":  { "@type": "${xsd}string",  "@value": "GREGORIAN" },
+                   |    "${knoraApi}dateValueHasStartYear":  { "@type": "${xsd}integer", "@value": 1800 },
+                   |    "${knoraApi}dateValueHasStartMonth": { "@type": "${xsd}integer", "@value": 3 },
+                   |    "${knoraApi}dateValueHasStartEra":   { "@type": "${xsd}string",  "@value": "CE" },
+                   |    "${knoraApi}dateValueHasEndYear":    { "@type": "${xsd}integer", "@value": 1900 },
+                   |    "${knoraApi}dateValueHasEndMonth":   { "@type": "${xsd}integer", "@value": 5 },
+                   |    "${knoraApi}dateValueHasEndEra":     { "@type": "${xsd}string",  "@value": "CE" }""".stripMargin,
+        startJDN = 2378556,
+        endJDN = 2415171,
+        startPrecision = "MONTH",
+        endPrecision = "MONTH",
+        dateString = "GREGORIAN:1800-03 CE:1900-05 CE",
+      )
+    },
+    test("year-precision range (no month or day fields)") {
+      runDateStage2(
+        inner = s""""${knoraApi}dateValueHasCalendar":  { "@type": "${xsd}string",  "@value": "GREGORIAN" },
+                   |    "${knoraApi}dateValueHasStartYear":  { "@type": "${xsd}integer", "@value": 1800 },
+                   |    "${knoraApi}dateValueHasStartEra":   { "@type": "${xsd}string",  "@value": "CE" },
+                   |    "${knoraApi}dateValueHasEndYear":    { "@type": "${xsd}integer", "@value": 1900 },
+                   |    "${knoraApi}dateValueHasEndEra":     { "@type": "${xsd}string",  "@value": "CE" }""".stripMargin,
+        startJDN = 2378497,
+        endJDN = 2415385,
+        startPrecision = "YEAR",
+        endPrecision = "YEAR",
+        dateString = "GREGORIAN:1800 CE:1900 CE",
+      )
+    },
+    test("single date (only start fields) collapses to one date") {
+      runDateStage2(
+        inner = s""""${knoraApi}dateValueHasCalendar":  { "@type": "${xsd}string",  "@value": "GREGORIAN" },
+                   |    "${knoraApi}dateValueHasStartYear":  { "@type": "${xsd}integer", "@value": 1800 },
+                   |    "${knoraApi}dateValueHasStartMonth": { "@type": "${xsd}integer", "@value": 1 },
+                   |    "${knoraApi}dateValueHasStartDay":   { "@type": "${xsd}integer", "@value": 2 },
+                   |    "${knoraApi}dateValueHasStartEra":   { "@type": "${xsd}string",  "@value": "CE" }""".stripMargin,
+        startJDN = 2378498,
+        endJDN = 2378498,
+        startPrecision = "DAY",
+        endPrecision = "DAY",
+        dateString = "GREGORIAN:1800-01-02 CE",
+      )
+    },
+  )
+
   override def spec = suite("OntologyTransformerSpec")(
     simpleScalarValues,
     iriRefValues,
@@ -603,6 +712,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
     dateValues,
     resourceMetadata,
     valueHasString,
+    dateValuesStage2,
   ).provide(OntologyTransformer.layer, StringFormatter.test, TestAppConfig.layer())
 
 }


### PR DESCRIPTION
### Description

The internal `knora-base` representation requires data that the public Knora-API v2 payload does not carry, so the transformer has to derive it. This adds two stage-2 conversions:

- **`valueHasString`** — the plain-text rendering every value needs for full-text search and display. Scalar values use the lexical form of their content literal, `ListValue` falls back to the list-node IRI, and a simple `TextValue` keeps the value it already has from the stage-1 rename.
- **`DateValue` → JDN** — `knora-base` stores dates as Julian Day Numbers, not calendar components. The v2 `dateValueHas{Calendar,Start*,End*}` properties are collapsed into `valueHasCalendar`, `valueHasStart/EndJDN`, `valueHasStart/EndPrecision` and the date-range `valueHasString`. Eras are not stored in `knora-base`; they only feed the JDN computation and are then dropped.

The date-component assembly and Julian-Day computation are shared via a new `CalendarDateRangeV2.fromComponents` in `CalendarDateUtilV2`, used by both the transformer and the existing v2 value parser (`DateValueContentV2.from`), removing the duplicated logic. The constructor constraints (a day requires a month, Gregorian/Julian dates require an era) are returned as a `Left` rather than thrown.

Value types whose `valueHasString` depends on structures built later — rich text (standoff), `LinkValue` and file values — are handled where those structures are produced and remain out of scope here.
