### PR TITLE
refactor!: rename project legal-info dataAuthorship to defaultDataAuthorship

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/AdminProjectsResourceSideLegalInfoE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/AdminProjectsResourceSideLegalInfoE2ESpec.scala
@@ -31,13 +31,13 @@ object AdminProjectsResourceSideLegalInfoE2ESpec extends E2EZSpec {
   private val validInfo = ResourceSideLegalInfo(
     dataLicense = Some(LicenseIri.CC_BY_4_0),
     dataCopyrightHolder = Some(CopyrightHolder.unsafeFrom("University of Basel")),
-    dataAuthorship = List("Hilma af Klint", "Lotte Reiniger").map(Authorship.unsafeFrom),
+    defaultDataAuthorship = List("Hilma af Klint", "Lotte Reiniger").map(Authorship.unsafeFrom),
   )
 
   private val emptyInfo = ResourceSideLegalInfo(
     dataLicense = None,
     dataCopyrightHolder = None,
-    dataAuthorship = List.empty,
+    defaultDataAuthorship = List.empty,
   )
 
   val e2eSpec = suite("The resource-side legal info admin endpoint")(
@@ -64,7 +64,7 @@ object AdminProjectsResourceSideLegalInfoE2ESpec extends E2EZSpec {
       } yield assertTrue(
         prj.dataLicense.contains(LicenseIri.CC_BY_4_0),
         prj.dataCopyrightHolder.contains(CopyrightHolder.unsafeFrom("University of Basel")),
-        prj.dataAuthorship == validInfo.dataAuthorship,
+        prj.defaultDataAuthorship == validInfo.defaultDataAuthorship,
       )
     },
     test("clearing it with an empty payload removes the previously saved values") {
@@ -80,7 +80,7 @@ object AdminProjectsResourceSideLegalInfoE2ESpec extends E2EZSpec {
         cleared == emptyInfo,
         prj.dataLicense.isEmpty,
         prj.dataCopyrightHolder.isEmpty,
-        prj.dataAuthorship.isEmpty,
+        prj.defaultDataAuthorship.isEmpty,
       )
     },
     test("a non-Creative-Commons license (CC0) is rejected with 400") {

--- a/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ProjectService.scala
@@ -82,7 +82,7 @@ final case class ProjectService(
       project.enabledLicenses,
       project.dataLicense,
       project.dataCopyrightHolder,
-      project.dataAuthorship,
+      project.defaultDataAuthorship,
     )
 
   def setProjectRestrictedView(project: Project, settings: RestrictedView): Task[RestrictedView] =

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/admin/ProjectsLegalInfoEndpoints.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/admin/ProjectsLegalInfoEndpoints.scala
@@ -51,7 +51,7 @@ object CopyrightHolderReplaceRequest {
 final case class ResourceSideLegalInfo(
   dataLicense: Option[LicenseIri],
   dataCopyrightHolder: Option[CopyrightHolder],
-  dataAuthorship: List[Authorship],
+  defaultDataAuthorship: List[Authorship],
 )
 object ResourceSideLegalInfo {
   given JsonCodec[ResourceSideLegalInfo] = DeriveJsonCodec.gen[ResourceSideLegalInfo]

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/admin/model/ProjectsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/admin/model/ProjectsMessagesADM.scala
@@ -48,7 +48,7 @@ case class Project(
   enabledLicenses: Set[LicenseIri],
   dataLicense: Option[LicenseIri] = None,
   dataCopyrightHolder: Option[CopyrightHolder] = None,
-  dataAuthorship: List[Authorship] = List.empty,
+  defaultDataAuthorship: List[Authorship] = List.empty,
 ) extends Ordered[Project] {
 
   /**

--- a/webapi/src/main/scala/org/knora/webapi/slice/api/admin/service/ProjectsLegalInfoRestService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/slice/api/admin/service/ProjectsLegalInfoRestService.scala
@@ -129,7 +129,7 @@ final case class ProjectsLegalInfoRestService(
                    project.id,
                    req.dataLicense,
                    req.dataCopyrightHolder,
-                   req.dataAuthorship,
+                   req.defaultDataAuthorship,
                  )
     } yield ResourceSideLegalInfo(updated.dataLicense, updated.dataCopyrightHolder, updated.defaultDataAuthorship)
 }


### PR DESCRIPTION
## Summary

Renames the **project-level authorship default** JSON key `dataAuthorship` → `defaultDataAuthorship` so its name signals it is a *default* that per-resource authorship overrides — consistent with the `default_permissions` precedent. Agreed on the dsp-tools review thread: https://github.com/dasch-swiss/dsp-tools/pull/2350#discussion_r3504039497 (authorship only; deferred to a dedicated PR).

- **Payload-key-only change**: the domain field (`KnoraProject.defaultDataAuthorship`) and the stored predicate (`knora-admin:hasDefaultDataAuthorship`) already use the new name, so **no data migration is needed**.
- Affects the `PUT /admin/projects/shortcode/{shortcode}/legal-info/resource` request/response (`ResourceSideLegalInfo`) and the admin `Project` response.
- `dataLicense` / `dataCopyrightHolder` intentionally stay as-is: they are project-wide and cannot be overridden per resource, so they are not defaults.
- The per-resource `knora-api:hasResourceAuthorship` is untouched.

## Breaking change

The admin API payload key changes. Risk is minimal: dsp-app `main` and dsp-js-lib do not reference `dataAuthorship`; the only consumers are the unmerged dsp-tools PR dasch-swiss/dsp-tools#2350 and the open dsp-app PR #3178 — follow-up PRs adapt both.

## Test plan

- `webapi` and `test-e2e` compile; `AdminProjectsResourceSideLegalInfoE2ESpec` renamed alongside (covers PUT round-trip, project GET, clearing, authz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iLHUkaKhAacsGLiNdem55