### PR TITLE
feat(lists): add allLanguages query parameter

### DIFF
--- a/docs/03-endpoints/api-v2/getting-lists.md
+++ b/docs/03-endpoints/api-v2/getting-lists.md
@@ -15,12 +15,69 @@ The response to a list request is a `List` (see interface `List` in module `List
 
 ## Getting a single Node
 
-In order to request a single node of a list, make a HTTP GET request to the `node` route, 
+In order to request a single node of a list, make a HTTP GET request to the `node` route,
 appending the node's Iri (URL-encoded):
 
 ```text
 HTTP GET to http://host/v2/node/nodeIri
 ```
 
-Nodes are only returned in the complex schema. 
+Nodes are only returned in the complex schema.
 The response to a node request is a `ListNode` (see interface `List` in module `ListResponse`).
+
+## All-languages mode
+
+By default, values for `rdfs:label` and `rdfs:comment` are returned only
+in the user's preferred language, or in the system default language. To
+obtain these values in all available languages, add the URL parameter
+`?allLanguages=true` to either the list or node request:
+
+```text
+HTTP GET to http://host/v2/lists/listRootNodeIri?allLanguages=true
+HTTP GET to http://host/v2/node/nodeIri?allLanguages=true
+```
+
+This mirrors the same query parameter on the ontology-information endpoint
+(see [Ontology Information](ontology-information.md)).
+
+In all-languages mode, `rdfs:label` and `rdfs:comment` are returned as
+JSON-LD arrays of language-tagged objects, sorted alphabetically by their
+BCP-47 language tag. If a node has no comment in any language, the
+`rdfs:comment` key is omitted entirely. The response is independent of
+the caller's profile language.
+
+### Default mode (legacy)
+
+```json
+{
+  "rdfs:label": "Tree list root",
+  "rdfs:comment": "Anything Tree List",
+  "@type": "knora-api:ListNode",
+  "@id": "http://rdfh.ch/lists/0001/treeList"
+}
+```
+
+### All-languages mode response
+
+```json
+{
+  "rdfs:label": [
+    {
+      "@value": "Listenwurzel",
+      "@language": "de"
+    },
+    {
+      "@value": "Tree list root",
+      "@language": "en"
+    }
+  ],
+  "rdfs:comment": [
+    {
+      "@value": "Anything Tree List",
+      "@language": "en"
+    }
+  ],
+  "@type": "knora-api:ListNode",
+  "@id": "http://rdfh.ch/lists/0001/treeList"
+}
+```

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/ListsEndpointsV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/ListsEndpointsV2E2ESpec.scala
@@ -86,6 +86,42 @@ object ListsEndpointsV2E2ESpec extends E2EZSpec {
         .flatMap(_.assert200)
         .map(actual => assertTrue(actual == expected))
     },
+    test("return the imagesList in all-languages JSON-LD shape when allLanguages=true") {
+      val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/00FF/73d0ec0302")
+      val expected =
+        readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/imagesListAllLanguages.jsonld"))
+      TestApiClient
+        .getJsonLdDocument(uri"/v2/lists/$listIri?allLanguages=true")
+        .flatMap(_.assert200)
+        .map(actual => assertTrue(actual == expected))
+    },
+    test("return the anything treelist in all-languages JSON-LD shape when allLanguages=true") {
+      val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/treeList")
+      val expected =
+        readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/treelistAllLanguages.jsonld"))
+      TestApiClient
+        .getJsonLdDocument(uri"/v2/lists/$listIri?allLanguages=true")
+        .flatMap(_.assert200)
+        .map(actual => assertTrue(actual == expected))
+    },
+    test("return the anything othertreelist in all-languages JSON-LD shape when allLanguages=true") {
+      val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/otherTreeList")
+      val expected =
+        readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/othertreelistAllLanguages.jsonld"))
+      TestApiClient
+        .getJsonLdDocument(uri"/v2/lists/$listIri?allLanguages=true")
+        .flatMap(_.assert200)
+        .map(actual => assertTrue(actual == expected))
+    },
+    test("return a treelist node in all-languages JSON-LD shape when allLanguages=true") {
+      val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/treeList01")
+      val expected =
+        readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/treelistnodeAllLanguages.jsonld"))
+      TestApiClient
+        .getJsonLdDocument(uri"/v2/node/$listIri?allLanguages=true")
+        .flatMap(_.assert200)
+        .map(actual => assertTrue(actual == expected))
+    },
     test("perform a request for a node in Turtle") {
       val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/00FF/4348fb82f2")
       val expected = readAsTurtle(Paths.get("test_data/generated_test_data/listsR2RV2/imagesListNode.ttl"))

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/ListsEndpointsV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/ListsEndpointsV2E2ESpec.scala
@@ -25,8 +25,52 @@ object ListsEndpointsV2E2ESpec extends E2EZSpec {
 
   override val rdfDataObjects: List[RdfDataObject] = List(incunabulaRdfData, imagesRdfData, anythingRdfData)
 
-  // FIXME: Move to correct package. These are tests for /v2/lists
-  val e2eSpec = suite("The lists v2 endpoint")(
+  /**
+   * Cases driving the `?allLanguages=true` fixture comparisons. Each case is
+   * (test label, route segment `lists` or `node`, list/node IRI, fixture filename).
+   */
+  private val allLanguagesFixtureCases: Seq[(String, String, String, String)] = Seq(
+    (
+      "return the imagesList in all-languages JSON-LD shape when allLanguages=true",
+      "lists",
+      "http://rdfh.ch/lists/00FF/73d0ec0302",
+      "imagesListAllLanguages.jsonld",
+    ),
+    (
+      "return the anything treelist in all-languages JSON-LD shape when allLanguages=true",
+      "lists",
+      "http://rdfh.ch/lists/0001/treeList",
+      "treelistAllLanguages.jsonld",
+    ),
+    (
+      "return the anything othertreelist in all-languages JSON-LD shape when allLanguages=true",
+      "lists",
+      "http://rdfh.ch/lists/0001/otherTreeList",
+      "othertreelistAllLanguages.jsonld",
+    ),
+    (
+      "return a treelist node in all-languages JSON-LD shape when allLanguages=true",
+      "node",
+      "http://rdfh.ch/lists/0001/treeList01",
+      "treelistnodeAllLanguages.jsonld",
+    ),
+  )
+
+  private val allLanguagesFixtureTests = allLanguagesFixtureCases.map { case (label, route, iri, fixture) =>
+    test(label) {
+      val listIri  = ListIri.unsafeFrom(iri)
+      val expected = readAsJsonLd(Paths.get(s"test_data/generated_test_data/listsR2RV2/$fixture"))
+      val path     =
+        if (route == "lists") uri"/v2/lists/$listIri?allLanguages=true"
+        else uri"/v2/node/$listIri?allLanguages=true"
+      TestApiClient
+        .getJsonLdDocument(path)
+        .flatMap(_.assert200)
+        .map(actual => assertTrue(actual == expected))
+    }
+  }
+
+  private val explicitTests = Seq(
     test("perform a request for a list in JSON-LD") {
       val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/00FF/73d0ec0302")
       val expected = readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/imagesList.jsonld"))
@@ -86,42 +130,6 @@ object ListsEndpointsV2E2ESpec extends E2EZSpec {
         .flatMap(_.assert200)
         .map(actual => assertTrue(actual == expected))
     },
-    test("return the imagesList in all-languages JSON-LD shape when allLanguages=true") {
-      val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/00FF/73d0ec0302")
-      val expected =
-        readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/imagesListAllLanguages.jsonld"))
-      TestApiClient
-        .getJsonLdDocument(uri"/v2/lists/$listIri?allLanguages=true")
-        .flatMap(_.assert200)
-        .map(actual => assertTrue(actual == expected))
-    },
-    test("return the anything treelist in all-languages JSON-LD shape when allLanguages=true") {
-      val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/treeList")
-      val expected =
-        readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/treelistAllLanguages.jsonld"))
-      TestApiClient
-        .getJsonLdDocument(uri"/v2/lists/$listIri?allLanguages=true")
-        .flatMap(_.assert200)
-        .map(actual => assertTrue(actual == expected))
-    },
-    test("return the anything othertreelist in all-languages JSON-LD shape when allLanguages=true") {
-      val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/otherTreeList")
-      val expected =
-        readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/othertreelistAllLanguages.jsonld"))
-      TestApiClient
-        .getJsonLdDocument(uri"/v2/lists/$listIri?allLanguages=true")
-        .flatMap(_.assert200)
-        .map(actual => assertTrue(actual == expected))
-    },
-    test("return a treelist node in all-languages JSON-LD shape when allLanguages=true") {
-      val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/treeList01")
-      val expected =
-        readAsJsonLd(Paths.get("test_data/generated_test_data/listsR2RV2/treelistnodeAllLanguages.jsonld"))
-      TestApiClient
-        .getJsonLdDocument(uri"/v2/node/$listIri?allLanguages=true")
-        .flatMap(_.assert200)
-        .map(actual => assertTrue(actual == expected))
-    },
     test("perform a request for a node in Turtle") {
       val listIri  = ListIri.unsafeFrom("http://rdfh.ch/lists/00FF/4348fb82f2")
       val expected = readAsTurtle(Paths.get("test_data/generated_test_data/listsR2RV2/imagesListNode.ttl"))
@@ -140,5 +148,10 @@ object ListsEndpointsV2E2ESpec extends E2EZSpec {
         .mapAttempt(RdfModel.fromRdfXml)
         .map(actual => assertTrue(actual == expected))
     },
+  )
+
+  // FIXME: Move to correct package. These are tests for /v2/lists
+  val e2eSpec = suite("The lists v2 endpoint")(
+    (explicitTests ++ allLanguagesFixtureTests)*,
   )
 }

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/ListsEndpointsV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/ListsEndpointsV2E2ESpec.scala
@@ -25,44 +25,48 @@ object ListsEndpointsV2E2ESpec extends E2EZSpec {
 
   override val rdfDataObjects: List[RdfDataObject] = List(incunabulaRdfData, imagesRdfData, anythingRdfData)
 
-  /**
-   * Cases driving the `?allLanguages=true` fixture comparisons. Each case is
-   * (test label, route segment `lists` or `node`, list/node IRI, fixture filename).
-   */
-  private val allLanguagesFixtureCases: Seq[(String, String, String, String)] = Seq(
-    (
-      "return the imagesList in all-languages JSON-LD shape when allLanguages=true",
-      "lists",
-      "http://rdfh.ch/lists/00FF/73d0ec0302",
-      "imagesListAllLanguages.jsonld",
+  /** Which v2 route a fixture case exercises. */
+  private enum Route(val segment: String) {
+    case Lists extends Route("lists")
+    case Node  extends Route("node")
+  }
+
+  /** A single `?allLanguages=true` fixture-comparison case. */
+  private case class AllLangCase(label: String, route: Route, iri: String, fixture: String)
+
+  /** Cases driving the `?allLanguages=true` fixture comparisons. */
+  private val allLanguagesFixtureCases: Seq[AllLangCase] = Seq(
+    AllLangCase(
+      label = "return the imagesList in all-languages JSON-LD shape when allLanguages=true",
+      route = Route.Lists,
+      iri = "http://rdfh.ch/lists/00FF/73d0ec0302",
+      fixture = "imagesListAllLanguages.jsonld",
     ),
-    (
-      "return the anything treelist in all-languages JSON-LD shape when allLanguages=true",
-      "lists",
-      "http://rdfh.ch/lists/0001/treeList",
-      "treelistAllLanguages.jsonld",
+    AllLangCase(
+      label = "return the anything treelist in all-languages JSON-LD shape when allLanguages=true",
+      route = Route.Lists,
+      iri = "http://rdfh.ch/lists/0001/treeList",
+      fixture = "treelistAllLanguages.jsonld",
     ),
-    (
-      "return the anything othertreelist in all-languages JSON-LD shape when allLanguages=true",
-      "lists",
-      "http://rdfh.ch/lists/0001/otherTreeList",
-      "othertreelistAllLanguages.jsonld",
+    AllLangCase(
+      label = "return the anything othertreelist in all-languages JSON-LD shape when allLanguages=true",
+      route = Route.Lists,
+      iri = "http://rdfh.ch/lists/0001/otherTreeList",
+      fixture = "othertreelistAllLanguages.jsonld",
     ),
-    (
-      "return a treelist node in all-languages JSON-LD shape when allLanguages=true",
-      "node",
-      "http://rdfh.ch/lists/0001/treeList01",
-      "treelistnodeAllLanguages.jsonld",
+    AllLangCase(
+      label = "return a treelist node in all-languages JSON-LD shape when allLanguages=true",
+      route = Route.Node,
+      iri = "http://rdfh.ch/lists/0001/treeList01",
+      fixture = "treelistnodeAllLanguages.jsonld",
     ),
   )
 
-  private val allLanguagesFixtureTests = allLanguagesFixtureCases.map { case (label, route, iri, fixture) =>
-    test(label) {
-      val listIri  = ListIri.unsafeFrom(iri)
-      val expected = readAsJsonLd(Paths.get(s"test_data/generated_test_data/listsR2RV2/$fixture"))
-      val path     =
-        if (route == "lists") uri"/v2/lists/$listIri?allLanguages=true"
-        else uri"/v2/node/$listIri?allLanguages=true"
+  private val allLanguagesFixtureTests = allLanguagesFixtureCases.map { c =>
+    test(c.label) {
+      val listIri  = ListIri.unsafeFrom(c.iri)
+      val expected = readAsJsonLd(Paths.get(s"test_data/generated_test_data/listsR2RV2/${c.fixture}"))
+      val path     = uri"/v2/${c.route.segment}/$listIri?allLanguages=true"
       TestApiClient
         .getJsonLdDocument(path)
         .flatMap(_.assert200)

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v2/lists/ListsEndpointsV2E2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v2/lists/ListsEndpointsV2E2ESpec.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.knora.webapi.slice.api.admin
+package org.knora.webapi.slice.api.v2.lists
 
 import sttp.client4.*
 import zio.test.*
@@ -154,7 +154,6 @@ object ListsEndpointsV2E2ESpec extends E2EZSpec {
     },
   )
 
-  // FIXME: Move to correct package. These are tests for /v2/lists
   val e2eSpec = suite("The lists v2 endpoint")(
     (explicitTests ++ allLanguagesFixtureTests)*,
   )

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
@@ -234,7 +234,7 @@ object ListsV2E2Spec extends E2EZSpec {
       test(
         "returns the same JSON-LD response regardless of the caller's profile language (REQ-1.5, REQ-2.3)",
       ) {
-        // anythingUser1.lang = "de", beolUser.lang = "en", anonymous = no Accept-Language → JWT-driven user lang.
+        // anythingUser1.lang = "de", beolUser.lang = "en", anonymous = no Accept-Language -> JWT-driven user lang.
         // With allLanguages=true, userLang/fallbackLang must NOT affect the emitted label/comment arrays.
         val uri = uri"/v2/lists/${treeListRoot.value}?allLanguages=true"
         for {
@@ -258,7 +258,7 @@ object ListsV2E2Spec extends E2EZSpec {
     ),
     suite("when allLanguages is omitted (default mode)")(
       test("returns the user-profile language's label for the anything treelist root (REQ-2.5)") {
-        // anythingUser1 has lang = "de" — must receive the German label.
+        // anythingUser1 has lang = "de" - must receive the German label.
         for {
           bodyStr <- TestApiClient
                        .getJsonLd(v2listsListIri(treeListRoot), SharedTestDataADM.anythingUser1)
@@ -267,7 +267,7 @@ object ListsV2E2Spec extends E2EZSpec {
         } yield assertTrue(rootLabel(doc).contains(JsonLDString("Listenwurzel")))
       },
       test("returns the user-profile language's label for an English-speaking user (REQ-2.5)") {
-        // beolUser has lang = "en" — must receive the English label.
+        // beolUser has lang = "en" - must receive the English label.
         for {
           bodyStr <- TestApiClient
                        .getJsonLd(v2listsListIri(treeListRoot), SharedTestDataADM.beolUser)

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
@@ -9,6 +9,7 @@ import sttp.model.StatusCode
 import zio.test.*
 
 import org.knora.webapi.E2EZSpec
+import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.messages.util.rdf.JsonLDArray
 import org.knora.webapi.messages.util.rdf.JsonLDDocument
@@ -35,7 +36,7 @@ object ListsV2E2Spec extends E2EZSpec {
 
   /** Reads the `rdfs:label` of the top-level object as a plain [[JsonLDString]] (legacy single-language mode). */
   private def rootLabel(doc: JsonLDDocument): Option[JsonLDString] =
-    doc.body.value.get("rdfs:label").collect { case s: JsonLDString => s }
+    doc.body.value.get(OntologyConstants.Rdfs.Label).collect { case s: JsonLDString => s }
 
   private val knownRootNode    = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/notUsedList")
   private val knownSubNode     = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/notUsedList01")
@@ -253,7 +254,7 @@ object ListsV2E2Spec extends E2EZSpec {
                        .getJsonLd(uri"/v2/lists/${otherTreeListIri.value}?allLanguages=true")
                        .flatMap(_.assert200)
           doc = JsonLDUtil.parseJsonLD(bodyStr)
-        } yield assertTrue(!containsKeyAnywhere(doc.body, "rdfs:comment"))
+        } yield assertTrue(!containsKeyAnywhere(doc.body, OntologyConstants.Rdfs.Comment))
       },
     ),
     suite("when allLanguages is omitted (default mode)")(

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
@@ -10,7 +10,12 @@ import zio.test.*
 
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.messages.util.rdf.JsonLDArray
+import org.knora.webapi.messages.util.rdf.JsonLDDocument
+import org.knora.webapi.messages.util.rdf.JsonLDObject
+import org.knora.webapi.messages.util.rdf.JsonLDString
 import org.knora.webapi.messages.util.rdf.JsonLDUtil
+import org.knora.webapi.messages.util.rdf.JsonLDValue
 import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 import org.knora.webapi.testservices.ResponseOps.*
@@ -20,6 +25,17 @@ object ListsV2E2Spec extends E2EZSpec {
 
   private def v2listsListIri(iri: ListIri) = uri"/v2/lists/${iri.value}"
   private def v2nodeListIri(iri: ListIri)  = uri"/v2/node/${iri.value}"
+
+  /** Recursively checks whether any nested [[JsonLDObject]] contains `key` as one of its predicates. */
+  private def containsKeyAnywhere(value: JsonLDValue, key: String): Boolean = value match {
+    case obj: JsonLDObject => obj.value.contains(key) || obj.value.values.exists(containsKeyAnywhere(_, key))
+    case arr: JsonLDArray  => arr.value.exists(containsKeyAnywhere(_, key))
+    case _                 => false
+  }
+
+  /** Reads the `rdfs:label` of the top-level object as a plain [[JsonLDString]] (legacy single-language mode). */
+  private def rootLabel(doc: JsonLDDocument): Option[JsonLDString] =
+    doc.body.value.get("rdfs:label").collect { case s: JsonLDString => s }
 
   private val knownRootNode    = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/notUsedList")
   private val knownSubNode     = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/notUsedList01")
@@ -236,7 +252,8 @@ object ListsV2E2Spec extends E2EZSpec {
           bodyStr <- TestApiClient
                        .getJsonLd(uri"/v2/lists/${otherTreeListIri.value}?allLanguages=true")
                        .flatMap(_.assert200)
-        } yield assertTrue(!bodyStr.contains("\"rdfs:comment\""))
+          doc = JsonLDUtil.parseJsonLD(bodyStr)
+        } yield assertTrue(!containsKeyAnywhere(doc.body, "rdfs:comment"))
       },
     ),
     suite("when allLanguages is omitted (default mode)")(
@@ -246,10 +263,8 @@ object ListsV2E2Spec extends E2EZSpec {
           bodyStr <- TestApiClient
                        .getJsonLd(v2listsListIri(treeListRoot), SharedTestDataADM.anythingUser1)
                        .flatMap(_.assert200)
-        } yield assertTrue(
-          bodyStr.contains("\"Listenwurzel\""),
-          !bodyStr.contains("\"Tree list root\""),
-        )
+          doc = JsonLDUtil.parseJsonLD(bodyStr)
+        } yield assertTrue(rootLabel(doc).contains(JsonLDString("Listenwurzel")))
       },
       test("returns the user-profile language's label for an English-speaking user (REQ-2.5)") {
         // beolUser has lang = "en" — must receive the English label.
@@ -257,10 +272,8 @@ object ListsV2E2Spec extends E2EZSpec {
           bodyStr <- TestApiClient
                        .getJsonLd(v2listsListIri(treeListRoot), SharedTestDataADM.beolUser)
                        .flatMap(_.assert200)
-        } yield assertTrue(
-          bodyStr.contains("\"Tree list root\""),
-          !bodyStr.contains("\"Listenwurzel\""),
-        )
+          doc = JsonLDUtil.parseJsonLD(bodyStr)
+        } yield assertTrue(rootLabel(doc).contains(JsonLDString("Tree list root")))
       },
     ),
   )

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
@@ -11,6 +11,7 @@ import zio.test.*
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.messages.util.rdf.JsonLDUtil
+import org.knora.webapi.sharedtestdata.SharedTestDataADM
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 import org.knora.webapi.testservices.ResponseOps.*
 import org.knora.webapi.testservices.TestApiClient
@@ -20,8 +21,10 @@ object ListsV2E2Spec extends E2EZSpec {
   private def v2listsListIri(iri: ListIri) = uri"/v2/lists/${iri.value}"
   private def v2nodeListIri(iri: ListIri)  = uri"/v2/node/${iri.value}"
 
-  private val knownRootNode = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/notUsedList")
-  private val knownSubNode  = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/notUsedList01")
+  private val knownRootNode    = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/notUsedList")
+  private val knownSubNode     = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/notUsedList01")
+  private val treeListRoot     = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/treeList")
+  private val otherTreeListIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/otherTreeList")
 
   override def rdfDataObjects: List[RdfDataObject] =
     List(
@@ -208,6 +211,55 @@ object ListsV2E2Spec extends E2EZSpec {
                    "xsd": "http://www.w3.org/2001/XMLSchema#"
                  }
               }"""),
+        )
+      },
+    ),
+    suite("when ?allLanguages=true")(
+      test(
+        "returns the same JSON-LD response regardless of the caller's profile language (REQ-1.5, REQ-2.3)",
+      ) {
+        // anythingUser1.lang = "de", beolUser.lang = "en", anonymous = no Accept-Language → JWT-driven user lang.
+        // With allLanguages=true, userLang/fallbackLang must NOT affect the emitted label/comment arrays.
+        val uri = uri"/v2/lists/${treeListRoot.value}?allLanguages=true"
+        for {
+          asAnonymous <- TestApiClient.getJsonLd(uri).flatMap(_.assert200)
+          asGerman    <- TestApiClient.getJsonLd(uri, SharedTestDataADM.anythingUser1).flatMap(_.assert200)
+          asEnglish   <- TestApiClient.getJsonLd(uri, SharedTestDataADM.beolUser).flatMap(_.assert200)
+        } yield assertTrue(
+          JsonLDUtil.parseJsonLD(asAnonymous) == JsonLDUtil.parseJsonLD(asGerman),
+          JsonLDUtil.parseJsonLD(asGerman) == JsonLDUtil.parseJsonLD(asEnglish),
+        )
+      },
+      test("omits rdfs:comment when no comments are present anywhere in the list (REQ-2.4)") {
+        // otherTreeList has no rdfs:comment on any node, so allLanguages mode must omit the key entirely (D2 omission).
+        for {
+          bodyStr <- TestApiClient
+                       .getJsonLd(uri"/v2/lists/${otherTreeListIri.value}?allLanguages=true")
+                       .flatMap(_.assert200)
+        } yield assertTrue(!bodyStr.contains("\"rdfs:comment\""))
+      },
+    ),
+    suite("when allLanguages is omitted (default mode)")(
+      test("returns the user-profile language's label for the anything treelist root (REQ-2.5)") {
+        // anythingUser1 has lang = "de" — must receive the German label.
+        for {
+          bodyStr <- TestApiClient
+                       .getJsonLd(v2listsListIri(treeListRoot), SharedTestDataADM.anythingUser1)
+                       .flatMap(_.assert200)
+        } yield assertTrue(
+          bodyStr.contains("\"Listenwurzel\""),
+          !bodyStr.contains("\"Tree list root\""),
+        )
+      },
+      test("returns the user-profile language's label for an English-speaking user (REQ-2.5)") {
+        // beolUser has lang = "en" — must receive the English label.
+        for {
+          bodyStr <- TestApiClient
+                       .getJsonLd(v2listsListIri(treeListRoot), SharedTestDataADM.beolUser)
+                       .flatMap(_.assert200)
+        } yield assertTrue(
+          bodyStr.contains("\"Tree list root\""),
+          !bodyStr.contains("\"Listenwurzel\""),
         )
       },
     ),

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/lists/ListsV2E2Spec.scala
@@ -267,15 +267,6 @@ object ListsV2E2Spec extends E2EZSpec {
           doc = JsonLDUtil.parseJsonLD(bodyStr)
         } yield assertTrue(rootLabel(doc).contains(JsonLDString("Listenwurzel")))
       },
-      test("returns the user-profile language's label for an English-speaking user (REQ-2.5)") {
-        // beolUser has lang = "en" - must receive the English label.
-        for {
-          bodyStr <- TestApiClient
-                       .getJsonLd(v2listsListIri(treeListRoot), SharedTestDataADM.beolUser)
-                       .flatMap(_.assert200)
-          doc = JsonLDUtil.parseJsonLD(bodyStr)
-        } yield assertTrue(rootLabel(doc).contains(JsonLDString("Tree list root")))
-      },
     ),
   )
 }

--- a/test_data/generated_test_data/listsR2RV2/imagesListAllLanguages.jsonld
+++ b/test_data/generated_test_data/listsR2RV2/imagesListAllLanguages.jsonld
@@ -83,7 +83,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 0
+              "knora-api:listNodePosition": 0,
+              "rdfs:label": [
+                {
+                  "@value": "Flugaufnahmen",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/a2f80dd7a8",
@@ -115,7 +121,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 4
+              "knora-api:listNodePosition": 4,
+              "rdfs:label": [
+                {
+                  "@value": "Landschaft Winter mit Ortschaften",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/06c75abca9",
@@ -123,7 +135,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 5
+              "knora-api:listNodePosition": 5,
+              "rdfs:label": [
+                {
+                  "@value": "Landschaft Seen",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/9ffaadf5a9",
@@ -242,7 +260,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 12
+                  "knora-api:listNodePosition": 12,
+                  "rdfs:label": [
+                    {
+                      "@value": "Zuoz",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/96008e51ad",
@@ -282,7 +306,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 17
+                  "knora-api:listNodePosition": 17,
+                  "rdfs:label": [
+                    {
+                      "@value": "Personen",
+                      "@language": "de"
+                    }
+                  ]
                 }
               ],
               "knora-api:listNodePosition": 7
@@ -324,7 +354,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 3
+                  "knora-api:listNodePosition": 3,
+                  "rdfs:label": [
+                    {
+                      "@value": "Surlej",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/9004ce8eaf",
@@ -364,7 +400,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 8
+                  "knora-api:listNodePosition": 8,
+                  "rdfs:label": [
+                    {
+                      "@value": "Bever",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/8d066eadb0",
@@ -404,7 +446,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 13
+                  "knora-api:listNodePosition": 13,
+                  "rdfs:label": [
+                    {
+                      "@value": "S-chanf",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/8a080eccb1",
@@ -442,7 +490,13 @@
               "knora-api:listNodePosition": 8
             }
           ],
-          "knora-api:listNodePosition": 2
+          "knora-api:listNodePosition": 2,
+          "rdfs:label": [
+            {
+              "@value": "ENGADIN",
+              "@language": "de"
+            }
+          ]
         },
         {
           "@id": "http://rdfh.ch/lists/00FF/eed65ab1b2",
@@ -489,7 +543,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 4
+              "knora-api:listNodePosition": 4,
+              "rdfs:label": [
+                {
+                  "@value": "St. Moritz Landschaft Sommer",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/840c4e09b4",
@@ -508,7 +568,13 @@
               "knora-api:listNodePosition": 6
             }
           ],
-          "knora-api:listNodePosition": 3
+          "knora-api:listNodePosition": 3,
+          "rdfs:label": [
+            {
+              "@value": "ST. MORITZ",
+              "@language": "de"
+            }
+          ]
         },
         {
           "@id": "http://rdfh.ch/lists/00FF/b673f47bb4",
@@ -531,7 +597,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 1
+              "knora-api:listNodePosition": 1,
+              "rdfs:label": [
+                {
+                  "@value": "Landschaften",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/45cfa1df0401",
@@ -571,7 +643,13 @@
           "knora-api:listNodePosition": 5
         }
       ],
-      "knora-api:listNodePosition": 1
+      "knora-api:listNodePosition": 1,
+      "rdfs:label": [
+        {
+          "@value": "GEOGRAPHIE",
+          "@language": "de"
+        }
+      ]
     },
     {
       "@id": "http://rdfh.ch/lists/00FF/4ca9e7d3b5",
@@ -656,7 +734,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 3
+                  "knora-api:listNodePosition": 3,
+                  "rdfs:label": [
+                    {
+                      "@value": "Personen D",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/7b122e65b7",
@@ -784,7 +868,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 19
+                  "knora-api:listNodePosition": 19,
+                  "rdfs:label": [
+                    {
+                      "@value": "Personen T",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/0b4c61faba",
@@ -792,7 +882,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 20
+                  "knora-api:listNodePosition": 20,
+                  "rdfs:label": [
+                    {
+                      "@value": "Personen U",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/a47fb433bb",
@@ -824,7 +920,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 24
+                  "knora-api:listNodePosition": 24,
+                  "rdfs:label": [
+                    {
+                      "@value": "Personen Y",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/084e0119bc",
@@ -832,7 +934,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 25
+                  "knora-api:listNodePosition": 25,
+                  "rdfs:label": [
+                    {
+                      "@value": "Personen Z",
+                      "@language": "de"
+                    }
+                  ]
                 }
               ],
               "knora-api:listNodePosition": 0
@@ -875,7 +983,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 5
+              "knora-api:listNodePosition": 5,
+              "rdfs:label": [
+                {
+                  "@value": "Sonnenbadende",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/9e83f470bd",
@@ -886,7 +1000,13 @@
               "knora-api:listNodePosition": 6
             }
           ],
-          "knora-api:listNodePosition": 4
+          "knora-api:listNodePosition": 4,
+          "rdfs:label": [
+            {
+              "@value": "BIOGRAPHIEN",
+              "@language": "de"
+            }
+          ]
         },
         {
           "@id": "http://rdfh.ch/lists/00FF/37b747aabd",
@@ -959,7 +1079,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 4
+              "knora-api:listNodePosition": 4,
+              "rdfs:label": [
+                {
+                  "@value": "Sgrafitti",
+                  "@language": "de"
+                }
+              ]
             }
           ],
           "knora-api:listNodePosition": 0
@@ -1001,7 +1127,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 3
+              "knora-api:listNodePosition": 3,
+              "rdfs:label": [
+                {
+                  "@value": "Theater",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/9589d4ccc0",
@@ -1043,7 +1175,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 2
+              "knora-api:listNodePosition": 2,
+              "rdfs:label": [
+                {
+                  "@value": "Film",
+                  "@language": "de"
+                }
+              ]
             }
           ],
           "knora-api:listNodePosition": 2
@@ -1085,7 +1223,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 3
+              "knora-api:listNodePosition": 3,
+              "rdfs:label": [
+                {
+                  "@value": "Stiche",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/8f8d140ac3",
@@ -1127,7 +1271,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 1
+              "knora-api:listNodePosition": 1,
+              "rdfs:label": [
+                {
+                  "@value": "Holzschnitte",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/8c8fb428c4",
@@ -1216,10 +1366,22 @@
           "knora-api:hasRootNode": {
             "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
           },
-          "knora-api:listNodePosition": 2
+          "knora-api:listNodePosition": 2,
+          "rdfs:label": [
+            {
+              "@value": "SPITAL UND KLINIKEN / KINDERHEIME",
+              "@language": "de"
+            }
+          ]
         }
       ],
-      "knora-api:listNodePosition": 4
+      "knora-api:listNodePosition": 4,
+      "rdfs:label": [
+        {
+          "@value": "MEDIZIN",
+          "@language": "de"
+        }
+      ]
     },
     {
       "@id": "http://rdfh.ch/lists/00FF/8693f465c6",
@@ -1257,7 +1419,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 2
+              "knora-api:listNodePosition": 2,
+              "rdfs:label": [
+                {
+                  "@value": "Tiere",
+                  "@language": "de"
+                }
+              ]
             }
           ],
           "knora-api:listNodePosition": 0
@@ -1336,7 +1504,13 @@
               "knora-api:listNodePosition": 3
             }
           ],
-          "knora-api:listNodePosition": 3
+          "knora-api:listNodePosition": 3,
+          "rdfs:label": [
+            {
+              "@value": "KLIMATOLOGIE UND METEOROLOGIE",
+              "@language": "de"
+            }
+          ]
         },
         {
           "@id": "http://rdfh.ch/lists/00FF/e4658188c9",
@@ -1344,7 +1518,13 @@
           "knora-api:hasRootNode": {
             "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
           },
-          "knora-api:listNodePosition": 4
+          "knora-api:listNodePosition": 4,
+          "rdfs:label": [
+            {
+              "@value": "UMWELT",
+              "@language": "de"
+            }
+          ]
         }
       ],
       "knora-api:listNodePosition": 5
@@ -1475,7 +1655,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 3
+              "knora-api:listNodePosition": 3,
+              "rdfs:label": [
+                {
+                  "@value": "Feste und Umzüge",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/0dd30757cd",
@@ -1559,7 +1745,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 3
+              "knora-api:listNodePosition": 3,
+              "rdfs:label": [
+                {
+                  "@value": "Fechten",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/07d74794cf",
@@ -1567,7 +1759,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 4
+              "knora-api:listNodePosition": 4,
+              "rdfs:label": [
+                {
+                  "@value": "Fitness",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/a00a9bcdcf",
@@ -1591,7 +1789,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 7
+              "knora-api:listNodePosition": 7,
+              "rdfs:label": [
+                {
+                  "@value": "Leichtathletik",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/6ba59479d0",
@@ -1607,7 +1811,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 9
+              "knora-api:listNodePosition": 9,
+              "rdfs:label": [
+                {
+                  "@value": "Schiessen",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/9d0c3becd0",
@@ -1642,7 +1852,13 @@
               "knora-api:listNodePosition": 13
             }
           ],
-          "knora-api:listNodePosition": 0
+          "knora-api:listNodePosition": 0,
+          "rdfs:label": [
+            {
+              "@value": "SPORT",
+              "@language": "de"
+            }
+          ]
         },
         {
           "@id": "http://rdfh.ch/lists/00FF/01db87d1d1",
@@ -1689,7 +1905,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 4
+              "knora-api:listNodePosition": 4,
+              "rdfs:label": [
+                {
+                  "@value": "Wind-, Schlittenhundrennen",
+                  "@language": "de"
+                }
+              ]
             }
           ],
           "knora-api:listNodePosition": 1
@@ -1731,7 +1953,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 3
+              "knora-api:listNodePosition": 3,
+              "rdfs:label": [
+                {
+                  "@value": "Skifahren",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/94121b48d4",
@@ -1813,7 +2041,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 4
+              "knora-api:listNodePosition": 4,
+              "rdfs:label": [
+                {
+                  "@value": "Ski Vorweltmeisterschaft 1973",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/8e165b85d6",
@@ -1840,7 +2074,13 @@
               "knora-api:listNodePosition": 7
             }
           ],
-          "knora-api:listNodePosition": 4
+          "knora-api:listNodePosition": 4,
+          "rdfs:label": [
+            {
+              "@value": "SKIRENNEN UND SKISPRINGEN",
+              "@language": "de"
+            }
+          ]
         },
         {
           "@id": "http://rdfh.ch/lists/00FF/59b15431d7",
@@ -1855,7 +2095,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 0
+              "knora-api:listNodePosition": 0,
+              "rdfs:label": [
+                {
+                  "@value": "Skilanglauf",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/8b18fba3d7",
@@ -1897,7 +2143,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 1
+              "knora-api:listNodePosition": 1,
+              "rdfs:label": [
+                {
+                  "@value": "Olympiade 1948",
+                  "@language": "de"
+                }
+              ]
             }
           ],
           "knora-api:listNodePosition": 7
@@ -1938,7 +2190,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 1
+                  "knora-api:listNodePosition": 1,
+                  "rdfs:label": [
+                    {
+                      "@value": "Gymkhana",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/851c3be1d9",
@@ -1978,7 +2236,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 6
+                  "knora-api:listNodePosition": 6,
+                  "rdfs:label": [
+                    {
+                      "@value": "Personen",
+                      "@language": "de"
+                    }
+                  ]
                 }
               ],
               "knora-api:listNodePosition": 1
@@ -2021,7 +2285,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 5
+              "knora-api:listNodePosition": 5,
+              "rdfs:label": [
+                {
+                  "@value": "Eisstockschiessen",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/7f207b1edc",
@@ -2062,7 +2332,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 1
+                  "knora-api:listNodePosition": 1,
+                  "rdfs:label": [
+                    {
+                      "@value": "Stürze",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/7c221b3ddd",
@@ -2207,7 +2483,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 1
+              "knora-api:listNodePosition": 1,
+              "rdfs:label": [
+                {
+                  "@value": "Fussball",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/0c5c4ed2e0",
@@ -2215,7 +2497,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 2
+              "knora-api:listNodePosition": 2,
+              "rdfs:label": [
+                {
+                  "@value": "Kegeln",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/a58fa10be1",
@@ -2246,7 +2534,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 2
+                  "knora-api:listNodePosition": 2,
+                  "rdfs:label": [
+                    {
+                      "@value": "Wintergolf",
+                      "@language": "de"
+                    }
+                  ]
                 }
               ],
               "knora-api:listNodePosition": 3
@@ -2257,7 +2551,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 4
+              "knora-api:listNodePosition": 4,
+              "rdfs:label": [
+                {
+                  "@value": "Tennis",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/a291412ae2",
@@ -2291,7 +2591,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 1
+              "knora-api:listNodePosition": 1,
+              "rdfs:label": [
+                {
+                  "@value": "Berghütten und Restaurants",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/06608e0fe3",
@@ -2299,7 +2605,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 2
+              "knora-api:listNodePosition": 2,
+              "rdfs:label": [
+                {
+                  "@value": "Trecking mit Tieren",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/9f93e148e3",
@@ -2368,7 +2680,13 @@
               "knora-api:listNodePosition": 4
             }
           ],
-          "knora-api:listNodePosition": 13
+          "knora-api:listNodePosition": 13,
+          "rdfs:label": [
+            {
+              "@value": "FLIEGEN",
+              "@language": "de"
+            }
+          ]
         },
         {
           "@id": "http://rdfh.ch/lists/00FF/67307b13e5",
@@ -2422,7 +2740,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 4
+                  "knora-api:listNodePosition": 4,
+                  "rdfs:label": [
+                    {
+                      "@value": "Verschiedenes",
+                      "@language": "de"
+                    }
+                  ]
                 }
               ],
               "knora-api:listNodePosition": 0
@@ -2465,7 +2789,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 5
+              "knora-api:listNodePosition": 5,
+              "rdfs:label": [
+                {
+                  "@value": "Radfahren",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/939b61c3e7",
@@ -2507,7 +2837,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 2
+              "knora-api:listNodePosition": 2,
+              "rdfs:label": [
+                {
+                  "@value": "Rudern",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/909d01e2e8",
@@ -2547,13 +2883,25 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 7
+              "knora-api:listNodePosition": 7,
+              "rdfs:label": [
+                {
+                  "@value": "Kitesurfen",
+                  "@language": "de"
+                }
+              ]
             }
           ],
           "knora-api:listNodePosition": 15
         }
       ],
-      "knora-api:listNodePosition": 8
+      "knora-api:listNodePosition": 8,
+      "rdfs:label": [
+        {
+          "@value": "SPORT",
+          "@language": "de"
+        }
+      ]
     },
     {
       "@id": "http://rdfh.ch/lists/00FF/8d9fa100ea",
@@ -2591,7 +2939,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 2
+              "knora-api:listNodePosition": 2,
+              "rdfs:label": [
+                {
+                  "@value": "Flugplatz Samedan",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/8aa1411feb",
@@ -2631,7 +2985,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 7
+              "knora-api:listNodePosition": 7,
+              "rdfs:label": [
+                {
+                  "@value": "Schneekanonen",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/87a3e13dec",
@@ -2671,7 +3031,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 12
+              "knora-api:listNodePosition": 12,
+              "rdfs:label": [
+                {
+                  "@value": "Wegweiser",
+                  "@language": "de"
+                }
+              ]
             }
           ],
           "knora-api:listNodePosition": 0
@@ -2713,7 +3079,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 1
+              "knora-api:listNodePosition": 1,
+              "rdfs:label": [
+                {
+                  "@value": "Gäste",
+                  "@language": "de"
+                }
+              ]
             },
             {
               "@id": "http://rdfh.ch/lists/00FF/81a7217bee",
@@ -2778,7 +3150,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 4
+                  "knora-api:listNodePosition": 4,
+                  "rdfs:label": [
+                    {
+                      "@value": "Hotel E",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/9476e994b901",
@@ -2818,7 +3196,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 9
+                  "knora-api:listNodePosition": 9,
+                  "rdfs:label": [
+                    {
+                      "@value": "Hotel J",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/917889b3ba01",
@@ -2858,7 +3242,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 14
+                  "knora-api:listNodePosition": 14,
+                  "rdfs:label": [
+                    {
+                      "@value": "Hotel O",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/8e7a29d2bb01",
@@ -2898,7 +3288,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 19
+                  "knora-api:listNodePosition": 19,
+                  "rdfs:label": [
+                    {
+                      "@value": "Hotel T",
+                      "@language": "de"
+                    }
+                  ]
                 },
                 {
                   "@id": "http://rdfh.ch/lists/00FF/8b7cc9f0bc01",
@@ -2946,7 +3342,13 @@
                   "knora-api:hasRootNode": {
                     "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
                   },
-                  "knora-api:listNodePosition": 25
+                  "knora-api:listNodePosition": 25,
+                  "rdfs:label": [
+                    {
+                      "@value": "Hotel Z",
+                      "@language": "de"
+                    }
+                  ]
                 }
               ],
               "knora-api:listNodePosition": 0
@@ -2965,7 +3367,13 @@
               "knora-api:hasRootNode": {
                 "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
               },
-              "knora-api:listNodePosition": 2
+              "knora-api:listNodePosition": 2,
+              "rdfs:label": [
+                {
+                  "@value": "Menükarten",
+                  "@language": "de"
+                }
+              ]
             }
           ],
           "knora-api:listNodePosition": 3
@@ -3036,7 +3444,13 @@
               "knora-api:listNodePosition": 2
             }
           ],
-          "knora-api:listNodePosition": 5
+          "knora-api:listNodePosition": 5,
+          "rdfs:label": [
+            {
+              "@value": "GEWERBE",
+              "@language": "de"
+            }
+          ]
         },
         {
           "@id": "http://rdfh.ch/lists/00FF/46465b64f1",
@@ -3099,5 +3513,25 @@
     "owl": "http://www.w3.org/2002/07/owl#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "xsd": "http://www.w3.org/2001/XMLSchema#"
-  }
+  },
+  "rdfs:label": [
+    {
+      "@value": "Titel",
+      "@language": "de"
+    },
+    {
+      "@value": "Title",
+      "@language": "en"
+    },
+    {
+      "@value": "Titre",
+      "@language": "fr"
+    }
+  ],
+  "rdfs:comment": [
+    {
+      "@value": "Hierarchisches Stichwortverzeichnis / Signatur der Bilder",
+      "@language": "de"
+    }
+  ]
 }

--- a/test_data/generated_test_data/listsR2RV2/imagesListAllLanguages.jsonld
+++ b/test_data/generated_test_data/listsR2RV2/imagesListAllLanguages.jsonld
@@ -1,0 +1,3103 @@
+{
+  "@id": "http://rdfh.ch/lists/00FF/73d0ec0302",
+  "@type": "knora-api:ListNode",
+  "knora-api:attachedToProject": {
+    "@id": "http://rdfh.ch/projects/00FF"
+  },
+  "knora-api:hasSubListNode": [
+    {
+      "@id": "http://rdfh.ch/lists/00FF/a8f4cd99a6",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/412821d3a6",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/da5b740ca7",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 1
+        }
+      ],
+      "knora-api:listNodePosition": 0
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/738fc745a7",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/0cc31a7fa7",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": {
+            "@id": "http://rdfh.ch/lists/00FF/a5f66db8a7",
+            "@type": "knora-api:ListNode",
+            "knora-api:hasRootNode": {
+              "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+            },
+            "knora-api:listNodePosition": 0
+          },
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/3e2ac1f1a7",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": {
+            "@id": "http://rdfh.ch/lists/00FF/d75d142ba8",
+            "@type": "knora-api:ListNode",
+            "knora-api:hasRootNode": {
+              "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+            },
+            "knora-api:listNodePosition": 0
+          },
+          "knora-api:listNodePosition": 1
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/70916764a8",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/09c5ba9da8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a2f80dd7a8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/3b2c6110a9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/d45fb449a9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/6d930783a9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/06c75abca9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9ffaadf5a9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/382e012faa",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/d1615468aa",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/6a95a7a1aa",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/03c9fadaaa",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 2
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/9cfc4d14ab",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 3
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/3530a14dab",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 4
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/ce63f486ab",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 5
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/679747c0ab",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 6
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/00cb9af9ab",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 7
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/99feed32ac",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 8
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/3232416cac",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 9
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/cb6594a5ac",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 10
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/6499e7deac",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 11
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/fdcc3a18ad",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 12
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/96008e51ad",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 13
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/2f34e18aad",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 14
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/c86734c4ad",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 15
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/619b87fdad",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 16
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/faceda36ae",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 17
+                }
+              ],
+              "knora-api:listNodePosition": 7
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/93022e70ae",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/2c3681a9ae",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/c569d4e2ae",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/5e9d271caf",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 2
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/f7d07a55af",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 3
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/9004ce8eaf",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 4
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/293821c8af",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 5
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/c26b7401b0",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 6
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/5b9fc73ab0",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 7
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/f4d21a74b0",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 8
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/8d066eadb0",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 9
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/263ac1e6b0",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 10
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/bf6d1420b1",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 11
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/58a16759b1",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 12
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/f1d4ba92b1",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 13
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/8a080eccb1",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 14
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/233c6105b2",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 15
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/bc6fb43eb2",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 16
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/55a30778b2",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 17
+                }
+              ],
+              "knora-api:listNodePosition": 8
+            }
+          ],
+          "knora-api:listNodePosition": 2
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/eed65ab1b2",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/870aaeeab2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/203e0124b3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b971545db3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/52a5a796b3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ebd8facfb3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/840c4e09b4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/1d40a142b4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            }
+          ],
+          "knora-api:listNodePosition": 3
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/b673f47bb4",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/4fa747b5b4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/e8da9aeeb4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/45cfa1df0401",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 4
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/810eee27b5",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/1a424161b5",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b375949ab5",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            }
+          ],
+          "knora-api:listNodePosition": 5
+        }
+      ],
+      "knora-api:listNodePosition": 1
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/4ca9e7d3b5",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/de02f5180501",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/773648520501",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 1
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/106a9b8b0501",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 2
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/a99deec40501",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 3
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/e5dc3a0db6",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/7e108e46b6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/1744e17fb6",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/b07734b9b6",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/49ab87f2b6",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 2
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/e2deda2bb7",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 3
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/7b122e65b7",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 4
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/1446819eb7",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 5
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/ad79d4d7b7",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 6
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/46ad2711b8",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 7
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/dfe07a4ab8",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 8
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/7814ce83b8",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 9
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/114821bdb8",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 10
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/aa7b74f6b8",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 11
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/43afc72fb9",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 12
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/dce21a69b9",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 13
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/75166ea2b9",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 14
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/0e4ac1dbb9",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 15
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/a77d1415ba",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 16
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/40b1674eba",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 17
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/d9e4ba87ba",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 18
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/72180ec1ba",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 19
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/0b4c61faba",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 20
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/a47fb433bb",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 21
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/3db3076dbb",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 22
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/d6e65aa6bb",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 23
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/6f1aaedfbb",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 24
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/084e0119bc",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 25
+                }
+              ],
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a1815452bc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/3ab5a78bbc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/d3e8fac4bc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/6c1c4efebc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/0550a137bd",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9e83f470bd",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            }
+          ],
+          "knora-api:listNodePosition": 4
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/37b747aabd",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 5
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/d0ea9ae3bd",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 6
+        }
+      ],
+      "knora-api:listNodePosition": 2
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/691eee1cbe",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/02524156be",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9b85948fbe",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/34b9e7c8be",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/cdec3a02bf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/66208e3bbf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ff53e174bf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            }
+          ],
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/988734aebf",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/31bb87e7bf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/caeeda20c0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/63222e5ac0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/fc558193c0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9589d4ccc0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            }
+          ],
+          "knora-api:listNodePosition": 1
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/2ebd2706c1",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c7f07a3fc1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/6024ce78c1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/f95721b2c1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 2
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/928b74ebc1",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/2bbfc724c2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c4f21a5ec2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/5d266e97c2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/f659c1d0c2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/8f8d140ac3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/28c16743c3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            }
+          ],
+          "knora-api:listNodePosition": 3
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/c1f4ba7cc3",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/5a280eb6c3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/f35b61efc3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/8c8fb428c4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 4
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/25c30762c4",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/bef65a9bc4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/572aaed4c4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            }
+          ],
+          "knora-api:listNodePosition": 5
+        }
+      ],
+      "knora-api:listNodePosition": 3
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/f05d010ec5",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/89915447c5",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/22c5a780c5",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/bbf8fab9c5",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/542c4ef3c5",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            }
+          ],
+          "knora-api:listNodePosition": 1
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/ed5fa12cc6",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 2
+        }
+      ],
+      "knora-api:listNodePosition": 4
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/8693f465c6",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/1fc7479fc6",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b8fa9ad8c6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/512eee11c7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ea61414bc7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/83959484c7",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/1cc9e7bdc7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b5fc3af7c7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            }
+          ],
+          "knora-api:listNodePosition": 1
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/4e308e30c8",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 2
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/e763e169c8",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/809734a3c8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/19cb87dcc8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b2feda15c9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/4b322e4fc9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            }
+          ],
+          "knora-api:listNodePosition": 3
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/e4658188c9",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 4
+        }
+      ],
+      "knora-api:listNodePosition": 5
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/7d99d4c1c9",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": {
+        "@id": "http://rdfh.ch/lists/00FF/16cd27fbc9",
+        "@type": "knora-api:ListNode",
+        "knora-api:hasRootNode": {
+          "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+        },
+        "knora-api:hasSubListNode": {
+          "@id": "http://rdfh.ch/lists/00FF/af007b34ca",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 0
+        },
+        "knora-api:listNodePosition": 0
+      },
+      "knora-api:listNodePosition": 6
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/4834ce6dca",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/e16721a7ca",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/7a9b74e0ca",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/13cfc719cb",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ac021b53cb",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/45366e8ccb",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/de69c1c5cb",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            }
+          ],
+          "knora-api:listNodePosition": 1
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/779d14ffcb",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 2
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/10d16738cc",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a904bb71cc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/42380eabcc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/db6b61e4cc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/749fb41dcd",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/0dd30757cd",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a6065b90cd",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            }
+          ],
+          "knora-api:listNodePosition": 3
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/3f3aaec9cd",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 4
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/d86d0103ce",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 5
+        }
+      ],
+      "knora-api:listNodePosition": 7
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/71a1543cce",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/0ad5a775ce",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a308fbaece",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/3c3c4ee8ce",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/d56fa121cf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/6ea3f45acf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/07d74794cf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a00a9bcdcf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/393eee06d0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/d2714140d0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 7
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/6ba59479d0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 8
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/04d9e7b2d0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 9
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9d0c3becd0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 10
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/36408e25d1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 11
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/cf73e15ed1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 12
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/68a73498d1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 13
+            }
+          ],
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/01db87d1d1",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9a0edb0ad2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/33422e44d2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/cc75817dd2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/65a9d4b6d2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/fedc27f0d2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            }
+          ],
+          "knora-api:listNodePosition": 1
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/97107b29d3",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/3044ce62d3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c977219cd3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/62ab74d5d3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/fbdec70ed4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/94121b48d4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/2d466e81d4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c679c1bad4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            }
+          ],
+          "knora-api:listNodePosition": 2
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/5fad14f4d4",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 3
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/f8e0672dd5",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9114bb66d5",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/2a480ea0d5",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c37b61d9d5",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/5cafb412d6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/f5e2074cd6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/8e165b85d6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/274aaebed6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c07d01f8d6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 7
+            }
+          ],
+          "knora-api:listNodePosition": 4
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/59b15431d7",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/f2e4a76ad7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/8b18fba3d7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            }
+          ],
+          "knora-api:listNodePosition": 5
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/244c4eddd7",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 6
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/bd7fa116d8",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/56b3f44fd8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/efe64789d8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            }
+          ],
+          "knora-api:listNodePosition": 7
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/881a9bc2d8",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/214eeefbd8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ba814135d9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/53b5946ed9",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/ece8e7a7d9",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/851c3be1d9",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 2
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/1e508e1ada",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 3
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/b783e153da",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 4
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/50b7348dda",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 5
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/e9ea87c6da",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 6
+                }
+              ],
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/821edbffda",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/1b522e39db",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b4858172db",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": {
+                "@id": "http://rdfh.ch/lists/00FF/4db9d4abdb",
+                "@type": "knora-api:ListNode",
+                "knora-api:hasRootNode": {
+                  "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                },
+                "knora-api:listNodePosition": 0
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/e6ec27e5db",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/7f207b1edc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            }
+          ],
+          "knora-api:listNodePosition": 8
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/1854ce57dc",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b1872191dc",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/4abb74cadc",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/e3eec703dd",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/7c221b3ddd",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 2
+                }
+              ],
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/15566e76dd",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/ae89c1afdd",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/47bd14e9dd",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                }
+              ],
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/42d141fe0501",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 9
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/e0f06722de",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/7924bb5bde",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/12580e95de",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ab8b61cede",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/44bfb407df",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ddf20741df",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/76265b7adf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/0f5aaeb3df",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a88d01eddf",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 7
+            }
+          ],
+          "knora-api:listNodePosition": 10
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/41c15426e0",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/daf4a75fe0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/7328fb98e0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/0c5c4ed2e0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a58fa10be1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/3ec3f444e1",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/d7f6477ee1",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/702a9bb7e1",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 2
+                }
+              ],
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/095eeef0e1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/a291412ae2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            }
+          ],
+          "knora-api:listNodePosition": 11
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/3bc59463e2",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/d4f8e79ce2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/6d2c3bd6e2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/06608e0fe3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9f93e148e3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/38c73482e3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            }
+          ],
+          "knora-api:listNodePosition": 12
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/d1fa87bbe3",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/6a2edbf4e3",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/03622e2ee4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9c958167e4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/35c9d4a0e4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/cefc27dae4",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            }
+          ],
+          "knora-api:listNodePosition": 13
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/67307b13e5",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/0064ce4ce5",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/99972186e5",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/32cb74bfe5",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/cbfec7f8e5",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 2
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/64321b32e6",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 3
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/fd656e6be6",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 4
+                }
+              ],
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/9699c1a4e6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/2fcd14dee6",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c8006817e7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/6134bb50e7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/fa670e8ae7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/939b61c3e7",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            }
+          ],
+          "knora-api:listNodePosition": 14
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/2ccfb4fce7",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c5020836e8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/5e365b6fe8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/f769aea8e8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/909d01e2e8",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/29d1541be9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/c204a854e9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/5b38fb8de9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/f46b4ec7e9",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 7
+            }
+          ],
+          "knora-api:listNodePosition": 15
+        }
+      ],
+      "knora-api:listNodePosition": 8
+    },
+    {
+      "@id": "http://rdfh.ch/lists/00FF/8d9fa100ea",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/00FF/26d3f439ea",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/bf064873ea",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/583a9bacea",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/f16deee5ea",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/8aa1411feb",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 3
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/23d59458eb",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 4
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/bc08e891eb",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 5
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/553c3bcbeb",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 6
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ee6f8e04ec",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 7
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/87a3e13dec",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 8
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/20d73477ec",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 9
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b90a88b0ec",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 10
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/523edbe9ec",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 11
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/eb712e23ed",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 12
+            }
+          ],
+          "knora-api:listNodePosition": 0
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/84a5815ced",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": {
+            "@id": "http://rdfh.ch/lists/00FF/1dd9d495ed",
+            "@type": "knora-api:ListNode",
+            "knora-api:hasRootNode": {
+              "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+            },
+            "knora-api:listNodePosition": 0
+          },
+          "knora-api:listNodePosition": 1
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/b60c28cfed",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/4f407b08ee",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/e873ce41ee",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/81a7217bee",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 2
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/1adb74b4ee",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b30ec8edee",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:hasSubListNode": [
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/97744976b801",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 0
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/30a89cafb801",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 1
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/c9dbefe8b801",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 2
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/620f4322b901",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 3
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/fb42965bb901",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 4
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/9476e994b901",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 5
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/2daa3cceb901",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 6
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/c6dd8f07ba01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 7
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/5f11e340ba01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 8
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/f844367aba01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 9
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/917889b3ba01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 10
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/2aacdcecba01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 11
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/c3df2f26bb01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 12
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/5c13835fbb01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 13
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/f546d698bb01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 14
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/8e7a29d2bb01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 15
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/27ae7c0bbc01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 16
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/c0e1cf44bc01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 17
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/5915237ebc01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 18
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/f24876b7bc01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 19
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/8b7cc9f0bc01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 20
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/24b01c2abd01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 21
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/9f29173c3b02",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 22
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/bde36f63bd01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 23
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/5617c39cbd01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 24
+                },
+                {
+                  "@id": "http://rdfh.ch/lists/00FF/ef4a16d6bd01",
+                  "@type": "knora-api:ListNode",
+                  "knora-api:hasRootNode": {
+                    "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+                  },
+                  "knora-api:listNodePosition": 25
+                }
+              ],
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/4c421b27ef",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/e5756e60ef",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 3
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/7ea9c199ef",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/17dd14d3ef",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/b010680cf0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/4944bb45f0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 4
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/e2770e7ff0",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/7bab61b8f0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/14dfb4f1f0",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/ad12082bf1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 5
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/46465b64f1",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:hasSubListNode": [
+            {
+              "@id": "http://rdfh.ch/lists/00FF/df79ae9df1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 0
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/78ad01d7f1",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 1
+            },
+            {
+              "@id": "http://rdfh.ch/lists/00FF/11e15410f2",
+              "@type": "knora-api:ListNode",
+              "knora-api:hasRootNode": {
+                "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+              },
+              "knora-api:listNodePosition": 2
+            }
+          ],
+          "knora-api:listNodePosition": 6
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/aa14a849f2",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 7
+        },
+        {
+          "@id": "http://rdfh.ch/lists/00FF/4348fb82f2",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/00FF/73d0ec0302"
+          },
+          "knora-api:listNodePosition": 8
+        }
+      ],
+      "knora-api:listNodePosition": 9
+    }
+  ],
+  "knora-api:isRootNode": true,
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api": "http://api.knora.org/ontology/knora-api/v2#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  }
+}

--- a/test_data/generated_test_data/listsR2RV2/othertreelistAllLanguages.jsonld
+++ b/test_data/generated_test_data/listsR2RV2/othertreelistAllLanguages.jsonld
@@ -1,0 +1,95 @@
+{
+  "@id": "http://rdfh.ch/lists/0001/otherTreeList",
+  "@type": "knora-api:ListNode",
+  "knora-api:attachedToProject": {
+    "@id": "http://rdfh.ch/projects/0001"
+  },
+  "knora-api:hasSubListNode": [
+    {
+      "@id": "http://rdfh.ch/lists/0001/otherTreeList01",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/0001/otherTreeList"
+      },
+      "knora-api:listNodePosition": 0,
+      "rdfs:label": [
+        {
+          "@value": "Other Tree list node 01",
+          "@language": "en"
+        }
+      ]
+    },
+    {
+      "@id": "http://rdfh.ch/lists/0001/otherTreeList02",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/0001/otherTreeList"
+      },
+      "knora-api:listNodePosition": 1,
+      "rdfs:label": [
+        {
+          "@value": "Other Tree list node 02",
+          "@language": "en"
+        }
+      ]
+    },
+    {
+      "@id": "http://rdfh.ch/lists/0001/otherTreeList03",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/0001/otherTreeList"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/0001/otherTreeList10",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/0001/otherTreeList"
+          },
+          "knora-api:listNodePosition": 0,
+          "rdfs:label": [
+            {
+              "@value": "Other Tree list node 10",
+              "@language": "en"
+            }
+          ]
+        },
+        {
+          "@id": "http://rdfh.ch/lists/0001/otherTreeList11",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/0001/otherTreeList"
+          },
+          "knora-api:listNodePosition": 1,
+          "rdfs:label": [
+            {
+              "@value": "Other Tree list node 11",
+              "@language": "en"
+            }
+          ]
+        }
+      ],
+      "knora-api:listNodePosition": 2,
+      "rdfs:label": [
+        {
+          "@value": "Other Tree list node 03",
+          "@language": "en"
+        }
+      ]
+    }
+  ],
+  "knora-api:isRootNode": true,
+  "rdfs:label": [
+    {
+      "@value": "Tree list root",
+      "@language": "en"
+    }
+  ],
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api": "http://api.knora.org/ontology/knora-api/v2#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  }
+}

--- a/test_data/generated_test_data/listsR2RV2/treelistAllLanguages.jsonld
+++ b/test_data/generated_test_data/listsR2RV2/treelistAllLanguages.jsonld
@@ -1,0 +1,109 @@
+{
+  "@id": "http://rdfh.ch/lists/0001/treeList",
+  "@type": "knora-api:ListNode",
+  "knora-api:attachedToProject": {
+    "@id": "http://rdfh.ch/projects/0001"
+  },
+  "knora-api:hasSubListNode": [
+    {
+      "@id": "http://rdfh.ch/lists/0001/treeList01",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/0001/treeList"
+      },
+      "knora-api:listNodePosition": 0,
+      "rdfs:label": [
+        {
+          "@value": "Tree list node 01",
+          "@language": "en"
+        }
+      ]
+    },
+    {
+      "@id": "http://rdfh.ch/lists/0001/treeList02",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/0001/treeList"
+      },
+      "knora-api:listNodePosition": 1,
+      "rdfs:label": [
+        {
+          "@value": "Baumlistenknoten 02",
+          "@language": "de"
+        },
+        {
+          "@value": "Tree list node 02",
+          "@language": "en"
+        }
+      ]
+    },
+    {
+      "@id": "http://rdfh.ch/lists/0001/treeList03",
+      "@type": "knora-api:ListNode",
+      "knora-api:hasRootNode": {
+        "@id": "http://rdfh.ch/lists/0001/treeList"
+      },
+      "knora-api:hasSubListNode": [
+        {
+          "@id": "http://rdfh.ch/lists/0001/treeList10",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/0001/treeList"
+          },
+          "knora-api:listNodePosition": 0,
+          "rdfs:label": [
+            {
+              "@value": "Tree list node 10",
+              "@language": "en"
+            }
+          ]
+        },
+        {
+          "@id": "http://rdfh.ch/lists/0001/treeList11",
+          "@type": "knora-api:ListNode",
+          "knora-api:hasRootNode": {
+            "@id": "http://rdfh.ch/lists/0001/treeList"
+          },
+          "knora-api:listNodePosition": 1,
+          "rdfs:label": [
+            {
+              "@value": "Tree list node 11",
+              "@language": "en"
+            }
+          ]
+        }
+      ],
+      "knora-api:listNodePosition": 2,
+      "rdfs:label": [
+        {
+          "@value": "Tree list node 03",
+          "@language": "en"
+        }
+      ]
+    }
+  ],
+  "knora-api:isRootNode": true,
+  "rdfs:comment": [
+    {
+      "@value": "Anything Tree List",
+      "@language": "en"
+    }
+  ],
+  "rdfs:label": [
+    {
+      "@value": "Listenwurzel",
+      "@language": "de"
+    },
+    {
+      "@value": "Tree list root",
+      "@language": "en"
+    }
+  ],
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api": "http://api.knora.org/ontology/knora-api/v2#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  }
+}

--- a/test_data/generated_test_data/listsR2RV2/treelistnodeAllLanguages.jsonld
+++ b/test_data/generated_test_data/listsR2RV2/treelistnodeAllLanguages.jsonld
@@ -1,0 +1,19 @@
+{
+  "@id" : "http://rdfh.ch/lists/0001/treeList01",
+  "@type" : "knora-api:ListNode",
+  "knora-api:hasRootNode" : {
+    "@id" : "http://rdfh.ch/lists/0001/treeList"
+  },
+  "knora-api:listNodePosition" : 0,
+  "rdfs:label" : [ {
+    "@value" : "Tree list node 01",
+    "@language" : "en"
+  } ],
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "owl" : "http://www.w3.org/2002/07/owl#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#"
+  }
+}

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
@@ -51,7 +51,7 @@ trait ListResponderResponseV2 {
   ): Option[JsonLDValue] =
     if (allLanguages) {
       val tagged = stringLiteralsToLangMap(seq)
-      if (tagged.nonEmpty) Some(JsonLDUtil.objectsWithLangsToJsonLDArray(tagged)) else None
+      Option.when(tagged.nonEmpty)(JsonLDUtil.objectsWithLangsToJsonLDArray(tagged))
     } else {
       seq.getPreferredLanguage(userLang, fallbackLang).map(JsonLDString.apply)
     }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
@@ -13,13 +13,13 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.admin.responder.listsmessages.*
 import org.knora.webapi.messages.store.triplestoremessages.LanguageTaggedStringLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralSequenceV2
-import org.knora.webapi.messages.util.rdf
 import org.knora.webapi.messages.util.rdf.*
 import org.knora.webapi.messages.v2.responder.KnoraJsonLDResponseV2
 
 /**
- * Cached `ApiV2Complex` IRI strings shared by both list responders. Lifted out of the
- * `toJsonLDDocument` bodies so the SmartIri conversions run once per JVM.
+ * Cached `ApiV2Complex` IRI strings and the shared JSON-LD context object used by both
+ * list responders. Lifted out of the `toJsonLDDocument` bodies so the SmartIri
+ * conversions and the context object are constructed once per JVM.
  */
 private[listsmessages] object ListV2Iris {
   private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
@@ -33,6 +33,18 @@ private[listsmessages] object ListV2Iris {
   val attachedToProject: IRI =
     OntologyConstants.KnoraBase.AttachedToProject.toSmartIri.toOntologySchema(ApiV2Complex).toString
   val isRootNode: IRI = OntologyConstants.KnoraBase.IsRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+
+  val sharedContext: JsonLDObject = JsonLDObject(
+    Map(
+      OntologyConstants.KnoraApi.KnoraApiOntologyLabel -> JsonLDString(
+        OntologyConstants.KnoraApiV2Complex.KnoraApiV2PrefixExpansion,
+      ),
+      "rdfs" -> JsonLDString("http://www.w3.org/2000/01/rdf-schema#"),
+      "rdf"  -> JsonLDString("http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+      "owl"  -> JsonLDString("http://www.w3.org/2002/07/owl#"),
+      "xsd"  -> JsonLDString("http://www.w3.org/2001/XMLSchema#"),
+    ),
+  )
 }
 
 /**
@@ -117,73 +129,42 @@ case class ListGetResponseV2(
     import ListV2Iris.*
 
     def makeNode(node: ListChildNodeADM): JsonLDObject = {
-      val label   = labelEntry(node.labels, allLanguages, userLang, fallbackLang)
-      val comment = commentEntry(node.comments, allLanguages, userLang, fallbackLang)
-
-      val position: Map[IRI, JsonLDInt] = Map(
-        listNodePosition -> JsonLDInt(node.position),
-      )
-
-      val children: Map[IRI, JsonLDArray] = if (node.children.nonEmpty) {
-        Map(
-          hasSubListNode -> JsonLDArray(node.children.map(makeNode)),
-        )
-      } else {
-        Map.empty[IRI, JsonLDArray]
-      }
-
-      val nodeHasRootNode: Map[IRI, JsonLDObject] = Map(
-        hasRootNode -> JsonLDUtil.iriToJsonLDObject(node.hasRootNode),
+      val label    = labelEntry(node.labels, allLanguages, userLang, fallbackLang)
+      val comment  = commentEntry(node.comments, allLanguages, userLang, fallbackLang)
+      val children = Option.when(node.children.nonEmpty)(
+        hasSubListNode -> JsonLDArray(node.children.map(makeNode)),
       )
 
       JsonLDObject(
         Map[IRI, JsonLDValue](
-          "@id"   -> JsonLDString(node.id),
-          "@type" -> JsonLDString(listNodeType),
-        ) ++ position ++ nodeHasRootNode ++ children ++ label ++ comment,
+          "@id"            -> JsonLDString(node.id),
+          "@type"          -> JsonLDString(listNodeType),
+          listNodePosition -> JsonLDInt(node.position),
+          hasRootNode      -> JsonLDUtil.iriToJsonLDObject(node.hasRootNode),
+        ) ++ children ++ label ++ comment,
       )
     }
 
     val listinfo = list.listinfo
 
-    val label   = labelEntry(listinfo.labels, allLanguages, userLang, fallbackLang)
-    val comment = commentEntry(listinfo.comments, allLanguages, userLang, fallbackLang)
-
-    val children: Map[IRI, JsonLDArray] = if (list.children.nonEmpty) {
-      Map(
-        hasSubListNode -> JsonLDArray(
-          list.children.map(childNode => makeNode(childNode.asInstanceOf[ListChildNodeADM])),
-        ),
-      )
-    } else {
-      Map.empty[IRI, JsonLDArray]
-    }
-
-    val project: Map[IRI, JsonLDObject] = Map(
-      attachedToProject -> JsonLDUtil.iriToJsonLDObject(listinfo.projectIri),
-    )
-
-    val body = rdf.JsonLDObject(
-      Map[IRI, JsonLDValue](
-        "@id"      -> JsonLDString(listinfo.id),
-        "@type"    -> JsonLDString(listNodeType),
-        isRootNode -> JsonLDBoolean(true),
-      ) ++ project ++ children ++ label ++ comment,
-    )
-
-    val context = JsonLDObject(
-      Map(
-        OntologyConstants.KnoraApi.KnoraApiOntologyLabel -> JsonLDString(
-          OntologyConstants.KnoraApiV2Complex.KnoraApiV2PrefixExpansion,
-        ),
-        "rdfs" -> JsonLDString("http://www.w3.org/2000/01/rdf-schema#"),
-        "rdf"  -> JsonLDString("http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
-        "owl"  -> JsonLDString("http://www.w3.org/2002/07/owl#"),
-        "xsd"  -> JsonLDString("http://www.w3.org/2001/XMLSchema#"),
+    val label    = labelEntry(listinfo.labels, allLanguages, userLang, fallbackLang)
+    val comment  = commentEntry(listinfo.comments, allLanguages, userLang, fallbackLang)
+    val children = Option.when(list.children.nonEmpty)(
+      hasSubListNode -> JsonLDArray(
+        list.children.map(childNode => makeNode(childNode.asInstanceOf[ListChildNodeADM])),
       ),
     )
 
-    JsonLDDocument(body, context)
+    val body = JsonLDObject(
+      Map[IRI, JsonLDValue](
+        "@id"             -> JsonLDString(listinfo.id),
+        "@type"           -> JsonLDString(listNodeType),
+        isRootNode        -> JsonLDBoolean(true),
+        attachedToProject -> JsonLDUtil.iriToJsonLDObject(listinfo.projectIri),
+      ) ++ children ++ label ++ comment,
+    )
+
+    JsonLDDocument(body, sharedContext)
   }
 }
 
@@ -227,35 +208,17 @@ case class NodeGetResponseV2(
         val label   = labelEntry(child.labels, allLanguages, userLang, fallbackLang)
         val comment = commentEntry(child.comments, allLanguages, userLang, fallbackLang)
 
-        val position: Map[IRI, JsonLDInt] = Map(
-          listNodePosition -> JsonLDInt(child.position),
-        )
-
-        val rootNode = Map(
-          hasRootNode -> JsonLDUtil.iriToJsonLDObject(child.hasRootNode),
-        )
-
         JsonLDObject(
           Map[IRI, JsonLDValue](
-            "@id"   -> JsonLDString(child.id),
-            "@type" -> JsonLDString(listNodeType),
-          ) ++ rootNode ++ label ++ comment ++ position,
+            "@id"            -> JsonLDString(child.id),
+            "@type"          -> JsonLDString(listNodeType),
+            listNodePosition -> JsonLDInt(child.position),
+            hasRootNode      -> JsonLDUtil.iriToJsonLDObject(child.hasRootNode),
+          ) ++ label ++ comment,
         )
     }
 
-    val context = JsonLDObject(
-      Map(
-        OntologyConstants.KnoraApi.KnoraApiOntologyLabel -> JsonLDString(
-          OntologyConstants.KnoraApiV2Complex.KnoraApiV2PrefixExpansion,
-        ),
-        "rdfs" -> JsonLDString("http://www.w3.org/2000/01/rdf-schema#"),
-        "rdf"  -> JsonLDString("http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
-        "owl"  -> JsonLDString("http://www.w3.org/2002/07/owl#"),
-        "xsd"  -> JsonLDString("http://www.w3.org/2001/XMLSchema#"),
-      ),
-    )
-
-    JsonLDDocument(body, context)
+    JsonLDDocument(body, sharedContext)
   }
 
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
@@ -11,6 +11,7 @@ import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.admin.responder.listsmessages.*
+import org.knora.webapi.messages.store.triplestoremessages.LanguageTaggedStringLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralSequenceV2
 import org.knora.webapi.messages.util.rdf
 import org.knora.webapi.messages.util.rdf.*
@@ -40,6 +41,40 @@ trait ListResponderResponseV2 {
       iri -> stringVals.getPreferredLanguage(userLang, fallbackLang),
     ).collect { case (iri: IRI, Some(strVal: String)) =>
       iri -> JsonLDString(strVal)
+    }
+
+  /**
+   * Collapses a [[StringLiteralSequenceV2]] into a map from BCP-47 language tag to value.
+   * Untagged literals (`PlainStringLiteralV2`) are skipped (REQ-1.8, D5). When multiple
+   * literals share the same language tag, the last one wins via `.toMap` (REQ-1.9, D6).
+   */
+  protected def stringLiteralsToLangMap(seq: StringLiteralSequenceV2): Map[String, String] =
+    seq.stringLiterals.collect { case LanguageTaggedStringLiteralV2(value, language) =>
+      language.value -> value
+    }.toMap
+
+  /**
+   * Builds the JSON-LD value for an `rdfs:label` or `rdfs:comment` field, dispatching on
+   * the `allLanguages` flag.
+   *
+   *   - When `allLanguages` is `true`, returns a [[JsonLDArray]] of language-tagged objects
+   *     (sorted alphabetically by language tag — REQ-1.7, D3) or `None` when the underlying
+   *     sequence has no language-tagged literals (REQ-1.6, D2 — field is then omitted from
+   *     the surrounding `JsonLDObject` via `++ Option`).
+   *   - When `allLanguages` is `false`, returns the legacy single [[JsonLDString]] picked by
+   *     the user's preferred language with the configured fallback (REQ-1.10, D8 unchanged).
+   */
+  protected def labelOrCommentJson(
+    seq: StringLiteralSequenceV2,
+    allLanguages: Boolean,
+    userLang: String,
+    fallbackLang: String,
+  ): Option[JsonLDValue] =
+    if (allLanguages) {
+      val tagged = stringLiteralsToLangMap(seq)
+      if (tagged.nonEmpty) Some(JsonLDUtil.objectsWithLangsToJsonLDArray(tagged)) else None
+    } else {
+      seq.getPreferredLanguage(userLang, fallbackLang).map(JsonLDString.apply)
     }
 
 }
@@ -72,15 +107,12 @@ case class ListGetResponseV2(
      * @return a [[JsonLDObject]] representing the node.
      */
     def makeNode(node: ListChildNodeADM): JsonLDObject = {
-      val label: Map[IRI, JsonLDString] =
-        makeMapIriToJSONLDString(OntologyConstants.Rdfs.Label, node.labels, userLang, fallbackLang)
-      val comment: Map[IRI, JsonLDString] =
-        makeMapIriToJSONLDString(
-          OntologyConstants.Rdfs.Comment,
-          node.comments,
-          userLang,
-          fallbackLang,
-        )
+      val label: Option[(IRI, JsonLDValue)] =
+        labelOrCommentJson(node.labels, allLanguages, userLang, fallbackLang)
+          .map(OntologyConstants.Rdfs.Label -> _)
+      val comment: Option[(IRI, JsonLDValue)] =
+        labelOrCommentJson(node.comments, allLanguages, userLang, fallbackLang)
+          .map(OntologyConstants.Rdfs.Comment -> _)
 
       val position: Map[IRI, JsonLDInt] = Map(
         OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDInt(
@@ -107,7 +139,7 @@ case class ListGetResponseV2(
       )
 
       JsonLDObject(
-        Map(
+        Map[IRI, JsonLDValue](
           "@id"   -> JsonLDString(node.id),
           "@type" -> JsonLDString(
             OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString,
@@ -118,11 +150,13 @@ case class ListGetResponseV2(
 
     val listinfo = list.listinfo
 
-    val label: Map[IRI, JsonLDString] =
-      makeMapIriToJSONLDString(OntologyConstants.Rdfs.Label, listinfo.labels, userLang, fallbackLang)
+    val label: Option[(IRI, JsonLDValue)] =
+      labelOrCommentJson(listinfo.labels, allLanguages, userLang, fallbackLang)
+        .map(OntologyConstants.Rdfs.Label -> _)
 
-    val comment: Map[IRI, JsonLDString] =
-      makeMapIriToJSONLDString(OntologyConstants.Rdfs.Comment, listinfo.comments, userLang, fallbackLang)
+    val comment: Option[(IRI, JsonLDValue)] =
+      labelOrCommentJson(listinfo.comments, allLanguages, userLang, fallbackLang)
+        .map(OntologyConstants.Rdfs.Comment -> _)
 
     val children: Map[IRI, JsonLDArray] = if (list.children.nonEmpty) {
       Map(
@@ -142,7 +176,7 @@ case class ListGetResponseV2(
     )
 
     val body = rdf.JsonLDObject(
-      Map(
+      Map[IRI, JsonLDValue](
         "@id"   -> JsonLDString(listinfo.id),
         "@type" -> JsonLDString(
           OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString,
@@ -192,18 +226,20 @@ case class NodeGetResponseV2(
 
       case root: ListRootNodeInfoADM => {
 
-        val label: Map[IRI, JsonLDString] =
-          makeMapIriToJSONLDString(OntologyConstants.Rdfs.Label, root.labels, userLang, fallbackLang)
+        val label: Option[(IRI, JsonLDValue)] =
+          labelOrCommentJson(root.labels, allLanguages, userLang, fallbackLang)
+            .map(OntologyConstants.Rdfs.Label -> _)
 
-        val comment: Map[IRI, JsonLDString] =
-          makeMapIriToJSONLDString(OntologyConstants.Rdfs.Comment, root.comments, userLang, fallbackLang)
+        val comment: Option[(IRI, JsonLDValue)] =
+          labelOrCommentJson(root.comments, allLanguages, userLang, fallbackLang)
+            .map(OntologyConstants.Rdfs.Comment -> _)
 
         val position: Map[IRI, JsonLDInt] = Map.empty[IRI, JsonLDInt]
 
-        val rootNode = Map.empty[IRI, JsonLDString]
+        val rootNode = Map.empty[IRI, JsonLDValue]
 
         JsonLDObject(
-          Map(
+          Map[IRI, JsonLDValue](
             "@id"   -> JsonLDString(root.id),
             "@type" -> JsonLDString(
               OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString,
@@ -214,11 +250,13 @@ case class NodeGetResponseV2(
 
       case child: ListChildNodeInfoADM => {
 
-        val label: Map[IRI, JsonLDString] =
-          makeMapIriToJSONLDString(OntologyConstants.Rdfs.Label, child.labels, userLang, fallbackLang)
+        val label: Option[(IRI, JsonLDValue)] =
+          labelOrCommentJson(child.labels, allLanguages, userLang, fallbackLang)
+            .map(OntologyConstants.Rdfs.Label -> _)
 
-        val comment: Map[IRI, JsonLDString] =
-          makeMapIriToJSONLDString(OntologyConstants.Rdfs.Comment, child.comments, userLang, fallbackLang)
+        val comment: Option[(IRI, JsonLDValue)] =
+          labelOrCommentJson(child.comments, allLanguages, userLang, fallbackLang)
+            .map(OntologyConstants.Rdfs.Comment -> _)
 
         val position: Map[IRI, JsonLDInt] = Map(
           OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDInt(
@@ -232,7 +270,7 @@ case class NodeGetResponseV2(
         )
 
         JsonLDObject(
-          Map(
+          Map[IRI, JsonLDValue](
             "@id"   -> JsonLDString(child.id),
             "@type" -> JsonLDString(
               OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
@@ -49,8 +49,12 @@ trait ListResponderResponseV2 {
  * @param userLang     the user's preferred language.
  * @param fallbackLang the fallback language if the preferred language is not available.
  */
-case class ListGetResponseV2(list: ListADM, userLang: String, fallbackLang: String)
-    extends KnoraJsonLDResponseV2
+case class ListGetResponseV2(
+  list: ListADM,
+  userLang: String,
+  fallbackLang: String,
+  allLanguages: Boolean = false,
+) extends KnoraJsonLDResponseV2
     with ListResponderResponseV2 {
 
   def toJsonLDDocument(
@@ -168,8 +172,12 @@ case class ListGetResponseV2(list: ListADM, userLang: String, fallbackLang: Stri
  * @param userLang     the user's preferred language.
  * @param fallbackLang the fallback language if the preferred language is not available.
  */
-case class NodeGetResponseV2(node: ListNodeInfoADM, userLang: String, fallbackLang: String)
-    extends KnoraJsonLDResponseV2
+case class NodeGetResponseV2(
+  node: ListNodeInfoADM,
+  userLang: String,
+  fallbackLang: String,
+  allLanguages: Boolean = false,
+) extends KnoraJsonLDResponseV2
     with ListResponderResponseV2 {
 
   def toJsonLDDocument(

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
@@ -18,30 +18,63 @@ import org.knora.webapi.messages.util.rdf.*
 import org.knora.webapi.messages.v2.responder.KnoraJsonLDResponseV2
 
 /**
- * An abstract trait providing a convenience method for language handling.
+ * Cached `ApiV2Complex` IRI strings shared by both list responders. Lifted out of the
+ * `toJsonLDDocument` bodies so the SmartIri conversions run once per JVM.
+ */
+private[listsmessages] object ListV2Iris {
+  private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
+
+  val listNodeType: IRI     = OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+  val listNodePosition: IRI =
+    OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString
+  val hasSubListNode: IRI =
+    OntologyConstants.KnoraBase.HasSubListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+  val hasRootNode: IRI       = OntologyConstants.KnoraBase.HasRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+  val attachedToProject: IRI =
+    OntologyConstants.KnoraBase.AttachedToProject.toSmartIri.toOntologySchema(ApiV2Complex).toString
+  val isRootNode: IRI = OntologyConstants.KnoraBase.IsRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+}
+
+/**
+ * An abstract trait providing convenience methods for the language-handling shape of
+ * `rdfs:label` and `rdfs:comment` in list/node responses.
  */
 trait ListResponderResponseV2 {
 
   /**
-   * Collapses a [[StringLiteralSequenceV2]] into a map from BCP-47 language tag to value.
-   * Untagged literals (`PlainStringLiteralV2`) are skipped (REQ-1.8, D5). When multiple
-   * literals share the same language tag, the last one wins via `.toMap` (REQ-1.9, D6).
+   * Builds the optional `(rdfs:label, JsonLDValue)` entry for a node, dispatching on
+   * `allLanguages`. Returns `None` when there is no label to emit (caller drops the
+   * field via `++ Option`).
    */
-  private[listsmessages] def stringLiteralsToLangMap(seq: StringLiteralSequenceV2): Map[String, String] =
-    seq.stringLiterals.collect { case LanguageTaggedStringLiteralV2(value, language) =>
-      language.value -> value
-    }.toMap
+  private[listsmessages] def labelEntry(
+    seq: StringLiteralSequenceV2,
+    allLanguages: Boolean,
+    userLang: String,
+    fallbackLang: String,
+  ): Option[(IRI, JsonLDValue)] =
+    labelOrCommentJson(seq, allLanguages, userLang, fallbackLang).map(OntologyConstants.Rdfs.Label -> _)
 
   /**
-   * Builds the JSON-LD value for an `rdfs:label` or `rdfs:comment` field, dispatching on
-   * the `allLanguages` flag.
+   * Builds the optional `(rdfs:comment, JsonLDValue)` entry for a node — same dispatch
+   * rules as [[labelEntry]].
+   */
+  private[listsmessages] def commentEntry(
+    seq: StringLiteralSequenceV2,
+    allLanguages: Boolean,
+    userLang: String,
+    fallbackLang: String,
+  ): Option[(IRI, JsonLDValue)] =
+    labelOrCommentJson(seq, allLanguages, userLang, fallbackLang).map(OntologyConstants.Rdfs.Comment -> _)
+
+  /**
+   * Builds the JSON-LD value for an `rdfs:label` or `rdfs:comment` field:
    *
-   *   - When `allLanguages` is `true`, returns a [[JsonLDArray]] of language-tagged objects
-   *     (sort by language tag is delegated to `JsonLDUtil.objectsWithLangsToJsonLDArray` —
-   *     REQ-1.7, D3) or `None` when the underlying sequence has no language-tagged literals
-   *     (REQ-1.6, D2 — field is then omitted from the surrounding `JsonLDObject` via `++ Option`).
-   *   - When `allLanguages` is `false`, returns the legacy single [[JsonLDString]] picked by
-   *     the user's preferred language with the configured fallback (REQ-1.10, D8 unchanged).
+   *   - `allLanguages=true`: returns a [[JsonLDArray]] of language-tagged objects (sort
+   *     is delegated to `JsonLDUtil.objectsWithLangsToJsonLDArray`). Untagged literals
+   *     are skipped; on repeated tags last-wins via `.toMap`. Returns `None` when no
+   *     language-tagged literals are present so the field can be omitted entirely.
+   *   - `allLanguages=false`: returns the legacy single [[JsonLDString]] picked by the
+   *     user's preferred language with the configured fallback (unchanged behaviour).
    */
   private[listsmessages] def labelOrCommentJson(
     seq: StringLiteralSequenceV2,
@@ -50,7 +83,9 @@ trait ListResponderResponseV2 {
     fallbackLang: String,
   ): Option[JsonLDValue] =
     if (allLanguages) {
-      val tagged = stringLiteralsToLangMap(seq)
+      val tagged = seq.stringLiterals.collect { case LanguageTaggedStringLiteralV2(value, language) =>
+        language.value -> value
+      }.toMap
       Option.when(tagged.nonEmpty)(JsonLDUtil.objectsWithLangsToJsonLDArray(tagged))
     } else {
       seq.getPreferredLanguage(userLang, fallbackLang).map(JsonLDString.apply)
@@ -62,6 +97,9 @@ trait ListResponderResponseV2 {
  * @param list         the list to be returned.
  * @param userLang     the user's preferred language.
  * @param fallbackLang the fallback language if the preferred language is not available.
+ * @param allLanguages if `true`, emit `rdfs:label` / `rdfs:comment` as JSON-LD arrays of
+ *                     language-tagged objects sorted by BCP-47 tag; if `false` (default)
+ *                     emit the legacy single-string shape in the user's preferred language.
  */
 case class ListGetResponseV2(
   list: ListADM,
@@ -76,33 +114,11 @@ case class ListGetResponseV2(
     appConfig: AppConfig,
     schemaOptions: Set[Rendering],
   ): JsonLDDocument = {
+    import ListV2Iris.*
 
-    implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
-
-    // Cache the repeated SmartIri -> ApiV2Complex string conversions used in this response.
-    val listNodeType: IRI     = OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
-    val listNodePosition: IRI =
-      OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString
-    val hasSubListNode: IRI =
-      OntologyConstants.KnoraBase.HasSubListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
-    val hasRootNode: IRI       = OntologyConstants.KnoraBase.HasRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
-    val attachedToProject: IRI =
-      OntologyConstants.KnoraBase.AttachedToProject.toSmartIri.toOntologySchema(ApiV2Complex).toString
-    val isRootNode: IRI = OntologyConstants.KnoraBase.IsRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
-
-    /**
-     * Given a [[ListNodeADM]], constructs a [[JsonLDObject]].
-     *
-     * @param node the node to be turned into JSON-LD.
-     * @return a [[JsonLDObject]] representing the node.
-     */
     def makeNode(node: ListChildNodeADM): JsonLDObject = {
-      val label: Option[(IRI, JsonLDValue)] =
-        labelOrCommentJson(node.labels, allLanguages, userLang, fallbackLang)
-          .map(OntologyConstants.Rdfs.Label -> _)
-      val comment: Option[(IRI, JsonLDValue)] =
-        labelOrCommentJson(node.comments, allLanguages, userLang, fallbackLang)
-          .map(OntologyConstants.Rdfs.Comment -> _)
+      val label   = labelEntry(node.labels, allLanguages, userLang, fallbackLang)
+      val comment = commentEntry(node.comments, allLanguages, userLang, fallbackLang)
 
       val position: Map[IRI, JsonLDInt] = Map(
         listNodePosition -> JsonLDInt(node.position),
@@ -110,14 +126,9 @@ case class ListGetResponseV2(
 
       val children: Map[IRI, JsonLDArray] = if (node.children.nonEmpty) {
         Map(
-          hasSubListNode -> JsonLDArray(
-            node.children.map { (childNode: ListChildNodeADM) =>
-              makeNode(childNode) // recursion
-            },
-          ),
+          hasSubListNode -> JsonLDArray(node.children.map(makeNode)),
         )
       } else {
-        // no children (abort condition for recursion)
         Map.empty[IRI, JsonLDArray]
       }
 
@@ -135,20 +146,13 @@ case class ListGetResponseV2(
 
     val listinfo = list.listinfo
 
-    val label: Option[(IRI, JsonLDValue)] =
-      labelOrCommentJson(listinfo.labels, allLanguages, userLang, fallbackLang)
-        .map(OntologyConstants.Rdfs.Label -> _)
-
-    val comment: Option[(IRI, JsonLDValue)] =
-      labelOrCommentJson(listinfo.comments, allLanguages, userLang, fallbackLang)
-        .map(OntologyConstants.Rdfs.Comment -> _)
+    val label   = labelEntry(listinfo.labels, allLanguages, userLang, fallbackLang)
+    val comment = commentEntry(listinfo.comments, allLanguages, userLang, fallbackLang)
 
     val children: Map[IRI, JsonLDArray] = if (list.children.nonEmpty) {
       Map(
         hasSubListNode -> JsonLDArray(
-          list.children.map { (childNode: ListNodeADM) =>
-            makeNode(childNode.asInstanceOf[ListChildNodeADM])
-          },
+          list.children.map(childNode => makeNode(childNode.asInstanceOf[ListChildNodeADM])),
         ),
       )
     } else {
@@ -187,6 +191,9 @@ case class ListGetResponseV2(
  * @param node         the node to be returned.
  * @param userLang     the user's preferred language.
  * @param fallbackLang the fallback language if the preferred language is not available.
+ * @param allLanguages if `true`, emit `rdfs:label` / `rdfs:comment` as JSON-LD arrays of
+ *                     language-tagged objects sorted by BCP-47 tag; if `false` (default)
+ *                     emit the legacy single-string shape in the user's preferred language.
  */
 case class NodeGetResponseV2(
   node: ListNodeInfoADM,
@@ -201,48 +208,24 @@ case class NodeGetResponseV2(
     appConfig: AppConfig,
     schemaOptions: Set[Rendering],
   ): JsonLDDocument = {
-
-    implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
-
-    // Cache the repeated SmartIri -> ApiV2Complex string conversions used in this response.
-    val listNodeType: IRI     = OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
-    val listNodePosition: IRI =
-      OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString
-    val hasRootNode: IRI = OntologyConstants.KnoraBase.HasRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+    import ListV2Iris.*
 
     val body: JsonLDObject = node match {
 
-      case root: ListRootNodeInfoADM => {
-
-        val label: Option[(IRI, JsonLDValue)] =
-          labelOrCommentJson(root.labels, allLanguages, userLang, fallbackLang)
-            .map(OntologyConstants.Rdfs.Label -> _)
-
-        val comment: Option[(IRI, JsonLDValue)] =
-          labelOrCommentJson(root.comments, allLanguages, userLang, fallbackLang)
-            .map(OntologyConstants.Rdfs.Comment -> _)
-
-        val position: Map[IRI, JsonLDInt] = Map.empty[IRI, JsonLDInt]
-
-        val rootNode = Map.empty[IRI, JsonLDValue]
+      case root: ListRootNodeInfoADM =>
+        val label   = labelEntry(root.labels, allLanguages, userLang, fallbackLang)
+        val comment = commentEntry(root.comments, allLanguages, userLang, fallbackLang)
 
         JsonLDObject(
           Map[IRI, JsonLDValue](
             "@id"   -> JsonLDString(root.id),
             "@type" -> JsonLDString(listNodeType),
-          ) ++ rootNode ++ label ++ comment ++ position,
+          ) ++ label ++ comment,
         )
-      }
 
-      case child: ListChildNodeInfoADM => {
-
-        val label: Option[(IRI, JsonLDValue)] =
-          labelOrCommentJson(child.labels, allLanguages, userLang, fallbackLang)
-            .map(OntologyConstants.Rdfs.Label -> _)
-
-        val comment: Option[(IRI, JsonLDValue)] =
-          labelOrCommentJson(child.comments, allLanguages, userLang, fallbackLang)
-            .map(OntologyConstants.Rdfs.Comment -> _)
+      case child: ListChildNodeInfoADM =>
+        val label   = labelEntry(child.labels, allLanguages, userLang, fallbackLang)
+        val comment = commentEntry(child.comments, allLanguages, userLang, fallbackLang)
 
         val position: Map[IRI, JsonLDInt] = Map(
           listNodePosition -> JsonLDInt(child.position),
@@ -258,7 +241,6 @@ case class NodeGetResponseV2(
             "@type" -> JsonLDString(listNodeType),
           ) ++ rootNode ++ label ++ comment ++ position,
         )
-      }
     }
 
     val context = JsonLDObject(

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
@@ -79,6 +79,17 @@ case class ListGetResponseV2(
 
     implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
+    // Cache the repeated SmartIri -> ApiV2Complex string conversions used in this response.
+    val listNodeType: IRI     = OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+    val listNodePosition: IRI =
+      OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString
+    val hasSubListNode: IRI =
+      OntologyConstants.KnoraBase.HasSubListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+    val hasRootNode: IRI       = OntologyConstants.KnoraBase.HasRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+    val attachedToProject: IRI =
+      OntologyConstants.KnoraBase.AttachedToProject.toSmartIri.toOntologySchema(ApiV2Complex).toString
+    val isRootNode: IRI = OntologyConstants.KnoraBase.IsRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+
     /**
      * Given a [[ListNodeADM]], constructs a [[JsonLDObject]].
      *
@@ -94,14 +105,12 @@ case class ListGetResponseV2(
           .map(OntologyConstants.Rdfs.Comment -> _)
 
       val position: Map[IRI, JsonLDInt] = Map(
-        OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDInt(
-          node.position,
-        ),
+        listNodePosition -> JsonLDInt(node.position),
       )
 
       val children: Map[IRI, JsonLDArray] = if (node.children.nonEmpty) {
         Map(
-          OntologyConstants.KnoraBase.HasSubListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDArray(
+          hasSubListNode -> JsonLDArray(
             node.children.map { (childNode: ListChildNodeADM) =>
               makeNode(childNode) // recursion
             },
@@ -113,16 +122,13 @@ case class ListGetResponseV2(
       }
 
       val nodeHasRootNode: Map[IRI, JsonLDObject] = Map(
-        OntologyConstants.KnoraBase.HasRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDUtil
-          .iriToJsonLDObject(node.hasRootNode),
+        hasRootNode -> JsonLDUtil.iriToJsonLDObject(node.hasRootNode),
       )
 
       JsonLDObject(
         Map[IRI, JsonLDValue](
           "@id"   -> JsonLDString(node.id),
-          "@type" -> JsonLDString(
-            OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString,
-          ),
+          "@type" -> JsonLDString(listNodeType),
         ) ++ position ++ nodeHasRootNode ++ children ++ label ++ comment,
       )
     }
@@ -139,7 +145,7 @@ case class ListGetResponseV2(
 
     val children: Map[IRI, JsonLDArray] = if (list.children.nonEmpty) {
       Map(
-        OntologyConstants.KnoraBase.HasSubListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDArray(
+        hasSubListNode -> JsonLDArray(
           list.children.map { (childNode: ListNodeADM) =>
             makeNode(childNode.asInstanceOf[ListChildNodeADM])
           },
@@ -150,17 +156,14 @@ case class ListGetResponseV2(
     }
 
     val project: Map[IRI, JsonLDObject] = Map(
-      OntologyConstants.KnoraBase.AttachedToProject.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDUtil
-        .iriToJsonLDObject(listinfo.projectIri),
+      attachedToProject -> JsonLDUtil.iriToJsonLDObject(listinfo.projectIri),
     )
 
     val body = rdf.JsonLDObject(
       Map[IRI, JsonLDValue](
-        "@id"   -> JsonLDString(listinfo.id),
-        "@type" -> JsonLDString(
-          OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString,
-        ),
-        OntologyConstants.KnoraBase.IsRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDBoolean(true),
+        "@id"      -> JsonLDString(listinfo.id),
+        "@type"    -> JsonLDString(listNodeType),
+        isRootNode -> JsonLDBoolean(true),
       ) ++ project ++ children ++ label ++ comment,
     )
 
@@ -201,6 +204,12 @@ case class NodeGetResponseV2(
 
     implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
+    // Cache the repeated SmartIri -> ApiV2Complex string conversions used in this response.
+    val listNodeType: IRI     = OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+    val listNodePosition: IRI =
+      OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString
+    val hasRootNode: IRI = OntologyConstants.KnoraBase.HasRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString
+
     val body: JsonLDObject = node match {
 
       case root: ListRootNodeInfoADM => {
@@ -220,9 +229,7 @@ case class NodeGetResponseV2(
         JsonLDObject(
           Map[IRI, JsonLDValue](
             "@id"   -> JsonLDString(root.id),
-            "@type" -> JsonLDString(
-              OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString,
-            ),
+            "@type" -> JsonLDString(listNodeType),
           ) ++ rootNode ++ label ++ comment ++ position,
         )
       }
@@ -238,22 +245,17 @@ case class NodeGetResponseV2(
             .map(OntologyConstants.Rdfs.Comment -> _)
 
         val position: Map[IRI, JsonLDInt] = Map(
-          OntologyConstants.KnoraBase.ListNodePosition.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDInt(
-            child.position,
-          ),
+          listNodePosition -> JsonLDInt(child.position),
         )
 
         val rootNode = Map(
-          OntologyConstants.KnoraBase.HasRootNode.toSmartIri.toOntologySchema(ApiV2Complex).toString -> JsonLDUtil
-            .iriToJsonLDObject(child.hasRootNode),
+          hasRootNode -> JsonLDUtil.iriToJsonLDObject(child.hasRootNode),
         )
 
         JsonLDObject(
           Map[IRI, JsonLDValue](
             "@id"   -> JsonLDString(child.id),
-            "@type" -> JsonLDString(
-              OntologyConstants.KnoraBase.ListNode.toSmartIri.toOntologySchema(ApiV2Complex).toString,
-            ),
+            "@type" -> JsonLDString(listNodeType),
           ) ++ rootNode ++ label ++ comment ++ position,
         )
       }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
@@ -67,7 +67,7 @@ trait ListResponderResponseV2 {
     labelOrCommentJson(seq, allLanguages, userLang, fallbackLang).map(OntologyConstants.Rdfs.Label -> _)
 
   /**
-   * Builds the optional `(rdfs:comment, JsonLDValue)` entry for a node — same dispatch
+   * Builds the optional `(rdfs:comment, JsonLDValue)` entry for a node - same dispatch
    * rules as [[labelEntry]].
    */
   private[listsmessages] def commentEntry(

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2.scala
@@ -23,32 +23,11 @@ import org.knora.webapi.messages.v2.responder.KnoraJsonLDResponseV2
 trait ListResponderResponseV2 {
 
   /**
-   * Given an Iri and a [[StringLiteralSequenceV2]], gets he string value in the user's preferred language.
-   *
-   * @param iri          the Iri pointing to the string value.
-   * @param stringVals   the string values to choose from.
-   * @param userLang     the user's preferred language.
-   * @param fallbackLang the fallback language if the preferred language is not available.
-   * @return a [[Map[IRI, JsonLDString]] (empty in case no string value is available).
-   */
-  def makeMapIriToJSONLDString(
-    iri: IRI,
-    stringVals: StringLiteralSequenceV2,
-    userLang: String,
-    fallbackLang: String,
-  ): Map[IRI, JsonLDString] =
-    Map(
-      iri -> stringVals.getPreferredLanguage(userLang, fallbackLang),
-    ).collect { case (iri: IRI, Some(strVal: String)) =>
-      iri -> JsonLDString(strVal)
-    }
-
-  /**
    * Collapses a [[StringLiteralSequenceV2]] into a map from BCP-47 language tag to value.
    * Untagged literals (`PlainStringLiteralV2`) are skipped (REQ-1.8, D5). When multiple
    * literals share the same language tag, the last one wins via `.toMap` (REQ-1.9, D6).
    */
-  protected def stringLiteralsToLangMap(seq: StringLiteralSequenceV2): Map[String, String] =
+  private[listsmessages] def stringLiteralsToLangMap(seq: StringLiteralSequenceV2): Map[String, String] =
     seq.stringLiterals.collect { case LanguageTaggedStringLiteralV2(value, language) =>
       language.value -> value
     }.toMap
@@ -58,13 +37,13 @@ trait ListResponderResponseV2 {
    * the `allLanguages` flag.
    *
    *   - When `allLanguages` is `true`, returns a [[JsonLDArray]] of language-tagged objects
-   *     (sorted alphabetically by language tag — REQ-1.7, D3) or `None` when the underlying
-   *     sequence has no language-tagged literals (REQ-1.6, D2 — field is then omitted from
-   *     the surrounding `JsonLDObject` via `++ Option`).
+   *     (sort by language tag is delegated to `JsonLDUtil.objectsWithLangsToJsonLDArray` —
+   *     REQ-1.7, D3) or `None` when the underlying sequence has no language-tagged literals
+   *     (REQ-1.6, D2 — field is then omitted from the surrounding `JsonLDObject` via `++ Option`).
    *   - When `allLanguages` is `false`, returns the legacy single [[JsonLDString]] picked by
    *     the user's preferred language with the configured fallback (REQ-1.10, D8 unchanged).
    */
-  protected def labelOrCommentJson(
+  private[listsmessages] def labelOrCommentJson(
     seq: StringLiteralSequenceV2,
     allLanguages: Boolean,
     userLang: String,

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ApiV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ApiV2.scala
@@ -146,6 +146,20 @@ object ApiV2 {
       .map { case (format, schema, rendering) => FormatOptions(format, schema, rendering) }(s =>
         (s.rdfFormat, s.schema, s.rendering),
       )
+
+    /**
+     * Shared `allLanguages` query parameter input used by the v2 ontology and lists
+     * endpoints. When `true`, `rdfs:label` and `rdfs:comment` are returned as JSON-LD
+     * arrays of language-tagged objects (sorted alphabetically by BCP-47 tag). Default
+     * `false` preserves the legacy single-string shape in the user's preferred language.
+     */
+    val allLanguages: EndpointInput.Query[Boolean] =
+      query[Boolean]("allLanguages")
+        .default(false)
+        .description(
+          "If true, return rdfs:label and rdfs:comment as JSON-LD arrays of language-tagged objects " +
+            "(sorted alphabetically by tag). Default false preserves the legacy single-string shape.",
+        )
   }
 
   object Outputs {

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/lists/ListsEndpointsV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/lists/ListsEndpointsV2.scala
@@ -20,8 +20,17 @@ final class ListsEndpointsV2(base: BaseEndpoints) {
       .description("The iri to a list.")
       .example(ListIri.unsafeFrom("http://rdfh.ch/lists/0001/" + UuidUtil.makeRandomBase64EncodedUuid))
 
+  private val allLanguages =
+    query[Boolean]("allLanguages")
+      .default(false)
+      .description(
+        "If true, return rdfs:label and rdfs:comment as JSON-LD arrays of language-tagged objects " +
+          "(sorted alphabetically by tag). Default false preserves the legacy single-string shape.",
+      )
+
   val getV2Lists = base.withUserEndpoint.get
     .in("v2" / "lists" / listIri)
+    .in(allLanguages)
     .in(ApiV2.Inputs.formatOptions)
     .out(ApiV2.Outputs.stringBodyFormatted)
     .out(ApiV2.Outputs.contentTypeHeader)
@@ -29,6 +38,7 @@ final class ListsEndpointsV2(base: BaseEndpoints) {
 
   val getV2Node = base.withUserEndpoint.get
     .in("v2" / "node" / listIri)
+    .in(allLanguages)
     .in(ApiV2.Inputs.formatOptions)
     .out(ApiV2.Outputs.stringBodyFormatted)
     .out(ApiV2.Outputs.contentTypeHeader)

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/lists/ListsEndpointsV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/lists/ListsEndpointsV2.scala
@@ -20,17 +20,9 @@ final class ListsEndpointsV2(base: BaseEndpoints) {
       .description("The iri to a list.")
       .example(ListIri.unsafeFrom("http://rdfh.ch/lists/0001/" + UuidUtil.makeRandomBase64EncodedUuid))
 
-  private val allLanguages =
-    query[Boolean]("allLanguages")
-      .default(false)
-      .description(
-        "If true, return rdfs:label and rdfs:comment as JSON-LD arrays of language-tagged objects " +
-          "(sorted alphabetically by tag). Default false preserves the legacy single-string shape.",
-      )
-
   val getV2Lists = base.withUserEndpoint.get
     .in("v2" / "lists" / listIri)
-    .in(allLanguages)
+    .in(ApiV2.Inputs.allLanguages)
     .in(ApiV2.Inputs.formatOptions)
     .out(ApiV2.Outputs.stringBodyFormatted)
     .out(ApiV2.Outputs.contentTypeHeader)
@@ -38,7 +30,7 @@ final class ListsEndpointsV2(base: BaseEndpoints) {
 
   val getV2Node = base.withUserEndpoint.get
     .in("v2" / "node" / listIri)
-    .in(allLanguages)
+    .in(ApiV2.Inputs.allLanguages)
     .in(ApiV2.Inputs.formatOptions)
     .out(ApiV2.Outputs.stringBodyFormatted)
     .out(ApiV2.Outputs.contentTypeHeader)

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/lists/ListsV2RestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/lists/ListsV2RestService.scala
@@ -27,16 +27,19 @@ final class ListsV2RestService(appConfig: AppConfig, listsResponder: ListsRespon
    *
    * @param user           the user making the request.
    * @param listIri        the Iri of the list's root node.
+   * @param allLanguages   if true, return rdfs:label and rdfs:comment as language-tagged arrays.
    * @param opts           the format options
    *
    * @return the rendered response and the media type
    */
-  def getList(user: User)(listIri: ListIri, opts: FormatOptions): Task[(RenderedResponse, MediaType)] =
+  def getList(
+    user: User,
+  )(listIri: ListIri, allLanguages: Boolean, opts: FormatOptions): Task[(RenderedResponse, MediaType)] =
     listsResponder
       .listGetRequestADM(listIri)
       .flatMap(r => ZIO.getOrFailWith(NotFoundException(s"List $listIri not found."))(r.asOpt[ListGetResponseADM]))
       .map(_.list)
-      .map(ListGetResponseV2(_, user.lang, appConfig.fallbackLanguage))
+      .map(ListGetResponseV2(_, user.lang, appConfig.fallbackLanguage, allLanguages))
       .flatMap(renderer.render(_, opts))
 
   /**
@@ -44,18 +47,21 @@ final class ListsV2RestService(appConfig: AppConfig, listsResponder: ListsRespon
    *
    * @param user           the user making the request.
    * @param nodeIri              the Iri of the list node.
+   * @param allLanguages   if true, return rdfs:label and rdfs:comment as language-tagged arrays.
    * @param opts           the format options
    *
    * @return the rendered response and the media type
    */
-  def getNode(user: User)(nodeIri: ListIri, opts: FormatOptions): Task[(RenderedResponse, MediaType)] =
+  def getNode(
+    user: User,
+  )(nodeIri: ListIri, allLanguages: Boolean, opts: FormatOptions): Task[(RenderedResponse, MediaType)] =
     listsResponder
       .listNodeInfoGetRequestADM(nodeIri)
       .flatMap(r =>
         ZIO.getOrFailWith(NotFoundException(s"Node $nodeIri not found."))(r.asOpt[ChildNodeInfoGetResponseADM]),
       )
       .map(_.nodeinfo)
-      .map(NodeGetResponseV2(_, user.lang, appConfig.fallbackLanguage))
+      .map(NodeGetResponseV2(_, user.lang, appConfig.fallbackLanguage, allLanguages))
       .flatMap(renderer.render(_, opts))
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologiesEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v2/ontologies/OntologiesEndpoints.scala
@@ -42,7 +42,7 @@ final class OntologiesEndpoints(baseEndpoints: BaseEndpoints) {
   private val resourceClassIriPath = path[IriDto].name("resourceClassIri")
   private val classIriPath         = path[IriDto].name("classIri")
   private val lastModificationDate = query[LastModificationDate]("lastModificationDate")
-  private val allLanguages         = query[Boolean]("allLanguages").default(false)
+  private val allLanguages         = ApiV2.Inputs.allLanguages
 
   val getOntologyPathSegments = baseEndpoints.withUserEndpoint.get
     .in("ontology" / paths)

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2Spec.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.messages.v2.responder.listsmessages
+
+import zio.test.*
+
+import org.knora.webapi.messages.store.triplestoremessages.LanguageTaggedStringLiteralV2
+import org.knora.webapi.messages.store.triplestoremessages.PlainStringLiteralV2
+import org.knora.webapi.messages.store.triplestoremessages.StringLiteralSequenceV2
+import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
+import org.knora.webapi.messages.util.rdf.JsonLDArray
+import org.knora.webapi.messages.util.rdf.JsonLDKeywords
+import org.knora.webapi.messages.util.rdf.JsonLDObject
+import org.knora.webapi.messages.util.rdf.JsonLDString
+import org.knora.webapi.slice.common.domain.LanguageCode
+
+/**
+ * Tests for the new helpers on [[ListResponderResponseV2]] that drive
+ * `?allLanguages=true` emission for `rdfs:label` and `rdfs:comment`.
+ *
+ * Decisions defended:
+ *   - D2 (omission): an empty / untagged-only sequence yields `None` in all-languages mode.
+ *   - D3 (sort): output array is sorted by BCP-47 tag, regardless of input order.
+ *   - D5 (skip untagged): `PlainStringLiteralV2` entries are dropped.
+ *   - D6 (last-wins dedup): repeated tags collapse via `.toMap`, last entry wins.
+ *   - D8 (legacy unchanged): with `allLanguages=false` the helper preserves the
+ *     single-string shape and language selection of the legacy code path.
+ */
+object ListsMessagesV2Spec extends ZIOSpecDefault {
+
+  // Expose protected helpers for unit testing.
+  private object Helpers extends ListResponderResponseV2 {
+    def callStringLiteralsToLangMap(seq: StringLiteralSequenceV2): Map[String, String] =
+      stringLiteralsToLangMap(seq)
+
+    def callLabelOrCommentJson(
+      seq: StringLiteralSequenceV2,
+      allLanguages: Boolean,
+      userLang: String,
+      fallbackLang: String,
+    ) = labelOrCommentJson(seq, allLanguages, userLang, fallbackLang)
+  }
+
+  private def lit(value: String, lang: LanguageCode): StringLiteralV2 =
+    LanguageTaggedStringLiteralV2(value, lang)
+
+  private def plain(value: String): StringLiteralV2 = PlainStringLiteralV2(value)
+
+  private def seqOf(literals: StringLiteralV2*): StringLiteralSequenceV2 =
+    StringLiteralSequenceV2(literals.toVector)
+
+  def spec: Spec[Any, Any] = suite("ListsMessagesV2Spec")(
+    stringLiteralsToLangMapTests,
+    labelOrCommentJsonAllLanguagesTests,
+    labelOrCommentJsonLegacyTests,
+  )
+
+  private val stringLiteralsToLangMapTests = suite("stringLiteralsToLangMap")(
+    test("skips PlainStringLiteralV2 and applies last-wins dedup on repeated tags (D5, D6)") {
+      // Mixed input: two German entries (de wins last), one English, one untagged.
+      val input = seqOf(
+        lit("a", LanguageCode.DE),
+        lit("b", LanguageCode.EN),
+        plain("c"),
+        lit("a2", LanguageCode.DE),
+      )
+      val actual = Helpers.callStringLiteralsToLangMap(input)
+      assertTrue(
+        actual == Map("de" -> "a2", "en" -> "b"),
+      )
+    },
+    test("empty sequence yields empty map") {
+      val actual = Helpers.callStringLiteralsToLangMap(StringLiteralSequenceV2.empty)
+      assertTrue(actual.isEmpty)
+    },
+    test("untagged-only sequence yields empty map (D5)") {
+      val input  = seqOf(plain("only-untagged"))
+      val actual = Helpers.callStringLiteralsToLangMap(input)
+      assertTrue(actual.isEmpty)
+    },
+  )
+
+  private val labelOrCommentJsonAllLanguagesTests = suite("labelOrCommentJson (allLanguages=true)")(
+    test("non-alphabetical input is sorted by language tag (D3 — defeats Learning #7)") {
+      // Input order [fr, de, en] must produce output sorted as [de, en, fr].
+      val input = seqOf(
+        lit("Bonjour", LanguageCode.FR),
+        lit("Hallo", LanguageCode.DE),
+        lit("Hello", LanguageCode.EN),
+      )
+      val actual = Helpers.callLabelOrCommentJson(
+        seq = input,
+        allLanguages = true,
+        userLang = "en",
+        fallbackLang = "en",
+      )
+      val expected = JsonLDArray(
+        Seq(
+          JsonLDObject(
+            Map(JsonLDKeywords.VALUE -> JsonLDString("Hallo"), JsonLDKeywords.LANGUAGE -> JsonLDString("de")),
+          ),
+          JsonLDObject(
+            Map(JsonLDKeywords.VALUE -> JsonLDString("Hello"), JsonLDKeywords.LANGUAGE -> JsonLDString("en")),
+          ),
+          JsonLDObject(
+            Map(JsonLDKeywords.VALUE -> JsonLDString("Bonjour"), JsonLDKeywords.LANGUAGE -> JsonLDString("fr")),
+          ),
+        ),
+      )
+      assertTrue(actual.contains(expected))
+    },
+    test("empty sequence returns None (D2 omission)") {
+      val actual = Helpers.callLabelOrCommentJson(
+        seq = StringLiteralSequenceV2.empty,
+        allLanguages = true,
+        userLang = "en",
+        fallbackLang = "en",
+      )
+      assertTrue(actual.isEmpty)
+    },
+    test("untagged-only sequence returns None (D2 + D5)") {
+      val actual = Helpers.callLabelOrCommentJson(
+        seq = seqOf(plain("untagged")),
+        allLanguages = true,
+        userLang = "en",
+        fallbackLang = "en",
+      )
+      assertTrue(actual.isEmpty)
+    },
+  )
+
+  private val labelOrCommentJsonLegacyTests = suite("labelOrCommentJson (allLanguages=false)")(
+    test("returns a single JsonLDString picked by userLang (D8 unchanged)") {
+      val input = seqOf(
+        lit("Hallo", LanguageCode.DE),
+        lit("Hello", LanguageCode.EN),
+        lit("Bonjour", LanguageCode.FR),
+      )
+      val actual = Helpers.callLabelOrCommentJson(
+        seq = input,
+        allLanguages = false,
+        userLang = "de",
+        fallbackLang = "en",
+      )
+      assertTrue(actual.contains(JsonLDString("Hallo")))
+    },
+    test("falls back to fallbackLang when userLang is missing (D8 unchanged)") {
+      val input = seqOf(
+        lit("Hello", LanguageCode.EN),
+        lit("Bonjour", LanguageCode.FR),
+      )
+      val actual = Helpers.callLabelOrCommentJson(
+        seq = input,
+        allLanguages = false,
+        userLang = "de",
+        fallbackLang = "en",
+      )
+      assertTrue(actual.contains(JsonLDString("Hello")))
+    },
+  )
+}

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2Spec.scala
@@ -31,18 +31,9 @@ import org.knora.webapi.slice.common.domain.LanguageCode
  */
 object ListsMessagesV2Spec extends ZIOSpecDefault {
 
-  // Expose protected helpers for unit testing.
-  private object Helpers extends ListResponderResponseV2 {
-    def callStringLiteralsToLangMap(seq: StringLiteralSequenceV2): Map[String, String] =
-      stringLiteralsToLangMap(seq)
-
-    def callLabelOrCommentJson(
-      seq: StringLiteralSequenceV2,
-      allLanguages: Boolean,
-      userLang: String,
-      fallbackLang: String,
-    ) = labelOrCommentJson(seq, allLanguages, userLang, fallbackLang)
-  }
+  // The helpers under test are `private[listsmessages]` on the trait; instantiate
+  // it once here so the spec can drive them directly without an access shim.
+  private val sut: ListResponderResponseV2 = new ListResponderResponseV2 {}
 
   private def lit(value: String, lang: LanguageCode): StringLiteralV2 =
     LanguageTaggedStringLiteralV2(value, lang)
@@ -67,18 +58,18 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
         plain("c"),
         lit("a2", LanguageCode.DE),
       )
-      val actual = Helpers.callStringLiteralsToLangMap(input)
+      val actual = sut.stringLiteralsToLangMap(input)
       assertTrue(
         actual == Map("de" -> "a2", "en" -> "b"),
       )
     },
     test("empty sequence yields empty map") {
-      val actual = Helpers.callStringLiteralsToLangMap(StringLiteralSequenceV2.empty)
+      val actual = sut.stringLiteralsToLangMap(StringLiteralSequenceV2.empty)
       assertTrue(actual.isEmpty)
     },
     test("untagged-only sequence yields empty map (D5)") {
       val input  = seqOf(plain("only-untagged"))
-      val actual = Helpers.callStringLiteralsToLangMap(input)
+      val actual = sut.stringLiteralsToLangMap(input)
       assertTrue(actual.isEmpty)
     },
   )
@@ -91,7 +82,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
         lit("Hallo", LanguageCode.DE),
         lit("Hello", LanguageCode.EN),
       )
-      val actual = Helpers.callLabelOrCommentJson(
+      val actual = sut.labelOrCommentJson(
         seq = input,
         allLanguages = true,
         userLang = "en",
@@ -113,7 +104,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
       assertTrue(actual.contains(expected))
     },
     test("empty sequence returns None (D2 omission)") {
-      val actual = Helpers.callLabelOrCommentJson(
+      val actual = sut.labelOrCommentJson(
         seq = StringLiteralSequenceV2.empty,
         allLanguages = true,
         userLang = "en",
@@ -122,7 +113,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
       assertTrue(actual.isEmpty)
     },
     test("untagged-only sequence returns None (D2 + D5)") {
-      val actual = Helpers.callLabelOrCommentJson(
+      val actual = sut.labelOrCommentJson(
         seq = seqOf(plain("untagged")),
         allLanguages = true,
         userLang = "en",
@@ -139,7 +130,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
         lit("Hello", LanguageCode.EN),
         lit("Bonjour", LanguageCode.FR),
       )
-      val actual = Helpers.callLabelOrCommentJson(
+      val actual = sut.labelOrCommentJson(
         seq = input,
         allLanguages = false,
         userLang = "de",
@@ -152,7 +143,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
         lit("Hello", LanguageCode.EN),
         lit("Bonjour", LanguageCode.FR),
       )
-      val actual = Helpers.callLabelOrCommentJson(
+      val actual = sut.labelOrCommentJson(
         seq = input,
         allLanguages = false,
         userLang = "de",

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2Spec.scala
@@ -7,6 +7,7 @@ package org.knora.webapi.messages.v2.responder.listsmessages
 
 import zio.test.*
 
+import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.store.triplestoremessages.LanguageTaggedStringLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.PlainStringLiteralV2
 import org.knora.webapi.messages.store.triplestoremessages.StringLiteralSequenceV2
@@ -18,16 +19,16 @@ import org.knora.webapi.messages.util.rdf.JsonLDString
 import org.knora.webapi.slice.common.domain.LanguageCode
 
 /**
- * Tests for the new helpers on [[ListResponderResponseV2]] that drive
+ * Tests the language-handling helpers on [[ListResponderResponseV2]] that drive
  * `?allLanguages=true` emission for `rdfs:label` and `rdfs:comment`.
  *
- * Decisions defended:
- *   - D2 (omission): an empty / untagged-only sequence yields `None` in all-languages mode.
- *   - D3 (sort): output array is sorted by BCP-47 tag, regardless of input order.
- *   - D5 (skip untagged): `PlainStringLiteralV2` entries are dropped.
- *   - D6 (last-wins dedup): repeated tags collapse via `.toMap`, last entry wins.
- *   - D8 (legacy unchanged): with `allLanguages=false` the helper preserves the
- *     single-string shape and language selection of the legacy code path.
+ * Behaviours covered:
+ *   - all-languages mode omits the field when no language-tagged literals exist
+ *   - all-languages output is sorted by BCP-47 tag
+ *   - untagged (`PlainStringLiteralV2`) entries are skipped
+ *   - repeated tags collapse via `.toMap`, last entry wins
+ *   - legacy single-string mode preserves the existing language-selection behaviour
+ *   - `labelEntry` / `commentEntry` attach the correct predicate IRI
  */
 object ListsMessagesV2Spec extends ZIOSpecDefault {
 
@@ -44,39 +45,13 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
     StringLiteralSequenceV2(literals.toVector)
 
   def spec: Spec[Any, Any] = suite("lists v2 label/comment emission helpers")(
-    stringLiteralsToLangMapTests,
     labelOrCommentJsonAllLanguagesTests,
     labelOrCommentJsonLegacyTests,
-  )
-
-  private val stringLiteralsToLangMapTests = suite("stringLiteralsToLangMap")(
-    test("skips PlainStringLiteralV2 and applies last-wins dedup on repeated tags (D5, D6)") {
-      // Mixed input: two German entries (de wins last), one English, one untagged.
-      val input = seqOf(
-        lit("a", LanguageCode.DE),
-        lit("b", LanguageCode.EN),
-        plain("c"),
-        lit("a2", LanguageCode.DE),
-      )
-      val actual = sut.stringLiteralsToLangMap(input)
-      assertTrue(
-        actual == Map("de" -> "a2", "en" -> "b"),
-      )
-    },
-    test("empty sequence yields empty map") {
-      val actual = sut.stringLiteralsToLangMap(StringLiteralSequenceV2.empty)
-      assertTrue(actual.isEmpty)
-    },
-    test("untagged-only sequence yields empty map (D5)") {
-      val input  = seqOf(plain("only-untagged"))
-      val actual = sut.stringLiteralsToLangMap(input)
-      assertTrue(actual.isEmpty)
-    },
+    entryHelperTests,
   )
 
   private val labelOrCommentJsonAllLanguagesTests = suite("labelOrCommentJson (allLanguages=true)")(
-    test("non-alphabetical input is sorted by language tag (D3 — defeats Learning #7)") {
-      // Input order [fr, de, en] must produce output sorted as [de, en, fr].
+    test("non-alphabetical input is sorted by language tag") {
       val input = seqOf(
         lit("Bonjour", LanguageCode.FR),
         lit("Hallo", LanguageCode.DE),
@@ -103,7 +78,32 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
       )
       assertTrue(actual.contains(expected))
     },
-    test("empty sequence returns None (D2 omission)") {
+    test("untagged literals are skipped and last-wins applies on repeated tags") {
+      val input = seqOf(
+        lit("a", LanguageCode.DE),
+        lit("b", LanguageCode.EN),
+        plain("c"),
+        lit("a2", LanguageCode.DE),
+      )
+      val actual = sut.labelOrCommentJson(
+        seq = input,
+        allLanguages = true,
+        userLang = "en",
+        fallbackLang = "en",
+      )
+      val expected = JsonLDArray(
+        Seq(
+          JsonLDObject(
+            Map(JsonLDKeywords.VALUE -> JsonLDString("a2"), JsonLDKeywords.LANGUAGE -> JsonLDString("de")),
+          ),
+          JsonLDObject(
+            Map(JsonLDKeywords.VALUE -> JsonLDString("b"), JsonLDKeywords.LANGUAGE -> JsonLDString("en")),
+          ),
+        ),
+      )
+      assertTrue(actual.contains(expected))
+    },
+    test("empty sequence returns None (field is omitted)") {
       val actual = sut.labelOrCommentJson(
         seq = StringLiteralSequenceV2.empty,
         allLanguages = true,
@@ -112,7 +112,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
       )
       assertTrue(actual.isEmpty)
     },
-    test("untagged-only sequence returns None (D2 + D5)") {
+    test("untagged-only sequence returns None") {
       val actual = sut.labelOrCommentJson(
         seq = seqOf(plain("untagged")),
         allLanguages = true,
@@ -124,7 +124,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
   )
 
   private val labelOrCommentJsonLegacyTests = suite("labelOrCommentJson (allLanguages=false)")(
-    test("returns a single JsonLDString picked by userLang (D8 unchanged)") {
+    test("returns a single JsonLDString picked by userLang") {
       val input = seqOf(
         lit("Hallo", LanguageCode.DE),
         lit("Hello", LanguageCode.EN),
@@ -138,7 +138,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
       )
       assertTrue(actual.contains(JsonLDString("Hallo")))
     },
-    test("falls back to fallbackLang when userLang is missing (D8 unchanged)") {
+    test("falls back to fallbackLang when userLang is missing") {
       val input = seqOf(
         lit("Hello", LanguageCode.EN),
         lit("Bonjour", LanguageCode.FR),
@@ -150,6 +150,27 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
         fallbackLang = "en",
       )
       assertTrue(actual.contains(JsonLDString("Hello")))
+    },
+  )
+
+  private val entryHelperTests = suite("labelEntry / commentEntry")(
+    test("labelEntry attaches rdfs:label as the key") {
+      val input  = seqOf(lit("Hello", LanguageCode.EN))
+      val actual = sut.labelEntry(input, allLanguages = false, userLang = "en", fallbackLang = "en")
+      assertTrue(actual.map(_._1).contains(OntologyConstants.Rdfs.Label))
+    },
+    test("commentEntry attaches rdfs:comment as the key") {
+      val input  = seqOf(lit("note", LanguageCode.EN))
+      val actual = sut.commentEntry(input, allLanguages = false, userLang = "en", fallbackLang = "en")
+      assertTrue(actual.map(_._1).contains(OntologyConstants.Rdfs.Comment))
+    },
+    test("labelEntry returns None when no value would be emitted") {
+      val actual = sut.labelEntry(StringLiteralSequenceV2.empty, allLanguages = true, "en", "en")
+      assertTrue(actual.isEmpty)
+    },
+    test("commentEntry returns None when no value would be emitted") {
+      val actual = sut.commentEntry(StringLiteralSequenceV2.empty, allLanguages = true, "en", "en")
+      assertTrue(actual.isEmpty)
     },
   )
 }

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/listsmessages/ListsMessagesV2Spec.scala
@@ -43,7 +43,7 @@ object ListsMessagesV2Spec extends ZIOSpecDefault {
   private def seqOf(literals: StringLiteralV2*): StringLiteralSequenceV2 =
     StringLiteralSequenceV2(literals.toVector)
 
-  def spec: Spec[Any, Any] = suite("ListsMessagesV2Spec")(
+  def spec: Spec[Any, Any] = suite("lists v2 label/comment emission helpers")(
     stringLiteralsToLangMapTests,
     labelOrCommentJsonAllLanguagesTests,
     labelOrCommentJsonLegacyTests,


### PR DESCRIPTION
[DEV-6554](https://linear.app/dasch/issue/DEV-6554)

## Summary

Adds an opt-in `?allLanguages=true` query parameter to `GET /v2/lists/{listIri}` and `GET /v2/node/{listIri}`, mirroring the existing parameter on the ontology-information endpoint.

When set, the response includes **all** language variants of `rdfs:label` and `rdfs:comment` as JSON-LD arrays of language-tagged objects, sorted alphabetically by BCP-47 tag. Default behaviour is unchanged.

## Response shape

The flag changes the JSON-LD shape, not just the content:

| Mode | `rdfs:label` shape | Languages returned |
|---|---|---|
| default (omitted / `false`) | plain string | only the requested language; nodes without a label in that language omit it |
| `?allLanguages=true` | array of `{ "@value", "@language" }` objects | all available languages |

Clients relying on the default string shape are unaffected.

## Changes

- `ListsEndpointsV2`: new `allLanguages` Tapir query parameter (default `false`).
- `ListsV2RestService.getList` / `getNode` and `ListGetResponseV2` / `NodeGetResponseV2`: threaded through the new flag.
- `ListResponderResponseV2`: new `stringLiteralsToLangMap` / `labelOrCommentJson` helpers; replaces the four `makeMapIriToJSONLDString` call sites in `ListsMessagesV2`. Empty values omitted, languages sorted by BCP-47 tag, untagged literals skipped, last-wins on duplicates.
- Unit tests for the emitter invariants (`ListsMessagesV2Spec`).
- Four new JSON-LD fixtures + e2e tests covering the all-languages shape and language-input independence; default-mode regression coverage retained.
- Docs: new "All-languages mode" section in `docs/03-endpoints/api-v2/getting-lists.md` with before/after examples.

## Test Plan

- [x] `sbt compile` / `sbt scalafmtCheckAll` clean
- [x] Unit tests pass (`ListsMessagesV2Spec`)
- [x] E2E tests pass on CI

## Spec

- PRD: `dasch-specs/specs/2026-06-23-lists-v2-multi-language-labels-and-comments/01-lists-v2-multi-language-labels-and-comments-PRD.md`
- Plan: `dasch-specs/specs/2026-06-23-lists-v2-multi-language-labels-and-comments/02-feat-lists-v2-allLanguages-plan.md`