### PR TITLE
test: harden flaky maintenance replace-user-iri auth e2e tests

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/MaintenanceReplaceUserIriInProjectE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/MaintenanceReplaceUserIriInProjectE2ESpec.scala
@@ -8,6 +8,7 @@ package org.knora.webapi.slice.api.admin
 import sttp.client4.UriContext
 import sttp.model.StatusCode
 import zio.ZIO
+import zio.durationInt
 import zio.json.ast.Json
 import zio.test.*
 
@@ -85,7 +86,7 @@ object MaintenanceReplaceUserIriInProjectE2ESpec extends E2EZSpec {
           replaceBody(normalUser.id, "http://rdfh.ch/users/e2e-new"),
         )
         .map(response => assertTrue(response.code == StatusCode.Unauthorized))
-    },
+    } @@ TestAspect.timeout(30.seconds) @@ TestAspect.flaky,
     test("returns 403 when the authenticated user is not SystemAdmin") {
       TestApiClient
         .postJson[Json, Json](
@@ -94,7 +95,7 @@ object MaintenanceReplaceUserIriInProjectE2ESpec extends E2EZSpec {
           normalUser,
         )
         .map(response => assertTrue(response.code == StatusCode.Forbidden))
-    },
+    } @@ TestAspect.timeout(30.seconds) @@ TestAspect.flaky,
     test("does not reject a built-in user IRI as oldIri (re-attributing SystemUser refs is valid)") {
       // No isBuiltInUser guard is applied at the RestService level for
       // this endpoint. A built-in oldIri is intentionally accepted - re-attributing references


### PR DESCRIPTION
## Problem

`MaintenanceReplaceUserIriInProjectE2ESpec` occasionally fails in CI on its trivial auth check (`POST .../replace-user-iri – returns 403 when the authenticated user is not SystemAdmin`), e.g. [run 28460412230](https://github.com/dasch-swiss/dsp-api/actions/runs/28460412230) (which passed on rerun).

The failure mode is a **`HttpTimeoutException` — the server returned no response within the 120s client read timeout**, not a wrong status code. The test does no fixture setup and no data rewrite, and it runs *before* the heavy triple-rewriting tests in the same suite. So neither the maintenance feature nor the test logic is at fault.

## Root cause

e2e-runner resource contention on a shared docker host. Each e2e spec boots its **own** full stack (Fuseki + Sipi + dsp-ingest + a `zio-http` API server on the fixed port 3333) via testcontainers through `E2EZSpec.bootstrap`, and tears it all down again when the spec's `Scope` closes.

That teardown is slow and the warning it produces is deterministic, not random. ZIO Test logs `"closing the scope of suite … taken more than 60 seconds … may indicate a resource leak"` on **every** CI run for the same data-heavy specs (`OntologyResponderV2Spec`, `SearchResponderV2GravsearchSpanE2ESpec`, `ProjectMigrationExportE2ESpec`). The container finalizer (`TestContainerOps`) runs `container.stop()` (a blocking ~10s-grace `docker stop`) inside `ZIO.succeed`, blocking a runtime thread, and stops the three containers serially. On a saturated runner this is exactly the kind of contention that leaves an unrelated spec's request hanging until the 120s timeout.

## Change (this PR — symptom mitigation only)

Mark the two assertion-free auth tests (401/403) with `@@ TestAspect.timeout(30.seconds) @@ TestAspect.flaky`, matching the existing pattern already applied to other admin/auth e2e tests (`AdminUsersProjectMemberShipsEndpointsE2ESpec`, `AdminUsersGroupMembershipsEndpointsE2ESpec`, `AdminUsersEndpointsE2ESpec`). The timeout fails fast (30s instead of 120s) and the flaky aspect retries, so a transient stall no longer fails the whole build.

The underlying teardown problem (blocking `docker stop` in `ZIO.succeed`, serial container shutdown) is a separate, higher-leverage fix tracked in its own PR.

## Verification

- `test-e2e/Test/compile` ✅
- `test-e2e/Test/scalafmtCheck` ✅
- `test-e2e/testOnly *MaintenanceReplaceUserIriInProjectE2ESpec*` → 12 tests passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)