### PR TITLE
fix(search): Skip non-resource IRIs in incoming-links search (DEV-6604)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
@@ -157,57 +157,60 @@ object GravsearchMainQueryGenerator {
    * Collects object variables and their values per main resource from the results returned by the prequery.
    * Value objects variables and their Iris are grouped by main resource.
    *
-   * @param prequeryResponse the results returned by the prequery.
-   * @param transformer      the transformer that was used to turn the Gravsearch query into the prequery.
-   * @param mainResourceVar  the variable representing the main resource.
+   * @param prequeryResponse              the results returned by the prequery.
+   * @param valueObjectVariablesConcat    the GROUP_CONCAT value-object variables present in the prequery's WHERE clause
+   *                                      (i.e. `transformer.valueObjectVariablesGroupConcat`).
+   * @param mainResourceVar               the variable representing the main resource.
    * @return [[ValueObjectVariablesAndValueObjectIris]].
    */
   def getValueObjectVarsAndIrisPerMainResource(
     prequeryResponse: SparqlSelectResult,
-    transformer: GravsearchToPrequeryTransformer,
+    valueObjectVariablesConcat: Set[QueryVariable],
     mainResourceVar: QueryVariable,
   ): ValueObjectVariablesAndValueObjectIris = {
-
-    // value objects variables present in the prequery's WHERE clause
-    val valueObjectVariablesConcat = transformer.valueObjectVariablesGroupConcat
 
     val valueObjVarsAndIris: Map[ResourceIri, Map[QueryVariable, Set[IRI]]] =
       prequeryResponse.results.bindings.foldLeft(Map.empty[ResourceIri, Map[QueryVariable, Set[IRI]]]) {
         (acc: Map[ResourceIri, Map[QueryVariable, Set[IRI]]], resultRow: VariableResultsRow) =>
-          // the main resource's Iri
-          val mainResIri: ResourceIri = ResourceIri.unsafeFrom(resultRow.rowMap(mainResourceVar.variableName))
+          // The main resource's Iri. For some incoming-link shapes (variable-predicate searches such as
+          // `searchIncomingLinks`) the prequery can bind the main resource variable to a non-resource IRI,
+          // e.g. a LinkValue node (`.../values/...`). Such rows are spurious and must be skipped rather than
+          // crashing the whole request — see DEV-6604.
+          ResourceIri.from(resultRow.rowMap(mainResourceVar.variableName)) match {
+            case Left(_) => acc
+            case Right(mainResIri) =>
+              // the the variables representing value objects and their Iris
+              val valueObjVarToIris: Map[QueryVariable, Set[IRI]] = valueObjectVariablesConcat.map {
+                (valueObjVarConcat: QueryVariable) =>
+                  // check if key exists: the variable representing value objects
+                  // could be contained in an OPTIONAL or a UNION and be unbound
+                  // It would be suppressed by `VariableResultsRow` in that case.
 
-          // the the variables representing value objects and their Iris
-          val valueObjVarToIris: Map[QueryVariable, Set[IRI]] = valueObjectVariablesConcat.map {
-            (valueObjVarConcat: QueryVariable) =>
-              // check if key exists: the variable representing value objects
-              // could be contained in an OPTIONAL or a UNION and be unbound
-              // It would be suppressed by `VariableResultsRow` in that case.
+                  // this logic works like in the case of dependent resources, see `getDependentResourceIrisPerMainResource` above.
+                  val valueObjIrisOption: Option[IRI] = resultRow.rowMap.get(valueObjVarConcat.variableName)
 
-              // this logic works like in the case of dependent resources, see `getDependentResourceIrisPerMainResource` above.
-              val valueObjIrisOption: Option[IRI] = resultRow.rowMap.get(valueObjVarConcat.variableName)
+                  val valueObjIris: Set[IRI] = valueObjIrisOption match {
 
-              val valueObjIris: Set[IRI] = valueObjIrisOption match {
+                    case Some(valObjIris) =>
+                      // IRIs are concatenated by GROUP_CONCAT using a separator, split them.
+                      // Ignore empty strings, which could result from unbound variables in a UNION.
+                      valObjIris.split(StringFormatter.INFORMATION_SEPARATOR_ONE).toSet.filter(_.nonEmpty)
 
-                case Some(valObjIris) =>
-                  // IRIs are concatenated by GROUP_CONCAT using a separator, split them.
-                  // Ignore empty strings, which could result from unbound variables in a UNION.
-                  valObjIris.split(StringFormatter.INFORMATION_SEPARATOR_ONE).toSet.filter(_.nonEmpty)
+                    case None => Set.empty[IRI] // since variable was inside aan OPTIONAL or UNION
 
-                case None => Set.empty[IRI] // since variable was inside aan OPTIONAL or UNION
+                  }
 
-              }
+                  valueObjVarConcat -> valueObjIris
+              }.toMap
 
-              valueObjVarConcat -> valueObjIris
-          }.toMap
-
-          val valueObjVarToIrisErrorHandlingMap = new ErrorHandlingMap(
-            valueObjVarToIris,
-            { (key: QueryVariable) =>
-              throw GravsearchException(s"variable not found: $key")
-            },
-          )
-          acc + (mainResIri -> valueObjVarToIrisErrorHandlingMap)
+              val valueObjVarToIrisErrorHandlingMap = new ErrorHandlingMap(
+                valueObjVarToIris,
+                { (key: QueryVariable) =>
+                  throw GravsearchException(s"variable not found: $key")
+                },
+              )
+              acc + (mainResIri -> valueObjVarToIrisErrorHandlingMap)
+          }
       }
 
     ValueObjectVariablesAndValueObjectIris(

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
@@ -177,7 +177,7 @@ object GravsearchMainQueryGenerator {
           // e.g. a LinkValue node (`.../values/...`). Such rows are spurious and must be skipped rather than
           // crashing the whole request — see DEV-6604.
           ResourceIri.from(resultRow.rowMap(mainResourceVar.variableName)) match {
-            case Left(_) => acc
+            case Left(_)           => acc
             case Right(mainResIri) =>
               // the the variables representing value objects and their Iris
               val valueObjVarToIris: Map[QueryVariable, Set[IRI]] = valueObjectVariablesConcat.map {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -853,7 +853,7 @@ final class SearchResponderV2Live(
             : GravsearchMainQueryGenerator.ValueObjectVariablesAndValueObjectIris =
             GravsearchMainQueryGenerator.getValueObjectVarsAndIrisPerMainResource(
               prequeryResponse = prequeryResponse,
-              transformer = gravsearchToPrequeryTransformer,
+              valueObjectVariablesConcat = gravsearchToPrequeryTransformer.valueObjectVariablesGroupConcat,
               mainResourceVar = mainResourceVar,
             )
 

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/mainquery/GravsearchMainQueryGeneratorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/mainquery/GravsearchMainQueryGeneratorSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.messages.util.search.gravsearch.mainquery
+
+import zio.test.Spec
+import zio.test.ZIOSpecDefault
+import zio.test.assertTrue
+
+import org.knora.webapi.messages.util.rdf.SparqlSelectResult
+import org.knora.webapi.messages.util.rdf.SparqlSelectResultBody
+import org.knora.webapi.messages.util.rdf.SparqlSelectResultHeader
+import org.knora.webapi.messages.util.rdf.VariableResultsRow
+import org.knora.webapi.messages.util.search.QueryVariable
+import org.knora.webapi.slice.common.ResourceIri
+
+/**
+ * Tests [[GravsearchMainQueryGenerator]].
+ */
+object GravsearchMainQueryGeneratorSpec extends ZIOSpecDefault {
+
+  private val mainResourceVar = QueryVariable("mainRes")
+
+  private def prequeryResultBindingMainResTo(values: String*): SparqlSelectResult =
+    SparqlSelectResult(
+      SparqlSelectResultHeader(Seq(mainResourceVar.variableName)),
+      SparqlSelectResultBody(values.map(v => VariableResultsRow(Map(mainResourceVar.variableName -> v)))),
+    )
+
+  val spec: Spec[Any, Any] =
+    suite("GravsearchMainQueryGenerator.getValueObjectVarsAndIrisPerMainResource")(
+      test(
+        "skip rows whose main-resource variable is bound to a non-resource IRI (e.g. a LinkValue) rather than throwing (DEV-6604)",
+      ) {
+        // For variable-predicate incoming-link searches the prequery can bind the main-resource variable to a
+        // LinkValue node (`.../values/...`). Before the fix this crashed the whole request with an
+        // IllegalArgumentException from `ResourceIri.unsafeFrom`; now the spurious row is dropped.
+        val resourceIri = "http://rdfh.ch/0828/eawbn9g4QVKouqfB8n0WiA"
+        val valueIri    = "http://rdfh.ch/0828/qMBgsLpPTMSHv9FYfG1Zcg/values/9KeFJfrLTjmPhB3158J65Q"
+
+        val result = GravsearchMainQueryGenerator.getValueObjectVarsAndIrisPerMainResource(
+          prequeryResponse = prequeryResultBindingMainResTo(resourceIri, valueIri),
+          valueObjectVariablesConcat = Set.empty,
+          mainResourceVar = mainResourceVar,
+        )
+
+        assertTrue(
+          result.valueObjectVariablesAndValueObjectIris.keySet == Set(ResourceIri.unsafeFrom(resourceIri)),
+        )
+      },
+      test("keep all rows when every main-resource binding is a valid resource IRI") {
+        val resourceIri1 = "http://rdfh.ch/0828/eawbn9g4QVKouqfB8n0WiA"
+        val resourceIri2 = "http://rdfh.ch/0810/0Y_87NRETpiNRp_Ujx-NHw"
+
+        val result = GravsearchMainQueryGenerator.getValueObjectVarsAndIrisPerMainResource(
+          prequeryResponse = prequeryResultBindingMainResTo(resourceIri1, resourceIri2),
+          valueObjectVariablesConcat = Set.empty,
+          mainResourceVar = mainResourceVar,
+        )
+
+        assertTrue(
+          result.valueObjectVariablesAndValueObjectIris.keySet ==
+            Set(ResourceIri.unsafeFrom(resourceIri1), ResourceIri.unsafeFrom(resourceIri2)),
+        )
+      },
+    )
+}


### PR DESCRIPTION
## Problem

`GET /v2/searchIncomingLinks/{resourceIri}` returns **HTTP 500** on prod for many resources (~21 occurrences on 2026-06-09 across projects 0810, 080C, 0828, 0806, 0102, 0838). Data-shape dependent — some resources work ("summary" resources), others fail.

```
java.lang.IllegalArgumentException:
  <http://rdfh.ch/0828/qMBgsLpPTMSHv9FYfG1Zcg/values/9KeFJfrLTjmPhB3158J65Q> is not a Knora resource IRI
    at org.knora.webapi.slice.common.ResourceIri$.unsafeFrom(Iris.scala:44)
    at GravsearchMainQueryGenerator$.getValueObjectVarsAndIrisPerMainResource(GravsearchMainQueryGenerator.scala:178)
```

## Root cause

The incoming-links query (`SearchResponderV2.searchIncomingLinksV2`) uses a **variable predicate**:

```sparql
?incomingRes a knora-api:Resource .
?incomingRes ?incomingProp <A> .
?incomingProp knora-api:objectType knora-api:Resource .
```

`a knora-api:Resource` and `objectType` are Gravsearch **type annotations** — the type inspector reads them, but they are stripped from the executable SPARQL. So the prequery binds `?incomingRes` to *any subject of a triple whose object is `<A>`*:

- **Resource subjects** via the direct link triple (`hasLinkTo` / `hasStandoffLinkTo` / a user link property) — these are the real incoming links → resource IRIs.
- **`LinkValue` subjects** via the reification triple `LV rdf:object <A>` — a knora-base `LinkValue` is an `rdf:Statement`, so the link's own reification node also has object `<A>` → value IRI (`.../values/...`).

Before #4116 ("Remove legacy abstractions and improve type safety") the main-resource binding was a plain `String` used only as a `Map` key, so the value IRI was tolerated. #4116 wrapped it in `ResourceIri.unsafeFrom`, which throws on a value IRI → uncaught → 500. That same commit deliberately switched the *parser* path to fail gracefully via `ResourceIri.from`, but **this call site was missed**.

Regular link values and standoff link values are structurally identical here (both are `LinkValue` reifications with `rdf:object → A`, both `⊑ hasLinkToValue`), so both produce the same spurious value-IRI row.

## Fix

- Skip prequery rows whose main-resource binding is not a resource IRI, using `ResourceIri.from(...)` instead of `unsafeFrom` — consistent with the graceful IRI handling #4116 applied elsewhere.
- Narrow `getValueObjectVarsAndIrisPerMainResource` to depend only on the `Set[QueryVariable]` it actually uses rather than the whole `GravsearchToPrequeryTransformer`, so the logic is unit-testable in isolation.
- Add `GravsearchMainQueryGeneratorSpec` regression test (uses the real prod IRIs): asserts the value-IRI row is dropped and valid rows are kept.

## Why this preserves all results (no incoming links are lost)

The returned resources are **not** determined by the changed function. In `SearchResponderV2.gravsearchV2`:

- `mainResourceIris` is read **raw from the prequery column** (`prequeryResponse.getColOrThrow(mainResourceVar...)`) — untouched by this change.
- Those IRIs feed `createMainQuery`, whose WHERE clause **mandates** `?mainResourceVar a knora-base:Resource` and `knora-base:isDeleted false` (`GravsearchMainQueryGenerator.scala:246-258`). A value IRI is a `LinkValue`, not a `Resource`, so it yields zero triples and is filtered out at the triplestore — both before #4116 and now.

`getValueObjectVarsAndIrisPerMainResource` only builds the value-object lookup map for resources that survive that filter. A value-IRI key never corresponded to a returned resource, so dropping it changes nothing in the output. The legitimate linking resource always appears as its own resource-IRI row and is untouched. **Net returned links are identical to pre-#4116; this only removes the exception.** This holds for regular and standoff links alike.

## Follow-up (Option 2)

A proper fix should tighten the prequery so the main-resource variable can't bind to a `LinkValue` node in the first place (variable-predicate link searches). Larger/riskier; tracked in DEV-6604.

## Verification

- New unit test `GravsearchMainQueryGeneratorSpec` (passes locally; full `webapi` module compiles).
- Post-deploy, confirm 200 for the prod-failing resources `http://rdfh.ch/0828/eawbn9g4QVKouqfB8n0WiA` and `http://rdfh.ch/0810/0Y_87NRETpiNRp_Ujx-NHw`.

Resolves DEV-6604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)