### PR TITLE
test(Observability): add span-assertion test harness

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -366,6 +366,7 @@ lazy val testkit: Project = Project(id = "testkit", base = file("modules/testkit
       Dependencies.testcontainers,
       Dependencies.wiremock,
       Dependencies.dataFaker,
+      Dependencies.openTelemetrySdkTesting,
     ),
     publish / skip := true,
     name           := "testkit",

--- a/modules/test-it/src/test/scala/org/knora/webapi/testservices/InMemoryTracingSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/testservices/InMemoryTracingSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.testservices
+
+import zio.*
+import zio.telemetry.opentelemetry.tracing.Tracing
+import zio.test.*
+
+object InMemoryTracingSpec extends ZIOSpecDefault {
+
+  private val tracing = ZIO.serviceWithZIO[Tracing]
+
+  // A fresh layer (and thus a fresh in-memory exporter) per test, so span counts are isolated.
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("InMemoryTracing")(
+      test("a trivial effect wrapped in tracing.span(\"x\") yields one finished span named x") {
+        (for {
+          _     <- tracing(_.span("x")(ZIO.unit))
+          spans <- InMemoryTracing.finishedSpans
+        } yield assertTrue(spans.size == 1) && SpanAssertions.hasSpan(spans, "x"))
+          .provide(InMemoryTracing.layer)
+      },
+      test("nested spans are captured as a parent-child pair") {
+        (for {
+          _     <- tracing(t => t.span("parent")(t.span("child")(ZIO.unit)))
+          spans <- InMemoryTracing.finishedSpans
+        } yield SpanAssertions.hasSpan(spans, "parent") &&
+          SpanAssertions.hasSpan(spans, "child") &&
+          SpanAssertions.isParentChild(spans, "parent", "child"))
+          .provide(InMemoryTracing.layer)
+      },
+      test("assertion helpers cover attribute, status and gravsearch.exit_reason") {
+        (for {
+          _     <- tracing(t => t.span("attributed")(t.setAttribute(SpanAssertions.GravsearchExitReasonKey, "limit")))
+          _     <- tracing(_.span("failing")(ZIO.fail(new RuntimeException("boom")))).either
+          spans <- InMemoryTracing.finishedSpans
+        } yield SpanAssertions.hasGravsearchExitReason(spans, "attributed", "limit") &&
+          SpanAssertions.hasAttributeKey(spans, "attributed", SpanAssertions.GravsearchExitReasonKey) &&
+          SpanAssertions.hasNoSpan(spans, "missing") &&
+          SpanAssertions.hasErrorStatus(spans, "failing"))
+          .provide(InMemoryTracing.layer)
+      },
+    )
+}

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/InMemoryTracing.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/InMemoryTracing.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.testservices
+
+import io.opentelemetry.api
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.ServiceAttributes
+import zio.*
+import zio.telemetry.opentelemetry.OpenTelemetry
+import zio.telemetry.opentelemetry.context.ContextStorage
+import zio.telemetry.opentelemetry.tracing.Tracing
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Test telemetry backed by an OpenTelemetry [[InMemorySpanExporter]]. Mirrors
+ * `org.knora.webapi.slice.infrastructure.OtelSetup.stdOut` but captures finished spans in memory
+ * instead of writing them to stdout, so tests can assert on the spans an effect produces.
+ *
+ * Provide [[layer]] to a spec exactly the way specs provide `OtelSetup.stdOut`, run the traced
+ * effect, then read the captured spans with [[finishedSpans]] and assert on them with
+ * [[SpanAssertions]].
+ *
+ * A [[SimpleSpanProcessor]] is used so spans are exported synchronously when they end - finished
+ * spans are visible to [[finishedSpans]] immediately after the traced effect completes, with no
+ * flush step.
+ */
+object InMemoryTracing {
+
+  private val exporterLayer: ULayer[InMemorySpanExporter] =
+    ZLayer.scoped(ZIO.fromAutoCloseable(ZIO.succeed(InMemorySpanExporter.create())))
+
+  private val openTelemetryLayer: URLayer[InMemorySpanExporter, api.OpenTelemetry] = {
+    val traceparentPropagator = ContextPropagators.create(
+      TextMapPropagator.composite(
+        W3CTraceContextPropagator.getInstance,
+      ),
+    )
+    ZLayer.scoped {
+      for {
+        exporter       <- ZIO.service[InMemorySpanExporter]
+        spanProcessor  <- ZIO.fromAutoCloseable(ZIO.succeed(SimpleSpanProcessor.create(exporter)))
+        tracerProvider <-
+          ZIO.fromAutoCloseable(
+            ZIO.succeed(
+              SdkTracerProvider
+                .builder()
+                .setResource(Resource.create(Attributes.of(ServiceAttributes.SERVICE_NAME, "dsp-api-test")))
+                .addSpanProcessor(spanProcessor)
+                .build(),
+            ),
+          )
+        openTelemetry <-
+          ZIO.fromAutoCloseable(
+            ZIO.succeed(
+              OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(traceparentPropagator)
+                .build,
+            ),
+          )
+      } yield openTelemetry
+    }
+  }
+
+  val layer: ULayer[api.OpenTelemetry & Tracing & ContextStorage & InMemorySpanExporter] =
+    ZLayer.make[api.OpenTelemetry & Tracing & ContextStorage & InMemorySpanExporter](
+      exporterLayer,
+      openTelemetryLayer,
+      OpenTelemetry.contextZIO,
+      OpenTelemetry.tracing("dsp-api-test"),
+    )
+
+  /** All spans that have finished (and been exported) so far, in completion order. */
+  val finishedSpans: URIO[InMemorySpanExporter, Chunk[SpanData]] =
+    ZIO.serviceWith[InMemorySpanExporter](exporter => Chunk.fromIterable(exporter.getFinishedSpanItems.asScala))
+
+  /** Discard all captured spans - useful to isolate scenarios that share a single layer instance. */
+  val reset: URIO[InMemorySpanExporter, Unit] =
+    ZIO.serviceWith[InMemorySpanExporter](_.reset())
+}

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/SpanAssertions.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/SpanAssertions.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.testservices
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.trace.data.SpanData
+import zio.test.TestResult
+import zio.test.assertTrue
+
+/**
+ * Reusable assertions over the spans captured by [[InMemoryTracing]].
+ *
+ * Each helper takes the finished spans (from `InMemoryTracing.finishedSpans`) plus the name of the
+ * span under test and returns a zio-test [[TestResult]], so several can be combined with `&&`.
+ * Helpers that target a single span fail if no span with that name was finished.
+ */
+object SpanAssertions {
+
+  /** Attribute key for the Gravsearch query exit reason, asserted by [[hasGravsearchExitReason]]. */
+  val GravsearchExitReasonKey: AttributeKey[String] = AttributeKey.stringKey("gravsearch.exit_reason")
+
+  /** The first finished span with the given name, if any. Escape hatch for ad-hoc assertions. */
+  def findSpan(spans: Seq[SpanData], name: String): Option[SpanData] =
+    spans.find(_.getName == name)
+
+  /** A span with the given name was finished. */
+  def hasSpan(spans: Seq[SpanData], name: String): TestResult =
+    assertTrue(spans.exists(_.getName == name))
+
+  /** No span with the given name was finished. */
+  def hasNoSpan(spans: Seq[SpanData], name: String): TestResult =
+    assertTrue(!spans.exists(_.getName == name))
+
+  /**
+   * `parent` is the direct parent of `child`, matched by span-id within the same trace. Fails if
+   * either span is missing.
+   */
+  def isParentChild(spans: Seq[SpanData], parent: String, child: String): TestResult =
+    assertTrue(
+      (for {
+        p <- findSpan(spans, parent)
+        c <- findSpan(spans, child)
+      } yield c.getParentSpanId == p.getSpanId && c.getTraceId == p.getTraceId).contains(true),
+    )
+
+  /** The named span carries `key` with exactly `value`. */
+  def hasAttribute[A](spans: Seq[SpanData], name: String, key: AttributeKey[A], value: A): TestResult =
+    assertTrue(findSpan(spans, name).flatMap(s => Option(s.getAttributes.get(key))).contains(value))
+
+  /** The named span carries `key` with any value. */
+  def hasAttributeKey(spans: Seq[SpanData], name: String, key: AttributeKey[?]): TestResult =
+    assertTrue(findSpan(spans, name).exists(s => Option(s.getAttributes.get(key)).isDefined))
+
+  /** The named span finished with status code ERROR. */
+  def hasErrorStatus(spans: Seq[SpanData], name: String): TestResult =
+    assertTrue(findSpan(spans, name).exists(_.getStatus.getStatusCode == StatusCode.ERROR))
+
+  /** The named span's status description equals `description`. */
+  def hasStatusDescription(spans: Seq[SpanData], name: String, description: String): TestResult =
+    assertTrue(findSpan(spans, name).exists(_.getStatus.getDescription == description))
+
+  /** The named span carries `gravsearch.exit_reason` equal to `reason`. */
+  def hasGravsearchExitReason(spans: Seq[SpanData], name: String, reason: String): TestResult =
+    hasAttribute(spans, name, GravsearchExitReasonKey, reason)
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -160,6 +160,9 @@ object Dependencies {
     "io.opentelemetry.semconv"       % "opentelemetry-semconv"               % "1.40.0",
   )
 
+  // In-memory span exporter for the span-assertion test harness (testkit).
+  val openTelemetrySdkTesting = "io.opentelemetry" % "opentelemetry-sdk-testing" % otelVersion
+
   val integrationTestDependencies = Seq(
     rdf4jClient,
     testcontainers,


### PR DESCRIPTION
[DEV-6632](https://linear.app/dasch/issue/DEV-6632)

## Summary
- Adds the span-assertion test harness — the foundation for all instrumentation testing (blocks the per-stage Gravsearch span work, DEV-6635).
- Net-new in-memory OpenTelemetry tracing layer plus reusable span assertions, placed in the shared `testkit` module so webapi/test-it/test-e2e can all consume it.

## Changes
**testkit (new test utilities)**
- `InMemoryTracing` — a test `Tracing` layer backed by OTel `InMemorySpanExporter` + `SdkTracerProvider`, mirroring `OtelSetup.stdOut` but swapping the exporter. Uses `SimpleSpanProcessor` for synchronous flush, so finished spans are visible immediately. Exposes `finishedSpans` and `reset`.
- `SpanAssertions` — helpers returning `TestResult`: span presence/absence by name, parent-child edges by span-id, attribute presence/value, ERROR status, status-description equality, and `gravsearch.exit_reason`.

**build**
- Adds `opentelemetry-sdk-testing` (for `InMemorySpanExporter`) to the testkit module.

**test-it**
- `InMemoryTracingSpec` validates the harness against the acceptance criteria.

## Test Plan
- `sbt "test-it/testOnly *InMemoryTracingSpec*"` → 3 tests pass:
  - a trivial effect wrapped in `tracing.span("x")` yields one finished span named `x`,
  - a nested span pair is asserted parent-child,
  - helpers cover attribute / ERROR status / `gravsearch.exit_reason`.
- `sbt testkit/compile`, `sbt scalafmtCheckAll`, `sbt headerCheckAll` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)