### PR TITLE
docs: clarify project data import is unrelated to project migration

### DIFF
--- a/docs/03-endpoints/api-v3/project-data-import.md
+++ b/docs/03-endpoints/api-v3/project-data-import.md
@@ -4,10 +4,8 @@ The project data import API creates a new project's data graph from a [knora-api
 JSON-LD payload. The server transforms the payload into the internal knora-base representation, validates it, and
 streams it into the triplestore.
 
-Unlike the [Project Migration Export/Import](project-migration.md) — which moves a complete project (admin data,
-ontologies, permissions, assets) between instances as a BagIt package — the data import handles **instance data
-only**. The project and its ontologies must already exist on the instance, and the project's data graph must not
-exist yet (create-only).
+The data import handles **instance data only** — the resources and their values. The project and its ontologies
+must already exist on the instance, and the project's data graph must not exist yet (create-only).
 
 ## Endpoints
 
@@ -71,10 +69,9 @@ The upload to Fuseki is **atomic** — if the upload fails, no partial data is w
 
 ## Import Validation
 
-Before anything is written to the triplestore, the transformed data is SHACL-validated against the same data shapes
-used by the [migration import](project-migration.md#shacl-validation). The project's ontologies are fetched from
-the triplestore to support the validation. Validation failure fails the task with a descriptive error message and
-leaves the triplestore untouched.
+Before anything is written to the triplestore, the transformed data is SHACL-validated against the knora-base data
+shapes. The project's ontologies are fetched from the triplestore to support the validation. Validation failure
+fails the task with a descriptive error message and leaves the triplestore untouched.
 
 ## Typical Workflow
 


### PR DESCRIPTION
## Description

The v3 project data-import endpoint doc (`docs/03-endpoints/api-v3/project-data-import.md`) framed the feature as a counterpart to the BagIt **Project Migration Export/Import**. The two are unrelated — bulk data import creates a new project's instance data and has nothing to do with the admin-only migration channel. Presenting them side by side is misleading.

Changes:

- Remove the "Unlike the Project Migration Export/Import …" BagIt comparison from the intro.
- Drop the migration cross-reference from the Import Validation section (the SHACL data-shapes fact is kept).

Follow-up from the Bulk Data Import spec work (dasch-specs PR #117). Tracked under the Linear project **Bulk Data Import** (https://linear.app/dasch/project/bulk-data-import-a0032e266968).