### PR TITLE
test: dedupe e2e console logger and harden flaky replace-user-iri auth tests

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/MaintenanceReplaceUserIriE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/MaintenanceReplaceUserIriE2ESpec.scala
@@ -8,6 +8,7 @@ package org.knora.webapi.slice.api.admin
 import sttp.client4.UriContext
 import sttp.model.StatusCode
 import zio.ZIO
+import zio.durationInt
 import zio.json.ast.Json
 import zio.test.*
 
@@ -50,12 +51,12 @@ object MaintenanceReplaceUserIriE2ESpec extends E2EZSpec {
       TestApiClient
         .postJson[Json, Json](endpoint, replaceBody(normalUser.id, "http://rdfh.ch/users/new-iri"))
         .map(response => assertTrue(response.code == StatusCode.Unauthorized))
-    },
+    } @@ TestAspect.timeout(30.seconds) @@ TestAspect.flaky,
     test("returns 403 when the authenticated user is not SystemAdmin") {
       TestApiClient
         .postJson[Json, Json](endpoint, replaceBody(normalUser.id, "http://rdfh.ch/users/new-iri"), normalUser)
         .map(response => assertTrue(response.code == StatusCode.Forbidden))
-    },
+    } @@ TestAspect.timeout(30.seconds) @@ TestAspect.flaky,
     test("returns 400 when oldIri is a built-in user IRI") {
       TestApiClient
         .postJson[Json, Json](endpoint, replaceBody(builtInUserIri, "http://rdfh.ch/users/new-iri"), rootUser)

--- a/modules/testkit/src/main/scala/org/knora/webapi/E2EZSpec.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/E2EZSpec.scala
@@ -36,13 +36,6 @@ abstract class E2EZSpec extends ZIOSpec[E2EZSpec.Environment] {
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
   val faker: Faker                 = new Faker()
 
-  private val testLogger: ULayer[Unit] = Runtime.removeDefaultLoggers >>> consoleLogger(
-    config = {
-      val default = ConsoleLoggerConfig.default
-      default.copy(filter = default.filter.withRootLevel(LogLevel.Error))
-    },
-  )
-
   /**
    * The OpenTelemetry layer the application under test runs with. Defaults to the stdout-exporter setup;
    * instrumentation specs override it (e.g. with an in-memory span exporter) to assert on emitted spans.
@@ -51,7 +44,7 @@ abstract class E2EZSpec extends ZIOSpec[E2EZSpec.Environment] {
   protected def otelLayer: ULayer[api.OpenTelemetry & Tracing & ContextStorage] = OtelSetup.layer
 
   override lazy val bootstrap: ULayer[E2EZSpec.Environment] =
-    testLogger >>>
+    E2EZSpec.testLogger >>>
       TestContainerLayers.all >+>
       LayersLive.remainingLayer(otelLayer) >+>
       ApiModule.layer >+>
@@ -89,6 +82,20 @@ abstract class E2EZSpec extends ZIOSpec[E2EZSpec.Environment] {
 }
 
 object E2EZSpec {
+
+  // zio-test's sbt runner installs every spec's `bootstrap` into a shared runtime, so a per-spec
+  // `consoleLogger(...)` layer adds a fresh logger instance for each E2EZSpec subclass in the run,
+  // duplicating every log line once per spec class. `FiberRef.currentLoggers` is a Set, so
+  // installing this single shared logger instance instead is idempotent.
+  private val sharedConsoleLogger: ZLogger[String, Any] = {
+    val config = {
+      val default = ConsoleLoggerConfig.default
+      default.copy(filter = default.filter.withRootLevel(LogLevel.Error))
+    }
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(makeConsoleLogger(config)).getOrThrowFiberFailure())
+  }
+
+  private val testLogger: ULayer[Unit] = Runtime.removeDefaultLoggers >>> Runtime.addLogger(sharedConsoleLogger)
 
   type Environment =
     // format: off


### PR DESCRIPTION
## Problem

CI run [28602440910](https://github.com/dasch-swiss/dsp-api/actions/runs/28602440910/job/84813904024) was unreadable: the *expected* "project already exists" import failures from `ProjectMigrationImportE2ESpec` produced **282 identical ERROR stack-trace blocks**, burying the actual failure.

## Root cause (commit 1)

zio-test's sbt runner installs every spec's `bootstrap` into a shared runtime. `E2EZSpec` installed a fresh `consoleLogger(...)` layer per spec class, so with **47** `E2EZSpec` subclasses in the e2e run, 47 distinct logger instances accumulated in `FiberRef.currentLoggers` — every server-side ERROR line was printed 47 times (2 log calls × 3 failed imports × 47 loggers = 282 blocks).

**Fix:** create a single shared `ZLogger` instance in `object E2EZSpec` and install it via `Runtime.addLogger`. `FiberRef.currentLoggers` is a `Set`, so installing the same instance once per spec bootstrap is idempotent — one logger for the whole run.

## Flaky auth test (commit 2)

The run's actual failure was `MaintenanceReplaceUserIriE2ESpec` — "returns 403 when the authenticated user is not SystemAdmin" — a client-side timeout, the same runner-contention failure mode analyzed in #4169. That PR hardened only the sibling `MaintenanceReplaceUserIriInProjectE2ESpec`; this commit applies the identical `@@ TestAspect.timeout(30.seconds) @@ TestAspect.flaky` mitigation to the users-endpoint spec's 401/403 tests. (The re-run of 28602440910 passed, confirming the flake.)

## Verification

- A/B test with two specs in one sbt invocation (`MaintenanceReplaceUserIriE2ESpec` + `ProjectMigrationImportE2ESpec`): baseline prints each ERROR line **2×**, fixed prints it exactly **1×**; all 14 tests pass in both runs.
- `test-e2e/Test/compile`, `sbt fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A33MeZAQDyeaL8tWiRyXpN