### PR TITLE
feat: add post-create resource authorship edit endpoint (DEV-6669)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -70,11 +70,12 @@ Do **not** use "Knora" in free-form human-readable text — commit messages, PR 
 
 ## Testing Conventions
 
+- **Every feature is tested.** Logic (parsers, query builders, services) gets unit tests; user-facing behaviour gets an integration/E2E round-trip (write → read-back reflects the change). "It compiles" is not coverage — a feature merged without tests should be flagged in review (see `REVIEW.md`).
 - `object XSpec extends ZIOSpecDefault`; `suite("X should")(test("...") { … })`; layers via `.provide(...)`. Use `TestAspect.withLiveClock` for time-dependent tests.
 - New repo traits ship an in-memory companion under `webapi/src/test/.../service/<Name>InMemory.scala`.
 - Test data: prefer self-contained fixtures next to the component. Only fall back to shared `test_data/` sets when unavoidable. When adding to a shared set, verify an actual *instance* of the scenario exists — not just that the schema supports it.
 - Test locations: unit → `webapi/src/test/scala/`; integration → `modules/test-it/`; ingest integration → `modules/test-ingest-integration/`; E2E → `modules/test-e2e/`; shared utilities → `modules/testkit/`.
-- For large or generated string output (SPARQL, serialized responses), mix in `GoldenTest` and assert with `assertGolden(actual, "suffix")`. The expected value is stored next to the spec under `src/test/resources/`; regenerate with `rewrite = true` (or `rewriteAll = true`) and inspect the `git diff`. See `webapi/src/test/scala/org/knora/webapi/GoldenTest.scala`.
+- For large or generated string output (SPARQL, serialized responses), mix in `GoldenTest` and assert with `assertGolden(actual, "suffix")`. The expected value is stored next to the spec under `src/test/resources/`; regenerate with `rewrite = true` (or `rewriteAll = true`) and inspect the `git diff`. See `webapi/src/test/scala/org/knora/webapi/GoldenTest.scala`. This is the **preferred** way to test query builders — not scattered `q.contains(...)` substring assertions (see `docs/development/dsp-api-sparql-queries.md` § Testing Query Builders).
 
 ## Commit Conventions
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -40,6 +40,7 @@ Agent reference card for the **review phase**. Pair with `CONVENTIONS.md` (work 
 ### SPARQL
 
 - [ ] No string concatenation in SPARQL — use rdf4j SparqlBuilder via the helpers in `slice/common/repo` (see `docs/development/dsp-api-sparql-queries.md`)
+- [ ] Query builders are tested with **golden snapshots** (`GoldenTest`), not scattered `q.contains(...)` / `!q.contains(...)` substring assertions (brittle on serialization, blind to clause placement) — see `docs/development/dsp-api-sparql-queries.md` § Testing Query Builders
 
 ### Observability
 
@@ -47,6 +48,7 @@ Agent reference card for the **review phase**. Pair with `CONVENTIONS.md` (work 
 
 ### Tests
 
+- [ ] **Every new feature/endpoint is actually tested — flag it when it is not.** Logic (parsers, query builders, services) has unit tests, and user-facing behaviour has an integration/E2E round-trip (e.g. write → read-back reflects the change). A feature whose only "test" is that it compiles is under-tested; say so in the review.
 - [ ] New tests: `object XSpec extends ZIOSpecDefault`; layers via `.provide(...)`; `TestAspect.withLiveClock` for time-dependent tests
 - [ ] Test data added in the right place — self-contained fixtures next to the component preferred over additions to shared `test_data/` sets
 - [ ] When adding to a shared dataset, an actual *instance* of the scenario is added (not just relying on schema support)

--- a/docs/development/dsp-api-conventions.md
+++ b/docs/development/dsp-api-conventions.md
@@ -236,12 +236,14 @@ object AuthServiceLiveSpec extends ZIOSpecDefault {
 
 **Rules:**
 
+- **Every feature is tested** — unit tests for logic (parsers, query builders, services) and an integration/E2E round-trip for user-facing behaviour (write → read-back reflects the change). A feature merged without tests is under-tested and should be flagged in review.
 - `object XSpec extends ZIOSpecDefault`
 - `suite("description")(test("...") { ... })`
 - Use `.provide(layers...)` for dependency injection
 - Use `@@ TestAspect.withLiveClock` for time-dependent tests
 - Use `.exit` to capture `Exit[E, A]` for error testing
 - Use `check(Gen[T])` for property-based testing
+- **Query builders: prefer golden snapshots** (`GoldenTest` + `assertGolden`) over scattered `q.contains(...)` substring assertions — see `dsp-api-sparql-queries.md` § Testing Query Builders
 
 ## Naming Conventions
 

--- a/docs/development/dsp-api-sparql-queries.md
+++ b/docs/development/dsp-api-sparql-queries.md
@@ -507,9 +507,45 @@ details on the query language and its internals.
 
 ## Testing Query Builders
 
+**Prefer golden tests as the default for query builders.** Snapshotting the full
+generated query keeps the entire SPARQL visible and reviewable in one file, verifies
+_clause placement_ (a triple is in DELETE vs INSERT vs WHERE) rather than mere substring
+presence, and stays readable as queries grow.
+
+**Avoid scattered `q.contains("...")` / `!q.contains("...")` substring assertions.** They
+are simultaneously brittle (they depend on exact serialization — spacing, escaping) and
+weak (they do not verify where a triple appears, so a query can be structurally wrong and
+still pass). Asserting the _absence_ of a keyword (e.g. `!q.contains("GRAPH")`) is
+especially fragile. Use a golden snapshot instead — a regression shows up as an obvious
+diff in the golden file.
+
+### Golden tests (preferred)
+
+Extend the spec with `GoldenTest` and snapshot the generated SPARQL. The golden file is
+written to the resources mirror of the spec's package
+(`src/test/scala/.../FooSpec.scala` → `src/test/resources/.../FooSpec__<suffix>.txt`).
+To create or update goldens, set `rewrite = true` on a call or `override val rewriteAll =
+true` on the spec, run once, then turn it off again; review the resulting diff.
+
+```scala
+object CreateLinkQuerySpec extends ZIOSpecDefault with GoldenTest {
+  test("should produce correct INSERT query") {
+    for {
+      query <- CreateLinkQuery.build(project, resourceIri, linkUpdate, uuid, instant, None)
+      result = replaceUuidPatterns(query.getQueryString) // normalise nondeterministic output (e.g. UUIDs)
+    } yield assertGolden(result, "createLink__basic")
+  }
+}
+```
+
+Golden comparison is exact-text, so the builder output must be deterministic; normalise
+any nondeterministic parts (random UUIDs, timestamps) before snapshotting, as
+`replaceUuidPatterns` does above. Triple _order_ is captured verbatim — fine for a
+deterministic builder.
+
 ### Direct string comparison
 
-For simple queries, compare the generated SPARQL string directly:
+For a trivial one-off query where an inline expectation reads better than a separate file:
 
 ```scala
 test("should produce correct DELETE query") {
@@ -520,23 +556,12 @@ test("should produce correct DELETE query") {
 }
 ```
 
-### Golden tests
-
-For complex queries, use the `GoldenTest` utility to compare against expected files:
-
-```scala
-test("should produce correct INSERT query") {
-  for {
-    query <- CreateLinkQuery.build(project, resourceIri, linkUpdate, uuid, instant, None)
-    result = replaceUuidPatterns(query.getQueryString)
-  } yield assertGolden(result, "createLink__basic")
-}
-```
-
 ### Apache Jena parsing for structural validation
 
-Parse the generated SPARQL with Apache Jena to verify it is syntactically valid,
-then inspect the parsed structure:
+When you need a _semantic_, order-insensitive check rather than an exact snapshot — for
+example asserting two queries are structurally equal regardless of formatting — parse the
+generated SPARQL with Apache Jena and compare or inspect the parsed structure (see
+`ResourcesRepoLiveSpec.assertUpdateQueriesEqual`):
 
 ```scala
 import org.apache.jena.update.UpdateFactory

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/it/v2/LegalInfoE2ESpec.scala
@@ -283,6 +283,27 @@ object LegalInfoE2ESpec extends E2EZSpec {
       } yield assert(onCreate)(hasSameElements(authors.map(_.value))) &&
         assert(onRead)(hasSameElements(authors.map(_.value)))
     },
+    test("editing a resource's authorship via PUT replaces it and is reflected when read back") {
+      val initial = List("Ada Lovelace").map(Authorship.unsafeFrom)
+      val updated = List("Lotte Reiniger", "Hilma af Klint").map(Authorship.unsafeFrom)
+      for {
+        createModel <- createThingWithResourceAuthorship(initial)
+        resourceIri <- resourceId(createModel)
+        _           <- putResourceAuthorship(resourceIri, updated).flatMap(_.assert200)
+        getModel    <- getResourceFromApi(resourceIri)
+        onRead      <- resourceAuthorshipValues(getModel)
+      } yield assert(onRead)(hasSameElements(updated.map(_.value)))
+    },
+    test("editing a resource's authorship to empty clears it") {
+      val initial = List("Ada Lovelace").map(Authorship.unsafeFrom)
+      for {
+        createModel <- createThingWithResourceAuthorship(initial)
+        resourceIri <- resourceId(createModel)
+        _           <- putResourceAuthorship(resourceIri, Nil).flatMap(_.assert200)
+        getModel    <- getResourceFromApi(resourceIri)
+        onRead      <- resourceAuthorshipValues(getModel)
+      } yield assertTrue(onRead.isEmpty)
+    },
   )
 
   val e2eSpec =
@@ -373,6 +394,23 @@ object LegalInfoE2ESpec extends E2EZSpec {
       responseBody <- TestApiClient.postJsonLd(uri"/v2/resources", jsonLd, rootUser).flatMap(_.assert200)
       model        <- ModelOps.fromJsonLd(responseBody).mapError(Exception(_))
     } yield model
+  }
+
+  // PUT /v2/resources/authorship. A freshly created resource has no lastModificationDate, so the first
+  // edit needs none in the body; an empty list clears authorship.
+  private def putResourceAuthorship(resourceIri: ResourceIri, authorship: List[Authorship]) = {
+    val arr    = authorship.map(a => Json.Str(a.value).toString).mkString("[", ", ", "]")
+    val jsonLd =
+      s"""{
+         |  "@id" : "${resourceIri.value}",
+         |  "@type" : "anything:Thing",
+         |  "knora-api:hasResourceAuthorship" : $arr,
+         |  "@context" : {
+         |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+         |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+         |  }
+         |}""".stripMargin
+    TestApiClient.putJsonLd(uri"/v2/resources/authorship", jsonLd, rootUser)
   }
 
   private def getValueFromApi(createResourceResponse: Model): ZIO[env, Throwable, Model] = for {

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -669,6 +669,80 @@ case class UpdateResourceMetadataResponseV2(
 }
 
 /**
+ * Represents a request to update a resource's per-resource (data-side) authorship.
+ *
+ * @param resourceIri               the IRI of the resource.
+ * @param resourceClassIri          the IRI of the resource class.
+ * @param resourceAuthorship        the new authorship; an empty sequence clears it.
+ * @param maybeLastModificationDate the resource's last modification date, if any.
+ * @param maybeNewModificationDate  the resource's new last modification date, if any.
+ */
+case class UpdateResourceAuthorshipRequestV2(
+  resourceIri: ResourceIri,
+  resourceClassIri: SmartIri,
+  resourceAuthorship: Seq[Authorship],
+  maybeLastModificationDate: Option[Instant] = None,
+  maybeNewModificationDate: Option[Instant] = None,
+  requestingUser: User,
+  apiRequestID: UUID,
+)
+
+/**
+ * Represents a response after updating a resource's per-resource (data-side) authorship.
+ *
+ * @param resourceIri          the IRI of the resource.
+ * @param resourceClassIri     the IRI of the resource class.
+ * @param lastModificationDate the resource's last modification date.
+ * @param resourceAuthorship   the resource's authorship after the update.
+ */
+case class UpdateResourceAuthorshipResponseV2(
+  resourceIri: ResourceIri,
+  resourceClassIri: SmartIri,
+  lastModificationDate: Instant,
+  resourceAuthorship: Seq[Authorship],
+) extends KnoraJsonLDResponseV2 {
+
+  override protected def toJsonLDDocument(
+    targetSchema: ApiV2Schema,
+    appConfig: AppConfig,
+    schemaOptions: Set[Rendering],
+  ): JsonLDDocument = {
+
+    implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
+
+    val knoraApiPrefixExpansion: IRI = targetSchema match {
+      case ApiV2Simple  => KnoraApiV2Simple.KnoraApiV2PrefixExpansion
+      case ApiV2Complex => KnoraApiV2Complex.KnoraApiV2PrefixExpansion
+    }
+
+    val context: JsonLDObject = JsonLDUtil.makeContext(
+      fixedPrefixes = Map(
+        "rdf"                          -> Rdf.RdfPrefixExpansion,
+        "rdfs"                         -> Rdfs.RdfsPrefixExpansion,
+        "xsd"                          -> Xsd.XsdPrefixExpansion,
+        KnoraApi.KnoraApiOntologyLabel -> knoraApiPrefixExpansion,
+      ),
+    )
+
+    val body = JsonLDObject(
+      Map(
+        KnoraApiV2Complex.ResourceIri          -> JsonLDString(resourceIri.value),
+        KnoraApiV2Complex.ResourceClassIri     -> JsonLDString(resourceClassIri.toString),
+        KnoraApiV2Complex.LastModificationDate -> JsonLDUtil.datatypeValueToJsonLDObject(
+          value = lastModificationDate.toString,
+          datatype = Xsd.DateTimeStamp.toSmartIri,
+        ),
+        KnoraApiV2Complex.HasResourceAuthorship -> JsonLDArray(
+          resourceAuthorship.map(authorship => JsonLDString(authorship.value)),
+        ),
+      ),
+    )
+
+    JsonLDDocument(body = body, context = context)
+  }
+}
+
+/**
  * Represents a request to mark a resource as deleted or to erase it from the triplestore.
  * This request deletes or erases depending on which http route it was sent through.
  *

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -291,6 +291,15 @@ final class ResourcesResponderV2(
                ZIO.fail(UpdateNotPerformedException(msg))
              }
 
+        // Verify that the authorship itself was persisted (order-insensitive), not just the modification date.
+        // Without this, a no-op update would be reported as a success while leaving the authorship unchanged.
+        _ <- ZIO.when(updatedResource.resourceAuthorship.toSet != request.resourceAuthorship.toSet) {
+               val msg =
+                 s"Updated resource authorship ${updatedResource.resourceAuthorship.map(_.value).sorted}, " +
+                   s"expected ${request.resourceAuthorship.map(_.value).sorted}"
+               ZIO.fail(UpdateNotPerformedException(msg))
+             }
+
       } yield UpdateResourceAuthorshipResponseV2(
         resourceIri = request.resourceIri,
         resourceClassIri = request.resourceClassIri,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -47,6 +47,7 @@ import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.common.service.IriConverter
+import org.knora.webapi.slice.resources.repo.ChangeResourceAuthorshipQuery
 import org.knora.webapi.slice.resources.repo.ChangeResourceMetadataQuery
 import org.knora.webapi.slice.resources.repo.DeleteResourceQuery
 import org.knora.webapi.slice.resources.repo.EraseResourceQuery
@@ -212,6 +213,89 @@ final class ResourcesResponderV2(
         maybeLabel = updateResourceMetadataRequestV2.maybeLabel,
         maybePermissions = updateResourceMetadataRequestV2.maybePermissions,
         lastModificationDate = newLmd.value,
+      ),
+    )
+
+  /**
+   * Updates a resource's per-resource (data-side) authorship, gated by `Modify` permission on the resource.
+   *
+   * @param request the update request.
+   * @return an [[UpdateResourceAuthorshipResponseV2]].
+   */
+  def updateResourceAuthorshipV2(
+    request: UpdateResourceAuthorshipRequestV2,
+  ): Task[UpdateResourceAuthorshipResponseV2] =
+    IriLocker.runWithIriLock(request.apiRequestID, request.resourceIri)(
+      for {
+        // Get the metadata of the resource to be updated.
+        resourcesSeq <- getResourcePreviewWithDeletedResource(
+                          resourceIris = Seq(request.resourceIri),
+                          targetSchema = ApiV2Complex,
+                          requestingUser = request.requestingUser,
+                        )
+
+        resource: ReadResourceV2 <- resourcesSeq.toResource(request.resourceIri)
+        internalResourceClassIri  = request.resourceClassIri.toOntologySchema(InternalSchema)
+
+        // Make sure that the resource's class is what the client thinks it is.
+        _ <- ZIO.when(resource.resourceClassIri != internalResourceClassIri) {
+               val msg =
+                 s"Resource <${resource.resourceIri}> is not a member of class <${request.resourceClassIri}>"
+               ZIO.fail(BadRequestException(msg))
+             }
+
+        _ <- ensureNoConflictingChange(resource, request.maybeLastModificationDate)
+
+        // Check that the user has permission to modify the resource.
+        _ <- resourceUtilV2.checkResourcePermission(
+               resource,
+               Permission.ObjectAccess.Modify,
+               request.requestingUser,
+             )
+
+        // Do the update.
+        project <- projectService
+                     .findById(resource.projectADM.id)
+                     .someOrFail(NotFoundException.notFound(resource.projectADM.id))
+        resourceClassIri <- iriConverter
+                              .asResourceClassIri(internalResourceClassIri)
+                              .mapError(BadRequestException.apply)
+        lmdAndUpdate <- ChangeResourceAuthorshipQuery.build(
+                          project,
+                          request.resourceIri,
+                          resourceClassIri,
+                          request.maybeLastModificationDate.map(LastModificationDate.from),
+                          request.maybeNewModificationDate.map(LastModificationDate.from),
+                          request.resourceAuthorship,
+                        )
+        (newLmd, updateQuery) = lmdAndUpdate
+        _                    <- triplestore.query(updateQuery)
+
+        // Verify that the update was performed by checking the new last modification date.
+        updatedResourcesSeq <-
+          getResourcePreviewWithDeletedResource(
+            resourceIris = Seq(request.resourceIri),
+            targetSchema = ApiV2Complex,
+            requestingUser = request.requestingUser,
+          )
+
+        _ <- ZIO.when(updatedResourcesSeq.resources.size != 1) {
+               ZIO.fail(AssertionException(s"Expected one resource, got ${updatedResourcesSeq.resources.size}"))
+             }
+
+        updatedResource: ReadResourceV2 = updatedResourcesSeq.resources.head
+
+        _ <- ZIO.when(!updatedResource.lastModificationDate.contains(newLmd.value)) {
+               val msg =
+                 s"Updated resource has last modification date ${updatedResource.lastModificationDate}, expected $newLmd"
+               ZIO.fail(UpdateNotPerformedException(msg))
+             }
+
+      } yield UpdateResourceAuthorshipResponseV2(
+        resourceIri = request.resourceIri,
+        resourceClassIri = request.resourceClassIri,
+        lastModificationDate = newLmd.value,
+        resourceAuthorship = request.resourceAuthorship,
       ),
     )
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/resources/ResourcesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/resources/ResourcesEndpoints.scala
@@ -187,6 +187,16 @@ final class ResourcesEndpoints(baseEndpoints: BaseEndpoints, graphConfig: GraphR
     .out(ApiV2.Outputs.contentTypeHeader)
     .description("Update resource metadata. Requires appropriate object access permissions on the resource.")
 
+  val putResourcesAuthorship = baseEndpoints.withUserEndpoint.put
+    .in(base / "authorship")
+    .in(ApiV2.Inputs.formatOptions)
+    .in(stringJsonBody)
+    .out(ApiV2.Outputs.stringBodyFormatted)
+    .out(ApiV2.Outputs.contentTypeHeader)
+    .description(
+      "Update a resource's authorship (data side). Requires Modify object access permission on the resource.",
+    )
+
   val endpoints: Seq[AnyEndpoint] = Seq(
     getResourcesIiifManifest,
     getResourcesPreview,
@@ -202,6 +212,7 @@ final class ResourcesEndpoints(baseEndpoints: BaseEndpoints, graphConfig: GraphR
     postResourcesDelete,
     postResources,
     putResources,
+    putResourcesAuthorship,
   ).map(_.endpoint).map(_.tag("V2 Resources"))
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/resources/ResourcesRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/resources/ResourcesRestService.scala
@@ -199,6 +199,18 @@ final case class ResourcesRestService(
       response <- renderer.render(result, formatOptions)
     } yield response
 
+  def updateResourceAuthorship(
+    user: User,
+  )(formatOptions: FormatOptions, jsonLd: String): Task[(RenderedResponse, MediaType)] =
+    for {
+      uuid    <- Random.nextUUID
+      request <- requestParser
+                   .updateResourceAuthorshipRequestV2(jsonLd, user, uuid)
+                   .mapError(BadRequestException.apply)
+      result   <- resourcesService.updateResourceAuthorshipV2(request)
+      response <- renderer.render(result, formatOptions)
+    } yield response
+
   private def parseResourceIri(iri: String): IO[BadRequestException, ResourceIri] =
     ZIO.fromEither(ResourceIri.from(iri)).mapError(BadRequestException.apply)
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/resources/ResourcesServerEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/resources/ResourcesServerEndpoints.scala
@@ -36,6 +36,7 @@ final class ResourcesServerEndpoints(resourcesEndpoints: ResourcesEndpoints, res
     resourcesEndpoints.postResourcesDelete.serverLogic(restService.deleteResource),
     resourcesEndpoints.postResources.serverLogic(restService.createResource),
     resourcesEndpoints.putResources.serverLogic(restService.updateResourceMetadata),
+    resourcesEndpoints.putResourcesAuthorship.serverLogic(restService.updateResourceAuthorship),
   )
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -28,6 +28,7 @@ import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceReq
 import org.knora.webapi.messages.v2.responder.resourcemessages.CreateResourceV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.CreateValueInNewResourceV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.DeleteOrEraseResourceRequestV2
+import org.knora.webapi.messages.v2.responder.resourcemessages.UpdateResourceAuthorshipRequestV2
 import org.knora.webapi.messages.v2.responder.resourcemessages.UpdateResourceMetadataRequestV2
 import org.knora.webapi.messages.v2.responder.valuemessages.*
 import org.knora.webapi.messages.v2.responder.valuemessages.ValueContentV2.FileInfo
@@ -172,6 +173,28 @@ final case class ApiComplexV2JsonLdRequestParser(
       lastModificationDate,
       label,
       permissions,
+      newModificationDate,
+      requestingUser,
+      uuid,
+    )
+  }
+
+  def updateResourceAuthorshipRequestV2(
+    str: String,
+    requestingUser: User,
+    uuid: UUID,
+  ): IO[String, UpdateResourceAuthorshipRequestV2] = ZIO.scoped {
+    for {
+      r                    <- RootResource.fromJsonLd(str)
+      resourceIri          <- r.resourceIriOrFail
+      resourceAuthorship   <- r.resourceAuthorship
+      lastModificationDate <- r.lastModificationDateOption
+      newModificationDate  <- r.newModificationDateOption
+    } yield UpdateResourceAuthorshipRequestV2(
+      resourceIri,
+      r.resourceClassSmartIri,
+      resourceAuthorship,
+      lastModificationDate,
       newModificationDate,
       requestingUser,
       uuid,

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
@@ -85,10 +85,18 @@ object ChangeResourceAuthorshipQuery extends QueryBuilderHelper {
         List(resourceTypePattern, lastModPattern, authorshipPattern)
       }
 
-      // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph is applied to the WHERE
-      // clause as well as DELETE/INSERT. With `.from`/`.into` the WHERE stays ungraphed and, on a
-      // triplestore without a union default graph (e.g. production Fuseki), matches nothing -- making
-      // the whole update a silent no-op. `with` is a Scala keyword, hence the backticks.
+      // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph applies to the WHERE
+      // clause as well as DELETE/INSERT. With `.from`/`.into` the DELETE/INSERT are GRAPH-wrapped but
+      // the WHERE stays ungraphed, matching the dataset default graph. On a store without a union
+      // default graph (e.g. the in-memory triplestore used in tests) that default graph is empty, so
+      // the WHERE matches nothing and the whole update silently no-ops. `WITH` keeps it correct
+      // regardless of the union-default-graph setting (production enables it, so `.from`/`.into` would
+      // work there too, but at the cost of scanning the union of all graphs).
+      // Invariant: this is correct only because every WHERE pattern here matches the resource's own
+      // triples in the data graph (its asserted rdf:type, lastModificationDate, hasResourceAuthorship).
+      // A pattern needing another graph (e.g. an ontology class or cardinality check) would not match
+      // under `WITH` and would require `USING <data> USING <ontology>` or explicit `GRAPH {}` blocks.
+      // `with` is a Scala keyword, hence the backticks.
       val query = Queries
         .MODIFY()
         .prefix(KB.NS, RDFS.NS, XSD.NS, RDF.NS)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
@@ -85,12 +85,15 @@ object ChangeResourceAuthorshipQuery extends QueryBuilderHelper {
         List(resourceTypePattern, lastModPattern, authorshipPattern)
       }
 
+      // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph is applied to the WHERE
+      // clause as well as DELETE/INSERT. With `.from`/`.into` the WHERE stays ungraphed and, on a
+      // triplestore without a union default graph (e.g. production Fuseki), matches nothing — making
+      // the whole update a silent no-op. `with` is a Scala keyword, hence the backticks.
       val query = Queries
         .MODIFY()
         .prefix(KB.NS, RDFS.NS, XSD.NS, RDF.NS)
-        .from(dataGraph)
+        .`with`(dataGraph)
         .delete(deletePatterns: _*)
-        .into(dataGraph)
         .insert(insertPatterns: _*)
         .where(wherePatterns: _*)
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
@@ -85,18 +85,11 @@ object ChangeResourceAuthorshipQuery extends QueryBuilderHelper {
         List(resourceTypePattern, lastModPattern, authorshipPattern)
       }
 
-      // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph applies to the WHERE
-      // clause as well as DELETE/INSERT. With `.from`/`.into` the DELETE/INSERT are GRAPH-wrapped but
-      // the WHERE stays ungraphed, matching the dataset default graph. On a store without a union
-      // default graph (e.g. the in-memory triplestore used in tests) that default graph is empty, so
-      // the WHERE matches nothing and the whole update silently no-ops. `WITH` keeps it correct
-      // regardless of the union-default-graph setting (production enables it, so `.from`/`.into` would
-      // work there too, but at the cost of scanning the union of all graphs).
-      // Invariant: this is correct only because every WHERE pattern here matches the resource's own
-      // triples in the data graph (its asserted rdf:type, lastModificationDate, hasResourceAuthorship).
-      // A pattern needing another graph (e.g. an ontology class or cardinality check) would not match
-      // under `WITH` and would require `USING <data> USING <ontology>` or explicit `GRAPH {}` blocks.
-      // `with` is a Scala keyword, hence the backticks.
+      // `WITH <graph>` scopes the named graph to the WHERE clause too, not just DELETE/INSERT;
+      // an ungraphed WHERE matches the default graph, which is empty (so the update no-ops) on a
+      // store without a union default graph, e.g. the in-memory test store. Safe only because the
+      // WHERE matches the resource's own data-graph triples; a cross-graph pattern (e.g. an ontology
+      // check) would need USING/GRAPH. (`with` is backticked because it is a Scala keyword.)
       val query = Queries
         .MODIFY()
         .prefix(KB.NS, RDFS.NS, XSD.NS, RDF.NS)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
@@ -64,7 +64,7 @@ object ChangeResourceAuthorshipQuery extends QueryBuilderHelper {
         lastModDelete ::: authorshipDelete
       }
 
-      // INSERT the new last modification date and one triple per new authorship value (none when empty ⇒ cleared).
+      // INSERT the new last modification date and one triple per new authorship value (none when empty => cleared).
       val insertPatterns: List[TriplePattern] = {
         val modificationDateInsert = resource.has(KB.lastModificationDate, toRdfLiteral(newModificationDate))
         val authorshipInsert       = authorship.map(a => resource.has(KB.hasResourceAuthorship, a.value)).toList
@@ -87,7 +87,7 @@ object ChangeResourceAuthorshipQuery extends QueryBuilderHelper {
 
       // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph is applied to the WHERE
       // clause as well as DELETE/INSERT. With `.from`/`.into` the WHERE stays ungraphed and, on a
-      // triplestore without a union default graph (e.g. production Fuseki), matches nothing — making
+      // triplestore without a union default graph (e.g. production Fuseki), matches nothing -- making
       // the whole update a silent no-op. `with` is a Scala keyword, hence the backticks.
       val query = Queries
         .MODIFY()

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuery.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.resources.repo
+
+import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.vocabulary.RDFS
+import org.eclipse.rdf4j.model.vocabulary.XSD
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
+import zio.*
+
+import dsp.errors.BadRequestException
+import org.knora.webapi.slice.admin.domain.model.Authorship
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
+import org.knora.webapi.slice.admin.domain.service.ProjectService
+import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
+import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
+
+object ChangeResourceAuthorshipQuery extends QueryBuilderHelper {
+
+  def build(
+    project: KnoraProject,
+    resourceIri: ResourceIri,
+    resourceClassIri: ResourceClassIri,
+    maybeLastModificationDate: Option[LastModificationDate],
+    maybeNewModificationDate: Option[LastModificationDate],
+    authorship: Seq[Authorship],
+  ): IO[BadRequestException, (LastModificationDate, Update)] = {
+
+    // Determine the new modification date: use the submitted value if provided and valid, otherwise use the current time.
+    val newModificationDateEffect: IO[BadRequestException, LastModificationDate] =
+      maybeNewModificationDate.fold(Clock.instant.map(LastModificationDate.from)) { submittedNewDate =>
+        maybeLastModificationDate match {
+          case Some(currentDate) if currentDate.value.isAfter(submittedNewDate.value) =>
+            val msg =
+              "Submitted knora-api:newModificationDate is before the resource's current knora-api:lastModificationDate"
+            ZIO.fail(BadRequestException(msg))
+          case _ => ZIO.succeed(submittedNewDate)
+        }
+      }
+
+    newModificationDateEffect.map { newModificationDate =>
+      val dataGraph               = Rdf.iri(ProjectService.projectDataNamedGraphV2(project).value)
+      val resource                = toRdfIri(resourceIri)
+      val resourceClass           = toRdfIri(resourceClassIri)
+      val oldAuthorship           = variable("oldAuthorship")
+      val anyLastModificationDate = variable("anyLastModificationDate")
+
+      // DELETE the previous last modification date (if any) and all existing authorship triples.
+      val deletePatterns: List[TriplePattern] = {
+        val lastModDelete =
+          maybeLastModificationDate.map(toRdfLiteral).map(resource.has(KB.lastModificationDate, _)).toList
+        val authorshipDelete = List(resource.has(KB.hasResourceAuthorship, oldAuthorship))
+        lastModDelete ::: authorshipDelete
+      }
+
+      // INSERT the new last modification date and one triple per new authorship value (none when empty ⇒ cleared).
+      val insertPatterns: List[TriplePattern] = {
+        val modificationDateInsert = resource.has(KB.lastModificationDate, toRdfLiteral(newModificationDate))
+        val authorshipInsert       = authorship.map(a => resource.has(KB.hasResourceAuthorship, a.value)).toList
+        modificationDateInsert :: authorshipInsert
+      }
+
+      // WHERE: the resource must exist with the expected class and lastModificationDate; bind existing authorship.
+      val wherePatterns: List[GraphPattern] = {
+        val resourceTypePattern = resource.isA(resourceClass)
+
+        val lastModPattern: GraphPattern = maybeLastModificationDate match {
+          case Some(lmd) => resource.has(KB.lastModificationDate, toRdfLiteral(lmd))
+          case None      => GraphPatterns.filterNotExists(resource.has(KB.lastModificationDate, anyLastModificationDate))
+        }
+
+        val authorshipPattern = resource.has(KB.hasResourceAuthorship, oldAuthorship).optional()
+
+        List(resourceTypePattern, lastModPattern, authorshipPattern)
+      }
+
+      val query = Queries
+        .MODIFY()
+        .prefix(KB.NS, RDFS.NS, XSD.NS, RDF.NS)
+        .from(dataGraph)
+        .delete(deletePatterns: _*)
+        .into(dataGraph)
+        .insert(insertPatterns: _*)
+        .where(wherePatterns: _*)
+
+      (newModificationDate, Update(query))
+    }
+  }
+}

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
@@ -95,7 +95,7 @@ object ChangeResourceMetadataQuery extends QueryBuilderHelper {
 
       // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph is applied to the WHERE
       // clause as well as DELETE/INSERT. With `.from`/`.into` the WHERE stays ungraphed and, on a
-      // triplestore without a union default graph (e.g. production Fuseki), matches nothing — making
+      // triplestore without a union default graph (e.g. production Fuseki), matches nothing -- making
       // the whole update a no-op. `with` is a Scala keyword, hence the backticks.
       val query = Queries
         .MODIFY()

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
@@ -93,10 +93,18 @@ object ChangeResourceMetadataQuery extends QueryBuilderHelper {
         List(resourceTypePattern, lastModPattern) ::: labelPattern ::: permissionsPattern
       }
 
-      // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph is applied to the WHERE
-      // clause as well as DELETE/INSERT. With `.from`/`.into` the WHERE stays ungraphed and, on a
-      // triplestore without a union default graph (e.g. production Fuseki), matches nothing -- making
-      // the whole update a no-op. `with` is a Scala keyword, hence the backticks.
+      // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph applies to the WHERE
+      // clause as well as DELETE/INSERT. With `.from`/`.into` the DELETE/INSERT are GRAPH-wrapped but
+      // the WHERE stays ungraphed, matching the dataset default graph. On a store without a union
+      // default graph (e.g. the in-memory triplestore used in tests) that default graph is empty, so
+      // the WHERE matches nothing and the whole update silently no-ops. `WITH` keeps it correct
+      // regardless of the union-default-graph setting (production enables it, so `.from`/`.into` would
+      // work there too, but at the cost of scanning the union of all graphs).
+      // Invariant: this is correct only because every WHERE pattern here matches the resource's own
+      // triples in the data graph (its asserted rdf:type, lastModificationDate, label, permissions). A
+      // pattern needing another graph (e.g. an ontology class or cardinality check) would not match
+      // under `WITH` and would require `USING <data> USING <ontology>` or explicit `GRAPH {}` blocks.
+      // `with` is a Scala keyword, hence the backticks.
       val query = Queries
         .MODIFY()
         .prefix(KB.NS, RDFS.NS, XSD.NS, RDF.NS)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
@@ -93,18 +93,11 @@ object ChangeResourceMetadataQuery extends QueryBuilderHelper {
         List(resourceTypePattern, lastModPattern) ::: labelPattern ::: permissionsPattern
       }
 
-      // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph applies to the WHERE
-      // clause as well as DELETE/INSERT. With `.from`/`.into` the DELETE/INSERT are GRAPH-wrapped but
-      // the WHERE stays ungraphed, matching the dataset default graph. On a store without a union
-      // default graph (e.g. the in-memory triplestore used in tests) that default graph is empty, so
-      // the WHERE matches nothing and the whole update silently no-ops. `WITH` keeps it correct
-      // regardless of the union-default-graph setting (production enables it, so `.from`/`.into` would
-      // work there too, but at the cost of scanning the union of all graphs).
-      // Invariant: this is correct only because every WHERE pattern here matches the resource's own
-      // triples in the data graph (its asserted rdf:type, lastModificationDate, label, permissions). A
-      // pattern needing another graph (e.g. an ontology class or cardinality check) would not match
-      // under `WITH` and would require `USING <data> USING <ontology>` or explicit `GRAPH {}` blocks.
-      // `with` is a Scala keyword, hence the backticks.
+      // `WITH <graph>` scopes the named graph to the WHERE clause too, not just DELETE/INSERT;
+      // an ungraphed WHERE matches the default graph, which is empty (so the update no-ops) on a
+      // store without a union default graph, e.g. the in-memory test store. Safe only because the
+      // WHERE matches the resource's own data-graph triples; a cross-graph pattern (e.g. an ontology
+      // check) would need USING/GRAPH. (`with` is backticked because it is a Scala keyword.)
       val query = Queries
         .MODIFY()
         .prefix(KB.NS, RDFS.NS, XSD.NS, RDF.NS)

--- a/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuery.scala
@@ -93,12 +93,15 @@ object ChangeResourceMetadataQuery extends QueryBuilderHelper {
         List(resourceTypePattern, lastModPattern) ::: labelPattern ::: permissionsPattern
       }
 
+      // Use `WITH <graph>` (not `.from`/`.into`) so the named project graph is applied to the WHERE
+      // clause as well as DELETE/INSERT. With `.from`/`.into` the WHERE stays ungraphed and, on a
+      // triplestore without a union default graph (e.g. production Fuseki), matches nothing — making
+      // the whole update a no-op. `with` is a Scala keyword, hence the backticks.
       val query = Queries
         .MODIFY()
         .prefix(KB.NS, RDFS.NS, XSD.NS, RDF.NS)
-        .from(dataGraph)
+        .`with`(dataGraph)
         .delete(deletePatterns: _*)
-        .into(dataGraph)
         .insert(insertPatterns: _*)
         .where(wherePatterns: _*)
 

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec__clearAuthorship.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec__clearAuthorship.txt
@@ -1,0 +1,11 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship ?oldAuthorship . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship ?oldAuthorship . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec__neverModified.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec__neverModified.txt
@@ -1,0 +1,11 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship ?oldAuthorship . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship "Ada Lovelace" . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+FILTER NOT EXISTS { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate ?anyLastModificationDate . }
+OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship ?oldAuthorship . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec__setAuthorship.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec__setAuthorship.txt
@@ -1,0 +1,13 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship ?oldAuthorship . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship "Ada Lovelace" .
+<http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship "Alan Turing" . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship ?oldAuthorship . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__label.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__label.txt
@@ -1,0 +1,12 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> rdfs:label "Updated Resource Label" . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__labelAndPermissions.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__labelAndPermissions.txt
@@ -1,0 +1,15 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel .
+<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> rdfs:label "New Label" .
+<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions "CR knora-admin:Creator" . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . }
+OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__neverModified.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__neverModified.txt
@@ -1,0 +1,11 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> rdfs:label "First Label" . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+FILTER NOT EXISTS { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate ?anyLastModificationDate . }
+OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__permissions.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__permissions.txt
@@ -1,0 +1,12 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:KnownUser" . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__specialCharsLabel.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__specialCharsLabel.txt
@@ -1,0 +1,12 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> rdfs:label "Label with \"quotes\" and \'apostrophes\'" . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }

--- a/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__specialCharsPermissions.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec__specialCharsPermissions.txt
@@ -1,0 +1,12 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+WITH <http://www.knora.org/data/0001/anything>
+DELETE { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . }
+INSERT { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
+<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser" . }
+WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
+<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
@@ -2096,6 +2096,30 @@ object ApiComplexV2JsonLdRequestParserSpec extends ZIOSpecDefault {
                   )
       } yield assertTrue(result.createResource.resourceAuthorship.isEmpty)
     },
+    test("updateResourceAuthorshipRequestV2 parses the resource IRI and the new authorship") {
+      for {
+        uuid   <- Random.nextUUID
+        result <- service(
+                    _.updateResourceAuthorshipRequestV2(
+                      """{
+                        |  "@id": "http://rdfh.ch/0001/a-thing",
+                        |  "@type": "ex:Thing",
+                        |  "ka:hasResourceAuthorship": [ "Lotte Reiniger", "Hilma af Klint" ],
+                        |  "@context": {
+                        |    "ka": "http://api.knora.org/ontology/knora-api/v2#",
+                        |    "ex": "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+                        |  }
+                        |}""".stripMargin,
+                      TestDataFactory.User.rootUser,
+                      uuid,
+                    ),
+                  )
+      } yield assertTrue(
+        result.resourceIri.value == "http://rdfh.ch/0001/a-thing",
+        result.resourceAuthorship ==
+          Seq(Authorship.unsafeFrom("Lotte Reiniger"), Authorship.unsafeFrom("Hilma af Klint")),
+      )
+    },
   ).provide(
     AdministrativePermissionRepoInMemory.layer,
     AdministrativePermissionService.layer,

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
@@ -2114,10 +2114,12 @@ object ApiComplexV2JsonLdRequestParserSpec extends ZIOSpecDefault {
                       uuid,
                     ),
                   )
+        // Authorship is a plain multi-valued datatype property (no rdf:List, no ORDER BY on read),
+        // so order does not round-trip through the triplestore. Compare as an unordered set.
       } yield assertTrue(
         result.resourceIri.value == "http://rdfh.ch/0001/a-thing",
-        result.resourceAuthorship ==
-          Seq(Authorship.unsafeFrom("Lotte Reiniger"), Authorship.unsafeFrom("Hilma af Klint")),
+        result.resourceAuthorship.toSet ==
+          Set(Authorship.unsafeFrom("Lotte Reiniger"), Authorship.unsafeFrom("Hilma af Klint")),
       )
     },
   ).provide(

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec.scala
@@ -11,6 +11,7 @@ import zio.test.*
 
 import java.time.Instant
 
+import org.knora.webapi.GoldenTest
 import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
@@ -22,7 +23,7 @@ import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
 
-object ChangeResourceAuthorshipQuerySpec extends ZIOSpecDefault {
+object ChangeResourceAuthorshipQuerySpec extends ZIOSpecDefault with GoldenTest {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
@@ -47,16 +48,16 @@ object ChangeResourceAuthorshipQuerySpec extends ZIOSpecDefault {
   private val testLastModificationDate = LastModificationDate.from(Instant.parse("2023-08-01T10:30:00Z"))
   private val testNewModificationDate  = LastModificationDate.from(Instant.parse("2023-08-02T15:45:00Z"))
 
-  private val dataGraph = "http://www.knora.org/data/0001/anything"
-  private val ada       = Authorship.unsafeFrom("Ada Lovelace")
-  private val alan      = Authorship.unsafeFrom("Alan Turing")
+  private val ada  = Authorship.unsafeFrom("Ada Lovelace")
+  private val alan = Authorship.unsafeFrom("Alan Turing")
 
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("ChangeResourceAuthorshipQuerySpec")(
     suite("build")(
-      // Regression guard for the silent no-op bug: the update MUST use `WITH <graph>` so the named
-      // project graph applies to the WHERE clause too. With GRAPH-wrapped DELETE/INSERT and an
-      // ungraphed WHERE, the WHERE matches the (empty) default graph on production Fuseki and the
-      // whole update no-ops. So: `WITH <graph>` present, and no `GRAPH` wrapper anywhere.
+      // The generated query is compared against a golden file (src/test/resources/.../<suffix>.txt).
+      // Regression guard for the silent no-op bug: the golden output MUST scope the named project graph
+      // with `WITH <graph>` (and no `GRAPH` wrapper), so the WHERE clause matches the resource in its
+      // graph rather than the dataset default graph -- which is empty on a store without a union default
+      // graph (e.g. the in-memory triplestore used in tests) and would make the whole update no-op.
       test("scopes the named graph with WITH (not GRAPH-wrapped clauses) when setting authorship") {
         ChangeResourceAuthorshipQuery
           .build(
@@ -68,21 +69,7 @@ object ChangeResourceAuthorshipQuerySpec extends ZIOSpecDefault {
             authorship = Seq(ada, alan),
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              // the new authorship values are inserted as string literals
-              q.contains("knora-base:hasResourceAuthorship \"Ada Lovelace\""),
-              q.contains("knora-base:hasResourceAuthorship \"Alan Turing\""),
-              // existing authorship is deleted via the bound variable, matched optionally in WHERE
-              q.contains("knora-base:hasResourceAuthorship ?oldAuthorship"),
-              q.contains("OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship ?oldAuthorship"),
-              // the existing lastModificationDate is matched in WHERE and bumped to the new one
-              q.contains("knora-base:lastModificationDate \"2023-08-01T10:30:00Z\"^^xsd:dateTime"),
-              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "setAuthorship")
           }
       },
       test("inserts no authorship triples when clearing authorship (empty sequence)") {
@@ -96,16 +83,7 @@ object ChangeResourceAuthorshipQuerySpec extends ZIOSpecDefault {
             authorship = Seq.empty,
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              // no authorship literal is inserted (clearing), but the existing one is still deleted
-              !q.contains("knora-base:hasResourceAuthorship \""),
-              q.contains("knora-base:hasResourceAuthorship ?oldAuthorship"),
-              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "clearAuthorship")
           }
       },
       test("uses FILTER NOT EXISTS for lastModificationDate when the resource was never modified") {
@@ -119,15 +97,7 @@ object ChangeResourceAuthorshipQuerySpec extends ZIOSpecDefault {
             authorship = Seq(ada),
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              q.contains("FILTER NOT EXISTS"),
-              q.contains("knora-base:hasResourceAuthorship \"Ada Lovelace\""),
-              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "neverModified")
           }
       },
     ),

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceAuthorshipQuerySpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.resources.repo
+
+import zio.*
+import zio.NonEmptyChunk
+import zio.test.*
+
+import java.time.Instant
+
+import org.knora.webapi.messages.IriConversions.ConvertibleIri
+import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
+import org.knora.webapi.slice.admin.domain.model.Authorship
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
+import org.knora.webapi.slice.admin.domain.model.RestrictedView
+import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
+import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.common.ResourceIri
+
+object ChangeResourceAuthorshipQuerySpec extends ZIOSpecDefault {
+
+  implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
+
+  private val testProject = KnoraProject(
+    ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001"),
+    Shortname.unsafeFrom("anything"),
+    Shortcode.unsafeFrom("0001"),
+    None,
+    NonEmptyChunk(Description.unsafeFrom(StringLiteralV2.from("Test project"))),
+    List.empty,
+    None,
+    Status.Active,
+    SelfJoin.CannotJoin,
+    RestrictedView.default,
+    Set.empty,
+    Set.empty,
+  )
+
+  private val testResourceIri      = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
+  private val testResourceClassIri =
+    ResourceClassIri.unsafeFrom("http://www.knora.org/ontology/0001/anything#Thing".toSmartIri)
+  private val testLastModificationDate = LastModificationDate.from(Instant.parse("2023-08-01T10:30:00Z"))
+  private val testNewModificationDate  = LastModificationDate.from(Instant.parse("2023-08-02T15:45:00Z"))
+
+  private val dataGraph = "http://www.knora.org/data/0001/anything"
+  private val ada       = Authorship.unsafeFrom("Ada Lovelace")
+  private val alan      = Authorship.unsafeFrom("Alan Turing")
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("ChangeResourceAuthorshipQuerySpec")(
+    suite("build")(
+      // Regression guard for the silent no-op bug: the update MUST use `WITH <graph>` so the named
+      // project graph applies to the WHERE clause too. With GRAPH-wrapped DELETE/INSERT and an
+      // ungraphed WHERE, the WHERE matches the (empty) default graph on production Fuseki and the
+      // whole update no-ops. So: `WITH <graph>` present, and no `GRAPH` wrapper anywhere.
+      test("scopes the named graph with WITH (not GRAPH-wrapped clauses) when setting authorship") {
+        ChangeResourceAuthorshipQuery
+          .build(
+            project = testProject,
+            resourceIri = testResourceIri,
+            resourceClassIri = testResourceClassIri,
+            maybeLastModificationDate = Some(testLastModificationDate),
+            maybeNewModificationDate = Some(testNewModificationDate),
+            authorship = Seq(ada, alan),
+          )
+          .map { case (lmd, update) =>
+            val q = update.sparql
+            assertTrue(
+              lmd == testNewModificationDate,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              // the new authorship values are inserted as string literals
+              q.contains("knora-base:hasResourceAuthorship \"Ada Lovelace\""),
+              q.contains("knora-base:hasResourceAuthorship \"Alan Turing\""),
+              // existing authorship is deleted via the bound variable, matched optionally in WHERE
+              q.contains("knora-base:hasResourceAuthorship ?oldAuthorship"),
+              q.contains("OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasResourceAuthorship ?oldAuthorship"),
+              // the existing lastModificationDate is matched in WHERE and bumped to the new one
+              q.contains("knora-base:lastModificationDate \"2023-08-01T10:30:00Z\"^^xsd:dateTime"),
+              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
+            )
+          }
+      },
+      test("inserts no authorship triples when clearing authorship (empty sequence)") {
+        ChangeResourceAuthorshipQuery
+          .build(
+            project = testProject,
+            resourceIri = testResourceIri,
+            resourceClassIri = testResourceClassIri,
+            maybeLastModificationDate = Some(testLastModificationDate),
+            maybeNewModificationDate = Some(testNewModificationDate),
+            authorship = Seq.empty,
+          )
+          .map { case (lmd, update) =>
+            val q = update.sparql
+            assertTrue(
+              lmd == testNewModificationDate,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              // no authorship literal is inserted (clearing), but the existing one is still deleted
+              !q.contains("knora-base:hasResourceAuthorship \""),
+              q.contains("knora-base:hasResourceAuthorship ?oldAuthorship"),
+              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
+            )
+          }
+      },
+      test("uses FILTER NOT EXISTS for lastModificationDate when the resource was never modified") {
+        ChangeResourceAuthorshipQuery
+          .build(
+            project = testProject,
+            resourceIri = testResourceIri,
+            resourceClassIri = testResourceClassIri,
+            maybeLastModificationDate = None,
+            maybeNewModificationDate = Some(testNewModificationDate),
+            authorship = Seq(ada),
+          )
+          .map { case (lmd, update) =>
+            val q = update.sparql
+            assertTrue(
+              lmd == testNewModificationDate,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              q.contains("FILTER NOT EXISTS"),
+              q.contains("knora-base:hasResourceAuthorship \"Ada Lovelace\""),
+              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
+            )
+          }
+      },
+    ),
+  )
+}

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec.scala
@@ -20,7 +20,6 @@ import org.knora.webapi.slice.admin.domain.model.RestrictedView
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
-import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
 object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
 
@@ -47,8 +46,14 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
   private val testLastModificationDate = LastModificationDate.from(Instant.parse("2023-08-01T10:30:00Z"))
   private val testNewModificationDate  = LastModificationDate.from(Instant.parse("2023-08-02T15:45:00Z"))
 
+  private val dataGraph = "http://www.knora.org/data/0001/anything"
+
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("ChangeResourceMetadataQuerySpec")(
     suite("build")(
+      // Regression guard for the silent no-op bug (DEV-6669): the update MUST scope the named project
+      // graph with `WITH <graph>` so the WHERE clause matches the resource in its graph. With
+      // GRAPH-wrapped DELETE/INSERT and an ungraphed WHERE, the WHERE matches the (empty) default graph
+      // on production Fuseki and the whole update no-ops. So: `WITH <graph>` present, no `GRAPH` wrapper.
       test("should produce the correct query when changing only the label") {
         ChangeResourceMetadataQuery
           .build(
@@ -61,19 +66,17 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = None,
           )
           .map { case (lmd, update) =>
+            val q = update.sparql
             assertTrue(
               lmd == testNewModificationDate,
-              update.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                                 |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }
-                                 |INSERT { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> rdfs:label "Updated Resource Label" . } }
-                                 |WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }""".stripMargin,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              q.contains("rdfs:label \"Updated Resource Label\""),
+              q.contains("rdfs:label ?oldLabel"),
+              q.contains("OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel"),
+              q.contains("knora-base:lastModificationDate \"2023-08-01T10:30:00Z\"^^xsd:dateTime"),
+              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
+              !q.contains("knora-base:hasPermissions"),
             )
           }
       },
@@ -89,19 +92,14 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = Some("CR knora-admin:Creator|V knora-admin:KnownUser"),
           )
           .map { case (lmd, update) =>
+            val q = update.sparql
             assertTrue(
               lmd == testNewModificationDate,
-              update.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                                 |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }
-                                 |INSERT { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:KnownUser" . } }
-                                 |WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }""".stripMargin,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              q.contains("knora-base:hasPermissions \"CR knora-admin:Creator|V knora-admin:KnownUser\""),
+              q.contains("knora-base:hasPermissions ?oldPermissions"),
+              !q.contains("rdfs:label"),
             )
           }
       },
@@ -117,22 +115,15 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = Some("CR knora-admin:Creator"),
           )
           .map { case (lmd, update) =>
+            val q = update.sparql
             assertTrue(
               lmd == testNewModificationDate,
-              update.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                                 |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }
-                                 |INSERT { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> rdfs:label "New Label" .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions "CR knora-admin:Creator" . } }
-                                 |WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . }
-                                 |OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }""".stripMargin,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              q.contains("rdfs:label \"New Label\""),
+              q.contains("rdfs:label ?oldLabel"),
+              q.contains("knora-base:hasPermissions \"CR knora-admin:Creator\""),
+              q.contains("knora-base:hasPermissions ?oldPermissions"),
             )
           }
       },
@@ -148,18 +139,14 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = None,
           )
           .map { case (lmd, update) =>
+            val q = update.sparql
             assertTrue(
               lmd == testNewModificationDate,
-              update.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                                 |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }
-                                 |INSERT { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> rdfs:label "First Label" . } }
-                                 |WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
-                                 |FILTER NOT EXISTS { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate ?anyLastModificationDate . }
-                                 |OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }""".stripMargin,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              q.contains("FILTER NOT EXISTS"),
+              q.contains("rdfs:label \"First Label\""),
+              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
             )
           }
       },
@@ -175,19 +162,14 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = None,
           )
           .map { case (lmd, update) =>
+            val q = update.sparql
             assertTrue(
               lmd == testNewModificationDate,
-              update.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                                 |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }
-                                 |INSERT { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> rdfs:label "Label with \"quotes\" and \'apostrophes\'" . } }
-                                 |WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel . } }""".stripMargin,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              // quotes and apostrophes are escaped in the emitted SPARQL string literal
+              q.contains("\\\"quotes\\\""),
+              q.contains("\\'apostrophes\\'"),
             )
           }
       },
@@ -203,19 +185,14 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = Some("CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser"),
           )
           .map { case (lmd, update) =>
+            val q = update.sparql
             assertTrue(
               lmd == testNewModificationDate,
-              update.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                                 |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }
-                                 |INSERT { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-02T15:45:00Z"^^xsd:dateTime .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser" . } }
-                                 |WHERE { <http://rdfh.ch/0001/a-thing> a <http://www.knora.org/ontology/0001/anything#Thing> .
-                                 |<http://rdfh.ch/0001/a-thing> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://rdfh.ch/0001/a-thing> knora-base:hasPermissions ?oldPermissions . } }""".stripMargin,
+              q.contains(s"WITH <$dataGraph>"),
+              !q.contains("GRAPH"),
+              q.contains(
+                "knora-base:hasPermissions \"CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser\"",
+              ),
             )
           }
       },

--- a/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/ChangeResourceMetadataQuerySpec.scala
@@ -11,6 +11,7 @@ import zio.test.*
 
 import java.time.Instant
 
+import org.knora.webapi.GoldenTest
 import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
@@ -21,7 +22,7 @@ import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.ResourceIri
 
-object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
+object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault with GoldenTest {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
@@ -46,14 +47,14 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
   private val testLastModificationDate = LastModificationDate.from(Instant.parse("2023-08-01T10:30:00Z"))
   private val testNewModificationDate  = LastModificationDate.from(Instant.parse("2023-08-02T15:45:00Z"))
 
-  private val dataGraph = "http://www.knora.org/data/0001/anything"
-
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("ChangeResourceMetadataQuerySpec")(
     suite("build")(
-      // Regression guard for the silent no-op bug (DEV-6669): the update MUST scope the named project
-      // graph with `WITH <graph>` so the WHERE clause matches the resource in its graph. With
-      // GRAPH-wrapped DELETE/INSERT and an ungraphed WHERE, the WHERE matches the (empty) default graph
-      // on production Fuseki and the whole update no-ops. So: `WITH <graph>` present, no `GRAPH` wrapper.
+      // The generated query is compared against a golden file (src/test/resources/.../<suffix>.txt).
+      // Regression guard for the silent no-op bug (DEV-6669): the golden output MUST scope the named
+      // project graph with `WITH <graph>` (and no `GRAPH` wrapper), so the WHERE clause matches the
+      // resource in its graph rather than the dataset default graph -- which is empty on a store without
+      // a union default graph (e.g. the in-memory triplestore used in tests) and would make the update
+      // no-op.
       test("should produce the correct query when changing only the label") {
         ChangeResourceMetadataQuery
           .build(
@@ -66,18 +67,7 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = None,
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              q.contains("rdfs:label \"Updated Resource Label\""),
-              q.contains("rdfs:label ?oldLabel"),
-              q.contains("OPTIONAL { <http://rdfh.ch/0001/a-thing> rdfs:label ?oldLabel"),
-              q.contains("knora-base:lastModificationDate \"2023-08-01T10:30:00Z\"^^xsd:dateTime"),
-              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
-              !q.contains("knora-base:hasPermissions"),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "label")
           }
       },
       test("should produce the correct query when changing only the permissions") {
@@ -92,15 +82,7 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = Some("CR knora-admin:Creator|V knora-admin:KnownUser"),
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              q.contains("knora-base:hasPermissions \"CR knora-admin:Creator|V knora-admin:KnownUser\""),
-              q.contains("knora-base:hasPermissions ?oldPermissions"),
-              !q.contains("rdfs:label"),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "permissions")
           }
       },
       test("should produce the correct query when changing both label and permissions") {
@@ -115,16 +97,7 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = Some("CR knora-admin:Creator"),
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              q.contains("rdfs:label \"New Label\""),
-              q.contains("rdfs:label ?oldLabel"),
-              q.contains("knora-base:hasPermissions \"CR knora-admin:Creator\""),
-              q.contains("knora-base:hasPermissions ?oldPermissions"),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "labelAndPermissions")
           }
       },
       test("should produce the correct query when lastModificationDate is None (resource never modified before)") {
@@ -139,15 +112,7 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = None,
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              q.contains("FILTER NOT EXISTS"),
-              q.contains("rdfs:label \"First Label\""),
-              q.contains("knora-base:lastModificationDate \"2023-08-02T15:45:00Z\"^^xsd:dateTime"),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "neverModified")
           }
       },
       test("should handle special characters in labels") {
@@ -162,15 +127,7 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = None,
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              // quotes and apostrophes are escaped in the emitted SPARQL string literal
-              q.contains("\\\"quotes\\\""),
-              q.contains("\\'apostrophes\\'"),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "specialCharsLabel")
           }
       },
       test("should handle special characters in permissions") {
@@ -185,15 +142,7 @@ object ChangeResourceMetadataQuerySpec extends ZIOSpecDefault {
             maybePermissions = Some("CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser"),
           )
           .map { case (lmd, update) =>
-            val q = update.sparql
-            assertTrue(
-              lmd == testNewModificationDate,
-              q.contains(s"WITH <$dataGraph>"),
-              !q.contains("GRAPH"),
-              q.contains(
-                "knora-base:hasPermissions \"CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser\"",
-              ),
-            )
+            assertTrue(lmd == testNewModificationDate) && assertGolden(update.sparql, "specialCharsPermissions")
           }
       },
     ),


### PR DESCRIPTION
Fixes DEV-6669

> **Stacked on [#4157](https://github.com/dasch-swiss/dsp-api/pull/4157) (api-2, DEV-6662)** — base branch is `feature/dev-6662-per-resource-authorship`, not `main`. Review/merge #4157 first, then rebase this onto main.

## Motivation

api-2 (#4157) added the `knora-base:hasResourceAuthorship` property with read + write-on-create. This PR (**api-2b**) adds the **post-create edit** path so a resource's authorship can be changed after creation — needed by dsp-app app-3's inline authorship edit (DEV-6667). It was split out of api-2 because it has no FileValue precedent and warranted a focused, design-first PR (spec §4.B).

## Summary

A new `Modify`-gated endpoint `PUT /v2/resources/authorship` that replaces a resource's authorship (an empty list clears it). Modeled end-to-end on the existing `updateResourceMetadataV2` chain.

## Key Changes

- **Messages** (`ResourceMessagesV2`): `UpdateResourceAuthorshipRequestV2` + `UpdateResourceAuthorshipResponseV2` (with `toJsonLDDocument` emitting `knora-api:hasResourceAuthorship` + the new `lastModificationDate`).
- **Parser** (`ApiComplexV2JsonLdRequestParser`): `updateResourceAuthorshipRequestV2` (reuses the `resourceAuthorship` accessor added in api-2).
- **SPARQL** (`ChangeResourceAuthorshipQuery`, new): mirrors `ChangeResourceMetadataQuery` — DELETE the old `hasResourceAuthorship` triples + last-mod-date, INSERT the new authorship (one triple per author) + new last-mod-date, with the same optimistic-lock `lastModificationDate` WHERE handling.
- **Responder** (`ResourcesResponderV2.updateResourceAuthorshipV2`): `IriLocker`, class check, `ensureNoConflictingChange`, `checkResourcePermission(_, Permission.ObjectAccess.Modify, _)`, run the update, verify the new last-mod-date.
- **Endpoint + wiring**: `putResourcesAuthorship` in `ResourcesEndpoints`, wired through `ResourcesServerEndpoints` and `ResourcesRestService`.

## Challenges and Decisions

- **Replace semantics.** The endpoint sets authorship to exactly the submitted list; an empty list clears it (viewer then shows the labeled "no authorship recorded" fallback). The multi-valued DELETE binds existing values via an OPTIONAL `?oldAuthorship` and re-inserts the new set.
- **Permission.** Gated by `Modify` object-access on the resource (server-side, via the shared `ResourceUtilV2.checkResourcePermission`) — a non-`Modify` user gets 403, matching WB-2.

## Gotchas

- Inherits api-2's R2R-fixture caveat (regenerate `knoraApiOntologyWithValueObjects.jsonld` with the stack) since it builds on that branch.
- This is **stacked** — its CI reflects api-2 + api-2b together.

## Test Plan

- Unit: `ApiComplexV2JsonLdRequestParserSpec` — `updateResourceAuthorshipRequestV2` parses the resource IRI and the new authorship.
- `webapi/compile` and `webapi/Test/compile` green; `sbt fmt` applied.
- Follow-up (needs the Docker stack): e2e edit round-trip + **non-Modify 403**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
