### PR TITLE
feat: expose mime type and direct file link in OAI metadata records (DEV-6684)

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/api/v3/export/MetadataRecord.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/v3/export/MetadataRecord.scala
@@ -42,6 +42,16 @@ object LegalInfo {
   )
 }
 
+// A downloadable file belonging to a record: its MIME type and a direct download link.
+final case class FileLink(
+  mimeType: String,
+  url: String,
+)
+
+object FileLink {
+  implicit val codec: JsonCodec[FileLink] = DeriveJsonCodec.gen[FileLink]
+}
+
 final case class MetadataRecord(
   id: String,
   pid: String,
@@ -58,6 +68,7 @@ final case class MetadataRecord(
   typeOfData: Option[String],
   size: Option[String],
   keywords: List[LangString],
+  file: Option[FileLink],
 )
 
 object MetadataRecord {

--- a/webapi/src/main/scala/org/knora/webapi/slice/export/api/service/ExportService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/export/api/service/ExportService.scala
@@ -27,6 +27,7 @@ import org.knora.webapi.messages.v2.responder.ontologymessages.ReadPropertyInfoV
 import org.knora.webapi.messages.v2.responder.resourcemessages.ReadResourceV2
 import org.knora.webapi.messages.v2.responder.standoffmessages.StandoffTagStringAttributeV2
 import org.knora.webapi.messages.v2.responder.valuemessages.AudioFileValueContentV2
+import org.knora.webapi.messages.v2.responder.valuemessages.FileValueContentV2
 import org.knora.webapi.messages.v2.responder.valuemessages.GeonameValueContentV2
 import org.knora.webapi.messages.v2.responder.valuemessages.HierarchicalListValueContentV2
 import org.knora.webapi.messages.v2.responder.valuemessages.LinkValueContentV2
@@ -40,6 +41,7 @@ import org.knora.webapi.responders.admin.ListsResponder
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.api.v3.`export`.FileLink
 import org.knora.webapi.slice.api.v3.`export`.LegalInfo
 import org.knora.webapi.slice.api.v3.`export`.MetadataRecord
 import org.knora.webapi.slice.api.v3.export_.ExportedResource
@@ -112,6 +114,7 @@ final case class ExportService(
                     typeOfData = typeOfDataOf(r),
                     size = None,
                     keywords = List.empty,
+                    file = fileLinkOf(project, r),
                   )
                 }
     } yield records.toJsonPretty
@@ -135,6 +138,16 @@ final case class ExportService(
       case _: AudioFileValueContentV2                                                => "Sound"
       case _: TextFileValueContentV2                                                 => "Text"
       case _: TextValueContentV2                                                     => "Text"
+    }
+
+  private def fileLinkOf(project: KnoraProject, r: ReadResourceV2): Option[FileLink] =
+    r.values.values.flatten.map(_.valueContent).collectFirst { case fc: FileValueContentV2 =>
+      val internalFilename = fc.fileValue.internalFilename
+      val assetId          = internalFilename.takeWhile(_ != '.')
+      FileLink(
+        mimeType = fc.fileValue.internalMimeType,
+        url = s"${appConfig.dspIngest.baseUrl}/projects/${project.shortcode.value}/assets/$assetId/original",
+      )
     }
 
   def exportResources(

--- a/webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec-1612-data.ttl
+++ b/webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec-1612-data.ttl
@@ -490,6 +490,32 @@ PREFIX xsd:         <http://www.w3.org/2001/XMLSchema#>
         knora-base:hasPermissions     "CR knora-admin:ProjectAdmin|D knora-admin:ProjectMember";
         knora-base:isDeleted          false .
 
+<http://rdfh.ch/1612/ImageResource>
+        rdf:type                          <http://www.knora.org/ontology/1612/Data#ImageTestClass>;
+        rdfs:label                        "ImageResource";
+        knora-base:hasStillImageFileValue <http://rdfh.ch/1612/ImageResource/values/imageFileVal>;
+        knora-base:attachedToProject      <http://rdfh.ch/projects/Vk0NruDmRyeZCZvOVwXOnw>;
+        knora-base:attachedToUser         <http://rdfh.ch/users/NK3AQVhRS-mciGJN3vF2fQ>;
+        knora-base:creationDate           "2026-03-19T10:00:00.000000Z"^^xsd:dateTime;
+        knora-base:hasPermissions         "CR knora-admin:ProjectAdmin|D knora-admin:ProjectMember";
+        knora-base:isDeleted              false .
+
+<http://rdfh.ch/1612/ImageResource/values/imageFileVal>
+        rdf:type                      knora-base:StillImageFileValue;
+        knora-base:valueHasUUID       "imageFileValUUID000000"^^xsd:string;
+        knora-base:valueHasString     "B1D0OkEgfFp-Cew2Seur7Wi.jp2";
+        knora-base:originalFilename   "test.tiff";
+        knora-base:originalMimeType   "image/tiff";
+        knora-base:internalFilename   "B1D0OkEgfFp-Cew2Seur7Wi.jp2";
+        knora-base:internalMimeType   "image/jp2";
+        knora-base:dimX               512;
+        knora-base:dimY               256;
+        knora-base:attachedToProject  <http://rdfh.ch/projects/Vk0NruDmRyeZCZvOVwXOnw>;
+        knora-base:attachedToUser     <http://rdfh.ch/users/NK3AQVhRS-mciGJN3vF2fQ>;
+        knora-base:valueCreationDate  "2026-03-19T10:00:00.000000Z"^^xsd:dateTime;
+        knora-base:hasPermissions     "CR knora-admin:ProjectAdmin|D knora-admin:ProjectMember";
+        knora-base:isDeleted          false .
+
 <http://rdfh.ch/lists/1612/PCkZVGmXQ9uMnkpyEU-4-Q>
         rdf:type                      knora-base:ListNode;
         rdfs:comment                  "Vocabulary of Funk"@en;

--- a/webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec-1612-onto.ttl
+++ b/webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec-1612-onto.ttl
@@ -171,6 +171,11 @@ PREFIX xsd:         <http://www.w3.org/2001/XMLSchema#>
         rdfs:label       "OrderingTestClass"@en;
         rdfs:subClassOf  knora-base:Resource .
 
+<http://www.knora.org/ontology/1612/Data#ImageTestClass>
+        rdf:type         owl:Class;
+        rdfs:label       "ImageTestClass"@en;
+        rdfs:subClassOf  knora-base:StillImageRepresentation .
+
 <http://www.knora.org/ontology/1612/Data>
         rdf:type                      owl:Ontology;
         rdfs:comment                  "Comment";

--- a/webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec__oai.txt
+++ b/webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec__oai.txt
@@ -369,5 +369,34 @@
     "datePublished" : "2026-03-18T10:00:00Z",
     "typeOfData" : "Text",
     "keywords" : []
+  },
+  {
+    "id" : "http://rdfh.ch/1612/ImageResource",
+    "pid" : "http://0.0.0.0:3336/ark:/72163/1/1612/ImageResourceP",
+    "label" : {
+      "en" : "ImageResource"
+    },
+    "accessRights" : "Full Open Access",
+    "legalInfo" : {
+      "license" : {
+        "licenseIdentifier" : "public domain",
+        "licenseDate" : "2023-01-01",
+        "licenseURI" : "https://creativecommons.org/publicdomain/zero/1.0/"
+      },
+      "copyrightHolder" : "DaSCH",
+      "authorship" : [
+        "DaSCH"
+      ]
+    },
+    "howToCite" : "ImageResource",
+    "publisher" : "DaSCH",
+    "dateCreated" : "2026-03-19T10:00:00Z",
+    "datePublished" : "2026-03-19T10:00:00Z",
+    "typeOfData" : "Image",
+    "keywords" : [],
+    "file" : {
+      "mimeType" : "image/jp2",
+      "url" : "http://localhost:3340/projects/1612/assets/B1D0OkEgfFp-Cew2Seur7Wi/original"
+    }
   }
 ]


### PR DESCRIPTION
Add an optional `file` field to the OAI `MetadataRecord` produced by `exportResourcesOai`. For resources that carry a file value, it exposes the internal MIME type and a direct download link to the dsp-ingest "original" endpoint (`/projects/{shortcode}/assets/{assetId}/original`). A resource has at most one file value, so the first one found is used (mirroring typeOfData).