### PR TITLE
fix: prevent lost requests on keep-alive connections (root cause of e2e CI flakiness)

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/AdminUsersGroupMembershipsEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/AdminUsersGroupMembershipsEndpointsE2ESpec.scala
@@ -97,9 +97,8 @@ object AdminUsersGroupMembershipsEndpointsE2ESpec extends E2EZSpec {
 
   private def addUserToGroup(user: UserDto, group: Group) =
     TestApiClient
-      .postJson[UserResponse, IRI](
+      .postJson[UserResponse](
         uri"/admin/users/iri/${user.id}/group-memberships/${group.groupIri}",
-        "",
         rootUser,
       )
       .flatMap(_.assert200)

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/AdminUsersProjectMemberShipsEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/admin/AdminUsersProjectMemberShipsEndpointsE2ESpec.scala
@@ -181,9 +181,8 @@ object AdminUsersProjectMemberShipsEndpointsE2ESpec extends E2EZSpec {
   private def addUserToProject(userIri: UserIri, projectIri: ProjectIri, requestingUser: User = rootUser) =
     addLogTiming("POST project-memberships") {
       TestApiClient
-        .postJson[UserResponse, String](
+        .postJson[UserResponse](
           uri"/admin/users/iri/$userIri/project-memberships/$projectIri",
-          "",
           requestingUser,
         )
     }
@@ -191,9 +190,8 @@ object AdminUsersProjectMemberShipsEndpointsE2ESpec extends E2EZSpec {
   private def addUserToProjectAsAdmin(userIri: UserIri, projectIri: ProjectIri, requestingUser: User = rootUser) =
     addLogTiming("POST project-admin-memberships") {
       TestApiClient
-        .postJson[UserResponse, String](
+        .postJson[UserResponse](
           uri"/admin/users/iri/$userIri/project-admin-memberships/$projectIri",
-          "",
           requestingUser,
         )
     }

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectMigrationExportE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectMigrationExportE2ESpec.scala
@@ -42,7 +42,7 @@ object ProjectMigrationExportE2ESpec extends E2EZSpec {
       for {
         triggerResponse <-
           TestApiClient
-            .postJson[Json, Json](uri"/v3/projects/$projectIri/exports", Json.Obj(), incunabulaProjectAdminUser)
+            .postJson[Json](uri"/v3/projects/$projectIri/exports", incunabulaProjectAdminUser)
         fakeId          = "AAAAAAAAAAAAAAAAAAAAAA"
         statusResponse <- TestApiClient
                             .getJson[Json](uri"/v3/projects/$projectIri/exports/$fakeId", incunabulaProjectAdminUser)
@@ -121,7 +121,7 @@ object ProjectMigrationExportE2ESpec extends E2EZSpec {
 
   private def triggerExportWithCleanup(): ZIO[TestApiClient, Throwable, DataTaskStatusResponse] =
     TestApiClient
-      .postJson[DataTaskStatusResponse, Json](uri"/v3/projects/$projectIri/exports", Json.Obj(), rootUser)
+      .postJson[DataTaskStatusResponse](uri"/v3/projects/$projectIri/exports", rootUser)
       .flatMap { response =>
         if (response.code == StatusCode.Conflict) {
           // Clean up existing export from a previous run, then retry
@@ -133,9 +133,8 @@ object ProjectMigrationExportE2ESpec extends E2EZSpec {
           } yield id
           for {
             _ <- ZIO.foreachDiscard(existingId)(id => deleteExport(DataTaskId.unsafeFrom(id)))
-            r <- TestApiClient.postJson[DataTaskStatusResponse, Json](
+            r <- TestApiClient.postJson[DataTaskStatusResponse](
                    uri"/v3/projects/$projectIri/exports",
-                   Json.Obj(),
                    rootUser,
                  )
             status <- ZIO.fromEither(r.body).mapError(new RuntimeException(_))

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectMigrationImportE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectMigrationImportE2ESpec.scala
@@ -215,7 +215,7 @@ object ProjectMigrationImportE2ESpec extends E2EZSpec {
 
   private def triggerExportWithCleanup(): ZIO[TestApiClient, Throwable, DataTaskStatusResponse] =
     TestApiClient
-      .postJson[DataTaskStatusResponse, Json](uri"/v3/projects/$projectIri/exports", Json.Obj(), rootUser)
+      .postJson[DataTaskStatusResponse](uri"/v3/projects/$projectIri/exports", rootUser)
       .flatMap { response =>
         if (response.code == StatusCode.Conflict) {
           val existingId = for {
@@ -226,9 +226,8 @@ object ProjectMigrationImportE2ESpec extends E2EZSpec {
           } yield id
           for {
             _ <- ZIO.foreachDiscard(existingId)(id => deleteExport(DataTaskId.unsafeFrom(id)))
-            r <- TestApiClient.postJson[DataTaskStatusResponse, Json](
+            r <- TestApiClient.postJson[DataTaskStatusResponse](
                    uri"/v3/projects/$projectIri/exports",
-                   Json.Obj(),
                    rootUser,
                  )
             status <- ZIO.fromEither(r.body).mapError(new RuntimeException(_))

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestAdminApiClient.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestAdminApiClient.scala
@@ -241,21 +241,20 @@ case class TestAdminApiClient(private val apiClient: TestApiClient) {
     projectIri: ProjectIri,
     user: User,
   ): Task[Response[Either[String, UserResponse]]] =
-    apiClient.postJson[UserResponse, String](uri"/admin/users/iri/$userIri/project-memberships/$projectIri", "", user)
+    apiClient.postJson[UserResponse](uri"/admin/users/iri/$userIri/project-memberships/$projectIri", user)
 
   def addUserToProjectAdmin(
     userIri: UserIri,
     projectIri: ProjectIri,
     user: User,
   ): Task[Response[Either[String, UserResponse]]] =
-    apiClient.postJson[UserResponse, String](
+    apiClient.postJson[UserResponse](
       uri"/admin/users/iri/$userIri/project-admin-memberships/$projectIri",
-      "",
       user,
     )
 
   def addUserToGroup(userIri: UserIri, groupIri: GroupIri, user: User): Task[Response[Either[String, UserResponse]]] =
-    apiClient.postJson[UserResponse, String](uri"/admin/users/iri/$userIri/group-memberships/$groupIri", "", user)
+    apiClient.postJson[UserResponse](uri"/admin/users/iri/$userIri/group-memberships/$groupIri", user)
 
   def removeUserFromProject(
     userIri: UserIri,

--- a/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestApiClient.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testservices/TestApiClient.scala
@@ -153,6 +153,14 @@ final case class TestApiClient(
     sendRequest(request)
   }
 
+  /** POST without a request body, for endpoints that declare no body input. */
+  def postJson[A: JsonDecoder](relativeUri: Uri, user: User): Task[Response[Either[String, A]]] = {
+    val request = basicRequest
+      .post(relativeUri)
+      .response(asJsonAlways[A].mapLeft((e: DeserializationException) => e.body))
+    sendRequest(request, Some(user))
+  }
+
   def postJsonReceiveString[B: JsonEncoder](
     relativeUri: Uri,
     body: B,
@@ -429,6 +437,13 @@ object TestApiClient {
     body: B,
   ): ZIO[TestApiClient, Throwable, Response[Either[String, A]]] =
     ZIO.serviceWithZIO[TestApiClient](_.postJson(relativeUri, body))
+
+  /** POST without a request body, for endpoints that declare no body input. */
+  def postJson[A: JsonDecoder](
+    relativeUri: Uri,
+    user: User,
+  ): ZIO[TestApiClient, Throwable, Response[Either[String, A]]] =
+    ZIO.serviceWithZIO[TestApiClient](_.postJson(relativeUri, user))
 
   def postJsonLd(
     relativeUri: Uri,

--- a/webapi/src/main/scala/org/knora/webapi/core/DspApiServer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/core/DspApiServer.scala
@@ -33,6 +33,7 @@ import sttp.tapir.server.ziohttp.ZioHttpServerOptions
 import zio.*
 import zio.http.*
 import zio.http.Server.Config.ResponseCompressionConfig
+import zio.http.Server.RequestStreaming
 import zio.telemetry.opentelemetry.context.ContextStorage
 import zio.telemetry.opentelemetry.tracing.StatusMapper
 import zio.telemetry.opentelemetry.tracing.Tracing
@@ -171,6 +172,15 @@ object DspApiServer {
 
   def startup: RIO[DspApiServer, Unit] = ZIO.serviceWithZIO[DspApiServer](_.startup())
 
+  // With fully streamed request bodies (RequestStreaming.Enabled), zio-http (<= 3.11.3) leaves the
+  // connection with autoRead=false when a handler responds without consuming the body — e.g. a
+  // tapir security failure (401/403), an unmatched route, or an endpoint that declares no body
+  // input. If the body bytes arrive after the initial read burst, the channel never reads again and
+  // the next keep-alive request on it is silently dropped (the client times out). Hybrid mode
+  // aggregates bodies up to this size so they are always fully read, and streams only larger ones
+  // (the project-import zip upload); this was the root cause of the recurring e2e CI timeouts.
+  private val maxAggregatedRequestBodySize: Int = 1024 * 1024
+
   private val serverLayer = ZLayer
     .service[KnoraApi]
     .flatMap(cfg =>
@@ -179,7 +189,8 @@ object DspApiServer {
       ZLayer.fromZIO(ZIO.logInfo(s"Binding DSP API server to $host:$port")) >>>
         Server
           .defaultWith(
-            _.binding(cfg.get.internalHost, cfg.get.internalPort).enableRequestStreaming
+            _.binding(cfg.get.internalHost, cfg.get.internalPort)
+              .requestStreaming(RequestStreaming.Hybrid(maxAggregatedRequestBodySize))
               .responseCompression(ResponseCompressionConfig.default),
           ),
     )


### PR DESCRIPTION
## Problem

The dominant e2e CI flake — a trivial 401/403 auth-check test hanging until the 120s client read
timeout (`sttp.client4.SttpClientException$TimeoutException` / `HttpTimeoutException: request timed
out`), e.g. runs [28661151812](https://github.com/dasch-swiss/dsp-api/actions/runs/28661151812/job/85001807798),
[28661119548](https://github.com/dasch-swiss/dsp-api/actions/runs/28661119548) (main),
[27553204224](https://github.com/dasch-swiss/dsp-api/actions/runs/27553204224) (main) — is **not**
runner/teardown contention as previously assumed (#4169, #4175). It is a zio-http server bug that
loses a request on a keep-alive connection.

## Root cause

With `RequestStreaming.Enabled` (our `.enableRequestStreaming`), zio-http (all versions ≤ 3.11.3)
adds an `AsyncBodyReader` to the Netty pipeline for **every** request and sets channel
`autoRead=false`. Reading resumes only when the handler consumes the body or the reader sees
`LastHttpContent`. When a handler responds **without consuming the request body** — a tapir security
failure (401/403 happen before body decoding), an unmatched route (404), or an endpoint that
declares **no body input** while the client sends one — and the body bytes arrive in a *later* TCP
read burst than the headers, the channel never reads from the socket again:

1. The 4xx/2xx response for the poisoning request is still written normally.
2. The **next** request on that pooled keep-alive connection is never read → the client times out
   after 120s and closes the connection.
3. The test after that gets a fresh connection and passes instantly — the classic flake signature.

The JDK `HttpClient` (what sttp uses in our testkit) writes headers and body as separate TCP
segments, so the race arms routinely; CI load widens the window between the two segments. This
also explains why the chronically retried `AdminUsers*MemberShips` tests needed
`@@ TestAspect.flaky`: the membership POST endpoints declare no body input, but the test helpers
sent a JSON `""` body — every such call was a potential connection poisoner *even on 200*.

**Reproduction** (standalone scala-cli, outside dsp-api):

- Deterministic: raw-socket client sends PUT headers, then the body in a delayed second segment,
  then a GET on the same connection → the GET is never answered. Fails on zio-http 3.8.0 (ours via
  tapir 1.13.19) and 3.11.3 (latest).
- Realistic: plain JDK `HttpClient` looping PUT-with-body→401 + GET pairs → request lost after
  **12 iterations on an idle laptop**.
- Both scenarios pass with `RequestStreaming.Hybrid` (2000 iterations clean).

Repro sources are attached to the Claude session; happy to move them into an upstream zio-http
issue (planned follow-up).

## Changes

1. **`DspApiServer`: `RequestStreaming.Enabled` → `RequestStreaming.Hybrid(1 MiB)`.** Bodies with
   `Content-Length` ≤ 1 MiB are aggregated by Netty (always fully read → no poisoning); larger
   bodies keep streaming exactly as before (project-import zip uploads). Behavior change to note:
   a *chunked* request without `Content-Length` now gets aggregated and would be rejected with 413
   beyond 1 MiB — our only streaming-input endpoint (v3 project import) is driven by clients that
   send `Content-Length`, so this should be theoretical.
2. **Testkit/e2e: stop sending bodies to endpoints that declare no body input.** New
   `TestApiClient.postJson[A](uri, user)` no-body variant; the membership helpers
   (`project-memberships`, `project-admin-memberships`, `group-memberships`) and the export trigger
   (`POST /v3/projects/…/exports`, which sent `Json.Obj()`) now use it. This removes the poisoning
   pattern from the test suite regardless of server config.

Not in this PR: removing the `@@ TestAspect.timeout(...) @@ TestAspect.flaky` band-aids from
#4169/#4175 — leaving them in place until the fix has soaked in CI, then they can be dropped in a
follow-up. The upstream bug is now filed as zio/zio-http#4193.

## Verification

- Deterministic + JDK-client repros pass with `Hybrid`, fail with `Enabled` (see above).
- `test-e2e/Test/compile`, `scalafmtCheckAll` ✅
- Locally ran the previously-flaky suites (`AdminUsersProjectMemberShipsEndpointsE2ESpec`,
  `AdminUsersGroupMembershipsEndpointsE2ESpec`, `MaintenanceReplaceUserIriE2ESpec`,
  `OntologyMappingEndpointsE2ESpec`, `ProjectMigrationExportE2ESpec`): 65 tests passed, 0 failed — and zero `retried:` markers (the membership tests that habitually burned retries passed first try).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UEjHuEm17j56jsEL3wWxW

