### PR TITLE
feat: Add create-only project data-graph import endpoints (v3)

### DIFF
--- a/docs/03-endpoints/api-v3/project-data-import.md
+++ b/docs/03-endpoints/api-v3/project-data-import.md
@@ -1,0 +1,109 @@
+# Project Data Import
+
+The project data import API creates a new project's data graph from a [knora-api (v2 external schema)](../api-v2/introduction.md)
+JSON-LD payload. The server transforms the payload into the internal knora-base representation, validates it, and
+streams it into the triplestore.
+
+Unlike the [Project Migration Export/Import](project-migration.md) — which moves a complete project (admin data,
+ontologies, permissions, assets) between instances as a BagIt package — the data import handles **instance data
+only**. The project and its ontologies must already exist on the instance, and the project's data graph must not
+exist yet (create-only).
+
+## Endpoints
+
+For request/response schemas, error codes, and interactive testing, see the
+[OpenAPI documentation](https://api.dasch.swiss/api/docs/#/API%20v3).
+
+| Route                                                | Method   | Description                             |
+| ---------------------------------------------------- | -------- | --------------------------------------- |
+| `/v3/projects/{projectIri}/data-imports`             | `POST`   | Upload JSON-LD and trigger async import |
+| `/v3/projects/{projectIri}/data-imports/{importId}`  | `GET`    | Poll import status                      |
+| `/v3/projects/{projectIri}/data-imports/{importId}`  | `DELETE` | Delete a completed/failed import        |
+
+## Authentication and Authorization
+
+All endpoints require a valid **Bearer JWT token** and **SystemAdmin** permissions.
+
+Requests from non-SystemAdmin users (e.g. project admins) are rejected with `403 Forbidden`.
+
+## Feature Flag
+
+The endpoints are gated behind the
+[`allow-project-data-import` feature flag](../../04-publishing-deployment/configuration.md#allow-project-data-import),
+which is disabled by default. When disabled, the endpoints return `404 Not Found`.
+
+## Request Format
+
+The request body is the project's data graph as JSON-LD in the knora-api v2 external (complex) schema, with content
+type `application/ld+json`. The payload contains resources and their values only — no admin data, ontologies, or
+permission data.
+
+Resource and value metadata that is managed by the server is synthesised during the import and need not (and should
+not) be supplied in the payload:
+
+- `attachedToProject` is derived from the `{projectIri}` path parameter.
+- `attachedToUser` is the authenticated user.
+- `hasPermissions` is resolved once from the project's default object access permissions (DOAPs) as they apply to
+  the authenticated user, and applied uniformly to every resource and value. Since the importer is always a system
+  admin, the project's ProjectAdmin-group DOAP has first precedence. Per-resource-class and per-property DOAPs are
+  not resolved per entity.
+- Creation dates are set to the time of the import.
+
+`@graph` declarations in the payload are ignored: all data is written exclusively into the project's data named
+graph, which is derived from the project.
+
+## Key Behaviors
+
+The import is **asynchronous**. Triggering an import returns `202 Accepted` with a task ID.
+Poll the status endpoint until `status` is `completed` or `failed`.
+The `status` field is one of: `in_progress`, `completed`, `failed`.
+
+The import is **create-only**: if the project already has a data graph, the request is rejected with
+`409 Conflict` and error code `data_graph_exists`. The precondition is checked synchronously when the import is
+triggered and re-verified immediately before the upload. Updating or extending an existing data graph is not
+possible with this API.
+
+Only **one data-graph import** can exist at a time. Attempting to create a second returns `409 Conflict` with the
+existing task's `id` in the error details. Delete the previous task before triggering a new one. Data-graph imports
+are tracked independently of migration imports and exports.
+
+The upload to Fuseki is **atomic** — if the upload fails, no partial data is written to the triplestore.
+
+## Import Validation
+
+Before anything is written to the triplestore, the transformed data is SHACL-validated against the same data shapes
+used by the [migration import](project-migration.md#shacl-validation). The project's ontologies are fetched from
+the triplestore to support the validation. Validation failure fails the task with a descriptive error message and
+leaves the triplestore untouched.
+
+## Typical Workflow
+
+```bash
+# Upload and trigger import
+curl -s --request POST \
+  --url 'https://server/v3/projects/http%3A%2F%2Frdfh.ch%2Fprojects%2F0001/data-imports' \
+  --header 'Authorization: Bearer <jwt>' \
+  --header 'Content-Type: application/ld+json' \
+  --data-binary @project-data.jsonld
+# Response: {"id": "<importId>", "status": "in_progress", ...}
+
+# Poll status until completed
+curl -s --request GET \
+  --url 'https://server/v3/projects/http%3A%2F%2Frdfh.ch%2Fprojects%2F0001/data-imports/<importId>' \
+  --header 'Authorization: Bearer <jwt>'
+# Response: {"status": "completed", ...}
+
+# Cleanup
+curl --request DELETE \
+  --url 'https://server/v3/projects/http%3A%2F%2Frdfh.ch%2Fprojects%2F0001/data-imports/<importId>' \
+  --header 'Authorization: Bearer <jwt>'
+```
+
+## Limitations
+
+- **Project and ontologies must already exist**: The import assumes class and property IRIs in the payload resolve
+  against ontologies already in the triplestore.
+- **Create-only**: Re-importing requires deleting the project's data graph first, which is out of scope for this API.
+- **No assets**: Binary assets are not part of the import; only RDF data is handled.
+- **JSON-LD only**: Other RDF serializations are not accepted.
+- **Single instance**: Task state is held in memory per instance (same constraint as migration import/export).

--- a/docs/04-publishing-deployment/configuration.md
+++ b/docs/04-publishing-deployment/configuration.md
@@ -71,6 +71,7 @@ via its environment variable or in `application.conf` under
 | app.features.disable-last-modification-date-check     | DISABLE_LAST_MODIFICATION_DATE_CHECK     | false         |
 | app.features.allow-import-migration-bagit             | ALLOW_IMPORT_MIGRATION_BAGIT             | true          |
 | app.features.allow-placeholder                        | ALLOW_PLACEHOLDER                        | true          |
+| app.features.allow-project-data-import                | ALLOW_PROJECT_DATA_IMPORT                | false         |
 
 ### `allow-erase-projects`
 
@@ -129,3 +130,11 @@ License urn:dasch:placeholder is the placeholder license and is not allowed on t
 
 This is checked at the server level — the placeholder license is rejected
 even if a project has explicitly enabled it.
+
+### `allow-project-data-import`
+
+Controls whether the project data-graph import endpoints are available.
+See [Project Data Import](../03-endpoints/api-v3/project-data-import.md)
+for the endpoint reference.
+
+When the flag is disabled, the data-graph import endpoints return `404 Not Found`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
           - Stores Endpoint: 03-endpoints/api-admin/stores.md
       - API V3:
           - Project Migration Export/Import: 03-endpoints/api-v3/project-migration.md
+          - Project Data Import: 03-endpoints/api-v3/project-data-import.md
       - Util API:
           - Version: 03-endpoints/api-util/version.md
       - Instrumentation API:

--- a/modules/test-e2e/src/test/resources/application.conf
+++ b/modules/test-e2e/src/test/resources/application.conf
@@ -15,5 +15,6 @@ app {
 
   features {
     allow-erase-projects = true
+    allow-project-data-import = true
   }
 }

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportE2ESpec.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.api.v3.projects
+
+import sttp.client4.*
+import sttp.model.*
+import zio.*
+import zio.json.ast.Json
+import zio.test.*
+
+import java.nio.charset.StandardCharsets
+
+import org.knora.webapi.E2EZSpec
+import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
+import org.knora.webapi.slice.`export`.domain.DataTaskId
+import org.knora.webapi.slice.`export`.domain.DataTaskStatus
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.testservices.TestApiClient
+
+object ProjectDataImportE2ESpec extends E2EZSpec {
+
+  // The incunabula project with its ontology but WITHOUT any project data — the data graph must not exist yet
+  // for the create-only import to succeed.
+  override def rdfDataObjects: List[RdfDataObject] = List(incunabulaRdfOntology)
+
+  private val projectIri  = incunabulaProjectIri.value
+  private val jsonLdType  = MediaType.unsafeApply("application", "ld+json")
+  private val resourceIri = ResourceIri.makeNew(Shortcode.unsafeFrom("0803"))
+
+  private val onto     = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#"
+  private val knoraApi = "http://api.knora.org/ontology/knora-api/v2#"
+
+  /** A minimal knora-api data graph: one incunabula book with a title value. */
+  private val dataGraphJsonLd =
+    s"""
+       |[{
+       |    "@id": "$resourceIri",
+       |    "@type": "${onto}book",
+       |    "rdfs:label": "Imported book",
+       |    "${onto}title": {
+       |      "@id": "$resourceIri/values/${java.util.UUID.randomUUID()}",
+       |      "@type": "${knoraApi}TextValue",
+       |      "${knoraApi}valueAsString": "An imported title"
+       |    },
+       |    "@context": {
+       |       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+       |    }
+       |}]""".stripMargin
+
+  override val e2eSpec: Spec[env, Any] = suite("Project Data Import E2E")(
+    test("return Forbidden for project admin user") {
+      for {
+        triggerResponse <- TestApiClient.postBinary[Json](
+                             uri"/v3/projects/$projectIri/data-imports",
+                             dataGraphJsonLd.getBytes(StandardCharsets.UTF_8),
+                             jsonLdType,
+                             incunabulaProjectAdminUser,
+                           )
+        fakeId          = "AAAAAAAAAAAAAAAAAAAAAA"
+        statusResponse <-
+          TestApiClient
+            .getJson[Json](uri"/v3/projects/$projectIri/data-imports/$fakeId", incunabulaProjectAdminUser)
+        deleteResponse <-
+          TestApiClient
+            .deleteJson[Json](uri"/v3/projects/$projectIri/data-imports/$fakeId", incunabulaProjectAdminUser)
+      } yield assertTrue(
+        triggerResponse.code == StatusCode.Forbidden,
+        statusResponse.code == StatusCode.Forbidden,
+        deleteResponse.code == StatusCode.Forbidden,
+      )
+    },
+    test("import a data graph, reject a second import, and clean up the task") {
+      for {
+        // Step 1: Trigger the import
+        triggerResponse <- TestApiClient.postBinary[DataTaskStatusResponse](
+                             uri"/v3/projects/$projectIri/data-imports",
+                             dataGraphJsonLd.getBytes(StandardCharsets.UTF_8),
+                             jsonLdType,
+                             rootUser,
+                           )
+        importStatus <- ZIO.fromEither(triggerResponse.body).mapError(new RuntimeException(_))
+        importId      = importStatus.id
+
+        // Step 2: Poll until completed
+        pollResult <- pollImportUntilDone(importId).retry(Schedule.spaced(500.millis) && Schedule.recurs(60))
+
+        // Step 3: The imported resource is visible through the normal API
+        resourceResponse <- TestApiClient.getJsonLd(uri"/v2/resources/${resourceIri.toString}", rootUser)
+
+        // Step 4: A second import is rejected — the project already has a data graph
+        secondResponse <- TestApiClient.postBinary[Json](
+                            uri"/v3/projects/$projectIri/data-imports",
+                            dataGraphJsonLd.getBytes(StandardCharsets.UTF_8),
+                            jsonLdType,
+                            rootUser,
+                          )
+
+        // Step 5: Delete the completed task
+        deleteResponse <- TestApiClient
+                            .deleteJson[Json](uri"/v3/projects/$projectIri/data-imports/${importId.value}", rootUser)
+
+        // Step 6: The deleted task is gone
+        statusAfterDelete <- TestApiClient
+                               .getJson[Json](uri"/v3/projects/$projectIri/data-imports/${importId.value}", rootUser)
+      } yield assertTrue(
+        triggerResponse.code == StatusCode.Accepted,
+        pollResult.status == DataTaskStatus.Completed,
+        resourceResponse.code == StatusCode.Ok,
+        resourceResponse.body.exists(_.contains("An imported title")),
+        secondResponse.code == StatusCode.Conflict,
+        secondResponse.body.exists(_.toString.contains("data_graph_exists")),
+        deleteResponse.code == StatusCode.NoContent,
+        statusAfterDelete.code == StatusCode.NotFound,
+      )
+    },
+  ) @@ TestAspect.sequential
+
+  private def pollImportUntilDone(importId: DataTaskId) =
+    TestApiClient
+      .getJson[DataTaskStatusResponse](uri"/v3/projects/$projectIri/data-imports/${importId.value}", rootUser)
+      .flatMap(r => ZIO.fromEither(r.body).mapError(new RuntimeException(_)))
+      .flatMap { status =>
+        status.status match {
+          case DataTaskStatus.Completed => ZIO.succeed(status)
+          case DataTaskStatus.Failed    => ZIO.succeed(status)
+          case _                        => ZIO.fail(new RuntimeException("Import still in progress"))
+        }
+      }
+}

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportE2ESpec.scala
@@ -20,6 +20,7 @@ import org.knora.webapi.slice.`export`.domain.DataTaskId
 import org.knora.webapi.slice.`export`.domain.DataTaskStatus
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.testservices.TestApiClient
 
 object ProjectDataImportE2ESpec extends E2EZSpec {
@@ -31,6 +32,8 @@ object ProjectDataImportE2ESpec extends E2EZSpec {
   private val projectIri  = incunabulaProjectIri.value
   private val jsonLdType  = MediaType.unsafeApply("application", "ld+json")
   private val resourceIri = ResourceIri.makeNew(Shortcode.unsafeFrom("0803"))
+  private val valueIri    = ValueIri.makeNew(resourceIri)
+  private val titleText   = "An imported title"
 
   private val onto     = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#"
   private val knoraApi = "http://api.knora.org/ontology/knora-api/v2#"
@@ -43,9 +46,9 @@ object ProjectDataImportE2ESpec extends E2EZSpec {
        |    "@type": "${onto}book",
        |    "rdfs:label": "Imported book",
        |    "${onto}title": {
-       |      "@id": "$resourceIri/values/${java.util.UUID.randomUUID()}",
+       |      "@id": "$valueIri",
        |      "@type": "${knoraApi}TextValue",
-       |      "${knoraApi}valueAsString": "An imported title"
+       |      "${knoraApi}valueAsString": "$titleText"
        |    },
        |    "@context": {
        |       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
@@ -74,9 +77,9 @@ object ProjectDataImportE2ESpec extends E2EZSpec {
         deleteResponse.code == StatusCode.Forbidden,
       )
     },
-    test("import a data graph, reject a second import, and clean up the task") {
+    test("import a data graph, read the resource and value via the v2 API, and clean up the task") {
       for {
-        // Step 1: Trigger the import
+        // Step 1: Trigger the import and poll until completed
         triggerResponse <- TestApiClient.postBinary[DataTaskStatusResponse](
                              uri"/v3/projects/$projectIri/data-imports",
                              dataGraphJsonLd.getBytes(StandardCharsets.UTF_8),
@@ -85,37 +88,44 @@ object ProjectDataImportE2ESpec extends E2EZSpec {
                            )
         importStatus <- ZIO.fromEither(triggerResponse.body).mapError(new RuntimeException(_))
         importId      = importStatus.id
+        pollResult   <- pollImportUntilDone(importId).retry(Schedule.spaced(500.millis) && Schedule.recurs(60))
 
-        // Step 2: Poll until completed
-        pollResult <- pollImportUntilDone(importId).retry(Schedule.spaced(500.millis) && Schedule.recurs(60))
-
-        // Step 3: The imported resource is visible through the normal API
+        // Step 2: The imported resource is readable through GET /v2/resources/{resourceIri}
         resourceResponse <- TestApiClient.getJsonLd(uri"/v2/resources/${resourceIri.toString}", rootUser)
 
-        // Step 4: A second import is rejected — the project already has a data graph
-        secondResponse <- TestApiClient.postBinary[Json](
-                            uri"/v3/projects/$projectIri/data-imports",
-                            dataGraphJsonLd.getBytes(StandardCharsets.UTF_8),
-                            jsonLdType,
-                            rootUser,
-                          )
+        // Step 3: The imported value is readable through GET /v2/values/{resourceIri}/{valueUuid}
+        valueResponse <-
+          TestApiClient.getJsonLd(uri"/v2/values/${resourceIri.toString}/${valueIri.valueId.value}", rootUser)
 
-        // Step 5: Delete the completed task
+        // Step 4: Delete the completed task, then confirm it is gone. The project data graph itself remains.
         deleteResponse <- TestApiClient
                             .deleteJson[Json](uri"/v3/projects/$projectIri/data-imports/${importId.value}", rootUser)
-
-        // Step 6: The deleted task is gone
         statusAfterDelete <- TestApiClient
                                .getJson[Json](uri"/v3/projects/$projectIri/data-imports/${importId.value}", rootUser)
       } yield assertTrue(
         triggerResponse.code == StatusCode.Accepted,
         pollResult.status == DataTaskStatus.Completed,
         resourceResponse.code == StatusCode.Ok,
-        resourceResponse.body.exists(_.contains("An imported title")),
-        secondResponse.code == StatusCode.Conflict,
-        secondResponse.body.exists(_.toString.contains("data_graph_exists")),
+        resourceResponse.body.exists(b => b.contains(valueIri.toString) && b.contains(titleText)),
+        valueResponse.code == StatusCode.Ok,
+        valueResponse.body.exists(b => b.contains(valueIri.toString) && b.contains(titleText)),
         deleteResponse.code == StatusCode.NoContent,
         statusAfterDelete.code == StatusCode.NotFound,
+      )
+    },
+    test("reject a second import when the project already has a data graph") {
+      // Relies on the previous test having created the project data graph (the suite runs sequentially).
+      // The create-only check fails synchronously with `data_graph_exists` before any task is created.
+      for {
+        response <- TestApiClient.postBinary[Json](
+                      uri"/v3/projects/$projectIri/data-imports",
+                      dataGraphJsonLd.getBytes(StandardCharsets.UTF_8),
+                      jsonLdType,
+                      rootUser,
+                    )
+      } yield assertTrue(
+        response.code == StatusCode.Conflict,
+        response.body.exists(_.toString.contains("data_graph_exists")),
       )
     },
   ) @@ TestAspect.sequential

--- a/modules/test-it/src/test/resources/application.conf
+++ b/modules/test-it/src/test/resources/application.conf
@@ -15,5 +15,6 @@ app {
 
   features {
     allow-erase-projects = true
+    allow-project-data-import = true
   }
 }

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -208,5 +208,8 @@ app {
 
         allow-placeholder = true
         allow-placeholder = ${?ALLOW_PLACEHOLDER}
+
+        allow-project-data-import = false
+        allow-project-data-import = ${?ALLOW_PROJECT_DATA_IMPORT}
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -171,6 +171,7 @@ final case class Features(
   triggerCompactionAfterProjectErasure: Boolean,
   allowImportMigrationBagit: Boolean,
   allowPlaceholder: Boolean,
+  allowProjectDataImport: Boolean,
 )
 
 object AppConfig {
@@ -205,6 +206,7 @@ object AppConfig {
          |* TRIGGER_COMPACTION_AFTER_PROJECT_ERASURE: ${c.features.triggerCompactionAfterProjectErasure}
          |* ALLOW_IMPORT_MIGRATION_BAGIT : ${c.features.allowImportMigrationBagit}
          |* ALLOW_PLACEHOLDER: ${c.features.allowPlaceholder}
+         |* ALLOW_PROJECT_DATA_IMPORT: ${c.features.allowProjectDataImport}
          |""".stripMargin,
     )
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -161,6 +161,43 @@ final class PermissionsResponder(
    * @param targetUser       the user for which the permissions need to be calculated.
    * @return an optional string with object access permission statements
    */
+  private def calculatePermissionWithPrecedence(
+    permissionsTasksInOrderOfPrecedence: List[Task[Option[Set[PermissionADM]]]],
+  ): Task[Option[Set[PermissionADM]]] =
+    ZIO.foldLeft(permissionsTasksInOrderOfPrecedence)(None: Option[Set[PermissionADM]]) { (acc, task) =>
+      if (acc.isDefined) {
+        ZIO.succeed(acc)
+      } else {
+        task.flatMap {
+          (acc, _) match
+            case (None, Some(permissions)) if permissions.nonEmpty => ZIO.some(permissions)
+            case _                                                 => ZIO.succeed(acc)
+        }
+      }
+    }
+
+  private def projectAdminDoap(projectIri: ProjectIri, targetUser: User): Task[Option[Set[PermissionADM]]] =
+    findDoapPermissionADM(projectIri, List(builtIn.ProjectAdmin.id))
+      .when(targetUser.isProjectAdmin(projectIri) || targetUser.isSystemAdmin)
+
+  private def customGroupsDoap(projectIri: ProjectIri, targetUser: User): Task[Option[Set[PermissionADM]]] = {
+    val otherGroups =
+      targetUser.permissions.groupsPerProject.getOrElse(projectIri.value, Seq.empty).map(GroupIri.unsafeFrom) diff
+        List(builtIn.KnownUser.id, builtIn.ProjectMember.id, builtIn.ProjectAdmin.id, builtIn.SystemAdmin.id)
+    ZIO.when(otherGroups.distinct.nonEmpty)(findDoapPermissionADM(projectIri, otherGroups))
+  }
+
+  private def projectMembersDoap(projectIri: ProjectIri, targetUser: User): Task[Option[Set[PermissionADM]]] =
+    findDoapPermissionADM(projectIri, List(builtIn.ProjectMember.id))
+      .when(targetUser.isProjectMember(projectIri) || targetUser.isSystemAdmin)
+
+  private def knownUserDoap(projectIri: ProjectIri, targetUser: User): Task[Option[Set[PermissionADM]]] =
+    findDoapPermissionADM(projectIri, List(builtIn.KnownUser.id))
+      .when(!targetUser.isAnonymousUser)
+
+  private val fallbackDoap: Set[PermissionADM] =
+    Set(PermissionADM.from(Permission.ObjectAccess.ChangeRights, builtIn.Creator.id.value))
+
   private def defaultObjectAccessPermissionsStringForEntityGetADM(
     projectIri: ProjectIri,
     resourceClassIri: ResourceClassIri,
@@ -168,25 +205,6 @@ final class PermissionsResponder(
     entityType: EntityType,
     targetUser: User,
   ): Task[DefaultObjectAccessPermissionsStringResponseADM] = {
-
-    def calculatePermissionWithPrecedence(
-      permissionsTasksInOrderOfPrecedence: List[Task[Option[Set[PermissionADM]]]],
-    ): Task[Option[Set[PermissionADM]]] =
-      ZIO.foldLeft(permissionsTasksInOrderOfPrecedence)(None: Option[Set[PermissionADM]]) { (acc, task) =>
-        if (acc.isDefined) {
-          ZIO.succeed(acc)
-        } else {
-          task.flatMap {
-            (acc, _) match
-              case (None, Some(permissions)) if permissions.nonEmpty => ZIO.some(permissions)
-              case _                                                 => ZIO.succeed(acc)
-          }
-        }
-      }
-
-    val projectAdmin =
-      findDoapPermissionADM(projectIri, List(builtIn.ProjectAdmin.id))
-        .when(targetUser.isProjectAdmin(projectIri) || targetUser.isSystemAdmin)
 
     val resourceClassProperty = ZIO
       .when(entityType == EntityType.Property)(
@@ -214,40 +232,40 @@ final class PermissionsResponder(
           .flatMap(p => findDoapPermissionADM(projectIri, ForWhat(p)))
       }
 
-    val customGroups = {
-      val otherGroups =
-        targetUser.permissions.groupsPerProject.getOrElse(projectIri.value, Seq.empty).map(GroupIri.unsafeFrom) diff
-          List(builtIn.KnownUser.id, builtIn.ProjectMember.id, builtIn.ProjectAdmin.id, builtIn.SystemAdmin.id)
-      ZIO.when(otherGroups.distinct.nonEmpty)(findDoapPermissionADM(projectIri, otherGroups))
-    }
-
-    val projectMembers = ZIO
-      .when(targetUser.isProjectMember(projectIri) || targetUser.isSystemAdmin)(
-        findDoapPermissionADM(projectIri, List(builtIn.ProjectMember.id)),
-      )
-
-    val knownUser = ZIO.when(!targetUser.isAnonymousUser)(
-      findDoapPermissionADM(projectIri, List(builtIn.KnownUser.id)),
-    )
-
     val permissionTasks: List[Task[Option[Set[PermissionADM]]]] =
       List(
-        projectAdmin,
+        projectAdminDoap(projectIri, targetUser),
         resourceClassProperty,
         resourceClass,
         property,
-        customGroups,
-        projectMembers,
-        knownUser,
+        customGroupsDoap(projectIri, targetUser),
+        projectMembersDoap(projectIri, targetUser),
+        knownUserDoap(projectIri, targetUser),
       )
 
     for {
       permissions <- calculatePermissionWithPrecedence(permissionTasks)
-      result       = permissions
-                 .getOrElse(Set(PermissionADM.from(Permission.ObjectAccess.ChangeRights, builtIn.Creator.id.value)))
-      resultStr = PermissionUtilADM.formatPermissionADMs(result, DOAP)
+      result       = permissions.getOrElse(fallbackDoap)
+      resultStr    = PermissionUtilADM.formatPermissionADMs(result, DOAP)
     } yield DefaultObjectAccessPermissionsStringResponseADM(resultStr)
   }
+
+  /**
+   * Resolves the default object access permissions literal for a project data-graph import, where a single user
+   * creates every resource and value and no per-entity (resource class / property) DOAPs are applied. Group-based
+   * precedence only: ProjectAdmin → custom groups → ProjectMember → KnownUser → fallback (`CR knora-admin:Creator`).
+   * Since the importer is always a system admin, the project's ProjectAdmin-group DOAP has first precedence and
+   * applies uniformly to all resources and values.
+   */
+  def newDataImportDefaultObjectAccessPermissions(projectIri: ProjectIri, targetUser: User): Task[String] =
+    calculatePermissionWithPrecedence(
+      List(
+        projectAdminDoap(projectIri, targetUser),
+        customGroupsDoap(projectIri, targetUser),
+        projectMembersDoap(projectIri, targetUser),
+        knownUserDoap(projectIri, targetUser),
+      ),
+    ).map(permissions => PermissionUtilADM.formatPermissionADMs(permissions.getOrElse(fallbackDoap), DOAP))
 
   private def validate(
     req: CreateDefaultObjectAccessPermissionAPIRequestADM,

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponder.scala
@@ -142,25 +142,6 @@ final class PermissionsResponder(
       .findByProjectAndForWhat(projectIri, forWhat)
       .map(_.map(DefaultObjectAccessPermissionADM.from).toSet.flatMap(_.hasPermissions))
 
-  /**
-   * Returns a string containing default object permissions statements ready for usage during creation of a new resource.
-   * The permissions include any default object access permissions defined for the resource class and on any groups the
-   * user is member of.
-   * The default object access permissions are determined with the following precedence:
-   *
-   *  1. ProjectAdmin
-   *  2. ProjectEntity
-   *  3. SystemEntity
-   *  4. CustomGroups
-   *  5. ProjectMember
-   *  6. KnownUser
-   *
-   * @param projectIri       the IRI of the project.
-   * @param resourceClassIri the IRI of the resource class for which the default object access permissions are requested.
-   * @param propertyIri      the IRI of the property for which the default object access permissions are requested.
-   * @param targetUser       the user for which the permissions need to be calculated.
-   * @return an optional string with object access permission statements
-   */
   private def calculatePermissionWithPrecedence(
     permissionsTasksInOrderOfPrecedence: List[Task[Option[Set[PermissionADM]]]],
   ): Task[Option[Set[PermissionADM]]] =
@@ -198,6 +179,25 @@ final class PermissionsResponder(
   private val fallbackDoap: Set[PermissionADM] =
     Set(PermissionADM.from(Permission.ObjectAccess.ChangeRights, builtIn.Creator.id.value))
 
+  /**
+   * Returns a string containing default object permissions statements ready for usage during creation of a new resource.
+   * The permissions include any default object access permissions defined for the resource class and on any groups the
+   * user is member of.
+   * The default object access permissions are determined with the following precedence:
+   *
+   *  1. ProjectAdmin
+   *  2. ProjectEntity
+   *  3. SystemEntity
+   *  4. CustomGroups
+   *  5. ProjectMember
+   *  6. KnownUser
+   *
+   * @param projectIri       the IRI of the project.
+   * @param resourceClassIri the IRI of the resource class for which the default object access permissions are requested.
+   * @param propertyIri      the IRI of the property for which the default object access permissions are requested.
+   * @param targetUser       the user for which the permissions need to be calculated.
+   * @return an optional string with object access permission statements
+   */
   private def defaultObjectAccessPermissionsStringForEntityGetADM(
     projectIri: ProjectIri,
     resourceClassIri: ResourceClassIri,

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/ApiV3Module.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/ApiV3Module.scala
@@ -9,6 +9,7 @@ import sttp.tapir.*
 import zio.*
 
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.`export`.domain.ProjectDataImportService
 import org.knora.webapi.slice.`export`.domain.ProjectMigrationExportService
 import org.knora.webapi.slice.`export`.domain.ProjectMigrationImportService
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
@@ -43,6 +44,7 @@ object ApiV3Module {
     KnoraProjectService &
     OntologyCache &
     OntologyRepo &
+    ProjectDataImportService &
     ProjectMigrationExportService &
     ProjectMigrationImportService &
     ResourcesRepo &

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/V3ErrorCode.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/V3ErrorCode.scala
@@ -28,6 +28,7 @@ enum V3ErrorCode(val template: String):
   case export_failed      extends V3ErrorCode("Export '{id}' failed for project '{projectIri}'.")
   case import_exists      extends V3ErrorCode("Import '{id}' exists for project '{projectIri}'.")
   case import_in_progress extends V3ErrorCode("Import '{id}' in progress for project '{projectIri}'.")
+  case data_graph_exists  extends V3ErrorCode("The data graph for project '{projectIri}' already exists.")
   // V3ErrorCode.BadRequest errors
   case invalid_ontology_mapping_iri extends V3ErrorCode("Invalid OntologyMappingIri: '{iri}'.")
 
@@ -38,7 +39,7 @@ object V3ErrorCode:
     property_not_found.type
 
   type Conflicts = export_exists.type | export_failed.type | export_in_progress.type | import_exists.type |
-    import_in_progress.type
+    import_in_progress.type | data_graph_exists.type
 
   given Schema[V3ErrorCode] = Schema.derivedEnumeration[V3ErrorCode].defaultStringBased
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsEndpoints.scala
@@ -56,7 +56,7 @@ class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
   private val importIdPathVar = path[DataTaskId]("importId")
 
   /** The streamed knora-api JSON-LD payload of a data-graph import. */
-  private case class JsonLdCodecFormat() extends CodecFormat {
+  private case object JsonLdCodecFormat extends CodecFormat {
     override val mediaType: MediaType = MediaType("application", "ld+json")
   }
 
@@ -161,6 +161,8 @@ class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
     )
 
   // import a project data graph
+  // Two distinct 409s: `import_exists` (a previous data-graph import task still exists — the per-kind task mutex)
+  // and `data_graph_exists` (the create-only precondition — the project already has a data graph).
   val postProjectIriDataImports = self.base
     .secured(
       oneOf(
@@ -171,7 +173,7 @@ class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
     .post
     .in(dataImportsBase)
     .in(
-      streamBinaryBody(ZioStreams)(JsonLdCodecFormat())
+      streamBinaryBody(ZioStreams)(JsonLdCodecFormat)
         .description("The project's data graph as knora-api (v2 external) JSON-LD"),
     )
     .out(statusCode(StatusCode.Accepted))

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsEndpoints.scala
@@ -47,12 +47,18 @@ object DataTaskStatusResponse {
 
 class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
 
-  private val basePath    = ApiV3.V3ProjectsProjectIri
-  private val exportsBase = basePath / "exports"
-  private val importsBase = basePath / "imports"
+  private val basePath        = ApiV3.V3ProjectsProjectIri
+  private val exportsBase     = basePath / "exports"
+  private val importsBase     = basePath / "imports"
+  private val dataImportsBase = basePath / "data-imports"
 
   private val exportIdPathVar = path[DataTaskId]("exportId")
   private val importIdPathVar = path[DataTaskId]("importId")
+
+  /** The streamed knora-api JSON-LD payload of a data-graph import. */
+  private case class JsonLdCodecFormat() extends CodecFormat {
+    override val mediaType: MediaType = MediaType("application", "ld+json")
+  }
 
   // trigger an export
   val postProjectIriExports = self.base
@@ -152,6 +158,58 @@ class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
     .description(
       "Checks the status of an import. " +
         "The response will indicate whether the import is still in progress, has completed successfully, or has failed.",
+    )
+
+  // import a project data graph
+  val postProjectIriDataImports = self.base
+    .secured(
+      oneOf(
+        notFoundVariant(V3ErrorCode.project_not_found, V3ErrorCode.feature_missing),
+        conflictVariant(V3ErrorCode.import_exists, V3ErrorCode.data_graph_exists),
+      ),
+    )
+    .post
+    .in(dataImportsBase)
+    .in(
+      streamBinaryBody(ZioStreams)(JsonLdCodecFormat())
+        .description("The project's data graph as knora-api (v2 external) JSON-LD"),
+    )
+    .out(statusCode(StatusCode.Accepted))
+    .out(jsonBody[DataTaskStatusResponse])
+    .description(
+      "Initiates an import of a project's data graph from a knora-api JSON-LD payload. " +
+        "The import will be performed asynchronously, and the response will contain an import ID that can be used to check the status of the import. " +
+        "The import is create-only: it fails if the project already has a data graph. " +
+        "An import can only be triggered when no other data-graph import exists.",
+    )
+
+  // get the status of a data-graph import
+  val getProjectIriDataImportsImportId = self.base
+    .secured(oneOf(notFoundVariant(V3ErrorCode.import_not_found, V3ErrorCode.feature_missing)))
+    .get
+    .in(dataImportsBase / importIdPathVar)
+    .out(statusCode(StatusCode.Ok))
+    .out(jsonBody[DataTaskStatusResponse])
+    .description(
+      "Checks the status of a data-graph import. " +
+        "The response will indicate whether the import is still in progress, has completed successfully, or has failed.",
+    )
+
+  // delete a data-graph import
+  val deleteProjectIriDataImportsImportId = self.base
+    .secured(
+      oneOf(
+        notFoundVariant(V3ErrorCode.import_not_found, V3ErrorCode.feature_missing),
+        conflictVariant(V3ErrorCode.import_in_progress),
+      ),
+    )
+    .delete
+    .in(dataImportsBase / importIdPathVar)
+    .out(statusCode(StatusCode.NoContent))
+    .description(
+      "Deletes a data-graph import. " +
+        "Only imports in state failed or completed can be deleted. " +
+        "If it is still in progress, the response will be 409 Conflict.",
     )
 
   // delete an import

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsRestService.scala
@@ -16,6 +16,7 @@ import org.knora.webapi.slice.`export`.domain.ExportFailedError
 import org.knora.webapi.slice.`export`.domain.ExportInProgressError
 import org.knora.webapi.slice.`export`.domain.ImportExistsError
 import org.knora.webapi.slice.`export`.domain.ImportInProgressError
+import org.knora.webapi.slice.`export`.domain.ProjectDataImportService
 import org.knora.webapi.slice.`export`.domain.ProjectMigrationExportService
 import org.knora.webapi.slice.`export`.domain.ProjectMigrationImportService
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
@@ -26,6 +27,7 @@ import org.knora.webapi.slice.api.v3.NotFound
 import org.knora.webapi.slice.api.v3.V3Authorizer
 import org.knora.webapi.slice.api.v3.V3ErrorCode.Conflicts
 import org.knora.webapi.slice.api.v3.V3ErrorCode.NotFounds
+import org.knora.webapi.slice.api.v3.V3ErrorCode.data_graph_exists
 import org.knora.webapi.slice.api.v3.V3ErrorCode.export_exists
 import org.knora.webapi.slice.api.v3.V3ErrorCode.export_failed
 import org.knora.webapi.slice.api.v3.V3ErrorCode.export_in_progress
@@ -39,6 +41,7 @@ final class V3ProjectsRestService(
   auth: V3Authorizer,
   exportService: ProjectMigrationExportService,
   importService: ProjectMigrationImportService,
+  dataImportService: ProjectDataImportService,
   projectService: KnoraProjectService,
 ) {
 
@@ -141,6 +144,58 @@ final class V3ProjectsRestService(
       for {
         _ <- auth.ensureSystemAdmin(user)
         _ <- importService
+               .deleteImport(importId)
+               .mapError {
+                 case Some(ImportInProgressError(t)) => conflict(import_in_progress, t.projectIri, t.id)
+                 case None                           => notFound(import_not_found, projectIri, importId)
+               }
+      } yield ()
+    }
+
+  private val failDataImportFeatureMissing: IO[V3ErrorInfo, Unit] = ZIO
+    .fail(NotFound.featureMissing("allowProjectDataImport"))
+    .unlessZIO(AppConfig.features(_.allowProjectDataImport))
+    .unit
+
+  private def dataGraphExistsConflict(projectIri: ProjectIri): Conflict =
+    Conflict(
+      data_graph_exists,
+      data_graph_exists.template.replace("{projectIri}", projectIri.value),
+      Map("projectIri" -> projectIri.value),
+    )
+
+  def triggerProjectDataImportCreate(
+    user: User,
+  )(projectIri: ProjectIri, stream: ZStream[Any, Throwable, Byte]): IO[V3ErrorInfo, DataTaskStatusResponse] =
+    failDataImportFeatureMissing.zipRight(for {
+      project <- ensureSystemAdminAndProjectExists(user, projectIri)
+      // Create-only precondition (synchronous, so the client receives a real 409). It is re-verified inside the
+      // import task immediately before the upload.
+      _ <- ZIO
+             .fail(dataGraphExistsConflict(projectIri))
+             .whenZIO(dataImportService.dataGraphExists(project).orDie)
+      state <-
+        dataImportService
+          .importDataGraph(project, user, stream)
+          .mapError { case ImportExistsError(t) => conflict(import_exists, t.projectIri, t.id) }
+    } yield DataTaskStatusResponse.from(state))
+
+  def getProjectDataImportStatus(
+    user: User,
+  )(projectIri: ProjectIri, importId: DataTaskId): IO[V3ErrorInfo, DataTaskStatusResponse] =
+    failDataImportFeatureMissing.zipRight {
+      for {
+        _     <- auth.ensureSystemAdmin(user)
+        state <-
+          dataImportService.getImportStatus(importId).orElseFail(notFound(import_not_found, projectIri, importId))
+      } yield DataTaskStatusResponse.from(state)
+    }
+
+  def deleteProjectDataImport(user: User)(projectIri: ProjectIri, importId: DataTaskId): IO[V3ErrorInfo, Unit] =
+    failDataImportFeatureMissing.zipRight {
+      for {
+        _ <- auth.ensureSystemAdmin(user)
+        _ <- dataImportService
                .deleteImport(importId)
                .mapError {
                  case Some(ImportInProgressError(t)) => conflict(import_in_progress, t.projectIri, t.id)

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsServerEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsServerEndpoints.scala
@@ -19,6 +19,9 @@ final class V3ProjectsServerEndpoints(endpoints: V3ProjectsEndpoints, restServic
     endpoints.postProjectIriImports.serverLogic(restService.triggerProjectImportCreate),
     endpoints.getProjectIriImportsImportId.serverLogic(restService.getProjectImportStatus),
     endpoints.deleteProjectIriImportsImportId.serverLogic(restService.deleteProjectImport),
+    endpoints.postProjectIriDataImports.serverLogic(restService.triggerProjectDataImportCreate),
+    endpoints.getProjectIriDataImportsImportId.serverLogic(restService.getProjectDataImportStatus),
+    endpoints.deleteProjectIriDataImportsImportId.serverLogic(restService.deleteProjectDataImport),
   )
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminUsersQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminUsersQuery.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.`export`.domain
+
+import org.eclipse.rdf4j.sparqlbuilder.core.query.ConstructQuery
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
+
+import org.knora.webapi.slice.admin.AdminConstants.adminDataNamedGraph
+import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraAdmin as KA
+
+object AdminUsersQuery extends QueryBuilderHelper {
+
+  /**
+   * CONSTRUCT projecting only the `?user a knora-admin:User` typing triples from the admin data graph. The SHACL
+   * data shapes check that every `attachedToUser` reference points to a `knora-admin:User` instance; the projection
+   * keeps the validation model's size independent of the instance's full admin data (user profiles, groups,
+   * projects, permissions).
+   */
+  def build: ConstructQuery = {
+    val user = variable("user")
+    Queries
+      .CONSTRUCT(user.isA(KA.User))
+      .where(user.isA(KA.User).from(Rdf.iri(adminDataNamedGraph.value)))
+  }
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/DataTaskStorage.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/DataTaskStorage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.`export`.domain
+
+import zio.*
+import zio.nio.file.Files
+import zio.nio.file.Path
+
+/** Filesystem helpers shared by the data-task storage services. */
+private[domain] object DataTaskStorage {
+
+  def ensureDirExists(path: Path, taskId: DataTaskId): UIO[Unit] =
+    Files.createDirectories(path).logError(s"$taskId: Failed to create directory at $path").orDie
+
+  /** Creates `baseDir/temp`, deleting it recursively when the scope closes. */
+  def scopedTempDir(taskId: DataTaskId, baseDir: Path): URIO[Scope, Path] = {
+    val tempPath = baseDir / "temp"
+    ZIO.acquireRelease(Files.createDirectories(tempPath).logError.orDie.as(tempPath)) { (path: Path) =>
+      ZIO.logInfo(s"$taskId: Deleting temp directory $path") *>
+        Files.deleteRecursive(path).logError(s"$taskId: Failed deleting temp directory $path").orDie
+    }
+  }
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ExportModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ExportModule.scala
@@ -8,10 +8,12 @@ package org.knora.webapi.slice.`export`.domain
 import zio.URLayer
 import zio.ZLayer
 
+import org.knora.webapi.responders.admin.PermissionsResponder
 import org.knora.webapi.slice.admin.domain.service.DspIngestClient
 import org.knora.webapi.slice.admin.domain.service.KnoraGroupService
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.admin.domain.service.KnoraUserService
+import org.knora.webapi.slice.ontology.OntologyTransformer
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 
@@ -23,16 +25,19 @@ object ExportModule {
     KnoraProjectService &
     KnoraUserService &
     OntologyCache &
+    OntologyTransformer &
+    PermissionsResponder &
     TriplestoreService
     // format: on
 
   type Provided =
     // format: off
+    ProjectDataImportService &
     ProjectMigrationExportService &
     ProjectMigrationImportService
     // format: on
 
   val layer: URLayer[Dependencies, Provided] =
     (ProjectMigrationStorageService.layer ++ ProjectMigrationImportValidator.layer) >>>
-      (ProjectMigrationExportService.layer ++ ProjectMigrationImportService.layer)
+      (ProjectMigrationExportService.layer ++ ProjectMigrationImportService.layer ++ ProjectDataImportService.layer)
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/FilesystemDataTaskPersistence.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/FilesystemDataTaskPersistence.scala
@@ -113,6 +113,8 @@ object FilesystemDataTaskPersistence {
     ZLayer(ZIO.serviceWithZIO[ProjectMigrationStorageService](_.exportsDir)) >>> layer >>> ZLayer(restore)
   def importLayer: URLayer[ProjectMigrationStorageService, DataTaskState] =
     ZLayer(ZIO.serviceWithZIO[ProjectMigrationStorageService](_.importsDir)) >>> layer >>> ZLayer(restore)
+  def dataImportLayer: URLayer[ProjectDataImportStorageService, DataTaskState] =
+    ZLayer(ZIO.serviceWithZIO[ProjectDataImportStorageService](_.dataImportsDir)) >>> layer >>> ZLayer(restore)
 
   private def restore = for {
     // Restore the current task from the filesystem if it exists,

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsQuery.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.`export`.domain
+
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
+import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
+
+object ProjectDataGraphExistsQuery extends QueryBuilderHelper {
+
+  /** ASK whether the project's data named graph contains any triples. */
+  def build(project: KnoraProject): Ask = {
+    val (s, p, o) = spo
+    Ask(s"""
+           |ASK
+           |WHERE {
+           |  ${s.has(p, o).from(graphIri(project)).getQueryString}
+           |}
+           |""".stripMargin)
+  }
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportService.scala
@@ -19,7 +19,6 @@ import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.ontology.ConversionContext
 import org.knora.webapi.slice.ontology.OntologyTransformer
-import org.knora.webapi.slice.ontology.repo.service.OntologyCache
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 
 /**
@@ -35,7 +34,6 @@ final class ProjectDataImportService(
   transformer: OntologyTransformer,
   validator: ProjectMigrationImportValidator,
   triplestore: TriplestoreService,
-  ontologyCache: OntologyCache,
 ) { self =>
 
   /** Whether the project's data named graph already contains any triples (create-only precondition, R7). */
@@ -72,14 +70,16 @@ final class ProjectDataImportService(
         ctx          = ConversionContext(createdBy.userIri, project, permissions)
         transformed <- transformer
                          .toKnoraBase(jsonLdPath.toFile.toPath, ctx)
-                         .mapError(e => new RuntimeException(e.message))
+                         .mapError(e => new RuntimeException(s"Transformation failed: ${e.message}"))
         _ <- ZIO.logInfo(s"$taskId: Transformed data to knora-base for project '${project.id}'")
 
         _ <- validate(taskId, project, Path.fromJava(transformed))
         _ <- ZIO.logInfo(s"$taskId: Validation passed for project '${project.id}'")
 
         // Re-verify the create-only precondition immediately before the upload: a data graph may have appeared
-        // since the synchronous check in the RestService (e.g. via a concurrent migration import).
+        // since the synchronous check in the RestService (e.g. via a concurrent migration import). This narrows but
+        // does not fully close the race window — acceptable for an admin-only, single-in-flight-task operation.
+        // Wording kept aligned with `V3ErrorCode.data_graph_exists`.
         _ <- ZIO
                .fail(new RuntimeException(s"The data graph for project '${project.id}' already exists."))
                .whenZIO(dataGraphExists(project))
@@ -89,15 +89,18 @@ final class ProjectDataImportService(
         _ <- state.complete(taskId).ignore
         _ <- ZIO.logInfo(s"$taskId: Data import completed for project '${project.id}'")
       } yield ()
-    }.logError.catchAll(e =>
+    }.catchAll(e =>
       ZIO.logError(s"$taskId: Data import failed for project '${project.id}' with error: ${e.getMessage}") *>
         state.fail(taskId, Option(e.getMessage).getOrElse(e.getClass.getSimpleName)).ignore,
     )
 
   /**
    * SHACL-validates the transformed NQuads, adapting the migration import's validation: the project's ontology
-   * graphs and the admin data graph (the data shapes check `attachedToUser` references against
-   * `knora-admin:User` instances) are fetched from the triplestore — the payload carries instance data only.
+   * graphs are fetched from the triplestore — the payload carries instance data only. The data shapes also check
+   * `attachedToUser` references against `knora-admin:User` instances, so a projection of the user typing triples
+   * is included in the data files (only the typing triples — downloading the full admin graph would scale with
+   * instance size, not import size). Including it in the data chunk means the shared validator's placeholder scan
+   * also runs over it, which is harmless for typing-only triples.
    */
   private def validate(taskId: DataTaskId, project: KnoraProject, dataFile: Path): ZIO[Scope, Throwable, Unit] = for {
     graphs <- projectService.getOntologyGraphsForProject(project)
@@ -106,17 +109,21 @@ final class ProjectDataImportService(
            .when(graphs.isEmpty)
     _             <- ZIO.logInfo(s"$taskId: Fetching ontologies '${graphs.map(_.value).mkString(",")}' for validation")
     tempDir       <- storage.tempDataImportScoped(taskId)
-    ontologyFiles <- ZIO.foreach(Chunk.fromIterable(graphs).zipWithIndex) { (g, i) =>
+    ontologyFiles <- ZIO.foreachPar(Chunk.fromIterable(graphs).zipWithIndex) { (g, i) =>
                        val file = tempDir / s"ontology-${i + 1}.nq"
                        Files.createFile(file) *> triplestore.downloadGraph(g, file, NQuads).as(file)
                      }
+    ontologyFilesNec <- ZIO
+                          .fromOption(NonEmptyChunk.fromChunk(ontologyFiles))
+                          .orDieWith(_ => new IllegalStateException("ontologyFiles is empty despite non-empty graphs"))
     adminFile = tempDir / "admin.nq"
-    _        <- Files.createFile(adminFile) *> triplestore.downloadGraph(adminDataNamedGraph, adminFile, NQuads)
-    _        <- validator.validate(NonEmptyChunk.fromChunk(ontologyFiles).get, NonEmptyChunk(adminFile, dataFile), project.id)
+    _        <- triplestore.queryToFile(AdminUsersQuery.build, adminDataNamedGraph, adminFile, NQuads)
+    _        <- validator.validate(ontologyFilesNec, NonEmptyChunk(adminFile, dataFile), project.id)
   } yield ()
 
+  // No ontology cache refresh: a data-graph import adds no ontology triples.
   private def uploadToTriplestore(nqFile: Path): Task[Unit] =
-    triplestore.uploadNQuads(ZStream.fromFile(nqFile.toFile)) *> ontologyCache.refreshCache().unit
+    triplestore.uploadNQuads(ZStream.fromFile(nqFile.toFile))
 
   def getImportStatus(importId: DataTaskId): IO[Option[Nothing], CurrentDataTask] = state.find(importId)
 
@@ -136,7 +143,7 @@ final class ProjectDataImportService(
 object ProjectDataImportService {
   val layer: URLayer[
     KnoraProjectService & PermissionsResponder & OntologyTransformer & ProjectMigrationImportValidator &
-      TriplestoreService & OntologyCache,
+      TriplestoreService,
     ProjectDataImportService,
   ] = (ProjectDataImportStorageService.layer >+> FilesystemDataTaskPersistence.dataImportLayer) >>>
     ZLayer.derive[ProjectDataImportService]

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportService.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.`export`.domain
+
+import zio.*
+import zio.nio.file.Files
+import zio.nio.file.Path
+import zio.stream.ZSink
+import zio.stream.ZStream
+
+import org.knora.webapi.messages.util.rdf.NQuads
+import org.knora.webapi.responders.admin.PermissionsResponder
+import org.knora.webapi.slice.admin.AdminConstants.adminDataNamedGraph
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
+import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
+import org.knora.webapi.slice.ontology.ConversionContext
+import org.knora.webapi.slice.ontology.OntologyTransformer
+import org.knora.webapi.slice.ontology.repo.service.OntologyCache
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+
+/**
+ * Imports a project's data graph from a knora-api JSON-LD payload: transforms it to knora-base NQuads (assigned to
+ * the project's data named graph), SHACL-validates the result against the project's ontologies fetched from the
+ * triplestore, and streams it into the triplestore. Create-only: the project's data graph must not exist yet.
+ */
+final class ProjectDataImportService(
+  state: DataTaskState,
+  storage: ProjectDataImportStorageService,
+  projectService: KnoraProjectService,
+  permissionsResponder: PermissionsResponder,
+  transformer: OntologyTransformer,
+  validator: ProjectMigrationImportValidator,
+  triplestore: TriplestoreService,
+  ontologyCache: OntologyCache,
+) { self =>
+
+  /** Whether the project's data named graph already contains any triples (create-only precondition, R7). */
+  def dataGraphExists(project: KnoraProject): Task[Boolean] =
+    triplestore.query(ProjectDataGraphExistsQuery.build(project))
+
+  def importDataGraph(
+    project: KnoraProject,
+    createdBy: User,
+    stream: ZStream[Any, Throwable, Byte],
+  ): IO[ImportExistsError, CurrentDataTask] = for {
+    task <- state.makeNew(project.id, createdBy).mapError { case StatesExistError(t) => ImportExistsError(t) }
+    _    <- saveJsonLdStream(task.id, stream)
+    _    <- doImport(task.id, project, createdBy).whenZIO(state.isInProgress(task.id)).forkDaemon
+  } yield task
+
+  private def saveJsonLdStream(taskId: DataTaskId, stream: ZStream[Any, Throwable, Byte]) = (
+    for {
+      _          <- storage.dataImportDir(taskId)
+      jsonLdPath <- storage.dataImportJsonLdPath(taskId)
+      _          <- stream.run(ZSink.fromFile(jsonLdPath.toFile))
+    } yield ()
+  ).tapError(e => state.fail(taskId, Option(e.getMessage).getOrElse(e.getClass.getSimpleName)).ignore).orDie
+
+  private def doImport(taskId: DataTaskId, project: KnoraProject, createdBy: User): UIO[Unit] =
+    ZIO.scoped {
+      for {
+        _          <- ZIO.logInfo(s"$taskId: Starting data import for project '${project.id}'")
+        jsonLdPath <- storage.dataImportJsonLdPath(taskId)
+
+        permissions <- permissionsResponder.newDataImportDefaultObjectAccessPermissions(project.id, createdBy)
+        _           <- ZIO.logInfo(s"$taskId: Using permissions '$permissions' for project '${project.id}'")
+
+        ctx          = ConversionContext(createdBy.userIri, project, permissions)
+        transformed <- transformer
+                         .toKnoraBase(jsonLdPath.toFile.toPath, ctx)
+                         .mapError(e => new RuntimeException(e.message))
+        _ <- ZIO.logInfo(s"$taskId: Transformed data to knora-base for project '${project.id}'")
+
+        _ <- validate(taskId, project, Path.fromJava(transformed))
+        _ <- ZIO.logInfo(s"$taskId: Validation passed for project '${project.id}'")
+
+        // Re-verify the create-only precondition immediately before the upload: a data graph may have appeared
+        // since the synchronous check in the RestService (e.g. via a concurrent migration import).
+        _ <- ZIO
+               .fail(new RuntimeException(s"The data graph for project '${project.id}' already exists."))
+               .whenZIO(dataGraphExists(project))
+
+        _ <- ZIO.logInfo(s"$taskId: Uploading data to triplestore for project '${project.id}'")
+        _ <- uploadToTriplestore(Path.fromJava(transformed))
+        _ <- state.complete(taskId).ignore
+        _ <- ZIO.logInfo(s"$taskId: Data import completed for project '${project.id}'")
+      } yield ()
+    }.logError.catchAll(e =>
+      ZIO.logError(s"$taskId: Data import failed for project '${project.id}' with error: ${e.getMessage}") *>
+        state.fail(taskId, Option(e.getMessage).getOrElse(e.getClass.getSimpleName)).ignore,
+    )
+
+  /**
+   * SHACL-validates the transformed NQuads, adapting the migration import's validation: the project's ontology
+   * graphs and the admin data graph (the data shapes check `attachedToUser` references against
+   * `knora-admin:User` instances) are fetched from the triplestore — the payload carries instance data only.
+   */
+  private def validate(taskId: DataTaskId, project: KnoraProject, dataFile: Path): ZIO[Scope, Throwable, Unit] = for {
+    graphs <- projectService.getOntologyGraphsForProject(project)
+    _      <- ZIO
+           .fail(new RuntimeException(s"Project '${project.id}' has no ontologies in the triplestore."))
+           .when(graphs.isEmpty)
+    _             <- ZIO.logInfo(s"$taskId: Fetching ontologies '${graphs.map(_.value).mkString(",")}' for validation")
+    tempDir       <- storage.tempDataImportScoped(taskId)
+    ontologyFiles <- ZIO.foreach(Chunk.fromIterable(graphs).zipWithIndex) { (g, i) =>
+                       val file = tempDir / s"ontology-${i + 1}.nq"
+                       Files.createFile(file) *> triplestore.downloadGraph(g, file, NQuads).as(file)
+                     }
+    adminFile = tempDir / "admin.nq"
+    _        <- Files.createFile(adminFile) *> triplestore.downloadGraph(adminDataNamedGraph, adminFile, NQuads)
+    _        <- validator.validate(NonEmptyChunk.fromChunk(ontologyFiles).get, NonEmptyChunk(adminFile, dataFile), project.id)
+  } yield ()
+
+  private def uploadToTriplestore(nqFile: Path): Task[Unit] =
+    triplestore.uploadNQuads(ZStream.fromFile(nqFile.toFile)) *> ontologyCache.refreshCache().unit
+
+  def getImportStatus(importId: DataTaskId): IO[Option[Nothing], CurrentDataTask] = state.find(importId)
+
+  def deleteImport(importId: DataTaskId): IO[Option[ImportInProgressError], Unit] =
+    for {
+      _ <- state
+             .deleteIfNotInProgress(importId)
+             .mapError {
+               case Some(StateInProgressError(s)) => Some(ImportInProgressError(s))
+               case None                          => None
+             }
+      dir <- storage.dataImportDir(importId).tap(dir => Files.deleteRecursive(dir).logError.ignore)
+      _   <- ZIO.logInfo(s"$importId: Cleaned data import dir $dir")
+    } yield ()
+}
+
+object ProjectDataImportService {
+  val layer: URLayer[
+    KnoraProjectService & PermissionsResponder & OntologyTransformer & ProjectMigrationImportValidator &
+      TriplestoreService & OntologyCache,
+    ProjectDataImportService,
+  ] = (ProjectDataImportStorageService.layer >+> FilesystemDataTaskPersistence.dataImportLayer) >>>
+    ZLayer.derive[ProjectDataImportService]
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportStorageService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportStorageService.scala
@@ -23,7 +23,7 @@ final class ProjectDataImportStorageService() { self =>
     AppConfig.config(_.tmpDatadir).map(dir => Path.fromJava(JPath.of(dir)) / "data-imports")
 
   def dataImportDir(taskId: DataTaskId): UIO[Path] =
-    self.dataImportsDir.map(_ / taskId.value).tap(ensureDirExists(_, taskId))
+    self.dataImportsDir.map(_ / taskId.value).tap(DataTaskStorage.ensureDirExists(_, taskId))
 
   /** The uploaded knora-api JSON-LD payload of the given task. */
   def dataImportJsonLdPath(taskId: DataTaskId): UIO[Path] = dataImportDir(taskId).map(_ / "data.jsonld")
@@ -35,16 +35,7 @@ final class ProjectDataImportStorageService() { self =>
    * @return the path to the temporary directory
    */
   def tempDataImportScoped(taskId: DataTaskId): URIO[Scope, Path] =
-    dataImportDir(taskId).flatMap { baseDir =>
-      val tempPath = baseDir / "temp"
-      ZIO.acquireRelease(Files.createDirectories(tempPath).logError.orDie.as(tempPath)) { (path: Path) =>
-        ZIO.logInfo(s"$taskId: Deleting temp directory $path") *>
-          Files.deleteRecursive(path).logError(s"$taskId: Failed deleting temp directory $path").orDie
-      }
-    }
-
-  private def ensureDirExists(path: Path, taskId: DataTaskId): UIO[Unit] =
-    Files.createDirectories(path).logError(s"$taskId: Failed to create directory at $path").orDie
+    dataImportDir(taskId).flatMap(DataTaskStorage.scopedTempDir(taskId, _))
 }
 
 object ProjectDataImportStorageService {

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportStorageService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportStorageService.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.`export`.domain
+
+import zio.*
+import zio.nio.file.Files
+import zio.nio.file.Path
+
+import java.nio.file.Path as JPath
+
+import org.knora.webapi.config.AppConfig
+
+/**
+ * Filesystem storage for project data-graph imports. Mirrors the migration import layout: a dedicated directory
+ * under the configured `tmpDatadir` with one subdirectory per task holding the uploaded JSON-LD and the task state.
+ */
+final class ProjectDataImportStorageService() { self =>
+
+  val dataImportsDir: UIO[Path] =
+    AppConfig.config(_.tmpDatadir).map(dir => Path.fromJava(JPath.of(dir)) / "data-imports")
+
+  def dataImportDir(taskId: DataTaskId): UIO[Path] =
+    self.dataImportsDir.map(_ / taskId.value).tap(ensureDirExists(_, taskId))
+
+  /** The uploaded knora-api JSON-LD payload of the given task. */
+  def dataImportJsonLdPath(taskId: DataTaskId): UIO[Path] = dataImportDir(taskId).map(_ / "data.jsonld")
+
+  /**
+   * Creates a temporary directory for the import task, and ensures that it is deleted when the scope is closed.
+   *
+   * @param taskId the ID of the import task
+   * @return the path to the temporary directory
+   */
+  def tempDataImportScoped(taskId: DataTaskId): URIO[Scope, Path] =
+    dataImportDir(taskId).flatMap { baseDir =>
+      val tempPath = baseDir / "temp"
+      ZIO.acquireRelease(Files.createDirectories(tempPath).logError.orDie.as(tempPath)) { (path: Path) =>
+        ZIO.logInfo(s"$taskId: Deleting temp directory $path") *>
+          Files.deleteRecursive(path).logError(s"$taskId: Failed deleting temp directory $path").orDie
+      }
+    }
+
+  private def ensureDirExists(path: Path, taskId: DataTaskId): UIO[Unit] =
+    Files.createDirectories(path).logError(s"$taskId: Failed to create directory at $path").orDie
+}
+
+object ProjectDataImportStorageService {
+  val layer: ULayer[ProjectDataImportStorageService] = ZLayer
+    .derive[ProjectDataImportStorageService]
+    .tap(env =>
+      val service = env.get[ProjectDataImportStorageService]
+      for {
+        dataImportsDir <- service.dataImportsDir
+        _              <- ZIO.logInfo(s"Ensuring project data import storage directory exists at $dataImportsDir")
+        _              <- Files.createDirectories(dataImportsDir).unlessZIO(Files.exists(dataImportsDir)).logError.orDie
+      } yield (),
+    )
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationStorageService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationStorageService.scala
@@ -21,13 +21,10 @@ final class ProjectMigrationStorageService() { self =>
   val importsDir: UIO[Path] = basePath.map(_ / "imports")
 
   def exportDir(taskId: DataTaskId): UIO[Path] =
-    self.exportsDir.map(_ / taskId.value).tap(ensureDirExists(_, taskId))
+    self.exportsDir.map(_ / taskId.value).tap(DataTaskStorage.ensureDirExists(_, taskId))
 
   def importDir(taskId: DataTaskId): UIO[Path] =
-    self.importsDir.map(_ / taskId.value).tap(ensureDirExists(_, taskId))
-
-  private def ensureDirExists(path: Path, taskId: DataTaskId): UIO[Unit] =
-    Files.createDirectories(path).logError(s"$taskId: Failed to create directory at $path").orDie
+    self.importsDir.map(_ / taskId.value).tap(DataTaskStorage.ensureDirExists(_, taskId))
 
   def exportBagItZipPath(taskId: DataTaskId): UIO[Path] = exportDir(taskId).map(_ / "bagit.zip")
   def importBagItZipPath(taskId: DataTaskId): UIO[Path] = importDir(taskId).map(_ / "bagit.zip")
@@ -53,14 +50,7 @@ final class ProjectMigrationStorageService() { self =>
       .flatMap { case (tempPath, _) => importBagItZipPath(taskId).map((tempPath, _)) }
 
   private def scopedTempDir(taskId: DataTaskId, baseDir: Path): URIO[Scope, (Path, Path)] =
-    val tempPath = baseDir / "temp"
-    for {
-      _ <- ensureDirExists(tempPath, taskId)
-      _ <- ZIO.acquireRelease(Files.createDirectories(tempPath).logError.orDie.as(tempPath)) { (path: Path) =>
-             ZIO.logInfo(s"$taskId: Deleting temp directory $path") *>
-               Files.deleteRecursive(path).logError(s"$taskId: Failed deleting temp directory $path").orDie
-           }
-    } yield (tempPath, baseDir)
+    DataTaskStorage.scopedTempDir(taskId, baseDir).map((_, baseDir))
 }
 
 object ProjectMigrationStorageService {

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyModule.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyModule.scala
@@ -31,12 +31,13 @@ object OntologyModule { self =>
     OntologyCache &
     OntologyCacheHelpers &
     OntologyRepo &
+    OntologyTransformer &
     OntologyTriplestoreHelpers &
     ValueRepo
     // format: on
 
   val layer: URLayer[self.Dependencies, self.Provided] =
-    (OntologyCacheLive.layer ++ PredicateRepositoryLive.layer ++ ValueRepo.layer) >+>
+    (OntologyCacheLive.layer ++ PredicateRepositoryLive.layer ++ ValueRepo.layer ++ OntologyTransformer.layer) >+>
       OntologyRepoLive.layer >+>
       (CardinalityService.layer ++ OntologyCacheHelpers.layer ++ OntologyTriplestoreHelpers.layer)
 }

--- a/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -9,11 +9,13 @@ import org.apache.jena.datatypes.xsd.XSDDatatype
 import org.apache.jena.graph.Node
 import org.apache.jena.graph.NodeFactory
 import org.apache.jena.graph.Triple
+import org.apache.jena.query.DatasetFactory
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.rdf.model.Property
 import org.apache.jena.rdf.model.RDFNode
 import org.apache.jena.rdf.model.Resource
 import org.apache.jena.riot.Lang
+import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.riot.RDFParser
 import org.apache.jena.riot.system.StreamRDF
 import org.apache.jena.riot.system.StreamRDFBase
@@ -40,8 +42,9 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.CalendarDateRangeV2
 import org.knora.webapi.messages.util.CalendarNameV2
 import org.knora.webapi.messages.util.DateEraV2
-import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.UserIri
+import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.jena.RdfDataMgr
@@ -53,11 +56,13 @@ final case class TransformerError(message: String)
  *
  * @param attachedToUser    the user every imported resource and value is attached to.
  * @param attachedToProject the project every imported resource belongs to; overrides any value in the input.
+ *                          Also determines the data named graph every output quad is assigned to — derived from
+ *                          the project, never from payload content (`@graph` declarations in the input are ignored).
  * @param permissions       the formatted `knora-base:hasPermissions` string used for every resource and value.
  */
 final case class ConversionContext(
   attachedToUser: UserIri,
-  attachedToProject: ProjectIri,
+  attachedToProject: KnoraProject,
   permissions: String,
 )
 
@@ -96,7 +101,8 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
 
   /**
    * Stage 2 — structural transformations on the stage-1 NQuads to produce valid `knora-base`. Loads the bounded
-   * intermediate file into a Jena [[Model]] so cross-triple context is available.
+   * intermediate file into a Jena [[Model]] so cross-triple context is available. The output is written as NQuads
+   * with every quad assigned to the project's data named graph, ready to stream into the triplestore.
    */
   private def restructure(nq: Path, ctx: ConversionContext): ZIO[Scope, TransformerError, Path] =
     (for {
@@ -108,9 +114,22 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
       _     <- ZIO.attempt(convertLinkValues(model))
       _     <- ZIO.attempt(addValueHasString(model))
       kb    <- tempFile("onto-transformer-kb-", ".nq")
-      _     <- RdfDataMgr.write(model, kb, Lang.NTRIPLES)
+      graph  = ProjectService.projectDataNamedGraphV2(ctx.attachedToProject)
+      _     <- writeNQuads(model, graph.value, kb)
     } yield kb)
       .mapError(e => TransformerError(s"Failed to restructure RDF: ${e.getMessage}"))
+
+  /** Writes the model as NQuads with every quad assigned to the given named graph. */
+  private def writeNQuads(model: Model, graph: String, target: Path): zio.Task[Unit] =
+    ZIO.attemptBlocking {
+      val dataset = DatasetFactory.create()
+      try {
+        dataset.addNamedModel(graph, model)
+        val os = new BufferedOutputStream(new FileOutputStream(target.toFile))
+        try RDFDataMgr.write(os, dataset, Lang.NQUADS)
+        finally os.close()
+      } finally dataset.close()
+    }
 
   /**
    * A temp file under the configured `tmpDatadir`, scoped to the surrounding `Scope`: created on acquire, deleted on
@@ -140,8 +159,8 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
     val isDeleted         = model.createProperty(KnoraBase.IsDeleted)
 
     val userResource    = model.createResource(ctx.attachedToUser.value)
-    val projectResource = model.createResource(ctx.attachedToProject.value)
-    val creationDateLit = model.createTypedLiteral(now.toString, XSDDatatype.XSDdateTimeStamp)
+    val projectResource = model.createResource(ctx.attachedToProject.id.value)
+    val creationDateLit = model.createTypedLiteral(now.toString, XSDDatatype.XSDdateTime)
     val falseLit        = model.createTypedLiteral("false", XSDDatatype.XSDboolean)
 
     val resources = model.listSubjects().asScala.filter { s =>
@@ -169,7 +188,7 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
     val valueHasUUID      = model.createProperty(KnoraBase.ValueHasUUID)
 
     val userResource    = model.createResource(ctx.attachedToUser.value)
-    val creationDateLit = model.createTypedLiteral(now.toString, XSDDatatype.XSDdateTimeStamp)
+    val creationDateLit = model.createTypedLiteral(now.toString, XSDDatatype.XSDdateTime)
     val falseLit        = model.createTypedLiteral("false", XSDDatatype.XSDboolean)
 
     model.listSubjects().asScala.flatMap(s => asValueIri(s).map((s, _))).foreach { case (v, iri) =>
@@ -383,14 +402,11 @@ final class OntologyTransformer(sf: StringFormatter) { self =>
         downstream.triple(
           Triple.create(rewriteNode(t.getSubject), rewriteNode(t.getPredicate), rewriteNode(t.getObject)),
         )
+      // The output graph is derived solely from the project; `@graph` declarations in the payload are ignored,
+      // so quads are flattened to triples here.
       override def quad(q: Quad): Unit =
-        downstream.quad(
-          Quad.create(
-            rewriteNode(q.getGraph),
-            rewriteNode(q.getSubject),
-            rewriteNode(q.getPredicate),
-            rewriteNode(q.getObject),
-          ),
+        downstream.triple(
+          Triple.create(rewriteNode(q.getSubject), rewriteNode(q.getPredicate), rewriteNode(q.getObject)),
         )
     }
   }

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -783,11 +783,37 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
     },
   )
 
+  private val graphHandling = suite("Stage 1 — @graph handling")(
+    test("flattens @graph declarations from the payload (the target graph comes from the project)") {
+      runTransform(
+        jsonLd = s"""
+                    |{
+                    |  "@id": "http://example.org/ignored-graph",
+                    |  "@graph": [{
+                    |      "@id": "$resourceIri",
+                    |      "@type": "${onto}Example",
+                    |      "rdfs:label": "test"
+                    |  }],
+                    |  "@context": { "rdfs": "http://www.w3.org/2000/01/rdf-schema#" }
+                    |}""".stripMargin,
+        expectedTurtle = s"""
+                            | PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                            | PREFIX onto: <http://www.knora.org/ontology/9999/onto#>
+                            |
+                            | <$resourceIri>
+                            |     a          onto:Example ;
+                            |     rdfs:label "test" .
+                            |""".stripMargin,
+      )
+    },
+  )
+
   override def spec = suite("OntologyTransformerSpec")(
     simpleScalarValues,
     iriRefValues,
     textValues,
     dateValues,
+    graphHandling,
     resourceMetadata,
     valueHasString,
     dateValuesStage2,

--- a/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -6,6 +6,7 @@
 package org.knora.webapi.slice.ontology
 
 import org.apache.jena.riot.Lang
+import zio.NonEmptyChunk
 import zio.ZIO
 import zio.test.*
 
@@ -13,14 +14,19 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
+import scala.jdk.CollectionConverters.*
 
 import org.knora.webapi.core.TestAppConfig
 import org.knora.webapi.messages.StringFormatter
-import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
-import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
+import org.knora.webapi.slice.admin.domain.model.RestrictedView
 import org.knora.webapi.slice.admin.domain.model.UserIri
+import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.ValueIri
+import org.knora.webapi.slice.common.jena.DatasetOps
 import org.knora.webapi.slice.common.jena.ModelOps
 
 object OntologyTransformerSpec extends ZIOSpecDefault {
@@ -108,24 +114,48 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
   private val valueIri2    = ValueIri.makeNew(resourceIri)
   private val knownInstant = Instant.parse("2026-01-01T00:00:00Z")
 
+  private val project = KnoraProject(
+    ProjectIri.unsafeFrom("http://rdfh.ch/projects/9999"),
+    Shortname.unsafeFrom("onto"),
+    shortcode,
+    None,
+    NonEmptyChunk(Description.unsafeFrom(StringLiteralV2.from("Some description"))),
+    List.empty,
+    None,
+    Status.Active,
+    SelfJoin.CannotJoin,
+    RestrictedView.default,
+    Set.empty,
+    Set.empty,
+  )
+
   private val ctx = ConversionContext(
     attachedToUser = UserIri.unsafeFrom("http://rdfh.ch/users/exampleUser"),
-    attachedToProject = ProjectIri.unsafeFrom("http://rdfh.ch/projects/9999"),
+    attachedToProject = project,
     permissions = "CR knora-admin:Creator|V knora-admin:KnownUser",
   )
 
-  /** Stage-2: drives the full `toKnoraBase` with a fixed clock so synthesised dates are deterministic. */
+  private val dataNamedGraph = ProjectService.projectDataNamedGraphV2(project).value
+
+  /**
+   * Stage-2: drives the full `toKnoraBase` with a fixed clock so synthesised dates are deterministic. The output is
+   * NQuads with every quad in the project's data named graph; the assertion extracts that named model and checks
+   * nothing landed in any other graph.
+   */
   private def runTransformStage2(jsonLd: String, expectedTurtle: String) =
     ZIO.scoped {
       for {
-        inputPath  <- ZIO.acquireRelease(writeTempFile(".jsonld", jsonLd).orDie)(deleteIfExists)
-        _          <- TestClock.setTime(knownInstant)
-        outputPath <- transformer(_.toKnoraBase(inputPath, ctx))
-        actualNQ   <- ZIO.attempt(new String(Files.readAllBytes(outputPath), StandardCharsets.UTF_8))
-        actual     <- ModelOps.from(actualNQ, Lang.NTRIPLES)
-        expected   <- ModelOps.fromTurtle(expectedTurtle)
-        iso         = actual.isIsomorphicWith(expected)
-      } yield assertTrue(iso)
+        inputPath   <- ZIO.acquireRelease(writeTempFile(".jsonld", jsonLd).orDie)(deleteIfExists)
+        _           <- TestClock.setTime(knownInstant)
+        outputPath  <- transformer(_.toKnoraBase(inputPath, ctx))
+        actualNQ    <- ZIO.attempt(new String(Files.readAllBytes(outputPath), StandardCharsets.UTF_8))
+        dataset     <- DatasetOps.from(actualNQ, Lang.NQUADS).mapError(new RuntimeException(_))
+        graphNames   = dataset.listModelNames().asScala.map(_.getURI).toList
+        actual       = dataset.getNamedModel(dataNamedGraph)
+        defaultEmpty = dataset.getDefaultModel.isEmpty
+        expected    <- ModelOps.fromTurtle(expectedTurtle)
+        iso          = actual.isIsomorphicWith(expected)
+      } yield assertTrue(iso, defaultEmpty, graphNames == List(dataNamedGraph))
     }
 
   private val simpleScalarValues = suite("Simple Scalar Values")(
@@ -404,9 +434,9 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     rdfs:label                   "test" ;
                             |     onto:testBoolean             <$valueIri> ;
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
-                            |     knora-base:attachedToProject <${ctx.attachedToProject.value}> ;
+                            |     knora-base:attachedToProject <${ctx.attachedToProject.id.value}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
-                            |     knora-base:creationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:creationDate      "$knownInstant"^^xsd:dateTime ;
                             |     knora-base:isDeleted         false .
                             |
                             | <$valueIri>
@@ -414,7 +444,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:valueHasBoolean   "true"^^xsd:boolean ;
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
-                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTime ;
                             |     knora-base:valueHasUUID      "${valueIri.valueId}" ;
                             |     knora-base:valueHasString    "true" ;
                             |     knora-base:isDeleted         false .
@@ -448,9 +478,9 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     rdfs:label                   "test" ;
                             |     onto:testInt                 <$valueIri>, <$valueIri2> ;
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
-                            |     knora-base:attachedToProject <${ctx.attachedToProject.value}> ;
+                            |     knora-base:attachedToProject <${ctx.attachedToProject.id.value}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
-                            |     knora-base:creationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:creationDate      "$knownInstant"^^xsd:dateTime ;
                             |     knora-base:isDeleted         false .
                             |
                             | <$valueIri>
@@ -458,7 +488,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:valueHasInteger   "1"^^xsd:int ;
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
-                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTime ;
                             |     knora-base:valueHasUUID      "${valueIri.valueId}" ;
                             |     knora-base:valueHasString    "1" ;
                             |     knora-base:isDeleted         false .
@@ -468,7 +498,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:valueHasInteger   "2"^^xsd:int ;
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
-                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTime ;
                             |     knora-base:valueHasUUID      "${valueIri2.valueId.value}" ;
                             |     knora-base:valueHasString    "2" ;
                             |     knora-base:isDeleted         false .
@@ -496,9 +526,9 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
        |     rdfs:label                   "test" ;
        |     onto:$propLocalName          <$valueIri> ;
        |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
-       |     knora-base:attachedToProject <${ctx.attachedToProject.value}> ;
+       |     knora-base:attachedToProject <${ctx.attachedToProject.id.value}> ;
        |     knora-base:hasPermissions    "${ctx.permissions}" ;
-       |     knora-base:creationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+       |     knora-base:creationDate      "$knownInstant"^^xsd:dateTime ;
        |     knora-base:isDeleted         false .
        |
        | <$valueIri>
@@ -506,7 +536,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
        |     $valueContent ;
        |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
        |     knora-base:hasPermissions    "${ctx.permissions}" ;
-       |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
+       |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTime ;
        |     knora-base:valueHasUUID      "${valueIri.valueId}" ;
        |     knora-base:valueHasString    "$valueHasString" ;
        |     knora-base:isDeleted         false .
@@ -619,9 +649,9 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                           |     rdfs:label                   "test" ;
                           |     onto:testSubDate1            <$valueIri> ;
                           |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
-                          |     knora-base:attachedToProject <${ctx.attachedToProject.value}> ;
+                          |     knora-base:attachedToProject <${ctx.attachedToProject.id.value}> ;
                           |     knora-base:hasPermissions    "${ctx.permissions}" ;
-                          |     knora-base:creationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+                          |     knora-base:creationDate      "$knownInstant"^^xsd:dateTime ;
                           |     knora-base:isDeleted         false .
                           |
                           | <$valueIri>
@@ -634,7 +664,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                           |     knora-base:valueHasString         "$dateString" ;
                           |     knora-base:attachedToUser         <${ctx.attachedToUser}> ;
                           |     knora-base:hasPermissions         "${ctx.permissions}" ;
-                          |     knora-base:valueCreationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+                          |     knora-base:valueCreationDate      "$knownInstant"^^xsd:dateTime ;
                           |     knora-base:valueHasUUID           "${valueIri.valueId}" ;
                           |     knora-base:isDeleted              false .
                           |""".stripMargin,
@@ -731,9 +761,9 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     onto:testHasLinkToValue      <$valueIri> ;
                             |     onto:testHasLinkTo           <$target> ;
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
-                            |     knora-base:attachedToProject <${ctx.attachedToProject.value}> ;
+                            |     knora-base:attachedToProject <${ctx.attachedToProject.id.value}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
-                            |     knora-base:creationDate      "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:creationDate      "$knownInstant"^^xsd:dateTime ;
                             |     knora-base:isDeleted         false .
                             |
                             | <$valueIri>
@@ -745,7 +775,7 @@ object OntologyTransformerSpec extends ZIOSpecDefault {
                             |     knora-base:valueHasString    "$target" ;
                             |     knora-base:attachedToUser    <${ctx.attachedToUser}> ;
                             |     knora-base:hasPermissions    "${ctx.permissions}" ;
-                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTimeStamp ;
+                            |     knora-base:valueCreationDate "$knownInstant"^^xsd:dateTime ;
                             |     knora-base:valueHasUUID      "${valueIri.valueId}" ;
                             |     knora-base:isDeleted         false .
                             |""".stripMargin,


### PR DESCRIPTION
### Description

Adds a v3 API to create a new project's data graph from a knora-api (v2 external schema) JSON-LD payload, so that data prepared outside DSP can be imported through the REST API without a full BagIt migration package. Until now the ontology transformer existed only as internal code with no API surface.

New endpoints (system-admin only, gated behind the new `allow-project-data-import` feature flag, disabled by default):

- `POST /v3/projects/{projectIri}/data-imports` — streams JSON-LD, returns `202` with a task ID (async, same pattern as the migration import)
- `GET /v3/projects/{projectIri}/data-imports/{importId}` — status polling
- `DELETE /v3/projects/{projectIri}/data-imports/{importId}` — task cleanup

Key design decisions:

- **Create-only**: importing fails with `409 data_graph_exists` if the project already has a data graph — checked synchronously at request time and re-verified before the upload, since data-graph imports are not mutually exclusive with migration imports (each task kind has its own `DataTaskState`).
- The transformer now emits N-Quads with every quad assigned to the project's data named graph, derived from the project — `@graph` declarations in the payload are ignored, making cross-graph contamination structurally impossible. Synthesised creation dates use `xsd:dateTime` to conform to knora-base and the SHACL shapes.
- The permissions literal is resolved once from the project's DOAPs for the importing system admin (ProjectAdmin-group DOAP has first precedence and applies uniformly); per-class/per-property DOAPs are not resolved per entity.
- SHACL validation reuses the migration import's shapes; the project's ontology graphs and the admin data graph are fetched from the triplestore since the payload carries instance data only.

See `docs/03-endpoints/api-v3/project-data-import.md` for the endpoint reference.
