### PR TITLE
chore: add checked-in Metals MCP server for agent workflows

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,5 +29,5 @@
   },
   "hooks": {},
   "includeCoAuthoredBy": true,
-  "enabledMcpjsonServers": []
+  "enabledMcpjsonServers": ["metals"]
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "metals": {
+      "command": "metals-mcp",
+      "args": ["--workspace", "${CLAUDE_PROJECT_DIR:-.}", "--transport", "stdio"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,15 @@ When changes are hard to test with local test data (e.g. they need realistic dat
 - Test config: `webapi/src/test/resources/test.conf`
 - Docker config: `docker-compose.yml`
 
+### Scala language intelligence (Metals MCP)
+
+This repo ships a checked-in `metals` MCP server giving agents real Scala language intelligence (compiler
+diagnostics, type-aware usage search, symbol docs and lookup). **Prefer the `metals` MCP tools over direct
+`sbt`/`sbtx` calls** — e.g. use `compile-file` / `compile-module` instead of `sbt compile`, and `get-usages`
+instead of grep. It is much faster (incremental, no JVM/sbt startup per call) and more capable (structured
+diagnostics, type-aware navigation). For setup, the full tool list, usage pattern, and the worktree/LOOM
+caveats see `docs/development/dsp-api-metals-mcp.md`.
+
 ## API Structure
 
 ### Endpoint Definition

--- a/docs/development/dsp-api-metals-mcp.md
+++ b/docs/development/dsp-api-metals-mcp.md
@@ -1,0 +1,128 @@
+# Scala language intelligence for agents (Metals MCP)
+
+This repo ships a checked-in MCP server config (`.mcp.json` at the repo root) that gives Claude Code and
+other agents real Scala language intelligence via [Metals](https://scalameta.org/metals/) — compiler
+diagnostics, type-aware usage search, symbol docs, and symbol lookup — instead of relying on `grep`/read.
+
+The server is defined as:
+
+```json
+{
+  "mcpServers": {
+    "metals": {
+      "command": "metals-mcp",
+      "args": ["--workspace", "${CLAUDE_PROJECT_DIR:-.}", "--transport", "stdio"]
+    }
+  }
+}
+```
+
+It runs over **stdio**, so each agent session spawns and manages its own `metals-mcp` process — there is no
+long-lived HTTP server or hardcoded port to go stale. `${CLAUDE_PROJECT_DIR:-.}` resolves to the repo root
+that Claude Code was launched from.
+
+## Prerequisites (one-time human setup)
+
+- **Install the server** via [Coursier](https://get-coursier.io/): `cs install metals-mcp`. This puts a
+  `metals-mcp` launcher on your PATH (typically under the Coursier bin dir).
+- **Minimum version: Metals ≥ 1.6.6** (Osmium, 2025) — the release that first shipped the standalone MCP
+  server. Anything older will not have `metals-mcp`. Check with `metals-mcp --version`.
+- Confirm it is on your PATH: `which metals-mcp`.
+
+If `metals-mcp` is not on your PATH, the `metals` server will simply fail to start and agents fall back to
+grep/read — the repo still works, you just lose the language intelligence.
+
+### First-use approval
+
+`metals` is listed in `.claude/settings.json` under `enabledMcpjsonServers`, so it is pre-approved for the
+team. On recent Claude Code versions, checked-in approvals are still ignored in a folder you have not marked
+as trusted, so you may see a one-time folder-trust / MCP-approval prompt the first time you launch Claude
+Code here. Approve it once.
+
+## The high-value tools
+
+| Tool | What it does |
+| --- | --- |
+| `compile-file` | Compile a single file and return diagnostics. **Reads fresh from disk on every call** — this is your source of truth for errors after an edit. |
+| `compile-module` | Compile a whole module (e.g. `webapi`). Refreshes the index for that module. |
+| `compile-full` | Compile the whole build. |
+| `get-usages` | Find references to a fully-qualified symbol (the find-references equivalent — there is no tool literally named `find-references`). |
+| `get-docs` | Fetch the docs/signature for a symbol. |
+| `get-source` | Fetch the source of a symbol. |
+| `inspect` | Inspect a symbol (type info). |
+| `glob-search` / `typed-glob-search` | Symbol search by name / by type. |
+| `list-modules` | List the build's modules. |
+
+Also available: `format-file`, `find-dep`, `test`, `import-build`, and scalafix tools.
+
+## How agents should use it
+
+**Prefer `compile-file` over shelling out to `sbt compile` for the tight edit → feedback loop.** A single-file
+incremental compile through Metals is far faster than a fresh sbt invocation and returns structured
+diagnostics.
+
+Recommended pattern:
+
+> Edit files on disk, then call the metals tool you need. `compile-file` always reflects current disk content —
+> treat it as the source of truth for diagnostics after an edit; no editor buffer or `didChange` is needed.
+> For navigation (`get-usages`, go-to-definition) that you want to fully trust on a large codebase, run
+> `compile-file` / `compile-module` first, then query. A compile is guaranteed to refresh the index and is
+> cheap incrementally.
+
+### Cold start — do not mistake slowness for breakage
+
+dsp-api is large and multi-module. The **first** `metals-mcp` startup in a fresh checkout runs `bloopInstall`
+plus a full index, which **can take several minutes**. During that window tool calls may be slow or return
+empty results. This is expected — it is not "broken." Give the first import time to finish before concluding a
+tool doesn't work.
+
+### Staleness on a large codebase
+
+Metals has a filesystem watcher that triggers a background recompile after edits. On a tiny project this is
+effectively instant; on a codebase the size of dsp-api a watcher-triggered reindex genuinely lags, so after an
+edit, navigation results (`get-usages`, go-to-def) are transiently stale.
+
+This was confirmed empirically on dsp-api: adding a new reference to a symbol and immediately calling
+`get-usages` (without compiling) did **not** include the new call site; the same query *after* a
+`compile-file` did. So **treat navigation as stale until you compile.** `compile-file` / `compile-module` are
+not subject to this — they read current disk state — so the rule is: after an edit, compile the touched
+file/module first, then run `get-usages` / go-to-def.
+
+`compile-file` diagnostics, by contrast, always reflect current disk content on every call (verified: a
+plain file write introducing a type error is reported precisely, and fixing it on disk clears it — no editor
+buffer or recompile step needed).
+
+## Concurrency, worktrees, and LOOM — read this before running multiple sessions
+
+### One `metals-mcp` per checkout (hard rule)
+
+Each Claude session spawns its own stdio `metals-mcp`. Two sessions pointed at the **same directory** both try
+to open the same embedded H2 database (`.metals/metals.mv.db`), which takes an exclusive file lock → the
+classic "another Metals server is already running" failure, and both sessions stomp each other's Bloop
+compiles.
+
+**Never run two agent sessions against the same checkout.** Use separate git worktrees instead.
+
+### Separate worktrees are fine (with a resource cost)
+
+Distinct directories get their own `.metals/` and `.bloop/`, so there is no DB lock and Bloop just treats each
+as another project. Correctness is fine **because** the config uses the repo-relative `${CLAUDE_PROJECT_DIR:-.}`
+rather than a hardcoded absolute path — an absolute path would funnel every worktree's session back onto one
+directory and reintroduce the H2-lock problem. **Do not hardcode an absolute `--workspace` path.**
+
+The real cost is resources: all worktrees share one global Bloop daemon on the machine. N concurrent cold
+imports (`bloopInstall` + full index, minutes each) and N× JVM heap / concurrent full compiles can exhaust
+RAM/CPU, and Bloop serializes compile requests. **Keep the number of simultaneously metals-active worktrees
+small.**
+
+### LOOM workspaces need an extra hop
+
+Claude Code discovers `.mcp.json` **only in the directory it was launched from** — it does not recurse into
+subdirectories or walk up parents. LOOM starts Claude at the workspace root (`~/workspaces/<name>/`), while the
+dsp-api checkout is a *subdirectory* of it. So the checked-in `.mcp.json` is **not** auto-discovered under
+LOOM, and even if it were, `${CLAUDE_PROJECT_DIR:-.}` would resolve to the workspace root, not the dsp-api
+directory.
+
+To use the metals server under LOOM, **launch Claude Code from inside the dsp-api checkout directory** (not the
+workspace root). The checked-in repo `.mcp.json` remains the single source of truth; LOOM users just need to
+start from the right cwd.


### PR DESCRIPTION
## What

Adds a checked-in, project-scoped **`metals` MCP server** so Claude Code / agent workflows get real Scala language intelligence in this repo — compiler diagnostics, type-aware usage search, symbol docs and lookup — instead of relying on grep/read.

## Changes

- **`.mcp.json`** (new, repo root): defines the `metals` server, launched as `metals-mcp --workspace ${CLAUDE_PROJECT_DIR:-.} --transport stdio`. stdio means each session spawns/manages its own process — no long-lived HTTP server or stale hardcoded port. `${CLAUDE_PROJECT_DIR:-.}` (not a bare `.`) is used because a spawned stdio server's cwd is not guaranteed to be the repo root.
- **`.claude/settings.json`**: `enabledMcpjsonServers: ["metals"]` to pre-approve the server for the team.
- **`docs/development/dsp-api-metals-mcp.md`** (new): full guidance — prerequisites (`cs install metals-mcp`, Metals ≥ 1.6.6), the high-value tools, the `edit → compile-file → query` usage pattern (with `compile-file` as source of truth), cold-start expectations on a large multi-module build, and the concurrency caveats (one server per checkout; separate worktrees OK with resource cost; **launch from the dsp-api directory under LOOM** since `.mcp.json` discovery is launch-cwd-only).
- **`CLAUDE.md`**: short pointer section to the new doc.

## Notes for reviewers

- Requires `metals-mcp` on each dev's PATH. If absent, the server just fails to start and agents fall back to grep/read — nothing else breaks.
- On recent Claude Code, checked-in approvals are ignored in untrusted folders, so a one-time folder-trust prompt may still appear on first use (documented).
- Pre-existing markdownlint issues elsewhere in `CLAUDE.md` were intentionally left untouched to keep the diff scoped; the new doc and the added section lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRmMML6ZcLJscjhfmfVrRy