### PR TITLE
chore: isolate coverage upload in its own CI job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,18 +45,11 @@ jobs:
           name: WebApi Unit Test Results
           path: ./webapi/target/test-reports/TEST-*.xml
           reporter: java-junit
-      - name: Upload coverage data to codacy
-        uses: codacy/codacy-coverage-reporter-action@v1
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ./target/scala-3.3.7/coverage-report/cobertura.xml
-      - name: Upload coverage data to codecov
-        uses: codecov/codecov-action@v5
-        with:
-          use_oidc: true
-          files: ./target/scala-3.3.7/coverage-report/cobertura.xml
-          flags: unit
-          fail_ci_if_error: true
+          name: coverage-unit
+          path: ./target/scala-3.3.7/coverage-report/cobertura.xml
 
   test-bagit:
     name: Test bagit
@@ -143,18 +136,11 @@ jobs:
           name: WebApi IT Test Results
           path: ./modules/test-it/target/test-reports/TEST-*.xml
           reporter: java-junit
-      - name: Upload coverage data to codacy
-        uses: codacy/codacy-coverage-reporter-action@v1
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ./target/scala-3.3.7/coverage-report/cobertura.xml
-      - name: Upload coverage data to codecov
-        uses: codecov/codecov-action@v5
-        with:
-          use_oidc: true
-          files: ./target/scala-3.3.7/coverage-report/cobertura.xml
-          flags: integration
-          fail_ci_if_error: true
+          name: coverage-integration
+          path: ./target/scala-3.3.7/coverage-report/cobertura.xml
 
   test-e2e:
     name: Build and E2E test
@@ -189,18 +175,65 @@ jobs:
           name: WebApi E2E Test Results
           path: ./modules/test-e2e/target/test-reports/TEST-*.xml
           reporter: java-junit
-      - name: Upload coverage data to codacy
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-e2e
+          path: ./target/scala-3.3.7/coverage-report/cobertura.xml
+
+  upload-coverage:
+    name: Upload coverage
+    runs-on: ubuntu-latest
+    needs: [build-and-test, test-it, test-e2e]
+    # Coverage reporting is advisory, not a merge gate. Isolating the Codacy and
+    # Codecov uploads in their own job means an outage in either (e.g. the
+    # Codecov CLI's GPG bootstrap failing) shows up as a red `Upload coverage`
+    # check instead of reddening a test job, and `continue-on-error` keeps it
+    # from blocking merges or releases. A red test job therefore always means a
+    # real test failure — never a coverage-upload hiccup.
+    continue-on-error: true
+    steps:
+      # Checkout so Codecov can resolve the cobertura report's relative paths
+      # against the source tree when building its file network.
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Download coverage reports
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage
+      - name: Upload unit coverage to codacy
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ./target/scala-3.3.7/coverage-report/cobertura.xml
-      - name: Upload coverage data to codecov
+          coverage-reports: coverage/coverage-unit/cobertura.xml
+      - name: Upload unit coverage to codecov
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
-          files: ./target/scala-3.3.7/coverage-report/cobertura.xml
+          files: coverage/coverage-unit/cobertura.xml
+          flags: unit
+      - name: Upload integration coverage to codacy
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/coverage-integration/cobertura.xml
+      - name: Upload integration coverage to codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage/coverage-integration/cobertura.xml
+          flags: integration
+      - name: Upload e2e coverage to codacy
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/coverage-e2e/cobertura.xml
+      - name: Upload e2e coverage to codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage/coverage-e2e/cobertura.xml
           flags: e2e
-          fail_ci_if_error: true
 
   test-ingest-integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

CI was failing intermittently on the **Upload coverage data to codecov** step — not on tests. The Codecov action downloads its CLI and verifies the binary's GPG signature; the public-key import returned no data (`gpg: no valid OpenPGP data found` → `Can't check signature: No public key`), so the step exited 1. Combined with `fail_ci_if_error: true`, this Codecov-side infra flake turned into a hard CI failure that blocked PRs and the release.

## Change

Coverage reporting is advisory, not a merge gate — so it shouldn't be able to redden a test job.

- The `build-and-test`, `test-it`, and `test-e2e` jobs no longer upload anywhere; each publishes its `cobertura.xml` as an artifact (`coverage-unit` / `coverage-integration` / `coverage-e2e`). They go red **only** on real test failures.
- A dedicated `upload-coverage` job (`needs` the three, `continue-on-error: true`) checks out source, downloads the artifacts, and re-runs the Codacy + Codecov uploads with the original flags.
- `fail_ci_if_error` dropped — default `false` plus job-level `continue-on-error` means a Codecov flake can never block.

## Effect

One glance at the checks list is enough: green test jobs ⇒ shippable; a red `Upload coverage` ⇒ a coverage-upload hiccup to ignore, never a code problem. Neither option makes Codecov itself less flaky — this just relocates where a flake shows so it stops gating merges/releases.

## ⚠️ Repo-settings follow-up

Do **not** add `Upload coverage` to required status checks in branch protection — otherwise a flake would block merges and defeat the purpose. The three test-job checks remain the gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)