### PR TITLE
fix(maintenance): allow built-in user IRIs as oldIri in replace-user-iri-in-project (DEV-6650)

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/MaintenanceReplaceUserIriInProjectE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/MaintenanceReplaceUserIriInProjectE2ESpec.scala
@@ -108,6 +108,27 @@ object MaintenanceReplaceUserIriInProjectE2ESpec extends E2EZSpec {
         )
         .map(response => assertTrue(response.code != StatusCode.BadRequest))
     },
+    test("returns 204 when oldIri is a built-in user IRI with references in the project graph") {
+      val newIri          = UserIri.unsafeFrom("http://rdfh.ch/users/e2e-proj-builtin-new")
+      val systemUserIri   = UserIri.unsafeFrom(builtInUserIri)
+      val anythingProject = "http://rdfh.ch/projects/0001"
+      for {
+        _        <- insertUserInAdminGraph(newIri)
+        _        <- addProjectMembership(newIri, anythingProject)
+        _        <- insertRefInProjectGraph(systemUserIri, anythingProjectGraph)
+        response <- TestApiClient.postJson[Json, Json](
+                      endpointFor(anythingShortcode),
+                      replaceBody(builtInUserIri, newIri.value),
+                      rootUser,
+                    )
+        oldGone  <- existsAsObjectInGraph(systemUserIri, anythingProjectGraph)
+        newThere <- existsAsObjectInGraph(newIri, anythingProjectGraph)
+      } yield assertTrue(
+        response.code == StatusCode.NoContent,
+        !oldGone,
+        newThere,
+      )
+    },
     test("returns 400 when oldIri and newIri are equal") {
       TestApiClient
         .postJson[Json, Json](

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/maintenance/ReplaceUserIriInProjectAction.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/maintenance/ReplaceUserIriInProjectAction.scala
@@ -36,10 +36,11 @@ final case class ReplaceUserIriInProjectAction(
       project <- knoraProjectService
                    .findByShortcode(shortcode)
                    .someOrFail(NotFoundException(s"project ${shortcode.value} not found."))
-      oldExists <- triplestoreService.query(existsInAdminGraph(oldIri))
-      _         <- ZIO.when(!oldExists)(
-             ZIO.fail(NotFoundException(s"user IRI ${oldIri.value} not found in admin named graph.")),
-           )
+      _ <- ZIO.unless(oldIri.isBuiltInUser) {
+             triplestoreService
+               .query(existsInAdminGraph(oldIri))
+               .filterOrFail(identity)(NotFoundException(s"user IRI ${oldIri.value} not found in admin named graph."))
+           }
       newExists <- triplestoreService.query(existsInAdminGraph(newIri))
       _         <- ZIO.when(!newExists)(
              ZIO.fail(NotFoundException(s"user IRI ${newIri.value} not found in admin named graph.")),

--- a/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/maintenance/ReplaceUserIriInProjectActionSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/maintenance/ReplaceUserIriInProjectActionSpec.scala
@@ -107,6 +107,29 @@ object ReplaceUserIriInProjectActionSpec extends ZIOSpecDefault {
         } yield assertTrue(exists)
       },
     ),
+    suite("execute - built-in user as oldIri")(
+      test("replaces oldIri with newIri when oldIri is a built-in user IRI") {
+        val systemUserIri = UserIri.unsafeFrom("http://www.knora.org/ontology/knora-admin#SystemUser")
+        val fixture       =
+          s"""
+             |@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+             |@prefix knora-base:  <http://www.knora.org/ontology/knora-base#> .
+             |<$adminGraph> {
+             |  <${newIri.value}> knora-admin:email "new@example.com" ;
+             |                    knora-admin:isInProject <${testProject.id.value}> .
+             |}
+             |<$projectAGraph> {
+             |  <http://rdfh.ch/resource1> knora-base:attachedToUser <${systemUserIri.value}> .
+             |}
+             |""".stripMargin
+        for {
+          _      <- createProject
+          _      <- TestTripleStore.setDatasetFromTriG(fixture)
+          _      <- service(_.execute(testProject.shortcode, systemUserIri, newIri, requester))
+          exists <- askObjectInGraph(newIri, projectAGraph)
+        } yield assertTrue(exists)
+      },
+    ),
     suite("execute - validation failures")(
       test("fails with NotFoundException when project is not found") {
         val unknownShortcode = Shortcode.unsafeFrom("FFFF")


### PR DESCRIPTION
## Summary

- `ReplaceUserIriInProjectAction` was rejecting `SystemUser` / `AnonymousUser` as `oldIri` with a spurious 404 because `existsInAdminGraph` queries `http://www.knora.org/data/admin`, but built-in users live in `http://www.knora.org/ontology/knora-admin`
- Fixed by skipping the admin graph existence check when `oldIri.isBuiltInUser` — built-in users are always valid by definition
- The `newIri` check is unchanged (must still be a regular user in the data graph and a project member)

## Test plan

- [x] Unit test added: `execute - built-in user as oldIri` in `ReplaceUserIriInProjectActionSpec` — seeds `SystemUser` refs in project graph without seeding SystemUser in the admin graph, asserts replacement succeeds
- [x] E2E test added: `returns 204 when oldIri is a built-in user IRI with references in the project graph` in `MaintenanceReplaceUserIriInProjectE2ESpec` — full round-trip using real triplestore
- [x] All 10 unit tests pass locally

Closes DEV-6650

🤖 Generated with [Claude Code](https://claude.com/claude-code)