### PR TITLE
docs(observability): Gravsearch trace runbook, TraceQL + instrumentation recipes (DEV-6636)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,22 @@ See also `CONVENTIONS.md` (work-phase agent reference card — code/testing/comm
 `docs/development/`) and `REVIEW.md` (review-phase checklist). Update these alongside `docs/development/` whenever a
 convention changes.
 
+### Observability
+
+When working on observability — OpenTelemetry tracing, spans, metrics, or anything that emits or
+reads telemetry (e.g. instrumenting a responder, adding span attributes, debugging a slow request via
+traces) — read `docs/observability/` first. Key entry points:
+
+- `docs/observability/index.md` — what is instrumented and where the traces live.
+- `docs/observability/instrumentation-recipe.md` — the mandatory pattern for adding per-stage tracing
+  to a responder (root + stage spans, bounded query shape, sanitized errors, `exit_reason`). Follow
+  it rather than re-deriving; the load-bearing `UNSET` status-mapper rule prevents leaking user data
+  into span status.
+- `docs/observability/gravsearch-trace-runbook.md` and `docs/observability/traceql-recipes.md` — how
+  to read traces and query them in Grafana.
+- `docs/observability/using-grafana.md` — how to run those queries in the Grafana UI and from Claude
+  Code via the Grafana MCP server.
+
 ### Markdown Formatting
 
 After editing any markdown files, run the `/fix-markdownlint` skill to ensure proper formatting.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -43,6 +43,10 @@ Scala 3, ZIO 2, Tapir, zio-json, sbt. Package root: `org.knora.webapi`. Triplest
 
 Never concatenate query strings. Use rdf4j SparqlBuilder via the helpers in `slice/common/repo`. See `docs/development/dsp-api-sparql-queries.md`.
 
+### Observability
+
+When adding or changing tracing/telemetry (spans, span attributes, metrics), read `docs/observability/` first — don't re-derive the pattern. Follow `docs/observability/instrumentation-recipe.md`: one root `INTERNAL` span per vertical plus bounded-name stage spans, a **bounded** query shape on the root (never raw query text, instance IRIs, or user IDs as attributes), and the load-bearing `UNSET` failure status-mapper that keeps `cause.prettyPrint` (user data) out of the span status. `docs/observability/using-grafana.md` covers reading/querying traces in Grafana and from Claude Code via the Grafana MCP server.
+
 ### Imports & formatting
 
 - No fully-qualified class names in code bodies — import at the top of the file.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -41,6 +41,10 @@ Agent reference card for the **review phase**. Pair with `CONVENTIONS.md` (work 
 
 - [ ] No string concatenation in SPARQL — use rdf4j SparqlBuilder via the helpers in `slice/common/repo` (see `docs/development/dsp-api-sparql-queries.md`)
 
+### Observability
+
+- [ ] Tracing/telemetry changes follow `docs/observability/instrumentation-recipe.md`: bounded span names, a bounded query shape on the root, **no raw query text / instance IRIs / user IDs in attributes**, failure status-mapper maps to `UNSET` (keeps `cause.prettyPrint` out of span status), interruptions set `exit_reason`
+
 ### Tests
 
 - [ ] New tests: `object XSpec extends ZIOSpecDefault`; layers via `.provide(...)`; `TestAspect.withLiveClock` for time-dependent tests

--- a/docs/observability/gravsearch-trace-runbook.md
+++ b/docs/observability/gravsearch-trace-runbook.md
@@ -1,0 +1,118 @@
+# Gravsearch Trace Runbook
+
+A one-page guide to diagnosing a slow Gravsearch query from its trace. The goal is that you can open
+a trace cold and name the dominant stage and read the time decomposition without prior briefing.
+
+## 1. Find a slow trace
+
+Open **Grafana → Explore → `grafanacloud-dasch-traces`** (Tempo), TraceQL tab, and run the
+slow-query recipe:
+
+```traceql
+{ span:name = "gravsearch" && span:duration > 2s }
+```
+
+See **[TraceQL Recipes](traceql-recipes.md)** for the full set (threshold relative to the baseline
+p95, drill-down by stage, filter by query shape, find errors and interruptions). Click a result to
+open the trace, then find the `gravsearch` span — it is an `INTERNAL` span nested under the HTTP
+`SERVER` span for the request.
+
+## 2. The span tree
+
+A full-path query (the prequery returned at least one main resource) produces this tree:
+
+```mermaid
+graph TD
+  H["HTTP SERVER span<br/>(endpoint path template)"] --> G["gravsearch (INTERNAL, root)"]
+  G --> P["gravsearch.parse"]
+  G --> TI["gravsearch.type_inspection"]
+  G --> PG["gravsearch.prequery.generate"]
+  G --> PE["gravsearch.prequery.execute"]
+  PE --> TSP["triplestore query<br/>(CLIENT span)"]
+  G --> MG["gravsearch.mainquery.generate"]
+  G --> ME["gravsearch.mainquery.execute"]
+  ME --> TSM["triplestore query<br/>(CLIENT span)"]
+  G --> RT["gravsearch.result_transform"]
+```
+
+All stage spans are direct children of the `gravsearch` root. The triplestore round-trips appear as
+`CLIENT` spans nested **under** the two `*.execute` stages — that nesting is how you separate time
+spent *in the triplestore* from time spent generating SPARQL or transforming results.
+
+## 3. What each stage means
+
+| Stage span | Measures | Typical cost driver |
+| --- | --- | --- |
+| `gravsearch.parse` | Parsing the Gravsearch string into a `ConstructQuery` AST | Negligible; only notable on parse failure |
+| `gravsearch.type_inspection` | Inferring entity/value types for the query | Large or deeply-typed queries |
+| `gravsearch.prequery.generate` | Building the prequery SPARQL (resource IRIs + ordering) | Complex WHERE clauses, many patterns/joins |
+| `gravsearch.prequery.execute` | Running the prequery against Fuseki (CLIENT span nested here) | **Most common hotspot** — triplestore time |
+| `gravsearch.mainquery.generate` | Building the main query for the page of resource IRIs | Many properties / large page |
+| `gravsearch.mainquery.execute` | Running the main query against Fuseki (CLIENT span nested here) | Triplestore time for the value graph |
+| `gravsearch.result_transform` | Permission filtering + assembling the API response | Large result pages, heavy markup |
+
+A **count** query (`/v2/searchextended/count`) runs only the prequery side: `gravsearch.parse`,
+`gravsearch.type_inspection`, `gravsearch.prequery.generate`, `gravsearch.prequery.execute` under
+the root — four prequery-side stages, no main-query or result-transform spans. This is expected
+(see [§6](#6-absent-spans-four-normal-topologies)), not a truncated trace.
+
+## 4. Root-span attributes
+
+The `gravsearch` root span carries a **query shape** — a bounded fingerprint of *what kind* of query
+this was, with no user data in it. Use it to group "queries like this one" without leaking FILTER
+literals or instance IRIs.
+
+| Attribute | Example | Use |
+| --- | --- | --- |
+| `gravsearch.query.shape` | `resource-list\|has_filter\|has_order_by\|patterns:4-7\|joins:1` | Bounded label; safe to group/aggregate by. Format: result-type, then each true flag, then `patterns:<bucket>` and `joins:<bucket>` (buckets: `0`, `1`, `2-3`, `4-7`, `8+`) |
+| `gravsearch.shape.has_filter` | `true` | Per-flag booleans for TraceQL filtering — also `has_optional`, `has_union`, `has_order_by`, `has_offset`, `has_link_traversal`, `is_fulltext` |
+| `gravsearch.schema_predicates` | `hasTitle,isPartOf` | Sorted, de-duplicated **ontology** predicate names only (never instance IRIs). Drill-down detail, not a metric label |
+
+On a failed or interrupted stage span you may also see:
+
+| Attribute / field | Meaning |
+| --- | --- |
+| span status `ERROR`, description `"<stage>: <ClassName>"` | A typed stage failure, e.g. `gravsearch.prequery.execute: TriplestoreException`. The message is sanitized — never the raw SPARQL or FILTER literal |
+| `error.type` | The exception class simple name |
+| `gravsearch.exit_reason = interrupted` | The fiber was interrupted (client disconnect / timeout / cancellation) — see [§6](#6-absent-spans-four-normal-topologies) |
+
+## 5. Reading the time decomposition
+
+1. Note the **root `gravsearch` duration** — that is the responder's total.
+2. Walk the stage spans in order; the one with the largest duration is the dominant stage.
+3. For an `*.execute` stage, compare the stage duration with its **nested triplestore `CLIENT`
+   span**: if they are close, the time is in Fuseki; if the stage is much longer than the client
+   span, the time is in DSP-API around the query.
+4. Stage durations do not perfectly sum to the root (there is glue between stages), but one stage
+   normally dominates. `gravsearch.prequery.execute` is the most common hotspot.
+
+## 6. Absent spans: four normal topologies
+
+The instrumentation deliberately **omits** spans for work that did not happen rather than emitting
+zero-duration placeholders. So a trace with fewer than eight spans is usually *correct*. Four
+distinct shapes look like "missing spans" but each means something specific — do not read any of
+them as broken instrumentation, and do not mistake one for another.
+
+| Topology | What you see | What it means | Tell-tale |
+| --- | --- | --- | --- |
+| **Empty result** | parse → type_inspection → prequery.generate → prequery.execute present; **no** `mainquery.*`, **no** `result_transform` | The prequery returned zero main resources, so there was nothing to fetch — "no rows", not an error | All present spans are `OK`; root has its shape attributes |
+| **Parse failure** | root + `gravsearch.parse` only, parse span is `ERROR` | The Gravsearch string was malformed; the pipeline never started | Only the parse span exists and it is `ERROR` (`gravsearch.parse: <Class>`) |
+| **Interruption / timeout** | early stages present, later stages absent, **last open span + root are `ERROR`** | The request fiber was interrupted (client disconnect, timeout, cancellation) mid-query | `gravsearch.exit_reason = interrupted` on the open span and the root |
+| **Shape-less early interrupt** | root present but **without `gravsearch.query.shape` / `gravsearch.shape.*`**, little or nothing below it | Interrupted (or failed) *before* parse completed, so the shape was never derived | Missing shape attributes **and** `exit_reason = interrupted` / `ERROR` on the root — not a broken shape derivation |
+
+How to tell them apart quickly:
+
+- **Later stages missing + everything `OK` + shape present** → empty result. Benign.
+- **Only the parse span + it is `ERROR`** → parse failure. Look at the client's query, not the
+  instrumentation.
+- **Later stages missing + an `ERROR` span carrying `exit_reason = interrupted`** → interruption.
+  The query was probably slow and got cancelled — this is exactly the trace you are hunting; read
+  the stages that *did* run to see where the time went before the cut.
+- **Root has no shape attributes at all** → shape-less early interrupt. The interruption happened so
+  early that parse/shape never ran; the absence of shape is expected, not a bug.
+
+!!! note "Why interruption is called out separately"
+    OTel span status has no `cancelled` value (only `Unset`/`Ok`/`Error`). Without the
+    `gravsearch.exit_reason = interrupted` attribute, an interrupted slow query — early stages
+    present, later stages absent — would be indistinguishable from a benign empty result, and from a
+    typed stage failure. The attribute is what disambiguates them.

--- a/docs/observability/index.md
+++ b/docs/observability/index.md
@@ -1,0 +1,36 @@
+# Observability
+
+DSP-API is instrumented with [OpenTelemetry](https://opentelemetry.io/) traces, exported to
+[Grafana Tempo](https://grafana.com/oss/tempo/) and explored in Grafana. This section is the
+engineer-facing layer on top of that instrumentation: how to read the traces, how to query them,
+and how to add new instrumentation.
+
+## What is instrumented
+
+- **HTTP server spans** — every request served by the API produces a root `SERVER` span, named
+  from the endpoint path template (low cardinality, not the concrete URL).
+- **Trace-context propagation** — the `traceparent` header is propagated from DSP-APP through the
+  API and on to the Fuseki triplestore, so a single trace spans the whole request path.
+- **Trace ↔ log correlation** — log lines carry the trace ID, so a trace can be pivoted to its logs
+  and back.
+- **Per-stage Gravsearch spans** — the `SearchResponderV2` is instrumented at responder granularity:
+  a `gravsearch` root span with one child span per pipeline stage. This is the first vertical
+  instrumented this deeply and the worked example for the rest of this section.
+
+## Where to look
+
+Traces live in the **`grafanacloud-dasch-traces`** Tempo datasource. Open **Grafana → Explore**,
+select that datasource, and use the **TraceQL** query tab. The metrics endpoint
+([Metrics Endpoint](../03-endpoints/instrumentation/metrics.md)) and health endpoint remain the
+place for Prometheus-format metrics and liveness — tracing complements them, it does not replace
+them.
+
+## Guides
+
+- **[Gravsearch Trace Runbook](gravsearch-trace-runbook.md)** — find a slow Gravsearch trace, read
+  the per-stage time decomposition, and interpret each span and attribute (including the cases where
+  *absent* spans are normal, not broken instrumentation).
+- **[TraceQL Recipes](traceql-recipes.md)** — ready-to-run TraceQL queries and a Grafana Explore
+  starter for hunting slow Gravsearch queries.
+- **[Instrumentation Recipe](instrumentation-recipe.md)** — the pattern used to instrument
+  `SearchResponderV2`, written so a second vertical can be instrumented without re-deriving it.

--- a/docs/observability/index.md
+++ b/docs/observability/index.md
@@ -20,13 +20,17 @@ and how to add new instrumentation.
 ## Where to look
 
 Traces live in the **`grafanacloud-dasch-traces`** Tempo datasource. Open **Grafana → Explore**,
-select that datasource, and use the **TraceQL** query tab. The metrics endpoint
+select that datasource, and use the **TraceQL** query tab. See [Using Grafana](using-grafana.md) for
+the UI walkthrough, the local-stack equivalent, and how to run all of this from Claude Code via the
+Grafana MCP server. The metrics endpoint
 ([Metrics Endpoint](../03-endpoints/instrumentation/metrics.md)) and health endpoint remain the
 place for Prometheus-format metrics and liveness — tracing complements them, it does not replace
 them.
 
 ## Guides
 
+- **[Using Grafana](using-grafana.md)** — where Grafana lives (cloud and local stack), the Explore /
+  TraceQL UI flow, and how to run every recipe from Claude Code via the Grafana MCP server.
 - **[Gravsearch Trace Runbook](gravsearch-trace-runbook.md)** — find a slow Gravsearch trace, read
   the per-stage time decomposition, and interpret each span and attribute (including the cases where
   *absent* spans are normal, not broken instrumentation).

--- a/docs/observability/instrumentation-recipe.md
+++ b/docs/observability/instrumentation-recipe.md
@@ -1,0 +1,174 @@
+# Instrumentation Recipe
+
+How to add per-stage tracing to a responder, using the pattern established for `SearchResponderV2`
+(Gravsearch). Follow it to instrument a second vertical without re-deriving the design. The
+reference implementation lives in
+`webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala`.
+
+The pattern in one sentence: open one **root** `INTERNAL` span named after the vertical, wrap each
+pipeline stage in a child span via a small `stageSpan` helper, attach a **bounded shape fingerprint**
+to the root, and make failures and interruptions legible without leaking user data.
+
+## 1. Wire `Tracing` into the service
+
+Declare `tracing` as an **abstract member of the trait** (not only a constructor param of the live
+impl) so that any default methods on the trait can open spans before delegating:
+
+```scala
+trait SearchResponderV2 {
+  // Telemetry used to open the root span and its per-stage child spans. Declared as an abstract
+  // member so the trait's default methods can open the root + parse spans before delegating.
+  protected def tracing: Tracing
+  // ...
+}
+```
+
+Provide it in the live class and add `Tracing` to the module's `Dependencies` alias so
+`ZLayer.derive` picks it up from the environment:
+
+```scala
+final class SearchResponderV2Live(
+  // ...other deps...
+  override protected val tracing: Tracing,
+) extends SearchResponderV2
+
+// SearchResponderV2Module.scala
+type Dependencies = /* ...other deps... */ & Tracing
+```
+
+## 2. Add the `stageSpan` helper
+
+Copy this helper (companion object of the responder). It opens an `INTERNAL` span that is
+automatically a child of whatever span is active on the fiber, records a **sanitized** error on
+failure, and marks interruptions — then maps the library status to `UNSET` so the library's own
+status-setter is a no-op and never overwrites what we set.
+
+```scala
+def stageSpan[A](tracing: Tracing, name: String)(effect: Task[A]): Task[A] =
+  tracing.span(name, SpanKind.INTERNAL, statusMapper = unsetOnFailure) {
+    tracing.getCurrentSpanUnsafe.flatMap { span =>
+      effect
+        .tapErrorCause(cause => ZIO.succeed(markSanitizedError(span, name, cause)))
+        .onExit {
+          case Exit.Failure(cause) if cause.isInterrupted =>
+            ZIO.succeed {
+              val _ = span.setAttribute("gravsearch.exit_reason", "interrupted")
+              val _ = span.setStatus(StatusCode.ERROR, "interrupted")
+            }
+          case _ => ZIO.unit
+        }
+    }
+  }
+```
+
+A thin `protected final` wrapper on the trait lets methods call `stageSpan("name") { ... }` without
+passing `tracing` each time:
+
+```scala
+protected final def stageSpan[A](name: String)(effect: Task[A]): Task[A] =
+  SearchResponderV2.stageSpan(tracing, name)(effect)
+```
+
+The **root** span is opened with the same helper — there is no separate root helper. Open the root,
+then open each stage inside it; FiberRef-carried context makes them children automatically.
+
+## 3. Name the spans
+
+- Root span = the vertical name: `gravsearch`.
+- Stage spans = `<vertical>.<stage>`, lowercase, dotted, from a **bounded** set:
+  `gravsearch.parse`, `gravsearch.type_inspection`, `gravsearch.prequery.generate`,
+  `gravsearch.prequery.execute`, `gravsearch.mainquery.generate`, `gravsearch.mainquery.execute`,
+  `gravsearch.result_transform`.
+- Never put variable data (IRIs, counts, user input) in a span name — that explodes cardinality.
+  Variable data goes in attributes, bounded data goes in the shape (step 5).
+
+## 4. Wrap each stage — and omit stages that did not run
+
+Wrap each stage effect in `stageSpan`. For example, the main-query trio runs only when the prequery
+returned at least one resource — keep those spans **inside** the conditional so an empty result
+simply has no main-query spans, rather than zero-duration placeholders:
+
+```scala
+mainQueryResults <-
+  if (mainResourceIris.nonEmpty) {
+    for {
+      sparql   <- stageSpan("gravsearch.mainquery.generate")(/* build SPARQL */)
+      response <- stageSpan("gravsearch.mainquery.execute")(/* triplestore.query(...) */)
+      result   <- stageSpan("gravsearch.result_transform")(/* permission filter + assemble */)
+    } yield result
+  } else {
+    ZIO.attempt(/* empty result */)
+  }
+```
+
+Absent spans are a documented, legible signal — see the runbook's
+[four absent-data topologies](gravsearch-trace-runbook.md#6-absent-spans-four-normal-topologies).
+The triplestore `CLIENT` span nests automatically under the `*.execute` stage because it runs inside
+that stage's effect.
+
+## 5. Attach a bounded shape, not user data
+
+The single most important attribute rule: **never** set raw query text, instance IRIs, or user IDs
+as attributes. Instead derive a bounded *shape* from the parsed query and attach it to the root span:
+
+```scala
+def setShapeOnRoot(tracing: Tracing, query: ConstructQuery, resultType: QueryResultType): UIO[Unit] =
+  tracing.getCurrentSpanUnsafe.map { span =>
+    val shape = queryShape(query, resultType)
+    val _     = span.setAttribute("gravsearch.query.shape", shape.label)
+    val _     = span.setAttribute("gravsearch.schema_predicates", shape.predicates.mkString(","))
+    shape.flags.foreach { case (flag, value) => val _ = span.setAttribute(s"gravsearch.shape.$flag", value) }
+  }
+```
+
+Split the cardinality deliberately:
+
+| Kind | Example | Cardinality | Use as |
+| --- | --- | --- | --- |
+| Composite shape label | `gravsearch.query.shape` = `resource-list\|has_filter\|patterns:4-7\|joins:1` | Bounded (enums + bucketed counts) | **Span attribute, safe as a metric label** |
+| Per-flag booleans | `gravsearch.shape.has_filter` = `true` | Bounded (fixed flag set) | Span attribute (for TraceQL filtering) |
+| Ontology predicate names | `gravsearch.schema_predicates` = `hasTitle,isPartOf` | Higher (but ontology-bounded, never instance IRIs) | **Span attribute only — never a metric label** |
+
+Bucket open-ended counts (pattern count, join count) into ranges (`0`, `1`, `2-3`, `4-7`, `8+`) so
+the shape label stays bounded. Set the shape on the root immediately after parse succeeds.
+
+## 6. Errors and interruptions without leaks
+
+The error handling has one load-bearing invariant. `zio-telemetry` writes `cause.prettyPrint` into
+the span status description on the `ERROR` branch — and for a SPARQL failure that string echoes the
+offending FILTER literal (user data). To prevent the leak, the failure status mapper **must** map to
+`UNSET` (which the OTel SDK no-ops), and we set our own sanitized status separately:
+
+```scala
+// LOAD-BEARING: must map to UNSET, never ERROR — UNSET is what stops cause.prettyPrint
+// (which echoes the user's FILTER literal) from reaching the span status description.
+private val unsetOnFailure: StatusMapper[Throwable, Any] =
+  StatusMapper.failureNoException[Throwable](_ => StatusCode.UNSET)
+
+/** Writes the sanitized ERROR status ("<stage>: <Class>", no message) + error.type onto the span. */
+private def markSanitizedError(span: Span, stage: String, cause: Cause[Throwable]): Unit = {
+  val kind = cause.failureOption.map(_.getClass.getSimpleName).getOrElse("defect")
+  val _    = span.setStatus(StatusCode.ERROR, s"$stage: $kind")
+  cause.failureOption.foreach { e => val _ = span.setAttribute("error.type", e.getClass.getSimpleName) }
+}
+```
+
+- **Typed failure** → status `ERROR`, description exactly `"<stage>: <ClassName>"` (e.g.
+  `gravsearch.prequery.execute: TriplestoreException`), plus `error.type`. No message, no stacktrace.
+- **Interruption** → `gravsearch.exit_reason = interrupted` + status `ERROR "interrupted"` (set in
+  `stageSpan`'s `onExit`). OTel has no `cancelled` status, so this attribute is what distinguishes an
+  interrupted query from a typed failure and from a benign empty result.
+
+!!! danger "Do not relax the status mapper"
+    Changing `unsetOnFailure` to map failures to `ERROR` re-introduces the `cause.prettyPrint` leak
+    in one edit. It is guarded by a description-equality test — keep that test.
+
+## Checklist for a new vertical
+
+- [ ] `tracing` is an abstract member of the trait; `Tracing` added to the module `Dependencies`.
+- [ ] One root `INTERNAL` span named after the vertical; one child span per stage, bounded names.
+- [ ] Stages that may not run are wrapped *inside* their conditional (no placeholder spans).
+- [ ] A bounded shape on the root; no raw text / instance IRIs / user IDs as attributes.
+- [ ] Cardinality split: composite label + booleans are metric-safe; predicate lists are drill-down only.
+- [ ] Failure mapper maps to `UNSET`; sanitized `ERROR` + `error.type` set explicitly; interruption sets `exit_reason`.
+- [ ] A test asserting the failure status description equals `"<stage>: <Class>"` (no message).

--- a/docs/observability/traceql-recipes.md
+++ b/docs/observability/traceql-recipes.md
@@ -1,0 +1,101 @@
+# TraceQL Recipes
+
+Ready-to-run [TraceQL](https://grafana.com/docs/tempo/latest/traceql/) queries for hunting slow
+Gravsearch queries. Run them in **Grafana → Explore**, datasource **`grafanacloud-dasch-traces`**
+(Tempo), TraceQL tab.
+
+The `gravsearch` span is an `INTERNAL` span nested under the request's HTTP `SERVER` span, so
+selecting on `span:name = "gravsearch"` targets the responder regardless of which endpoint triggered
+it. See the [Gravsearch Trace Runbook](gravsearch-trace-runbook.md) for how to read the results.
+
+## Grafana Explore starter
+
+Open this Explore link (datasource and query pre-filled) and adjust the time range:
+
+[Slow Gravsearch traces — open in Grafana Explore](https://dasch.grafana.net/explore?left=%7B%22datasource%22%3A%22grafanacloud-traces%22%2C%22queries%22%3A%5B%7B%22query%22%3A%22%7B+span%3Aname+%3D+%5C%22gravsearch%5C%22+%5Cu0026%5Cu0026+span%3Aduration+%5Cu003e+2s+%7D%22%2C%22queryType%22%3A%22traceql%22%2C%22refId%22%3A%22A%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-6h%22%2C%22to%22%3A%22now%22%7D%7D)
+
+## 1. Slow Gravsearch traces (the main recipe)
+
+```traceql
+{ span:name = "gravsearch" && span:duration > 2s }
+```
+
+!!! warning "Set the threshold relative to the baseline, not a constant"
+    `2s` is a placeholder. The threshold should be **baseline-relative** — e.g. the production p95
+    of `gravsearch` duration. Compute the live baseline with the metrics query in
+    [§2](#2-compute-the-baseline-p50p95p99) and substitute its p95. (The production baseline is
+    being captured under the Gravsearch performance-baseline work; until it lands, pick a value from
+    §2 for your time range.)
+
+## 2. Compute the baseline (p50/p95/p99)
+
+TraceQL metrics turn the same selection into a time series — use it to derive the threshold above:
+
+```traceql
+{ span:name = "gravsearch" } | quantile_over_time(span:duration, .50, .95, .99)
+```
+
+Break the percentiles down by query shape (bounded, safe to group by) to see which *kinds* of query
+are slow:
+
+```traceql
+{ span:name = "gravsearch" } | quantile_over_time(span:duration, .95) by (span.gravsearch.query.shape)
+```
+
+## 3. Drill into the dominant stage
+
+Find traces where the triplestore prequery — the most common hotspot — is slow:
+
+```traceql
+{ span:name = "gravsearch.prequery.execute" && span:duration > 1s }
+```
+
+Or select slow `gravsearch` traces and return the main-query execution span using the descendant
+operator (`>>` returns the right-hand spans that are descendants of the left):
+
+```traceql
+{ span:name = "gravsearch" && span:duration > 2s } >> { span:name = "gravsearch.mainquery.execute" }
+```
+
+## 4. Filter by query shape
+
+The root span carries per-flag booleans, so you can isolate query *kinds* without any user data.
+Slow queries that use a FILTER:
+
+```traceql
+{ span:name = "gravsearch" && span.gravsearch.shape.has_filter = true && span:duration > 2s }
+```
+
+Slow full-text or link-traversal queries:
+
+```traceql
+{ span:name = "gravsearch" && span.gravsearch.shape.is_fulltext = true && span:duration > 2s }
+{ span:name = "gravsearch" && span.gravsearch.shape.has_link_traversal = true && span:duration > 2s }
+```
+
+Match on the composite shape label (regex is fully anchored — wrap with `.*`):
+
+```traceql
+{ span:name = "gravsearch" && span.gravsearch.query.shape =~ ".*has_union.*" }
+```
+
+## 5. Errors and interruptions
+
+Any failed Gravsearch stage (the status description is sanitized — `"<stage>: <Class>"`, no SPARQL):
+
+```traceql
+{ span:name =~ "gravsearch.*" && span:status = error }
+```
+
+Queries that were interrupted (client disconnect / timeout / cancellation) — these are slow queries
+that got cut off, and exactly what you are usually hunting:
+
+```traceql
+{ span:name =~ "gravsearch.*" && span.gravsearch.exit_reason = "interrupted" }
+```
+
+!!! note "Attribute name syntax"
+    Custom span attributes use dot notation after `span.`, including dotted keys —
+    `span.gravsearch.query.shape`, `span.gravsearch.shape.has_filter`,
+    `span.gravsearch.exit_reason`. Intrinsics use a colon — `span:name`, `span:duration`,
+    `span:status`, `trace:rootName`.

--- a/docs/observability/using-grafana.md
+++ b/docs/observability/using-grafana.md
@@ -1,0 +1,101 @@
+# Using Grafana
+
+How to actually run the queries from the rest of this section — both in the **Grafana UI** and from
+**Claude Code via the Grafana MCP server**. The [TraceQL Recipes](traceql-recipes.md) and
+[Gravsearch Trace Runbook](gravsearch-trace-runbook.md) tell you *what* to ask; this page tells you
+*where to type it*.
+
+## Where Grafana lives
+
+| Environment | URL | Tempo datasource | Auth |
+| --- | --- | --- | --- |
+| **Production / dev (Grafana Cloud)** | [dasch.grafana.net](https://dasch.grafana.net) | `grafanacloud-dasch-traces` | DaSCH SSO |
+| **Local dev stack** | <http://localhost:3001> | Tempo (built into `otel-lgtm`) | anonymous (admin) |
+
+The local stack ships a single `grafana/otel-lgtm` container (Grafana + Tempo + Loki + Prometheus +
+Pyroscope) wired to the same OTLP endpoint the services export to, so traces you generate locally are
+queryable with the *same* TraceQL — only the datasource name and URL differ. Bring it up with
+`just stack-start` (or `docker compose up alloy`); the API, Sipi and Fuseki export to it
+automatically. Grafana is on port **3001** locally (3000 is taken), login is anonymous with admin
+rights.
+
+## In the Grafana UI
+
+The flow behind every recipe in this section:
+
+1. Open **Explore** (compass icon in the left nav).
+2. Pick the **Tempo** datasource — `grafanacloud-dasch-traces` in the cloud, `Tempo` locally.
+3. Select the **TraceQL** query tab (not "Search") and paste a query from
+   [TraceQL Recipes](traceql-recipes.md), e.g. `{ span:name = "gravsearch" && span:duration > 2s }`.
+4. Adjust the **time range** (top right) — traces are short-lived, so widen it if a result set is
+   empty.
+5. Click a row to open the trace, then read the span tree per the
+   [Runbook](gravsearch-trace-runbook.md).
+
+A few UI affordances worth knowing:
+
+- **TraceQL metrics** (the `| quantile_over_time(...)` recipes) render as a time-series graph rather
+  than a trace list — switch the panel to the graph view.
+- **Metrics** (Prometheus) and **logs** (Loki) are separate datasources in the same Explore view; a
+  trace ID pivots to its logs via the trace-to-logs link (see the trace ↔ log correlation note in the
+  [Overview](index.md)).
+- The [Grafana Explore starter link](traceql-recipes.md#grafana-explore-starter) opens Explore with
+  the datasource and query pre-filled — the fastest way in.
+
+## From Claude Code (Grafana MCP)
+
+The [Grafana MCP server](https://github.com/grafana/mcp-grafana) (`mcp-grafana`) lets Claude Code
+query Grafana directly — run TraceQL, fetch a trace, compute baselines, query Prometheus, and read
+dashboards — without you leaving the editor or hand-building Explore URLs. It is the fastest way to
+turn "why was this Gravsearch slow?" into an answer while you are already in a coding session.
+
+!!! note "Setup is per-developer, not in this repo"
+    The MCP server is configured in your Claude Code settings, not committed here, because it needs a
+    Grafana **service-account token**. Point an `mcp-grafana` server at `https://dasch.grafana.net`
+    with a token that has at least Viewer + datasource-query access, and Claude Code will expose the
+    tools below (prefixed `mcp__<server-name>__`, e.g. `mcp__grafana-cloud__`). A second server
+    pointed at `http://localhost:3001` lets you query the local stack the same way.
+
+### Mapping the recipes to MCP tools
+
+Every recipe in [TraceQL Recipes](traceql-recipes.md) has a direct MCP equivalent. Hand Claude the
+query — or just describe the goal — and it calls the right tool:
+
+| Goal (see the recipe) | MCP tool | Notes |
+| --- | --- | --- |
+| Run a TraceQL search ([§1](traceql-recipes.md#1-slow-gravsearch-traces-the-main-recipe), [§3](traceql-recipes.md#3-drill-into-the-dominant-stage)–[§5](traceql-recipes.md#5-errors-and-interruptions)) | `tempo_traceql-search` | Pass the TraceQL string verbatim; returns matching traces |
+| Open one trace and read its span tree ([Runbook §2](gravsearch-trace-runbook.md#2-the-span-tree)) | `tempo_get-trace` | Pass the trace ID from a search result |
+| Compute the baseline p50/p95/p99 ([§2](traceql-recipes.md#2-compute-the-baseline-p50p95p99)) | `tempo_traceql-metrics-instant` / `tempo_traceql-metrics-range` | The `quantile_over_time(...)` queries; instant for a point, range for a series |
+| Discover available span attributes / values | `tempo_get-attribute-names` / `tempo_get-attribute-values` | Useful to confirm a `gravsearch.shape.*` flag exists before filtering on it |
+| Check TraceQL syntax | `tempo_docs-traceql` | The server's own TraceQL reference |
+| Query a Prometheus metric (e.g. the [metrics endpoint](../03-endpoints/instrumentation/metrics.md) series) | `query_prometheus` / `query_prometheus_histogram` | PromQL; histogram helper for `_bucket` series |
+| List metric names / labels | `list_prometheus_metric_names`, `list_prometheus_label_values` | Explore what is emitted |
+| Find / read a dashboard | `search_dashboards`, `get_dashboard_by_uid`, `get_dashboard_panel_queries` | Reuse a panel's query as a starting point |
+| Hand a result back as a clickable Explore link | `generate_deeplink` | Produces a shareable Grafana URL for a human to open |
+
+### Example prompts
+
+Phrase the goal; let Claude pick the datasource and tool. For example:
+
+- *"Using the Grafana MCP, find Gravsearch traces slower than 2s in the last 6 hours and tell me which
+  stage dominates."* — runs `tempo_traceql-search` with the
+  [main recipe](traceql-recipes.md#1-slow-gravsearch-traces-the-main-recipe), opens the slowest with
+  `tempo_get-trace`, and reads the time decomposition.
+- *"What's the current p95 of the `gravsearch` span, broken down by query shape?"* — runs the
+  [baseline metrics recipe](traceql-recipes.md#2-compute-the-baseline-p50p95p99) via
+  `tempo_traceql-metrics-instant`.
+- *"Show me Gravsearch traces that were interrupted in the last hour."* — runs the
+  [interruption recipe](traceql-recipes.md#5-errors-and-interruptions)
+  (`span.gravsearch.exit_reason = "interrupted"`).
+
+!!! tip "Use the local stack for verifying instrumentation"
+    When you add or change instrumentation (see the [Instrumentation Recipe](instrumentation-recipe.md)),
+    point an MCP server at the local `otel-lgtm` stack, generate a request, and ask Claude to fetch the
+    trace and confirm the span tree and attributes match what you intended — a fast feedback loop that
+    does not touch production data.
+
+## See also
+
+- [TraceQL Recipes](traceql-recipes.md) — the queries to run here.
+- [Gravsearch Trace Runbook](gravsearch-trace-runbook.md) — how to read what comes back.
+- [Instrumentation Recipe](instrumentation-recipe.md) — what produces the spans in the first place.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Configuration: 04-publishing-deployment/configuration.md
   - Observability:
       - Overview: observability/index.md
+      - Using Grafana: observability/using-grafana.md
       - Gravsearch Trace Runbook: observability/gravsearch-trace-runbook.md
       - TraceQL Recipes: observability/traceql-recipes.md
       - Instrumentation Recipe: observability/instrumentation-recipe.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,11 @@ nav:
   - Publishing and Deployment:
       - Publishing: 04-publishing-deployment/publishing.md
       - Configuration: 04-publishing-deployment/configuration.md
+  - Observability:
+      - Overview: observability/index.md
+      - Gravsearch Trace Runbook: observability/gravsearch-trace-runbook.md
+      - TraceQL Recipes: observability/traceql-recipes.md
+      - Instrumentation Recipe: observability/instrumentation-recipe.md
   - DSP Internals:
       - Design:
           - Architectural Decision Records (ADR):


### PR DESCRIPTION
[DEV-6636](https://linear.app/dasch/issue/DEV-6636)

## Summary

- New top-level **Observability** docs section (publishes to docs.dasch.swiss) covering the per-stage Gravsearch tracing added in DEV-6635 (#4155).
- The anti-Faro usability layer: makes the trace data readable and queryable, and documents the instrumentation pattern so the next vertical can reuse it.

## Changes

New `docs/observability/` section (4 pages, wired into the `mkdocs.yml` nav under a new top-level "Observability" node):

- `index.md` — observability / tracing overview and entry point.
- `gravsearch-trace-runbook.md` (REQ-3.3) — find a slow trace, the span tree, per-stage time decomposition, root shape attributes, and the **four absent-data topologies** (empty-result, parse-failure, interruption/timeout, shape-less early interrupt) so none is misread as broken instrumentation.
- `traceql-recipes.md` (REQ-3.1/3.2) — TraceQL queries for slow Gravsearch traces (threshold parameterised on the baseline p95), stage drill-down, query-shape filtering, errors/interrupts, plus a Grafana Explore starter link.
- `instrumentation-recipe.md` (REQ-4.1) — the abstract-`tracing`-member pattern, `stageSpan` helper, span naming, bounded `gravsearch.query.shape` with the metric-label vs drill-down cardinality split, and the `error → UNSET` + sanitized-ERROR + `exit_reason=interrupted` handling — enough to instrument a second vertical without re-deriving it.

## Test Plan

- Span/attribute names verified against the merged DEV-6635 code (PR #4155): root `gravsearch` + `gravsearch.{parse,type_inspection,prequery.generate,prequery.execute,mainquery.generate,mainquery.execute,result_transform}`; attributes `gravsearch.query.shape`, `gravsearch.shape.*`, `gravsearch.schema_predicates`, `gravsearch.exit_reason`.
- TraceQL syntax validated against Tempo's own TraceQL docs (intrinsics `span:`/`trace:`, dotted custom attributes `span.<key>`, structural `>>`).
- Markdown validated by hand against `.markdownlint.yml` (nav targets, internal links/anchors, MD033/MD007); local `mkdocs`/`npm` were unavailable, so **CI `mkdocs build --strict` is the build gate.**
- ⚠️ Span names were provisional until DEV-6635 was reviewed; a final validation pass is due once #4155 lands on `main`.

## Screenshots

N/A — docs only (the mermaid span-tree diagram and admonitions render on docs.dasch.swiss).
