### PR TITLE
feat(ontology): Reify LinkValues in transformer

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -105,6 +105,7 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
       _     <- ZIO.attempt(addResourceMetadata(model, ctx, now))
       _     <- ZIO.attempt(addValueMetadata(model, ctx, now))
       _     <- ZIO.attempt(convertDateValues(model))
+      _     <- ZIO.attempt(convertLinkValues(model))
       _     <- ZIO.attempt(addValueHasString(model))
       kb    <- tempFile("onto-transformer-kb-", ".nq")
       _     <- RdfDataMgr.write(model, kb, Lang.NTRIPLES)
@@ -143,7 +144,7 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
     val creationDateLit = model.createTypedLiteral(now.toString, XSDDatatype.XSDdateTimeStamp)
     val falseLit        = model.createTypedLiteral("false", XSDDatatype.XSDboolean)
 
-    val resources = model.listSubjects().asScala.toList.filter { s =>
+    val resources = model.listSubjects().asScala.filter { s =>
       s.isURIResource && ResourceIri.from(s.getURI).isRight
     }
     resources.foreach { r =>
@@ -171,7 +172,7 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
     val creationDateLit = model.createTypedLiteral(now.toString, XSDDatatype.XSDdateTimeStamp)
     val falseLit        = model.createTypedLiteral("false", XSDDatatype.XSDboolean)
 
-    model.listSubjects().asScala.toList.flatMap(s => asValueIri(s).map((s, _))).foreach { case (v, iri) =>
+    model.listSubjects().asScala.flatMap(s => asValueIri(s).map((s, _))).foreach { case (v, iri) =>
       v.removeAll(attachedToUser)
         .removeAll(hasPermissions)
         .removeAll(valueCreationDate)
@@ -232,7 +233,7 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
     def eraOf(v: Resource, p: Property): Option[DateEraV2] =
       stringOf(v, p).flatMap(DateEraV2.fromString(_).toOption)
 
-    val dateValues = model.listSubjects().asScala.toList.filter { s =>
+    val dateValues = model.listSubjects().asScala.filter { s =>
       asValueIri(s).isDefined &&
       Option(s.getProperty(rdfType)).map(_.getObject).exists(n => n.isURIResource && n.asResource.getURI == dateValue)
     }
@@ -271,6 +272,56 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
   }
 
   /**
+   * Step 4 — reify every `LinkValue` as an `rdf:Statement` and add the direct-link triple, mirroring
+   * `ResourcesRepoLive.buildLinkValuePatterns`. The link property is found from the unique `<resource> <linkProp>
+   * <value>` edge; the direct property is the link property without its `Value` suffix. The `linkValueHasTargetIri`
+   * is replaced by `rdf:subject`/`rdf:predicate`/`rdf:object` plus `valueHasRefCount` (1 for an explicit link) and a
+   * `valueHasString` of the target IRI. Standoff-derived links (step 5) will find-and-bump these by
+   * `(resource, directProp, target)` rather than duplicate them.
+   */
+  private def convertLinkValues(model: Model): Unit = {
+    val rdfType            = model.createProperty(Rdf.Type)
+    val linkValueType      = KnoraBase.LinkValue
+    val linkValueHasTarget = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "linkValueHasTargetIri")
+    val rdfSubject         = model.createProperty(Rdf.Subject)
+    val rdfPredicate       = model.createProperty(Rdf.Predicate)
+    val rdfObject          = model.createProperty(Rdf.Object)
+    val valueHasRefCount   = model.createProperty(KnoraBase.ValueHasRefCount)
+    val valueHasString     = model.createProperty(KnoraBase.ValueHasString)
+
+    val linkValues = model.listSubjects().asScala.filter { s =>
+      isValue(s) &&
+      Option(s.getProperty(rdfType))
+        .map(_.getObject)
+        .exists(n => n.isURIResource && n.asResource.getURI == linkValueType)
+    }
+
+    linkValues.foreach { v =>
+      val parent = model.listStatements(null, null, v).asScala.toList match {
+        case st :: Nil => st
+        case other     =>
+          throw new IllegalArgumentException(s"LinkValue $v must have exactly one incoming edge, found ${other.size}")
+      }
+      val resource = parent.getSubject
+      val linkProp = parent.getPredicate.getURI
+      val target   = Option(v.getProperty(linkValueHasTarget))
+        .map(_.getObject)
+        .collect { case n if n.isURIResource => n.asResource }
+        .getOrElse(throw new IllegalArgumentException(s"LinkValue $v has no linkValueHasTargetIri"))
+
+      val directProp = model.createProperty(linkProp.stripSuffix("Value"))
+
+      resource.addProperty(directProp, target)
+      v.removeAll(linkValueHasTarget)
+      v.addProperty(rdfSubject, resource)
+      v.addProperty(rdfPredicate, model.createResource(directProp.getURI))
+      v.addProperty(rdfObject, target)
+      v.addProperty(valueHasRefCount, model.createTypedLiteral("1", XSDDatatype.XSDinteger))
+      v.addProperty(valueHasString, target.getURI)
+    }
+  }
+
+  /**
    * Step 2 (`valueHasString`) — derive the plain-text `knora-base:valueHasString` from each value's content. Scalar
    * values use the lexical form of their content literal; `ListValue` falls back to the list-node IRI. `TextValue`
    * already carries `valueHasString` from the stage-1 rename and is left untouched. `DateValue` (step 3), `LinkValue`
@@ -299,7 +350,7 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
     def lexicalOf(v: Resource, p: Property): Option[String] =
       Option(v.getProperty(p)).map(_.getObject).collect { case n if n.isLiteral => n.asLiteral.getLexicalForm }
 
-    model.listSubjects().asScala.toList.filter(isValue).foreach { v =>
+    model.listSubjects().asScala.filter(isValue).foreach { v =>
       if (!v.hasProperty(valueHasString)) {
         val string = typeOf(v).flatMap {
           case cls if literalContent.contains(cls) => lexicalOf(v, literalContent(cls))

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -415,7 +415,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
                             |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
-                            |     knora-base:valueHasUUID      "${valueIri.valueId.value}" ;
+                            |     knora-base:valueHasUUID      "${valueIri.valueId}" ;
                             |     knora-base:valueHasString    "true" ;
                             |     knora-base:isDeleted         false .
                             |""".stripMargin,
@@ -459,7 +459,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
                             |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
-                            |     knora-base:valueHasUUID      "${valueIri.valueId.value}" ;
+                            |     knora-base:valueHasUUID      "${valueIri.valueId}" ;
                             |     knora-base:valueHasString    "1" ;
                             |     knora-base:isDeleted         false .
                             |
@@ -507,7 +507,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
        |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
        |     knora-base:hasPermissions    "${ctx.permissions}" ;
        |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
-       |     knora-base:valueHasUUID      "${valueIri.valueId.value}" ;
+       |     knora-base:valueHasUUID      "${valueIri.valueId}" ;
        |     knora-base:valueHasString    "$valueHasString" ;
        |     knora-base:isDeleted         false .
        |""".stripMargin
@@ -635,7 +635,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                           |     knora-base:attachedToUser         <${ctx.attachedToUser}> ;
                           |     knora-base:hasPermissions         "${ctx.permissions}" ;
                           |     knora-base:valueCreationDate      "$knownInstant"^^xsd:dateTimeStamp ;
-                          |     knora-base:valueHasUUID           "${valueIri.valueId.value}" ;
+                          |     knora-base:valueHasUUID           "${valueIri.valueId}" ;
                           |     knora-base:isDeleted              false .
                           |""".stripMargin,
     )
@@ -709,6 +709,50 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
     },
   )
 
+  private val linkValuesStage2 = suite("Stage 2 — LinkValue reification")(
+    test("reifies the LinkValue, adds the direct-link triple, refCount and valueHasString") {
+      val target = "http://rdfh.ch/9999/CV9Lea7hSESPWPuILr8dyw"
+      runTransformStage2(
+        jsonLd = resourceWithValueJsonLd(
+          valueProp = s"${onto}testHasLinkToValue",
+          valueClass = s"${knoraApi}LinkValue",
+          inner = s""""${knoraApi}linkValueHasTargetIri": { "@id": "$target" }""",
+        ),
+        expectedTurtle = s"""
+                            | PREFIX rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                            | PREFIX rdfs:       <http://www.w3.org/2000/01/rdf-schema#>
+                            | PREFIX xsd:        <http://www.w3.org/2001/XMLSchema#>
+                            | PREFIX onto:       <http://www.knora.org/ontology/9999/onto#>
+                            | PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                            |
+                            | <$resourceIri>
+                            |     a                            onto:Example ;
+                            |     rdfs:label                   "test" ;
+                            |     onto:testHasLinkToValue      <$valueIri> ;
+                            |     onto:testHasLinkTo           <$target> ;
+                            |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
+                            |     knora-base:attachedToProject <${ctx.attachedToProject.value}> ;
+                            |     knora-base:hasPermissions    "${ctx.permissions}" ;
+                            |     knora-base:creationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:isDeleted         false .
+                            |
+                            | <$valueIri>
+                            |     a                            knora-base:LinkValue ;
+                            |     rdf:subject                  <$resourceIri> ;
+                            |     rdf:predicate                onto:testHasLinkTo ;
+                            |     rdf:object                   <$target> ;
+                            |     knora-base:valueHasRefCount  1 ;
+                            |     knora-base:valueHasString    "$target" ;
+                            |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
+                            |     knora-base:hasPermissions    "${ctx.permissions}" ;
+                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:valueHasUUID      "${valueIri.valueId}" ;
+                            |     knora-base:isDeleted         false .
+                            |""".stripMargin,
+      )
+    },
+  )
+
   override def spec = suite("OntologyTransformerSpec")(
     simpleScalarValues,
     iriRefValues,
@@ -717,6 +761,6 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
     resourceMetadata,
     valueHasString,
     dateValuesStage2,
+    linkValuesStage2,
   ).provide(OntologyTransformer.layer, StringFormatter.test, TestAppConfig.layer())
-
 }


### PR DESCRIPTION
### Description

A `knora-base` `LinkValue` is an `rdf:Statement` reification of a direct link between two resources, and the public Knora-API v2 representation does not carry that reified form. This stage-2 step rebuilds it.

For each `LinkValue`, the transformer derives the direct property from the link property (dropping the `Value` suffix), emits the direct-link triple between the resource and the target, and reifies the value with `rdf:subject`/`rdf:predicate`/`rdf:object`, a `valueHasRefCount` of 1, and a `valueHasString` of the target IRI — mirroring how the API itself writes link values. The transient `linkValueHasTargetIri` is dropped.

The reification is keyed on `(resource, directProperty, target)` so the upcoming standoff conversion can find and bump the reference count of an existing link rather than create a duplicate.
