### PR TITLE
test: fix ~60s e2e suite teardown hang from forked server fiber

### DIFF
--- a/modules/testkit/src/main/scala/org/knora/webapi/E2EZSpec.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/E2EZSpec.scala
@@ -64,7 +64,11 @@ abstract class E2EZSpec extends ZIOSpec[E2EZSpec.Environment] {
   private def prepare = for {
     _ <- Db.initWithTestData(rdfDataObjects)
     _ <- ZIO.serviceWithZIO[CacheManager](_.clearAll())
-    _ <- (DspApiServer.startup *> ZIO.never).provideSomeAuto(DspApiServer.layer).forkScoped
+    // Build the server layer into the spec Scope rather than forking `startup *> ZIO.never`:
+    // the forked keepalive fiber's interruption tangled with its nested layer scope and hung
+    // suite teardown ~60s before reaching the zio-http shutdown.
+    built <- DspApiServer.layer.build
+    _     <- built.get[DspApiServer].startup()
     // wait max 5 seconds until api is ready
     _ <- TestApiClient
            .getJson[Json](uri"/version")


### PR DESCRIPTION
## Problem

Every e2e spec (`E2EZSpec`) started the API server as:

```scala
_ <- (DspApiServer.startup *> ZIO.never).provideSomeAuto(DspApiServer.layer).forkScoped
```

At suite teardown, ZIO Test consistently logged:

> `Warning: ZIO Test is attempting to close the scope of suite … has taken more than 60 seconds to complete. This may indicate a resource leak.`

This fires on **every CI run** for the data-heaviest specs (`OntologyResponderV2Spec`, `SearchResponderV2GravsearchSpanE2ESpec`, `ProjectMigrationExportE2ESpec`), and locally *every* spec pays a ~60s teardown. It inflates the e2e job runtime and is the underlying resource contention behind occasional request-timeout flakes (e.g. the `MaintenanceReplaceUserIriInProjectE2ESpec` 403 timeout).

## Root cause

Not Netty, and not the server's shutdown work. It's ZIO scope teardown of the *wrapper*:

- `forkScoped` runs the fiber as `restore(self).onExit(child.close(_))` and registers `child.addFinalizer(interrupt(fiber))`. At teardown, a finalizer fiber runs `interruptAs(serverFiber)` and **awaits** the `ZIO.never` keepalive fiber.
- Because `self` was `(startup *> never).provideSomeAuto(DspApiServer.layer)`, the **entire server layer scope — including its own inner `forkScoped` zio-http driver fiber — was nested inside that keepalive fiber**. Interrupting it had to unwind the nested scope while the fiber's own `onExit(child.close)` re-entered the same scope being closed. That interruption/reentrancy stalled ~60s and **never progressed to the Netty shutdown** — which is why the event loops sat idle the whole time (confirmed via ZIO fiber dumps + thread dumps).

Investigation ruled out (with source + experiments): request draining (`gracefulShutdownTimeout`, default 10s, overridden to 100ms — no effect), Netty event-loop shutdown (`NettyConfig.defaultWithFastShutdown` — no effect), `idleTimeout`, container stops (<1s each), and the blocking-pool 60s keep-alive (idle-thread reaping only).

## Fix

Build the server layer directly into the spec's `Scope` and start it — no forked `ZIO.never`, no nested `provideSomeAuto` scope. This mirrors how production wires the server (`Main.scala` calls `DspApiServer.startup` under `provideSomeAuto` directly). The layer now tears down cleanly, in order, at suite end.

## Results

| | Before | After |
|---|---|---|
| `MaintenanceReplaceUserIriInProjectE2ESpec` teardown | ~65s + leak warning | **~6.5s, clean** |
| 3 specs in one JVM | ~195s+ | **~17.6s, clean, no port conflict** |

## Verification

- `testkit/compile`, `testkit/scalafmtCheck` ✅
- `test-e2e/testOnly *MaintenanceReplaceUserIriInProjectE2ESpec*` → 12 passed, ~6.5s ✅
- `test-e2e/testOnly` of 3 specs together → 50 passed, ~17.6s, no leak warning, no `Address already in use` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)