### PR TITLE
fix: don't inject order index into JSON-LD value objects on resource create

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParser.scala
@@ -74,7 +74,10 @@ final case class ApiComplexV2JsonLdRequestParser(
         val modified = obj.fields.map {
           case (key, Json.Arr(values)) if !key.startsWith("@") =>
             val indexed = values.zipWithIndex.map {
-              case (Json.Obj(fields), idx) =>
+              // only node objects carry an order; JSON-LD value objects (those with an @value entry,
+              // e.g. a bare datatype property such as hasResourceAuthorship) must be left untouched,
+              // as an extra entry would make them an invalid value object during expansion
+              case (Json.Obj(fields), idx) if !fields.exists(_._1 == "@value") =>
                 Json.Obj(fields :+ (OrderIndexProperty -> Json.Num(idx)))
               case (other, _) => other
             }

--- a/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/slice/common/ApiComplexV2JsonLdRequestParserSpec.scala
@@ -2074,6 +2074,38 @@ object ApiComplexV2JsonLdRequestParserSpec extends ZIOSpecDefault {
           Set(Authorship.unsafeFrom("Lotte Reiniger"), Authorship.unsafeFrom("Hilma af Klint")),
       )
     },
+    test("createResourceRequestV2 parses hasResourceAuthorship sent as typed value objects (dsp-tools serialisation)") {
+      for {
+        _      <- ZIO.serviceWithZIO[KnoraProjectRepo](_.save(TestDataFactory.someProject))
+        uuid   <- Random.nextUUID
+        result <- service(
+                    _.createResourceRequestV2(
+                      """{
+                        |  "@type": "ex:Thing",
+                        |  "rdfs:label": "test resource",
+                        |  "ka:attachedToProject": { "@id": "http://rdfh.ch/projects/0001" },
+                        |  "ka:hasResourceAuthorship": [
+                        |    { "@value": "Lotte Reiniger", "@type": "xsd:string" },
+                        |    { "@value": "Hilma af Klint", "@type": "xsd:string" }
+                        |  ],
+                        |  "@context": {
+                        |    "ka": "http://api.knora.org/ontology/knora-api/v2#",
+                        |    "ex": "http://0.0.0.0:3333/ontology/0001/anything/v2#",
+                        |    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+                        |    "xsd": "http://www.w3.org/2001/XMLSchema#"
+                        |  }
+                        |}""".stripMargin,
+                      TestDataFactory.User.rootUser,
+                      uuid,
+                    ),
+                  )
+        // dsp-tools serialises the bare datatype property as JSON-LD value objects; the order-index
+        // injection must leave these untouched, otherwise expansion fails with INVALID_VALUE_OBJECT.
+      } yield assertTrue(
+        result.createResource.resourceAuthorship.toSet ==
+          Set(Authorship.unsafeFrom("Lotte Reiniger"), Authorship.unsafeFrom("Hilma af Klint")),
+      )
+    },
     test("createResourceRequestV2 leaves resourceAuthorship empty when none is provided") {
       for {
         _      <- ZIO.serviceWithZIO[KnoraProjectRepo](_.save(TestDataFactory.someProject))


### PR DESCRIPTION
### Description

**Bug fix.**

Creating a resource that carries a bare datatype property serialised as JSON-LD *value objects* (e.g. `knora-api:hasResourceAuthorship` sent as `[{"@value": "...", "@type": "xsd:string"}, ...]`, which is how dsp-tools serialises it) failed with:

```
400  JsonLdError: A value object with disallowed entries has been detected [INVALID_VALUE_OBJECT]
```

**Root cause:** `ApiComplexV2JsonLdRequestParser.injectOrderIndices` appends an internal `orderIndex` entry to *every* element of *every* top-level array property. For value objects (literals) this produces `{"@value": ..., "@type": ..., "orderIndex": 0}` — an invalid value object — so JSON-LD expansion rejects the whole request.

This never surfaced before because:
- **file** authorship (`hasAuthorship`) is nested inside the file-value object, not a top-level array key, so it was never touched;
- authorship sent as **plain strings** (`["a", "b"]`) has non-object array elements, so it was never touched — which is the only form the existing tests used.

**Fix:** only inject the order index into node objects; skip JSON-LD value objects (those with an `@value` member). Order indices are only meaningful for Knora value nodes, and bare datatype properties are unordered.

Found while running dsp-tools' e2e round-trip against a dev API image for [dsp-tools#2350](https://github.com/dasch-swiss/dsp-tools/pull/2350) (resource-side legal metadata). Without this, any `xmlupload` of a resource with resource-side authorship 400s.

**Tests:** added a parser test covering the typed-value-object serialisation; the existing plain-string test is retained, so both formats are now covered. `webapi/testOnly *ApiComplexV2JsonLdRequestParserSpec` passes (65 tests); scalafmt clean.

**Breaking change?** No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tvarQfKWHQiNi1zKEMuZt