### PR TITLE
chore: skip CI checks on the release PR (DEV-6678)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,10 +23,20 @@ permissions:
 env:
   JAVA_VERSION: 25
 
+# Release PRs (head branch `release-please--*`, opened by release-please) only
+# bump CHANGELOG.md and version.txt — no source changes — so every job below is
+# skipped for them via `!startsWith(github.head_ref, 'release-please')`. This
+# saves CI resources and lets the release PR go green immediately. On `push`
+# events `github.head_ref` is empty, so main pushes still run the full suite
+# (incl. the Codecov baseline). A required check skipped by a job-level `if:`
+# counts as passing in branch protection, so the release PR stays mergeable.
+# See DEV-6678.
+
 jobs:
   build-and-test:
     name: Build and test
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
@@ -54,7 +64,7 @@ jobs:
   test-bagit:
     name: Test bagit
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' # gate-only; no coverage upload
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please') # gate-only, no coverage upload; release PRs skipped (DEV-6678)
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
@@ -73,7 +83,7 @@ jobs:
   test-jwt:
     name: Test jwt
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' # gate-only; no coverage upload
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please') # gate-only, no coverage upload; release PRs skipped (DEV-6678)
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
@@ -92,7 +102,7 @@ jobs:
   test-shacl-validator:
     name: Test shacl-validator
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' # gate-only; no coverage upload
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please') # gate-only, no coverage upload; release PRs skipped (DEV-6678)
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
@@ -111,6 +121,7 @@ jobs:
   test-it:
     name: Build and IT test
     runs-on: ubuntu-latest # previously: buildjet-4vcpu-ubuntu-2204
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     concurrency:
       group: ${{ github.ref }}-it
       cancel-in-progress: true
@@ -145,6 +156,7 @@ jobs:
   test-e2e:
     name: Build and E2E test
     runs-on: ubuntu-latest-large-runner
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     concurrency:
       group: ${{ github.ref }}-e2e
       cancel-in-progress: true
@@ -237,7 +249,7 @@ jobs:
 
   test-ingest-integration:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' # gate-only; no coverage upload
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please') # gate-only, no coverage upload; release PRs skipped (DEV-6678)
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
@@ -266,7 +278,7 @@ jobs:
   test-docs-build:
     name: Test docs
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' # gate-only; no coverage upload
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please') # gate-only, no coverage upload; release PRs skipped (DEV-6678)
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
@@ -288,7 +300,7 @@ jobs:
   check-fuseki-version-consistency:
     name: Check Fuseki version consistency
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' # gate-only; no coverage upload
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please') # gate-only, no coverage upload; release PRs skipped (DEV-6678)
     steps:
       - uses: actions/checkout@v4
       - name: Assert fuseki/Dockerfile, Dependencies.scala, and docker-compose.yml agree
@@ -307,7 +319,7 @@ jobs:
   check-formatting:
     name: Check formatting
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' # gate-only; no coverage upload
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please') # gate-only, no coverage upload; release PRs skipped (DEV-6678)
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main
@@ -319,7 +331,7 @@ jobs:
   docker-healthcheck:
     name: Run the healthcheck from the container
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' # gate-only; no coverage upload
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please') # gate-only, no coverage upload; release PRs skipped (DEV-6678)
     steps:
       - name: Run preparatory steps
         uses: dasch-swiss/dsp-api/.github/actions/preparation@main


### PR DESCRIPTION
[DEV-6678](https://linear.app/dasch/issue/DEV-6678)

## Summary
- Release PRs (head branch `release-please--*`) only bump `CHANGELOG.md` and `version.txt` — no source changes — yet they currently run the full `build-and-test.yml` suite (unit, IT, E2E, bagit/jwt/shacl, ingest-IT, docs, formatting, fuseki-version, healthcheck). This wastes CI resources and delays the release PR going green.
- Every job in `build-and-test.yml` is now gated on `!startsWith(github.head_ref, 'release-please')`, so all of them skip on the release PR. This mirrors the approach already in use in dsp-app.

## Changes
- `.github/workflows/build-and-test.yml`:
  - Jobs that ran on both push and PR (`build-and-test`, `test-it`, `test-e2e`) gain `if: ${{ !startsWith(github.head_ref, 'release-please') }}`.
  - PR-gated jobs (`test-bagit`, `test-jwt`, `test-shacl-validator`, `test-ingest-integration`, `test-docs-build`, `check-fuseki-version-consistency`, `check-formatting`, `docker-healthcheck`) get the same clause appended to their existing `github.event_name == 'pull_request'` condition.
  - `upload-coverage` needs the skipped jobs, so it skips automatically — no change.
  - Added a comment block explaining the rationale and the branch-protection semantics.

## Why this is safe
- **Normal PRs**: `head_ref` is the feature branch → full suite runs (unchanged).
- **Push to main**: `head_ref` is empty → `!startsWith('', 'release-please')` is true → `build-and-test`/`test-it`/`test-e2e` still run, preserving the per-main-commit Codecov baseline; PR-gated jobs stay off via `github.event_name`. The post-merge release-commit run is intentionally **not** skipped.
- **Release PR**: all jobs skip. A required status check skipped via a job-level `if:` is reported as `skipped`, which branch protection counts as passing — so the release PR stays mergeable. The whole workflow still triggers (no `on:`-level filtering), avoiding the "never reported → blocks merge" footgun.
- Scope is `build-and-test.yml` only; the separate `Check PR Title` workflow is left running (the release title matches its regex; sub-second cost).

## Test Plan
- `actionlint` passes on the change (only a pre-existing warning about the custom `ubuntu-latest-large-runner` label, unrelated to this PR).
- YAML parses; inline `# gate-only` comments do not bleed into the `if:` expressions.
- The expression form `!startsWith(github.head_ref, 'release-please')` is already used in dsp-app's `codeql-analysis.yml` and `cloud-run-pr-preview.yml`, and dsp-app's gated jobs are themselves required checks — first-party confirmation that skipped-required-via-`if` passes branch protection in this org.
- No local unit test is possible for GitHub Actions skip semantics; final confirmation is observational on the next release PR (checks show as skipped and the PR is mergeable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)