### PR TITLE
feat(gravsearch): add matchFulltext function

### DIFF
--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -698,6 +698,35 @@ except that the first argument is a variable representing a resource:
 FILTER knora-api:matchLabel(?book, "Zeitglöcklein")
 ```
 
+### Filtering on Any Indexed Text of a Resource
+
+The function `knora-api:matchFulltext` searches for matching words anywhere the
+full-text index covers for a resource: its `rdfs:label`, any of its text values, any
+of its value comments, or a list node (including sub-nodes) referenced by one of its
+list values. It gives the same result set as the `GET /v2/search/{term}` endpoint,
+expressed as a Gravsearch function so it can be combined with structured criteria in
+one query.
+
+The first argument is a variable representing a resource (main or linked). The
+second argument is a string literal containing the search terms, with the same
+[Lucene Query Parser syntax](../../07-lucene/lucene-query-parser-syntax.md) support
+as `knora-api:matchText` and the fulltext endpoint (Lucene's default operator is a
+logical OR when submitting several search terms).
+
+This function can only be used as the top-level expression in a `FILTER`, and at
+most once per query — a second call is rejected, since evaluating it twice is
+significantly slower and no known use case needs it.
+
+```sparql
+FILTER knora-api:matchFulltext(?book, "Zeitglöcklein")
+```
+
+Deleted resources and deleted values never match. A search term containing `"` or
+`\` is safely escaped before being passed to the full-text index. As with
+`knora-api:matchText`, the search term is otherwise passed through to Lucene as-is,
+including its default result-count limit for very high-hit terms — the same
+limitation the fulltext endpoint has.
+
 ### Filtering on Resource IRIs
 
 A `FILTER` can compare a variable with another variable or IRI

--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -724,8 +724,9 @@ FILTER knora-api:matchFulltext(?book, "Zeitglöcklein")
 Deleted resources, deleted text values, and deleted list nodes never match. One
 subtlety on the list path: a resource can still match via a *deleted* list value, as
 long as the list node that value points to is itself not deleted — for the list path
-the deletion check is on the matched list node, not on the intervening list value. A
-search term containing `"`, `\`, or a newline is safely escaped before being passed to
+the deletion check is on the matched list node, not on the intervening list value.
+
+A search term containing `"`, `\`, or a newline is safely escaped before being passed to
 the full-text index. As with `knora-api:matchText`, the search term is otherwise passed
 through to Lucene as-is, including its default result-count limit for very high-hit
 terms — the same limitation the fulltext endpoint has.

--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -721,11 +721,14 @@ significantly slower and no known use case needs it.
 FILTER knora-api:matchFulltext(?book, "Zeitglöcklein")
 ```
 
-Deleted resources and deleted values never match. A search term containing `"` or
-`\` is safely escaped before being passed to the full-text index. As with
-`knora-api:matchText`, the search term is otherwise passed through to Lucene as-is,
-including its default result-count limit for very high-hit terms — the same
-limitation the fulltext endpoint has.
+Deleted resources, deleted text values, and deleted list nodes never match. One
+subtlety on the list path: a resource can still match via a *deleted* list value, as
+long as the list node that value points to is itself not deleted — for the list path
+the deletion check is on the matched list node, not on the intervening list value. A
+search term containing `"`, `\`, or a newline is safely escaped before being passed to
+the full-text index. As with `knora-api:matchText`, the search term is otherwise passed
+through to Lucene as-is, including its default result-count limit for very high-hit
+terms — the same limitation the fulltext endpoint has.
 
 ### Filtering on Resource IRIs
 

--- a/docs/05-internals/design/api-v2/gravsearch.md
+++ b/docs/05-internals/design/api-v2/gravsearch.md
@@ -464,3 +464,63 @@ CONSTRUCT {
 
 In this case, the algorithm tries to break the cycles in order to sort the graph. If this is not possible,
 the query statements are not reordered.
+
+## The `matchFulltext` Function Expansion
+
+`knora-api:matchFulltext` (see
+[Filtering on Any Indexed Text of a Resource](../../../03-endpoints/api-v2/query-language.md#filtering-on-any-indexed-text-of-a-resource))
+gives the same result set as the `GET /v2/search/{term}` fulltext endpoint, expressed as a Gravsearch function.
+Its handler, `AbstractPrequeryGenerator.handleMatchFulltextFunction`, replaces the `FILTER` with a hand-proven
+SPARQL shape that mirrors the WHERE core of `SearchFulltextQuery` (the fulltext endpoint's own query builder):
+a Lucene hit anchors the match, two `OPTIONAL` blocks resolve it to a containing resource — either the resource
+that owns the matched value (a text value or a value comment), or the resource that references a matched list
+node (including sub-nodes) via a list value — and a `BIND(COALESCE(...))` picks whichever resolved, falling back
+to the match itself for a direct label hit.
+
+### Why the Expansion Needs an Opaque Group
+
+A naive expansion using ordinary `OptionalPattern`/`BindPattern`/`StatementPattern` nodes breaks in two ways once
+it goes through the passes described above:
+
+1. **The optimizer passes hoist or reorder statements independently of scoping.** `moveBindToBeginning` would
+   hoist the `BIND(COALESCE(...))` above the `OPTIONAL` blocks it depends on, leaving it referencing unbound
+   variables. `reorderPatternsByDependency` (topological sorting, above) would place the trailing
+   `?resourceVar a ?resClass` check before the `BIND` that introduces `?resourceVar`, which is illegal SPARQL
+   scoping.
+2. **The inference pass rejects `rdf:type` statements with a variable object.** `OntologyInferencer.transformStatementInWhere`
+   throws `GravsearchException` when the object of `rdf:type` is a variable rather than an IRI (see
+   [Inference](#inference), above) — but the expansion's value-type check (`?match a ?valType`) and its final
+   resource-class check (`?resourceVar a ?resClass`) both need exactly that shape, because the type isn't known
+   in advance.
+
+Both problems disappear if nothing after the handler ever looks inside the expansion. `GroupPattern` (in
+`SparqlQuery.scala`) is a `QueryPattern` that exists for exactly this: it renders its contents verbatim inside
+`{ ... }`, and every pass that matches on `QueryPattern` either has a wildcard fallback that returns it
+unchanged, or (for the two passes that match exhaustively — `QueryTraverser.transformWherePatterns` and
+`GravsearchTypeInspectionUtil.transformPattern`) has an explicit case added that does the same. The
+`OntologyInferencer`, `GravsearchQueryOptimisation`, and `InferenceOptimizationService` passes never see a
+`GroupPattern`'s interior at all, so the handler can emit the same statement shapes `SearchFulltextQuery` already
+proves correct, unmodified.
+
+### Why the Expansion Must Be Hoisted
+
+Even with an opaque group, *where* it sits in the WHERE clause matters. A classless `matchFulltext` query (no
+resource class selected) still carries the user's `?mainRes a knora-api:Resource`, and because that gives the
+relevant-ontologies inference nothing to narrow on, `OntologyInferencer` expands it into a `VALUES` block
+enumerating every resource class in the repository. Evaluating that block before the (cheap, index-anchored)
+Lucene lookup measured roughly 300× slower in the performance spike behind this feature — the classic
+join-order pessimization `moveLuceneToBeginning` (above) already exists to prevent for a bare Lucene
+`StatementPattern`. `moveLuceneToBeginning` was extended to also recognize a `GroupPattern` whose contents
+include a Lucene statement, so the whole expansion — not just a bare statement — gets hoisted ahead of
+patterns like the class-enumeration `VALUES` block.
+
+### Determinism for Snapshot Testing
+
+`OntologyInferencer` names the `VALUES` variables it introduces (e.g. `?resTypes`, `?subProp`) using
+`Random.nextInt` unless a `queryVariableSuffix` is supplied — harmless for correctness, but it means the same
+query produces different SPARQL text on every run. `SelectTransformer` now supplies a per-instance,
+per-statement counter as that suffix, so the same query always renders the same SPARQL — a prerequisite for
+`GravsearchToPrequeryTransformerE2ESpec`'s golden-snapshot tests on the matchFulltext expansion. The suffix must
+be unique per statement, not a shared constant: a constant would collapse unrelated `VALUES` variables (e.g. one
+from `?mainRes a Resource`, another from `?val a Value`) into the same variable, intersecting their blocks into
+silently empty results.

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/MatchFulltextE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/MatchFulltextE2ESpec.scala
@@ -1,0 +1,297 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.e2e.v2
+
+import sttp.client4.UriContext
+import zio.*
+import zio.test.*
+
+import org.knora.webapi.E2EZSpec
+import org.knora.webapi.e2e.v2.SearchEndpointE2ESpecHelper.postGravsearchQuery
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.testservices.ResponseOps.assert200
+import org.knora.webapi.testservices.ResponseOps.assert400
+import org.knora.webapi.testservices.TestApiClient
+
+/**
+ * E2E tests for the `knora-api:matchFulltext` Gravsearch function (DEV-6715). Uses a dedicated,
+ * self-contained fixture (matchfulltext-data.ttl) rather than extending anything-data.ttl, per
+ * CLAUDE.md: shared datasets are loaded by many tests, so a new record there risks cascading
+ * failures in unrelated specs. The fixture reuses the existing "anything" project/ontology, so no
+ * new project/user registration is needed.
+ */
+object MatchFulltextE2ESpec extends E2EZSpec {
+
+  override val rdfDataObjects: List[RdfDataObject] = SearchEndpointE2ESpecHelper.rdfDataObjects :+
+    RdfDataObject(
+      path = "test_data/generated_test_data/e2e.v2.MatchFulltextE2ESpec/matchfulltext-data.ttl",
+      name = "http://www.knora.org/data/0001/matchfulltexttest",
+    )
+
+  private def matchFulltextCountQuery(
+    term: String,
+    extraWhere: String = "",
+    mainResVar: String = "mainRes",
+    complexSchema: Boolean = false,
+  ): String = {
+    val knoraApiIri =
+      if (complexSchema) "http://api.knora.org/ontology/knora-api/v2#"
+      else "http://api.knora.org/ontology/knora-api/simple/v2#"
+    s"""PREFIX knora-api: <$knoraApiIri>
+       |CONSTRUCT {
+       |    ?$mainResVar knora-api:isMainResource true .
+       |} WHERE {
+       |    ?$mainResVar a knora-api:Resource .
+       |    $extraWhere
+       |    FILTER knora-api:matchFulltext(?$mainResVar, "$term")
+       |}""".stripMargin
+  }
+
+  private def verifyCount(query: String, expectedCount: Int) = for {
+    response    <- TestApiClient.postJsonLdDocument(uri"/v2/searchextended/count", query)
+    jsonLd      <- response.assert200
+    actualCount <- ZIO.fromEither(jsonLd.body.getRequiredInt(OntologyConstants.SchemaOrg.NumberOfItems))
+  } yield assertTrue(actualCount == expectedCount)
+
+  private def oldEndpointCount(term: String) = for {
+    response    <- TestApiClient.getJsonLdDocument(uri"/v2/search/count/$term")
+    jsonLd      <- response.assert200
+    actualCount <- ZIO.fromEither(jsonLd.body.getRequiredInt(OntologyConstants.SchemaOrg.NumberOfItems))
+  } yield actualCount
+
+  private def newEndpointCount(query: String) = for {
+    response    <- TestApiClient.postJsonLdDocument(uri"/v2/searchextended/count", query)
+    jsonLd      <- response.assert200
+    actualCount <- ZIO.fromEither(jsonLd.body.getRequiredInt(OntologyConstants.SchemaOrg.NumberOfItems))
+  } yield actualCount
+
+  override def e2eSpec = suite("MatchFulltext")(
+    suite("match paths")(
+      test("matches via the resource's label") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3Label"), 1)
+      },
+      test("matches via a text value") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3Text"), 1)
+      },
+      test("matches via a value comment") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3Comment"), 1)
+      },
+      test("matches via a list node's label (including sub-nodes)") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3Listnode"), 1)
+      },
+      test("matches a second, otherwise unrelated resource via its label only") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3OnlyLabel"), 1)
+      },
+      test("counts a resource matching via two independent paths (label + text value) exactly once") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3Dedup"), 1)
+      },
+    ),
+    suite("deleted-value handling")(
+      test("a deleted-value-only match is absent") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3DeletedText"), 0)
+      },
+      test("an explicit isDeleted true in the query does not resurrect a deleted-value match (D6)") {
+        // knora-api:isDeleted is only exposed in the complex schema; its object must be a variable.
+        verifyCount(
+          matchFulltextCountQuery(
+            "Zqxvnonce7f3DeletedText",
+            extraWhere = "?mainRes knora-api:isDeleted ?isDeleted . FILTER(?isDeleted = true)",
+            complexSchema = true,
+          ),
+          0,
+        )
+      },
+      test("a deleted list value whose node still matches is present (D11)") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3D11List"), 1)
+      },
+    ),
+    suite("combined with structured criteria")(
+      test("combines with a class restriction and a property filter (AND semantics)") {
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+            |CONSTRUCT {
+            |    ?thing knora-api:isMainResource true .
+            |} WHERE {
+            |    ?thing a anything:Thing .
+            |    ?thing anything:hasListItem ?listItem .
+            |    FILTER(?listItem = "Zqxvnonce7f3Listnode"^^knora-api:ListNode)
+            |    FILTER knora-api:matchFulltext(?thing, "Zqxvnonce7f3Label")
+            |}""".stripMargin
+        verifyCount(query, 1)
+      },
+      test("returns nothing when the structured criterion doesn't match the fulltext hit's resource") {
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+            |CONSTRUCT {
+            |    ?thing knora-api:isMainResource true .
+            |} WHERE {
+            |    ?thing a anything:Thing .
+            |    ?thing anything:hasListItem ?listItem .
+            |    FILTER(?listItem = "Zqxvnonce7f3D11List"^^knora-api:ListNode)
+            |    FILTER knora-api:matchFulltext(?thing, "Zqxvnonce7f3Label")
+            |}""".stripMargin
+        verifyCount(query, 0)
+      },
+    ),
+    suite("project scoping")(
+      test("limitToProject scopes results to the given project") {
+        for {
+          response <- TestApiClient.postJsonLdDocument(
+                        uri"/v2/searchextended/count".addParam("limitToProject", "http://rdfh.ch/projects/0001"),
+                        matchFulltextCountQuery("Zqxvnonce7f3Label"),
+                      )
+          jsonLd      <- response.assert200
+          actualCount <- ZIO.fromEither(jsonLd.body.getRequiredInt(OntologyConstants.SchemaOrg.NumberOfItems))
+        } yield assertTrue(actualCount == 1)
+      },
+    ),
+    suite("non-main-resource variable usage")(
+      test("matchFulltext works on a linked (non-main) resource variable") {
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+            |CONSTRUCT {
+            |    ?thing knora-api:isMainResource true .
+            |    ?thing anything:hasOtherThing ?other .
+            |} WHERE {
+            |    ?thing a anything:Thing .
+            |    ?thing anything:hasOtherThing ?other .
+            |    FILTER knora-api:matchFulltext(?other, "Zqxvnonce7f3Label")
+            |}""".stripMargin
+        verifyCount(query, 1)
+      },
+    ),
+    suite("parity with GET /v2/search")(
+      test("matchFulltext count matches the old fulltext endpoint's count for 'Narr'") {
+        for {
+          oldCount <- oldEndpointCount("Narr")
+          newCount <- newEndpointCount(matchFulltextCountQuery("Narr"))
+        } yield assertTrue(newCount == oldCount)
+      },
+      test("matchFulltext count matches the old fulltext endpoint's count for 'Uniform'") {
+        for {
+          oldCount <- oldEndpointCount("Uniform")
+          newCount <- newEndpointCount(matchFulltextCountQuery("Uniform"))
+        } yield assertTrue(newCount == oldCount)
+      },
+    ),
+    suite("schema variants")(
+      test("matchFulltext works in the simple schema (default in this spec's other tests)") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3Label", complexSchema = false), 1)
+      },
+      test("matchFulltext works in the complex schema") {
+        verifyCount(matchFulltextCountQuery("Zqxvnonce7f3Label", complexSchema = true), 1)
+      },
+    ),
+    suite("errors")(
+      test("rejects an IRI in place of a variable as the first argument") {
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?mainRes knora-api:isMainResource true .
+            |} WHERE {
+            |    ?mainRes a knora-api:Resource .
+            |    FILTER knora-api:matchFulltext(<http://rdfh.ch/0001/matchfulltextA>, "Zqxvnonce7f3Label")
+            |}""".stripMargin
+        for {
+          response <- postGravsearchQuery(query)
+          actual   <- response.assert400
+        } yield assertTrue(actual.contains("Variable required as function argument"))
+      },
+      test("rejects matchFulltext nested inside a boolean && expression") {
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?mainRes knora-api:isMainResource true .
+            |} WHERE {
+            |    ?mainRes a knora-api:Resource .
+            |    FILTER(knora-api:matchFulltext(?mainRes, "Zqxvnonce7f3Label") && knora-api:matchFulltext(?mainRes, "Zqxvnonce7f3Label"))
+            |}""".stripMargin
+        for {
+          response <- postGravsearchQuery(query)
+          actual   <- response.assert400
+        } yield assertTrue(actual.contains("must be the top-level expression in a FILTER"))
+      },
+      test("rejects an empty search term") {
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?mainRes knora-api:isMainResource true .
+            |} WHERE {
+            |    ?mainRes a knora-api:Resource .
+            |    FILTER knora-api:matchFulltext(?mainRes, "")
+            |}""".stripMargin
+        for {
+          response <- postGravsearchQuery(query)
+          actual   <- response.assert400
+        } yield assertTrue(actual.contains("Invalid search string"))
+      },
+      test("rejects a search term shorter than the configured minimum length") {
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?mainRes knora-api:isMainResource true .
+            |} WHERE {
+            |    ?mainRes a knora-api:Resource .
+            |    FILTER knora-api:matchFulltext(?mainRes, "ab")
+            |}""".stripMargin
+        for {
+          response <- postGravsearchQuery(query)
+          actual   <- response.assert400
+        } yield assertTrue(actual.contains("is expected to have at least length of"))
+      },
+      test("rejects a second matchFulltext call in the same query") {
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?mainRes knora-api:isMainResource true .
+            |} WHERE {
+            |    ?mainRes a knora-api:Resource .
+            |    FILTER knora-api:matchFulltext(?mainRes, "Zqxvnonce7f3Label")
+            |    FILTER knora-api:matchFulltext(?mainRes, "Zqxvnonce7f3Label")
+            |}""".stripMargin
+        for {
+          response <- postGravsearchQuery(query)
+          actual   <- response.assert400
+        } yield assertTrue(actual.contains("may only be used once per query"))
+      },
+      test("escapes a search term containing a double quote and a backslash safely, without SPARQL injection (D7)") {
+        // The raw term (after SPARQL unescaping) is itself invalid Lucene query syntax - an
+        // unescaped internal quote/backslash - so Jena's text index rejects it downstream with its
+        // own 400, exactly like the old endpoint does for the same raw term (same underlying Lucene
+        // index, no pre-validation on either path). D7's actual guarantee is upstream of that: the
+        // term is escaped before being embedded in the *generated SPARQL* literal, so it cannot
+        // break out of that literal - the SPARQL itself parses fine, and the failure below is a
+        // clean Lucene-level 400 from deep inside query execution, not a SPARQL syntax error or 500.
+        val rawTerm           = "foo\"bar\\baz"     // as understood after SPARQL unescaping: foo"bar\baz
+        val sparqlLiteralTerm = """foo\"bar\\baz""" // the same term, escaped for the generated SPARQL literal
+        val query             =
+          s"""PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+             |CONSTRUCT {
+             |    ?mainRes knora-api:isMainResource true .
+             |} WHERE {
+             |    ?mainRes a knora-api:Resource .
+             |    FILTER knora-api:matchFulltext(?mainRes, "$sparqlLiteralTerm")
+             |}""".stripMargin
+        for {
+          oldResponse <- TestApiClient.getJsonLdDocument(uri"/v2/search/count/$rawTerm")
+          newResponse <- TestApiClient.postJsonLdDocument(uri"/v2/searchextended/count", query)
+        } yield assertTrue(oldResponse.code.code == newResponse.code.code, newResponse.code.code != 500)
+      },
+      test("passes invalid Lucene syntax through with the same behavior as the old endpoint (D4)") {
+        // A bare boolean operator is invalid Lucene query syntax; matchFulltext does not validate
+        // it (parity with the old endpoint, which has the same passthrough behavior).
+        for {
+          oldResponse <- TestApiClient.getJsonLdDocument(uri"/v2/search/count/AND")
+          newResponse <- TestApiClient.postJsonLdDocument(uri"/v2/searchextended/count", matchFulltextCountQuery("AND"))
+        } yield assertTrue(oldResponse.code.code == newResponse.code.code)
+      },
+    ),
+  )
+}

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/MatchFulltextE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/MatchFulltextE2ESpec.scala
@@ -35,7 +35,6 @@ object MatchFulltextE2ESpec extends E2EZSpec {
   private def matchFulltextCountQuery(
     term: String,
     extraWhere: String = "",
-    mainResVar: String = "mainRes",
     complexSchema: Boolean = false,
   ): String = {
     val knoraApiIri =
@@ -43,11 +42,11 @@ object MatchFulltextE2ESpec extends E2EZSpec {
       else "http://api.knora.org/ontology/knora-api/simple/v2#"
     s"""PREFIX knora-api: <$knoraApiIri>
        |CONSTRUCT {
-       |    ?$mainResVar knora-api:isMainResource true .
+       |    ?mainRes knora-api:isMainResource true .
        |} WHERE {
-       |    ?$mainResVar a knora-api:Resource .
+       |    ?mainRes a knora-api:Resource .
        |    $extraWhere
-       |    FILTER knora-api:matchFulltext(?$mainResVar, "$term")
+       |    FILTER knora-api:matchFulltext(?mainRes, "$term")
        |}""".stripMargin
   }
 
@@ -283,6 +282,23 @@ object MatchFulltextE2ESpec extends E2EZSpec {
           oldResponse <- TestApiClient.getJsonLdDocument(uri"/v2/search/count/$rawTerm")
           newResponse <- TestApiClient.postJsonLdDocument(uri"/v2/searchextended/count", query)
         } yield assertTrue(oldResponse.code.code == newResponse.code.code, newResponse.code.code != 500)
+      },
+      test("escapes an embedded newline in a search term without producing invalid SPARQL (D7)") {
+        // Unlike a raw `"` or `\`, an embedded LF is not itself invalid Lucene syntax (Lucene treats
+        // it as whitespace), so this must succeed with 200 - a SPARQL-level failure here would mean
+        // escapeForSparqlLiteral let a raw LF reach the generated string literal, which SPARQL's
+        // STRING_LITERAL_QUOTE grammar disallows unescaped, exactly as it disallows a raw `"` or `\`.
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?mainRes knora-api:isMainResource true .
+            |} WHERE {
+            |    ?mainRes a knora-api:Resource .
+            |    FILTER knora-api:matchFulltext(?mainRes, "foo\nbar")
+            |}""".stripMargin
+        for {
+          response <- TestApiClient.postJsonLdDocument(uri"/v2/searchextended/count", query)
+        } yield assertTrue(response.code.code == 200)
       },
       test("passes invalid Lucene syntax through with the same behavior as the old endpoint (D4)") {
         // A bare boolean operator is invalid Lucene query syntax; matchFulltext does not validate

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/MatchFulltextE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/v2/MatchFulltextE2ESpec.scala
@@ -50,11 +50,8 @@ object MatchFulltextE2ESpec extends E2EZSpec {
        |}""".stripMargin
   }
 
-  private def verifyCount(query: String, expectedCount: Int) = for {
-    response    <- TestApiClient.postJsonLdDocument(uri"/v2/searchextended/count", query)
-    jsonLd      <- response.assert200
-    actualCount <- ZIO.fromEither(jsonLd.body.getRequiredInt(OntologyConstants.SchemaOrg.NumberOfItems))
-  } yield assertTrue(actualCount == expectedCount)
+  private def verifyCount(query: String, expectedCount: Int) =
+    newEndpointCount(query).map(actualCount => assertTrue(actualCount == expectedCount))
 
   private def oldEndpointCount(term: String) = for {
     response    <- TestApiClient.getJsonLdDocument(uri"/v2/search/count/$term")

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ExportEndpointsE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/resources/api/ExportEndpointsE2ESpec.scala
@@ -9,6 +9,7 @@ import zio.*
 import zio.test.*
 
 import org.knora.webapi.E2EZSpec
+import org.knora.webapi.GoldenTest
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.api.v3.`export`.ExportRequest

--- a/modules/test-it/src/test/resources/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerE2ESpec__classlessMatchFulltext.txt
+++ b/modules/test-it/src/test/resources/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerE2ESpec__classlessMatchFulltext.txt
@@ -1,0 +1,37 @@
+SELECT DISTINCT (COUNT(DISTINCT ?mainRes) AS ?count)
+WHERE {
+{
+?match__matchFulltext <http://jena.apache.org/text#query> "Zeitglöcklein"^^<http://www.w3.org/2001/XMLSchema#string> .
+OPTIONAL {
+?match__matchFulltext <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?valType__matchFulltext .
+?valType__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Value> .
+FILTER(((?valType__matchFulltext != <http://www.knora.org/ontology/knora-base#LinkValue>) && (?valType__matchFulltext != <http://www.knora.org/ontology/knora-base#ListValue>)))
+?containingRes__matchFulltext ?prop__matchFulltext ?match__matchFulltext .
+?prop__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
+FILTER NOT EXISTS {
+ ?match__matchFulltext <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+OPTIONAL {
+?match__matchFulltext <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.knora.org/ontology/knora-base#ListNode> .
+?match__matchFulltext <http://www.knora.org/ontology/knora-base#hasSubListNode>* ?subNode__matchFulltext .
+?listVal__matchFulltext <http://www.knora.org/ontology/knora-base#valueHasListNode> ?subNode__matchFulltext .
+?resWithListVal__matchFulltext ?pred__matchFulltext ?listVal__matchFulltext .
+FILTER NOT EXISTS {
+ ?match__matchFulltext <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+BIND(COALESCE(?containingRes__matchFulltext, ?resWithListVal__matchFulltext, ?match__matchFulltext) AS ?mainRes)
+?mainRes <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resClass__matchFulltext .
+?resClass__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> .
+}
+VALUES ?resTypes1 { <http://www.knora.org/ontology/0801/beol#endnote> <http://www.knora.org/ontology/knora-base#XSLTransformation> <http://www.knora.org/ontology/00FF/images#bild> <http://www.knora.org/ontology/knora-base#Representation> <http://www.knora.org/ontology/0001/anything#ThingDocument> <http://www.knora.org/ontology/0001/anything#AudioThing> <http://www.knora.org/ontology/0801/beol#basicLetter> <http://www.knora.org/ontology/0803/incunabula#misc> <http://www.knora.org/ontology/0801/beol#letter> <http://www.knora.org/ontology/knora-base#AudioSegment> <http://www.knora.org/ontology/0801/biblio#Journal> <http://www.knora.org/ontology/0801/biblio#Publication> <http://www.knora.org/ontology/00FF/images#bildformat> <http://www.knora.org/ontology/0806/webern#Person> <http://www.knora.org/ontology/0801/biblio#JournalArticle> <http://www.knora.org/ontology/0801/biblio#Webpage> <http://www.knora.org/ontology/knora-base#Resource> <http://www.knora.org/ontology/0801/beol#section> <http://www.knora.org/ontology/0801/biblio#EditedBook> <http://www.knora.org/ontology/0001/anything#ThingWithRequiredInt> <http://www.knora.org/ontology/0001/anything#ThingWithSeqnum> <http://www.knora.org/ontology/knora-base#LinkObj> <http://www.knora.org/ontology/0801/beol#person> <http://www.knora.org/ontology/0801/beol#manuscriptEntry> <http://www.knora.org/ontology/0801/biblio#Publisher> <http://www.knora.org/ontology/0801/beol#page> <http://www.knora.org/ontology/0803/incunabula#book> <http://www.knora.org/ontology/0801/beol#Archive> <http://www.knora.org/ontology/0001/anything#Thing> <http://www.knora.org/ontology/0804/dokubib#person> <http://www.knora.org/ontology/0801/biblio#Collection> <http://www.knora.org/ontology/0801/biblio#Translation> <http://www.knora.org/ontology/knora-base#Region> <http://www.knora.org/ontology/knora-base#Annotation> <http://www.knora.org/ontology/0801/biblio#Article> <http://www.knora.org/ontology/0001/anything#ThingWithRepresentation> <http://www.knora.org/ontology/0001/anything#TrivialThing> <http://www.knora.org/ontology/0801/beol#writtenSource> <http://www.knora.org/ontology/0801/biblio#letter> <http://www.knora.org/ontology/0801/beol#facsimile> <http://www.knora.org/ontology/0001/anything#ThingWithRegion> <http://www.knora.org/ontology/0804/dokubib#bildformat> <http://www.knora.org/ontology/0001/anything#BlueThing> <http://www.knora.org/ontology/knora-base#TextRepresentation> <http://www.knora.org/ontology/0001/anything#ThingText> <http://www.knora.org/ontology/0803/incunabula#Sideband> <http://www.knora.org/ontology/0801/beol#figure> <http://www.knora.org/ontology/0801/biblio#CollectionArticle> <http://www.knora.org/ontology/0001/anything#ThingPicture> <http://www.knora.org/ontology/knora-base#StillImageRepresentation> <http://www.knora.org/ontology/knora-base#DeletedResource> <http://www.knora.org/ontology/0801/biblio#Book> <http://www.knora.org/ontology/0801/biblio#Organization> <http://www.knora.org/ontology/0801/beol#transcription> <http://www.knora.org/ontology/0001/something#Something> <http://www.knora.org/ontology/0001/anything#VideoThing> <http://www.knora.org/ontology/0801/beol#documentImage> <http://www.knora.org/ontology/0801/beol#manuscript> <http://www.knora.org/ontology/0801/biblio#Website> <http://www.knora.org/ontology/0801/biblio#BookContent> <http://www.knora.org/ontology/knora-base#ExternalResource> <http://www.knora.org/ontology/knora-base#AudioRepresentation> <http://www.knora.org/ontology/0803/incunabula#page> <http://www.knora.org/ontology/0801/biblio#Edition> <http://www.knora.org/ontology/00FF/images#person> <http://www.knora.org/ontology/0801/beol#introduction> <http://www.knora.org/ontology/0001/anything#ThingArchive> <http://www.knora.org/ontology/knora-base#VideoSegment> <http://www.knora.org/ontology/0801/beol#entryComment> <http://www.knora.org/ontology/knora-base#DocumentRepresentation> <http://www.knora.org/ontology/knora-base#MovingImageRepresentation> <http://www.knora.org/ontology/0801/biblio#VPArticle> <http://www.knora.org/ontology/knora-base#ArchiveRepresentation> <http://www.knora.org/ontology/0801/biblio#WebsiteArticle> <http://www.knora.org/ontology/knora-base#Segment> <http://www.knora.org/ontology/0804/dokubib#bild> <http://www.knora.org/ontology/knora-base#DDDRepresentation> }
+?mainRes <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resTypes1 .
+FILTER NOT EXISTS {
+ ?mainRes <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+LIMIT 1

--- a/modules/test-it/src/test/resources/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec__classRestrictedMatchFulltext.txt
+++ b/modules/test-it/src/test/resources/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec__classRestrictedMatchFulltext.txt
@@ -1,0 +1,39 @@
+SELECT DISTINCT ?thing
+WHERE {
+{
+?match__matchFulltext <http://jena.apache.org/text#query> "Zeitglöcklein"^^<http://www.w3.org/2001/XMLSchema#string> .
+OPTIONAL {
+?match__matchFulltext <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?valType__matchFulltext .
+?valType__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Value> .
+FILTER(((?valType__matchFulltext != <http://www.knora.org/ontology/knora-base#LinkValue>) && (?valType__matchFulltext != <http://www.knora.org/ontology/knora-base#ListValue>)))
+?containingRes__matchFulltext ?prop__matchFulltext ?match__matchFulltext .
+?prop__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
+FILTER NOT EXISTS {
+ ?match__matchFulltext <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+OPTIONAL {
+?match__matchFulltext <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.knora.org/ontology/knora-base#ListNode> .
+?match__matchFulltext <http://www.knora.org/ontology/knora-base#hasSubListNode>* ?subNode__matchFulltext .
+?listVal__matchFulltext <http://www.knora.org/ontology/knora-base#valueHasListNode> ?subNode__matchFulltext .
+?resWithListVal__matchFulltext ?pred__matchFulltext ?listVal__matchFulltext .
+FILTER NOT EXISTS {
+ ?match__matchFulltext <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+BIND(COALESCE(?containingRes__matchFulltext, ?resWithListVal__matchFulltext, ?match__matchFulltext) AS ?thing)
+?thing <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resClass__matchFulltext .
+?resClass__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> .
+}
+VALUES ?resTypes1 { <http://www.knora.org/ontology/0001/anything#BlueThing> <http://www.knora.org/ontology/0001/anything#Thing> <http://www.knora.org/ontology/0001/anything#ThingWithSeqnum> }
+?thing <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resTypes1 .
+FILTER NOT EXISTS {
+ ?thing <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+GROUP BY ?thing
+ORDER BY ASC(?thing)
+LIMIT 25

--- a/modules/test-it/src/test/resources/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec__classlessMatchFulltext.txt
+++ b/modules/test-it/src/test/resources/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec__classlessMatchFulltext.txt
@@ -1,0 +1,39 @@
+SELECT DISTINCT ?mainRes
+WHERE {
+{
+?match__matchFulltext <http://jena.apache.org/text#query> "Zeitglöcklein"^^<http://www.w3.org/2001/XMLSchema#string> .
+OPTIONAL {
+?match__matchFulltext <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?valType__matchFulltext .
+?valType__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Value> .
+FILTER(((?valType__matchFulltext != <http://www.knora.org/ontology/knora-base#LinkValue>) && (?valType__matchFulltext != <http://www.knora.org/ontology/knora-base#ListValue>)))
+?containingRes__matchFulltext ?prop__matchFulltext ?match__matchFulltext .
+?prop__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
+FILTER NOT EXISTS {
+ ?match__matchFulltext <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+OPTIONAL {
+?match__matchFulltext <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.knora.org/ontology/knora-base#ListNode> .
+?match__matchFulltext <http://www.knora.org/ontology/knora-base#hasSubListNode>* ?subNode__matchFulltext .
+?listVal__matchFulltext <http://www.knora.org/ontology/knora-base#valueHasListNode> ?subNode__matchFulltext .
+?resWithListVal__matchFulltext ?pred__matchFulltext ?listVal__matchFulltext .
+FILTER NOT EXISTS {
+ ?match__matchFulltext <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+BIND(COALESCE(?containingRes__matchFulltext, ?resWithListVal__matchFulltext, ?match__matchFulltext) AS ?mainRes)
+?mainRes <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resClass__matchFulltext .
+?resClass__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> .
+}
+VALUES ?resTypes1 { <http://www.knora.org/ontology/0801/beol#endnote> <http://www.knora.org/ontology/knora-base#XSLTransformation> <http://www.knora.org/ontology/00FF/images#bild> <http://www.knora.org/ontology/knora-base#Representation> <http://www.knora.org/ontology/0001/anything#ThingDocument> <http://www.knora.org/ontology/0001/anything#AudioThing> <http://www.knora.org/ontology/0801/beol#basicLetter> <http://www.knora.org/ontology/0803/incunabula#misc> <http://www.knora.org/ontology/0801/beol#letter> <http://www.knora.org/ontology/knora-base#AudioSegment> <http://www.knora.org/ontology/0801/biblio#Journal> <http://www.knora.org/ontology/0801/biblio#Publication> <http://www.knora.org/ontology/00FF/images#bildformat> <http://www.knora.org/ontology/0806/webern#Person> <http://www.knora.org/ontology/0801/biblio#JournalArticle> <http://www.knora.org/ontology/0801/biblio#Webpage> <http://www.knora.org/ontology/knora-base#Resource> <http://www.knora.org/ontology/0801/beol#section> <http://www.knora.org/ontology/0801/biblio#EditedBook> <http://www.knora.org/ontology/0001/anything#ThingWithRequiredInt> <http://www.knora.org/ontology/0001/anything#ThingWithSeqnum> <http://www.knora.org/ontology/knora-base#LinkObj> <http://www.knora.org/ontology/0801/beol#person> <http://www.knora.org/ontology/0801/beol#manuscriptEntry> <http://www.knora.org/ontology/0801/biblio#Publisher> <http://www.knora.org/ontology/0801/beol#page> <http://www.knora.org/ontology/0803/incunabula#book> <http://www.knora.org/ontology/0801/beol#Archive> <http://www.knora.org/ontology/0001/anything#Thing> <http://www.knora.org/ontology/0804/dokubib#person> <http://www.knora.org/ontology/0801/biblio#Collection> <http://www.knora.org/ontology/0801/biblio#Translation> <http://www.knora.org/ontology/knora-base#Region> <http://www.knora.org/ontology/knora-base#Annotation> <http://www.knora.org/ontology/0801/biblio#Article> <http://www.knora.org/ontology/0001/anything#ThingWithRepresentation> <http://www.knora.org/ontology/0001/anything#TrivialThing> <http://www.knora.org/ontology/0801/beol#writtenSource> <http://www.knora.org/ontology/0801/biblio#letter> <http://www.knora.org/ontology/0801/beol#facsimile> <http://www.knora.org/ontology/0001/anything#ThingWithRegion> <http://www.knora.org/ontology/0804/dokubib#bildformat> <http://www.knora.org/ontology/0001/anything#BlueThing> <http://www.knora.org/ontology/knora-base#TextRepresentation> <http://www.knora.org/ontology/0001/anything#ThingText> <http://www.knora.org/ontology/0803/incunabula#Sideband> <http://www.knora.org/ontology/0801/beol#figure> <http://www.knora.org/ontology/0801/biblio#CollectionArticle> <http://www.knora.org/ontology/0001/anything#ThingPicture> <http://www.knora.org/ontology/knora-base#StillImageRepresentation> <http://www.knora.org/ontology/knora-base#DeletedResource> <http://www.knora.org/ontology/0801/biblio#Book> <http://www.knora.org/ontology/0801/biblio#Organization> <http://www.knora.org/ontology/0801/beol#transcription> <http://www.knora.org/ontology/0001/something#Something> <http://www.knora.org/ontology/0001/anything#VideoThing> <http://www.knora.org/ontology/0801/beol#documentImage> <http://www.knora.org/ontology/0801/beol#manuscript> <http://www.knora.org/ontology/0801/biblio#Website> <http://www.knora.org/ontology/0801/biblio#BookContent> <http://www.knora.org/ontology/knora-base#ExternalResource> <http://www.knora.org/ontology/knora-base#AudioRepresentation> <http://www.knora.org/ontology/0803/incunabula#page> <http://www.knora.org/ontology/0801/biblio#Edition> <http://www.knora.org/ontology/00FF/images#person> <http://www.knora.org/ontology/0801/beol#introduction> <http://www.knora.org/ontology/0001/anything#ThingArchive> <http://www.knora.org/ontology/knora-base#VideoSegment> <http://www.knora.org/ontology/0801/beol#entryComment> <http://www.knora.org/ontology/knora-base#DocumentRepresentation> <http://www.knora.org/ontology/knora-base#MovingImageRepresentation> <http://www.knora.org/ontology/0801/biblio#VPArticle> <http://www.knora.org/ontology/knora-base#ArchiveRepresentation> <http://www.knora.org/ontology/0801/biblio#WebsiteArticle> <http://www.knora.org/ontology/knora-base#Segment> <http://www.knora.org/ontology/0804/dokubib#bild> <http://www.knora.org/ontology/knora-base#DDDRepresentation> }
+?mainRes <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resTypes1 .
+FILTER NOT EXISTS {
+ ?mainRes <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+GROUP BY ?mainRes
+ORDER BY ASC(?mainRes)
+LIMIT 25

--- a/modules/test-it/src/test/resources/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec__matchFulltextInUnion.txt
+++ b/modules/test-it/src/test/resources/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec__matchFulltextInUnion.txt
@@ -1,0 +1,52 @@
+SELECT DISTINCT ?thing
+WHERE {
+{
+{
+?match__matchFulltext <http://jena.apache.org/text#query> "Zeitglöcklein"^^<http://www.w3.org/2001/XMLSchema#string> .
+OPTIONAL {
+?match__matchFulltext <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?valType__matchFulltext .
+?valType__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Value> .
+FILTER(((?valType__matchFulltext != <http://www.knora.org/ontology/knora-base#LinkValue>) && (?valType__matchFulltext != <http://www.knora.org/ontology/knora-base#ListValue>)))
+?containingRes__matchFulltext ?prop__matchFulltext ?match__matchFulltext .
+?prop__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
+FILTER NOT EXISTS {
+ ?match__matchFulltext <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+OPTIONAL {
+?match__matchFulltext <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.knora.org/ontology/knora-base#ListNode> .
+?match__matchFulltext <http://www.knora.org/ontology/knora-base#hasSubListNode>* ?subNode__matchFulltext .
+?listVal__matchFulltext <http://www.knora.org/ontology/knora-base#valueHasListNode> ?subNode__matchFulltext .
+?resWithListVal__matchFulltext ?pred__matchFulltext ?listVal__matchFulltext .
+FILTER NOT EXISTS {
+ ?match__matchFulltext <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+BIND(COALESCE(?containingRes__matchFulltext, ?resWithListVal__matchFulltext, ?match__matchFulltext) AS ?thing)
+?thing <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resClass__matchFulltext .
+?resClass__matchFulltext <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> .
+}
+?thing <http://www.knora.org/ontology/0001/anything#hasInteger> ?int1 .
+FILTER NOT EXISTS {
+ ?thing <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+FILTER NOT EXISTS {
+ ?int1 <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+} UNION {
+?thing <http://www.knora.org/ontology/0001/anything#hasInteger> ?int2 .
+?int2 <http://www.knora.org/ontology/knora-base#valueHasInteger> ?int2__valueHasInteger .
+FILTER((?int2__valueHasInteger = "1"^^<http://www.w3.org/2001/XMLSchema#integer>))
+FILTER NOT EXISTS {
+ ?int2 <http://www.knora.org/ontology/knora-base#isDeleted> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+}
+}
+}
+GROUP BY ?thing
+ORDER BY ASC(?thing)
+LIMIT 25

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchInferencePipelineTestSupport.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchInferencePipelineTestSupport.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.messages.util.search.gravsearch.prequery
+
+import zio.*
+
+import dsp.errors.AssertionException
+import org.knora.webapi.ApiV2Schema
+import org.knora.webapi.config.AppConfig
+import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.util.search.ConstructClause
+import org.knora.webapi.messages.util.search.QueryTraverser
+import org.knora.webapi.messages.util.search.SelectQuery
+import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
+import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
+import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
+import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
+import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionResult
+import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionRunner
+import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
+
+/**
+ * Shared by [[GravsearchToPrequeryTransformerE2ESpec]] and [[GravsearchToCountPrequeryTransformerE2ESpec]]:
+ * runs the full two-stage prequery pipeline — prequery generation (transformConstructToSelect, where a
+ * FILTER like matchFulltext is replaced by its expansion) followed by the inference pass
+ * (transformSelectToSelect via SelectTransformer, where the optimizer's moveLuceneToBeginning hoists a
+ * GroupPattern expansion and OntologyInferencer expands rdf:type/property statements). This mirrors
+ * SearchResponderV2.gravsearchV2's own composition and is what golden-snapshotting an expansion needs:
+ * taking the snapshot after only the first stage would miss traps (BIND hoisting, rdf:type-with-variable-object
+ * rejection, join-order pessimization) that only manifest once the inference pass runs.
+ */
+object GravsearchInferencePipelineTestSupport {
+
+  def transformQueryWithInference(
+    query: String,
+    buildTransformer: (ConstructClause, GravsearchTypeInspectionResult, ApiV2Schema, AppConfig) => AbstractPrequeryGenerator,
+    dropOrderBy: Boolean = false,
+  )(implicit sf: StringFormatter): ZIO[
+    AppConfig & QueryTraverser & GravsearchTypeInspectionRunner & OntologyInferencer & InferenceOptimizationService,
+    Throwable,
+    SelectQuery,
+  ] = for {
+    parsedQuery            <- ZIO.attempt(GravsearchParser.parseQuery(query))
+    sanitizedWhereClause   <- GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
+    typeInspectionResult   <-
+      ZIO.serviceWithZIO[GravsearchTypeInspectionRunner](_.inspectTypes(parsedQuery.whereClause))
+    _                      <- GravsearchQueryChecker.checkConstructClause(parsedQuery.constructClause, typeInspectionResult)
+    querySchema            <-
+      ZIO.fromOption(parsedQuery.querySchema).orElseFail(AssertionException(s"WhereClause has no querySchema"))
+    appConfig              <- ZIO.service[AppConfig]
+    prequeryTransformer    <-
+      ZIO.attempt(buildTransformer(parsedQuery.constructClause, typeInspectionResult, querySchema, appConfig))
+    // Count queries don't need sorting (there's only ever one result row), mirroring
+    // SearchResponderV2.fulltextSearchCountV2, which drops orderBy the same way.
+    queryForPrequery        = parsedQuery.copy(
+                         whereClause = sanitizedWhereClause,
+                         orderBy = if (dropOrderBy) Seq.empty else parsedQuery.orderBy,
+                       )
+    prequery               <- ZIO.serviceWithZIO[QueryTraverser](
+                    _.transformConstructToSelect(queryForPrequery, prequeryTransformer),
+                  )
+    ontologyInferencer     <- ZIO.service[OntologyInferencer]
+    inferenceOptimization  <- ZIO.service[InferenceOptimizationService]
+    ontologiesForInference <- inferenceOptimization.getOntologiesRelevantForInference(parsedQuery.whereClause)
+    selectTransformer       = new SelectTransformer(
+                          simulateInference = prequeryTransformer.useInference,
+                          ontologyInferencer,
+                          prequeryTransformer.mainResourceVariable,
+                          sf,
+                        )
+    transformedPrequery    <- ZIO.serviceWithZIO[QueryTraverser](
+                             _.transformSelectToSelect(
+                               inputQuery = prequery,
+                               transformer = selectTransformer,
+                               limitInferenceToOntologies = ontologiesForInference,
+                               limitResultsToProject = None,
+                             ),
+                           )
+  } yield transformedPrequery
+}

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchInferencePipelineTestSupport.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchInferencePipelineTestSupport.scala
@@ -36,32 +36,39 @@ object GravsearchInferencePipelineTestSupport {
 
   def transformQueryWithInference(
     query: String,
-    buildTransformer: (ConstructClause, GravsearchTypeInspectionResult, ApiV2Schema, AppConfig) => AbstractPrequeryGenerator,
+    buildTransformer: (
+      ConstructClause,
+      GravsearchTypeInspectionResult,
+      ApiV2Schema,
+      AppConfig,
+    ) => AbstractPrequeryGenerator,
     dropOrderBy: Boolean = false,
-  )(implicit sf: StringFormatter): ZIO[
+  )(implicit
+    sf: StringFormatter,
+  ): ZIO[
     AppConfig & QueryTraverser & GravsearchTypeInspectionRunner & OntologyInferencer & InferenceOptimizationService,
     Throwable,
     SelectQuery,
   ] = for {
-    parsedQuery            <- ZIO.attempt(GravsearchParser.parseQuery(query))
-    sanitizedWhereClause   <- GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
-    typeInspectionResult   <-
+    parsedQuery          <- ZIO.attempt(GravsearchParser.parseQuery(query))
+    sanitizedWhereClause <- GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
+    typeInspectionResult <-
       ZIO.serviceWithZIO[GravsearchTypeInspectionRunner](_.inspectTypes(parsedQuery.whereClause))
-    _                      <- GravsearchQueryChecker.checkConstructClause(parsedQuery.constructClause, typeInspectionResult)
-    querySchema            <-
+    _           <- GravsearchQueryChecker.checkConstructClause(parsedQuery.constructClause, typeInspectionResult)
+    querySchema <-
       ZIO.fromOption(parsedQuery.querySchema).orElseFail(AssertionException(s"WhereClause has no querySchema"))
-    appConfig              <- ZIO.service[AppConfig]
-    prequeryTransformer    <-
+    appConfig           <- ZIO.service[AppConfig]
+    prequeryTransformer <-
       ZIO.attempt(buildTransformer(parsedQuery.constructClause, typeInspectionResult, querySchema, appConfig))
     // Count queries don't need sorting (there's only ever one result row), mirroring
     // SearchResponderV2.fulltextSearchCountV2, which drops orderBy the same way.
-    queryForPrequery        = parsedQuery.copy(
+    queryForPrequery = parsedQuery.copy(
                          whereClause = sanitizedWhereClause,
                          orderBy = if (dropOrderBy) Seq.empty else parsedQuery.orderBy,
                        )
-    prequery               <- ZIO.serviceWithZIO[QueryTraverser](
-                    _.transformConstructToSelect(queryForPrequery, prequeryTransformer),
-                  )
+    prequery <- ZIO.serviceWithZIO[QueryTraverser](
+                  _.transformConstructToSelect(queryForPrequery, prequeryTransformer),
+                )
     ontologyInferencer     <- ZIO.service[OntologyInferencer]
     inferenceOptimization  <- ZIO.service[InferenceOptimizationService]
     ontologiesForInference <- inferenceOptimization.getOntologiesRelevantForInference(parsedQuery.whereClause)
@@ -71,7 +78,7 @@ object GravsearchInferencePipelineTestSupport {
                           prequeryTransformer.mainResourceVariable,
                           sf,
                         )
-    transformedPrequery    <- ZIO.serviceWithZIO[QueryTraverser](
+    transformedPrequery <- ZIO.serviceWithZIO[QueryTraverser](
                              _.transformSelectToSelect(
                                inputQuery = prequery,
                                transformer = selectTransformer,

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerE2ESpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerE2ESpec.scala
@@ -10,6 +10,7 @@ import zio.test.*
 
 import dsp.errors.AssertionException
 import org.knora.webapi.E2EZSpec
+import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.search.*
@@ -27,7 +28,8 @@ object GravsearchToCountPrequeryTransformerE2ESpec extends E2EZSpec {
 
   private def transformQuery(
     query: String,
-  ): ZIO[QueryTraverser & GravsearchTypeInspectionRunner, Throwable, SelectQuery] = for {
+  ): ZIO[AppConfig & QueryTraverser & GravsearchTypeInspectionRunner, Throwable, SelectQuery] = for {
+    appConfig            <- ZIO.service[AppConfig]
     query                <- ZIO.attempt(GravsearchParser.parseQuery(query))
     inspectionResult     <- inspectionRunner(_.inspectTypes(query.whereClause))
     _                    <- GravsearchQueryChecker.checkConstructClause(query.constructClause, inspectionResult)
@@ -36,7 +38,12 @@ object GravsearchToCountPrequeryTransformerE2ESpec extends E2EZSpec {
     prequery             <- queryTraverser(
                   _.transformConstructToSelect(
                     query.copy(whereClause = sanitizedWhereClause, orderBy = Seq.empty),
-                    new GravsearchToCountPrequeryTransformer(query.constructClause, inspectionResult, querySchema),
+                    new GravsearchToCountPrequeryTransformer(
+                      query.constructClause,
+                      inspectionResult,
+                      querySchema,
+                      appConfig.v2.fulltextSearch.searchValueMinLength,
+                    ),
                   ),
                 )
   } yield prequery

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerE2ESpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerE2ESpec.scala
@@ -18,7 +18,6 @@ import org.knora.webapi.messages.util.search.*
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
 import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
-import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionRunner
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
 
@@ -51,53 +50,23 @@ object GravsearchToCountPrequeryTransformerE2ESpec extends E2EZSpec with GoldenT
                 )
   } yield prequery
 
-  /**
-   * Two-stage pipeline (prequery generation + inference pass) for the count variant, mirroring
-   * SearchResponderV2.fulltextSearchCountV2's own composition. See transformQueryWithInference in
-   * GravsearchToPrequeryTransformerE2ESpec for why the golden snapshot needs both stages.
-   */
+  /** See [[GravsearchInferencePipelineTestSupport]] for why the golden snapshot needs the full pipeline. */
   private def transformQueryWithInference(query: String): ZIO[
     AppConfig & QueryTraverser & GravsearchTypeInspectionRunner & OntologyInferencer & InferenceOptimizationService,
     Throwable,
     SelectQuery,
-  ] = for {
-    appConfig            <- ZIO.service[AppConfig]
-    parsedQuery          <- ZIO.attempt(GravsearchParser.parseQuery(query))
-    typeInspectionResult <- inspectionRunner(_.inspectTypes(parsedQuery.whereClause))
-    _                    <- GravsearchQueryChecker.checkConstructClause(parsedQuery.constructClause, typeInspectionResult)
-    sanitizedWhereClause <- GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
-    querySchema          <-
-      ZIO.fromOption(parsedQuery.querySchema).orElseFail(AssertionException(s"WhereClause has no querySchema"))
-    countTransformer = new GravsearchToCountPrequeryTransformer(
-                         parsedQuery.constructClause,
-                         typeInspectionResult,
-                         querySchema,
-                         appConfig.v2.fulltextSearch.searchValueMinLength,
-                       )
-    prequery <- queryTraverser(
-                  _.transformConstructToSelect(
-                    parsedQuery.copy(whereClause = sanitizedWhereClause, orderBy = Seq.empty),
-                    countTransformer,
-                  ),
-                )
-    ontologyInferencer     <- ZIO.service[OntologyInferencer]
-    inferenceOptimization  <- ZIO.service[InferenceOptimizationService]
-    ontologiesForInference <- inferenceOptimization.getOntologiesRelevantForInference(parsedQuery.whereClause)
-    selectTransformer       = new SelectTransformer(
-                          simulateInference = countTransformer.useInference,
-                          ontologyInferencer,
-                          countTransformer.mainResourceVariable,
-                          sf,
-                        )
-    transformedPrequery <- queryTraverser(
-                             _.transformSelectToSelect(
-                               inputQuery = prequery,
-                               transformer = selectTransformer,
-                               limitInferenceToOntologies = ontologiesForInference,
-                               limitResultsToProject = None,
-                             ),
-                           )
-  } yield transformedPrequery
+  ] =
+    GravsearchInferencePipelineTestSupport.transformQueryWithInference(
+      query,
+      (constructClause, typeInspectionResult, querySchema, appConfig) =>
+        new GravsearchToCountPrequeryTransformer(
+          constructClause,
+          typeInspectionResult,
+          querySchema,
+          appConfig.v2.fulltextSearch.searchValueMinLength,
+        ),
+      dropOrderBy = true,
+    )
 
   val queryClasslessMatchFulltext: String =
     """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerE2ESpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformerE2ESpec.scala
@@ -10,16 +10,19 @@ import zio.test.*
 
 import dsp.errors.AssertionException
 import org.knora.webapi.E2EZSpec
+import org.knora.webapi.GoldenTest
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.search.*
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
+import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
+import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionRunner
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
 
-object GravsearchToCountPrequeryTransformerE2ESpec extends E2EZSpec {
+object GravsearchToCountPrequeryTransformerE2ESpec extends E2EZSpec with GoldenTest {
 
   private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
@@ -47,6 +50,63 @@ object GravsearchToCountPrequeryTransformerE2ESpec extends E2EZSpec {
                   ),
                 )
   } yield prequery
+
+  /**
+   * Two-stage pipeline (prequery generation + inference pass) for the count variant, mirroring
+   * SearchResponderV2.fulltextSearchCountV2's own composition. See transformQueryWithInference in
+   * GravsearchToPrequeryTransformerE2ESpec for why the golden snapshot needs both stages.
+   */
+  private def transformQueryWithInference(query: String): ZIO[
+    AppConfig & QueryTraverser & GravsearchTypeInspectionRunner & OntologyInferencer & InferenceOptimizationService,
+    Throwable,
+    SelectQuery,
+  ] = for {
+    appConfig            <- ZIO.service[AppConfig]
+    parsedQuery          <- ZIO.attempt(GravsearchParser.parseQuery(query))
+    typeInspectionResult <- inspectionRunner(_.inspectTypes(parsedQuery.whereClause))
+    _                    <- GravsearchQueryChecker.checkConstructClause(parsedQuery.constructClause, typeInspectionResult)
+    sanitizedWhereClause <- GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
+    querySchema          <-
+      ZIO.fromOption(parsedQuery.querySchema).orElseFail(AssertionException(s"WhereClause has no querySchema"))
+    countTransformer = new GravsearchToCountPrequeryTransformer(
+                         parsedQuery.constructClause,
+                         typeInspectionResult,
+                         querySchema,
+                         appConfig.v2.fulltextSearch.searchValueMinLength,
+                       )
+    prequery <- queryTraverser(
+                  _.transformConstructToSelect(
+                    parsedQuery.copy(whereClause = sanitizedWhereClause, orderBy = Seq.empty),
+                    countTransformer,
+                  ),
+                )
+    ontologyInferencer     <- ZIO.service[OntologyInferencer]
+    inferenceOptimization  <- ZIO.service[InferenceOptimizationService]
+    ontologiesForInference <- inferenceOptimization.getOntologiesRelevantForInference(parsedQuery.whereClause)
+    selectTransformer       = new SelectTransformer(
+                          simulateInference = countTransformer.useInference,
+                          ontologyInferencer,
+                          countTransformer.mainResourceVariable,
+                          sf,
+                        )
+    transformedPrequery <- queryTraverser(
+                             _.transformSelectToSelect(
+                               inputQuery = prequery,
+                               transformer = selectTransformer,
+                               limitInferenceToOntologies = ontologiesForInference,
+                               limitResultsToProject = None,
+                             ),
+                           )
+  } yield transformedPrequery
+
+  val queryClasslessMatchFulltext: String =
+    """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+      |CONSTRUCT {
+      |    ?mainRes knora-api:isMainResource true .
+      |} WHERE {
+      |    ?mainRes a knora-api:Resource .
+      |    FILTER knora-api:matchFulltext(?mainRes, "Zeitglöcklein")
+      |}""".stripMargin
 
   val inputQueryWithDecimalOptionalSortCriterionAndFilter: String =
     """
@@ -269,6 +329,10 @@ object GravsearchToCountPrequeryTransformerE2ESpec extends E2EZSpec {
     )
 
   override val e2eSpec = suite("The NonTriplestoreSpecificGravsearchToCountPrequeryGenerator object")(
+    test("generate the fulltext-index-anchored matchFulltext expansion for a classless count query") {
+      transformQueryWithInference(queryClasslessMatchFulltext)
+        .map(actual => assertGolden(actual.toSparql, "classlessMatchFulltext"))
+    },
     test("transform an input query with a decimal as an optional sort criterion and a filter") {
       transformQuery(inputQueryWithDecimalOptionalSortCriterionAndFilter)
         .map(actual => assertTrue(actual == transformedQueryWithDecimalOptionalSortCriterionAndFilter))

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec.scala
@@ -12,6 +12,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import dsp.errors.AssertionException
 import org.knora.webapi.E2EZSpec
+import org.knora.webapi.GoldenTest
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.IriConversions.*
 import org.knora.webapi.messages.OntologyConstants
@@ -19,10 +20,12 @@ import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.messages.util.search.*
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
+import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
+import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionRunner
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
 
-object GravsearchToPrequeryTransformerE2ESpec extends E2EZSpec {
+object GravsearchToPrequeryTransformerE2ESpec extends E2EZSpec with GoldenTest {
 
   private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
@@ -50,6 +53,61 @@ object GravsearchToPrequeryTransformerE2ESpec extends E2EZSpec {
                   _.transformConstructToSelect(query.copy(whereClause = sanitizedWhereClause), transformer),
                 )
   } yield preQuery
+
+  /**
+   * Runs the full two-stage prequery pipeline: prequery generation (transformConstructToSelect, where
+   * FILTER matchFulltext is replaced by its GroupPattern expansion) followed by the inference pass
+   * (transformSelectToSelect via SelectTransformer, where the optimizer's moveLuceneToBeginning hoists
+   * the expansion and OntologyInferencer expands rdf:type/property statements). This mirrors
+   * SearchResponderV2.gravsearchV2's own composition and is what golden-snapshotting the matchFulltext
+   * expansion needs: taking the snapshot after only the first stage (as [[transformQuery]] does) would
+   * miss the traps (BIND hoisting, rdf:type-with-variable-object rejection, join-order pessimization)
+   * that only manifest once the inference pass runs.
+   */
+  private def transformQueryWithInference(query: String): ZIO[
+    AppConfig & QueryTraverser & GravsearchTypeInspectionRunner & OntologyInferencer & InferenceOptimizationService,
+    Throwable,
+    SelectQuery,
+  ] = for {
+    parsedQuery          <- ZIO.attempt(GravsearchParser.parseQuery(query))
+    sanitizedWhereClause <- GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
+    typeInspectionResult <- inspectionRunner(_.inspectTypes(parsedQuery.whereClause))
+    _                    <- GravsearchQueryChecker.checkConstructClause(parsedQuery.constructClause, typeInspectionResult)
+    querySchema          <-
+      ZIO.fromOption(parsedQuery.querySchema).orElseFail(AssertionException(s"WhereClause has no querySchema"))
+    appConfig           <- ZIO.service[AppConfig]
+    prequeryTransformer <- ZIO.attempt(
+                             new GravsearchToPrequeryTransformer(
+                               constructClause = parsedQuery.constructClause,
+                               typeInspectionResult = typeInspectionResult,
+                               querySchema = querySchema,
+                               appConfig = appConfig,
+                             ),
+                           )
+    prequery <- queryTraverser(
+                  _.transformConstructToSelect(
+                    parsedQuery.copy(whereClause = sanitizedWhereClause),
+                    prequeryTransformer,
+                  ),
+                )
+    ontologyInferencer     <- ZIO.service[OntologyInferencer]
+    inferenceOptimization  <- ZIO.service[InferenceOptimizationService]
+    ontologiesForInference <- inferenceOptimization.getOntologiesRelevantForInference(parsedQuery.whereClause)
+    selectTransformer       = new SelectTransformer(
+                          simulateInference = prequeryTransformer.useInference,
+                          ontologyInferencer,
+                          prequeryTransformer.mainResourceVariable,
+                          sf,
+                        )
+    transformedPrequery <- queryTraverser(
+                             _.transformSelectToSelect(
+                               inputQuery = prequery,
+                               transformer = selectTransformer,
+                               limitInferenceToOntologies = ontologiesForInference,
+                               limitResultsToProject = None,
+                             ),
+                           )
+  } yield transformedPrequery
 
   val inputQueryWithDateNonOptionalSortCriterion: String =
     """
@@ -2619,6 +2677,43 @@ object GravsearchToPrequeryTransformerE2ESpec extends E2EZSpec {
     useDistinct = true,
   )
 
+  val queryClasslessMatchFulltext: String =
+    """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+      |CONSTRUCT {
+      |    ?mainRes knora-api:isMainResource true .
+      |} WHERE {
+      |    ?mainRes a knora-api:Resource .
+      |    FILTER knora-api:matchFulltext(?mainRes, "Zeitglöcklein")
+      |}""".stripMargin
+
+  val queryClassRestrictedMatchFulltext: String =
+    """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+      |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+      |CONSTRUCT {
+      |    ?thing knora-api:isMainResource true .
+      |} WHERE {
+      |    ?thing a anything:Thing .
+      |    FILTER knora-api:matchFulltext(?thing, "Zeitglöcklein")
+      |}""".stripMargin
+
+  val queryMatchFulltextInUnion: String =
+    """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+      |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+      |CONSTRUCT {
+      |    ?thing knora-api:isMainResource true .
+      |} WHERE {
+      |    ?thing a anything:Thing .
+      |    {
+      |        ?thing anything:hasInteger ?int1 .
+      |        FILTER knora-api:matchFulltext(?thing, "Zeitglöcklein")
+      |    }
+      |    UNION
+      |    {
+      |        ?thing anything:hasInteger ?int2 .
+      |        FILTER(?int2 = 1)
+      |    }
+      |}""".stripMargin
+
   val queryWithKnoraApiResource: String =
     """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
       |CONSTRUCT {
@@ -2751,6 +2846,20 @@ object GravsearchToPrequeryTransformerE2ESpec extends E2EZSpec {
     test("reorder a query with a cycle") {
       transformQuery(queryToReorderWithCycle)
         .map(actual => assertTrue(actual == transformedQueryToReorderWithCycle))
+    },
+    test(
+      "generate the fulltext-index-anchored matchFulltext expansion for a classless query, hoisted ahead of the class-VALUES block",
+    ) {
+      transformQueryWithInference(queryClasslessMatchFulltext)
+        .map(actual => assertGolden(actual.toSparql, "classlessMatchFulltext"))
+    },
+    test("generate the fulltext-index-anchored matchFulltext expansion for a class-restricted query") {
+      transformQueryWithInference(queryClassRestrictedMatchFulltext)
+        .map(actual => assertGolden(actual.toSparql, "classRestrictedMatchFulltext"))
+    },
+    test("generate the matchFulltext expansion when the FILTER is inside a UNION block") {
+      transformQueryWithInference(queryMatchFulltextInUnion)
+        .map(actual => assertGolden(actual.toSparql, "matchFulltextInUnion"))
     },
     test("not remove rdf:type knora-api:Resource if it's needed") {
       transformQuery(queryWithKnoraApiResource)

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformerE2ESpec.scala
@@ -21,7 +21,6 @@ import org.knora.webapi.messages.util.search.*
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchParser
 import org.knora.webapi.messages.util.search.gravsearch.GravsearchQueryChecker
 import org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer
-import org.knora.webapi.messages.util.search.gravsearch.transformers.SelectTransformer
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionRunner
 import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil
 
@@ -54,60 +53,22 @@ object GravsearchToPrequeryTransformerE2ESpec extends E2EZSpec with GoldenTest {
                 )
   } yield preQuery
 
-  /**
-   * Runs the full two-stage prequery pipeline: prequery generation (transformConstructToSelect, where
-   * FILTER matchFulltext is replaced by its GroupPattern expansion) followed by the inference pass
-   * (transformSelectToSelect via SelectTransformer, where the optimizer's moveLuceneToBeginning hoists
-   * the expansion and OntologyInferencer expands rdf:type/property statements). This mirrors
-   * SearchResponderV2.gravsearchV2's own composition and is what golden-snapshotting the matchFulltext
-   * expansion needs: taking the snapshot after only the first stage (as [[transformQuery]] does) would
-   * miss the traps (BIND hoisting, rdf:type-with-variable-object rejection, join-order pessimization)
-   * that only manifest once the inference pass runs.
-   */
+  /** See [[GravsearchInferencePipelineTestSupport]] for why the golden snapshot needs the full pipeline. */
   private def transformQueryWithInference(query: String): ZIO[
     AppConfig & QueryTraverser & GravsearchTypeInspectionRunner & OntologyInferencer & InferenceOptimizationService,
     Throwable,
     SelectQuery,
-  ] = for {
-    parsedQuery          <- ZIO.attempt(GravsearchParser.parseQuery(query))
-    sanitizedWhereClause <- GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
-    typeInspectionResult <- inspectionRunner(_.inspectTypes(parsedQuery.whereClause))
-    _                    <- GravsearchQueryChecker.checkConstructClause(parsedQuery.constructClause, typeInspectionResult)
-    querySchema          <-
-      ZIO.fromOption(parsedQuery.querySchema).orElseFail(AssertionException(s"WhereClause has no querySchema"))
-    appConfig           <- ZIO.service[AppConfig]
-    prequeryTransformer <- ZIO.attempt(
-                             new GravsearchToPrequeryTransformer(
-                               constructClause = parsedQuery.constructClause,
-                               typeInspectionResult = typeInspectionResult,
-                               querySchema = querySchema,
-                               appConfig = appConfig,
-                             ),
-                           )
-    prequery <- queryTraverser(
-                  _.transformConstructToSelect(
-                    parsedQuery.copy(whereClause = sanitizedWhereClause),
-                    prequeryTransformer,
-                  ),
-                )
-    ontologyInferencer     <- ZIO.service[OntologyInferencer]
-    inferenceOptimization  <- ZIO.service[InferenceOptimizationService]
-    ontologiesForInference <- inferenceOptimization.getOntologiesRelevantForInference(parsedQuery.whereClause)
-    selectTransformer       = new SelectTransformer(
-                          simulateInference = prequeryTransformer.useInference,
-                          ontologyInferencer,
-                          prequeryTransformer.mainResourceVariable,
-                          sf,
-                        )
-    transformedPrequery <- queryTraverser(
-                             _.transformSelectToSelect(
-                               inputQuery = prequery,
-                               transformer = selectTransformer,
-                               limitInferenceToOntologies = ontologiesForInference,
-                               limitResultsToProject = None,
-                             ),
-                           )
-  } yield transformedPrequery
+  ] =
+    GravsearchInferencePipelineTestSupport.transformQueryWithInference(
+      query,
+      (constructClause, typeInspectionResult, querySchema, appConfig) =>
+        new GravsearchToPrequeryTransformer(
+          constructClause = constructClause,
+          typeInspectionResult = typeInspectionResult,
+          querySchema = querySchema,
+          appConfig = appConfig,
+        ),
+    )
 
   val inputQueryWithDateNonOptionalSortCriterion: String =
     """

--- a/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionRunnerSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionRunnerSpec.scala
@@ -552,6 +552,59 @@ object GravsearchTypeInspectionRunnerSpec extends E2EZSpec {
       )
       inspectTypes(queryVarTypeFromFunction).map(actual => assertTrue(actual.entities == expected))
     },
+    test("infer the type of a resource variable used as the argument of matchFulltext in a FILTER") {
+      val queryVarTypeFromMatchFulltext: String =
+        """
+          |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?book knora-api:isMainResource true .
+          |} WHERE {
+          |    ?book rdf:type incunabula:book .
+          |    FILTER knora-api:matchFulltext(?book, "Zeitglöcklein")
+          |}
+          |""".stripMargin
+      val expected = Map(
+        TypeableVariable(variableName = "book") -> NonPropertyTypeInfo(
+          typeIri = "http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri,
+          isResourceType = true,
+        ),
+      )
+      inspectTypes(queryVarTypeFromMatchFulltext).map(actual => assertTrue(actual.entities == expected))
+    },
+    test("reject matchFulltext with an IRI instead of a variable as its first argument") {
+      val queryMatchFulltextWithIriArg: String =
+        """
+          |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?book knora-api:isMainResource true .
+          |} WHERE {
+          |    ?book rdf:type incunabula:book .
+          |    FILTER knora-api:matchFulltext(<http://rdfh.ch/0803/e41ab5695c>, "Zeitglöcklein")
+          |}
+          |""".stripMargin
+      inspectTypes(queryMatchFulltextWithIriArg).exit.map(actual => assert(actual)(failsWithA[GravsearchException]))
+    },
+    test("reject matchFulltext whose argument has an inconsistent (non-resource) type elsewhere in the query") {
+      val queryMatchFulltextWithInconsistentType: String =
+        """
+          |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?thing knora-api:isMainResource true .
+          |} WHERE {
+          |    ?thing anything:hasText ?text .
+          |    FILTER knora-api:matchFulltext(?text, "Zeitglöcklein")
+          |}
+          |""".stripMargin
+      inspectTypes(queryMatchFulltextWithInconsistentType).exit.map(actual =>
+        assert(actual)(failsWithA[GravsearchException]),
+      )
+    },
     test("infer the type of a non-property IRI used as the argument of a function in a FILTER") {
       val queryIriTypeFromFunction: String =
         """

--- a/modules/testkit/src/main/scala/org/knora/webapi/GoldenTest.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/GoldenTest.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.knora.webapi.slice.resources.api
+package org.knora.webapi
 
 import zio.test.*
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -861,6 +861,7 @@ object OntologyConstants {
     val MatchTextFunction: IRI           = KnoraApiV2PrefixExpansion + "matchText"
     val MatchTextInStandoffFunction: IRI = KnoraApiV2PrefixExpansion + "matchTextInStandoff"
     val MatchLabelFunction: IRI          = KnoraApiV2PrefixExpansion + "matchLabel"
+    val MatchFulltextFunction: IRI       = KnoraApiV2PrefixExpansion + "matchFulltext"
     val StandoffLinkFunction: IRI        = KnoraApiV2PrefixExpansion + "standoffLink"
 
     val GravsearchOptions: IRI = KnoraApiV2PrefixExpansion + "GravsearchOptions"
@@ -883,9 +884,10 @@ object OntologyConstants {
 
     val ObjectType: IRI = KnoraApiV2PrefixExpansion + "objectType"
 
-    val IsMainResource: IRI     = KnoraApiV2PrefixExpansion + "isMainResource"
-    val MatchTextFunction: IRI  = KnoraApiV2PrefixExpansion + "matchText"
-    val MatchLabelFunction: IRI = KnoraApiV2PrefixExpansion + "matchLabel"
+    val IsMainResource: IRI        = KnoraApiV2PrefixExpansion + "isMainResource"
+    val MatchTextFunction: IRI     = KnoraApiV2PrefixExpansion + "matchText"
+    val MatchLabelFunction: IRI    = KnoraApiV2PrefixExpansion + "matchLabel"
+    val MatchFulltextFunction: IRI = KnoraApiV2PrefixExpansion + "matchFulltext"
 
     val ResourceProperty: IRI = KnoraApiV2PrefixExpansion + "resourceProperty"
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
@@ -137,6 +137,9 @@ final class QueryTraverser()(implicit stringFormatter: StringFormatter) {
                                case valuesPattern: ValuesPattern => ZIO.succeed(Seq(valuesPattern))
 
                                case bindPattern: BindPattern => ZIO.succeed(Seq(bindPattern))
+
+                               // Opaque: rendered verbatim, never optimised or inference-expanded.
+                               case groupPattern: GroupPattern => ZIO.succeed(Seq(groupPattern))
                              }
     } yield transformedPatterns.flatten
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlQuery.scala
@@ -400,6 +400,17 @@ case class FunctionCallExpression(functionIri: IriRef, args: Seq[Entity]) extend
 }
 
 /**
+ * Represents the SPARQL `COALESCE` function.
+ *
+ * @param args the candidate expressions, evaluated in order; COALESCE returns the first bound one.
+ */
+case class CoalesceFunction(args: Seq[Entity]) extends Expression {
+  override def toSparql: String = s"COALESCE(${args.map(_.toSparql).mkString(", ")})"
+
+  override def getVariables: Set[QueryVariable] = args.toSet.flatMap((arg: Entity) => arg.getVariables)
+}
+
+/**
  * Represents a FILTER pattern in a query.
  *
  * @param expression the expression in the FILTER.
@@ -468,6 +479,21 @@ case class FilterNotExistsPattern(patterns: Seq[QueryPattern]) extends QueryPatt
  */
 case class MinusPattern(patterns: Seq[QueryPattern]) extends QueryPattern {
   override def toSparql: String = s"MINUS {\n ${patterns.map(_.toSparql).mkString}\n}\n"
+}
+
+/**
+ * Represents a fully opaque group of patterns, rendered verbatim as `{ ... }`. Every traversal pass
+ * (both [[org.knora.webapi.messages.util.search.gravsearch.prequery.GravsearchQueryOptimisation]]
+ * optimizations and the [[org.knora.webapi.messages.util.search.gravsearch.transformers.OntologyInferencer]]
+ * inference pass) treats a `GroupPattern` as an opaque leaf and passes it through unchanged; only
+ * [[QueryTraverser]] and [[org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInspectionUtil]]
+ * need an explicit case for it (their matches are otherwise exhaustive). Used to emit hand-proven SPARQL
+ * shapes whose interior must survive unmodified, e.g. the `matchFulltext` function's expansion.
+ *
+ * @param patterns the patterns contained in the group, rendered verbatim in document order.
+ */
+case class GroupPattern(patterns: Seq[QueryPattern]) extends QueryPattern {
+  override def toSparql: String = "{\n" + patterns.map(_.toSparql).mkString + "}\n"
 }
 
 /**

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -2049,13 +2049,15 @@ abstract class AbstractPrequeryGenerator(
   }
 
   /**
-   * Escapes a string for safe embedding in a SPARQL string literal: a raw `"` or `\` in the search
-   * term would otherwise break out of the literal, since [[XsdLiteral.toSparql]] concatenates its
-   * value without escaping. The same pre-existing gap affects `matchText`/`matchLabel`; tracked
-   * separately (fixing it here only protects `matchFulltext`).
+   * Escapes a string for safe embedding in a SPARQL string literal: a raw `"`, `\`, LF, or CR in the
+   * search term would otherwise break out of the literal (SPARQL's `STRING_LITERAL_QUOTE` grammar
+   * disallows all four unescaped), since [[XsdLiteral.toSparql]] concatenates its value without
+   * escaping. The backslash must be escaped first, or the backslashes this method inserts for the
+   * other characters would themselves be re-escaped. The same pre-existing gap affects
+   * `matchText`/`matchLabel`; tracked separately (fixing it here only protects `matchFulltext`).
    */
   private def escapeForSparqlLiteral(s: String): String =
-    s.replace("\\", "\\\\").replace("\"", "\\\"")
+    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
 
   /**
    * Builds the fulltext-index-anchored expansion for `matchFulltext`, mirroring the WHERE core of
@@ -2074,30 +2076,41 @@ abstract class AbstractPrequeryGenerator(
    * @param searchTerm  the raw (unescaped) Lucene query string, exactly as passed to `matchFulltext`.
    */
   private def matchFulltextExpansion(resourceVar: QueryVariable, searchTerm: String): GroupPattern = {
-    def internalVar(name: String): QueryVariable = QueryVariable(name + matchFulltextVariableSuffix)
+    val matchVar          = matchFulltextVar("match")
+    val containingResVar  = matchFulltextVar("containingRes")
+    val resWithListValVar = matchFulltextVar("resWithListVal")
 
-    val matchVar          = internalVar("match")
-    val valTypeVar        = internalVar("valType")
-    val containingResVar  = internalVar("containingRes")
-    val propVar           = internalVar("prop")
-    val subNodeVar        = internalVar("subNode")
-    val listValVar        = internalVar("listVal")
-    val resWithListValVar = internalVar("resWithListVal")
-    val predVar           = internalVar("pred")
-    val resClassVar       = internalVar("resClass")
+    val bindResource = BindPattern(
+      variable = resourceVar,
+      // Falls back to the match itself, which covers a direct label hit (the resource is its own label's subject).
+      expression = CoalesceFunction(Seq(containingResVar, resWithListValVar, matchVar)),
+    )
 
-    def isNotDeleted(subj: Entity): FilterNotExistsPattern =
-      FilterNotExistsPattern(
-        Seq(
-          StatementPattern(
-            subj = subj,
-            pred = IriRef(OntologyConstants.KnoraBase.IsDeleted.toSmartIri),
-            obj = XsdLiteral(value = "true", datatype = OntologyConstants.Xsd.Boolean.toSmartIri),
-          ),
+    GroupPattern(
+      Seq(
+        matchFulltextLuceneStatement(matchVar, searchTerm),
+        matchFulltextValueBranch(matchVar, containingResVar),
+        matchFulltextListBranch(matchVar, resWithListValVar),
+        bindResource,
+      ) ++ matchFulltextResourceClassCheck(resourceVar),
+    )
+  }
+
+  private def matchFulltextVar(name: String): QueryVariable = QueryVariable(name + matchFulltextVariableSuffix)
+
+  private def matchFulltextIsNotDeleted(subj: Entity): FilterNotExistsPattern =
+    FilterNotExistsPattern(
+      Seq(
+        StatementPattern(
+          subj = subj,
+          pred = IriRef(OntologyConstants.KnoraBase.IsDeleted.toSmartIri),
+          obj = XsdLiteral(value = "true", datatype = OntologyConstants.Xsd.Boolean.toSmartIri),
         ),
-      )
+      ),
+    )
 
-    val luceneStatement = StatementPattern(
+  private def matchFulltextLuceneStatement(matchVar: QueryVariable, searchTerm: String): StatementPattern =
+    StatementPattern(
       subj = matchVar,
       pred = IriRef(OntologyConstants.Fuseki.luceneQueryPredicate.toSmartIri),
       obj = XsdLiteral(
@@ -2106,8 +2119,12 @@ abstract class AbstractPrequeryGenerator(
       ),
     )
 
-    // A text value or value comment containing the match, and the resource that owns it.
-    val valueBranch = OptionalPattern(
+  /** A text value or value comment containing the match, and the resource that owns it. */
+  private def matchFulltextValueBranch(matchVar: QueryVariable, containingResVar: QueryVariable): OptionalPattern = {
+    val valTypeVar = matchFulltextVar("valType")
+    val propVar    = matchFulltextVar("prop")
+
+    OptionalPattern(
       Seq(
         StatementPattern(subj = matchVar, pred = IriRef(OntologyConstants.Rdf.Type.toSmartIri), obj = valTypeVar),
         StatementPattern(
@@ -2135,12 +2152,18 @@ abstract class AbstractPrequeryGenerator(
           pred = IriRef(OntologyConstants.Rdfs.SubPropertyOf.toSmartIri, propertyPathOperator = Some('*')),
           obj = IriRef(OntologyConstants.KnoraBase.HasValue.toSmartIri),
         ),
-        isNotDeleted(matchVar),
+        matchFulltextIsNotDeleted(matchVar),
       ),
     )
+  }
 
-    // A list node (or one of its sub-nodes) containing the match, and the resource referencing it via a list value.
-    val listBranch = OptionalPattern(
+  /** A list node (or one of its sub-nodes) containing the match, and the resource referencing it via a list value. */
+  private def matchFulltextListBranch(matchVar: QueryVariable, resWithListValVar: QueryVariable): OptionalPattern = {
+    val subNodeVar = matchFulltextVar("subNode")
+    val listValVar = matchFulltextVar("listVal")
+    val predVar    = matchFulltextVar("pred")
+
+    OptionalPattern(
       Seq(
         StatementPattern(
           subj = matchVar,
@@ -2158,17 +2181,15 @@ abstract class AbstractPrequeryGenerator(
           obj = subNodeVar,
         ),
         StatementPattern(subj = resWithListValVar, pred = predVar, obj = listValVar),
-        isNotDeleted(matchVar),
+        matchFulltextIsNotDeleted(matchVar),
       ),
     )
+  }
 
-    // Fall back to the match itself, which covers a direct label hit (the resource is its own label's subject).
-    val bindResource = BindPattern(
-      variable = resourceVar,
-      expression = CoalesceFunction(Seq(containingResVar, resWithListValVar, matchVar)),
-    )
+  private def matchFulltextResourceClassCheck(resourceVar: QueryVariable): Seq[StatementPattern] = {
+    val resClassVar = matchFulltextVar("resClass")
 
-    val resourceClassCheck = Seq(
+    Seq(
       StatementPattern(subj = resourceVar, pred = IriRef(OntologyConstants.Rdf.Type.toSmartIri), obj = resClassVar),
       StatementPattern(
         subj = resClassVar,
@@ -2176,8 +2197,6 @@ abstract class AbstractPrequeryGenerator(
         obj = IriRef(OntologyConstants.KnoraBase.Resource.toSmartIri),
       ),
     )
-
-    GroupPattern(Seq(luceneStatement, valueBranch, listBranch, bindResource) ++ resourceClassCheck)
   }
 
   /**

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -28,13 +28,16 @@ import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 /**
  * An abstract base class for [[WhereTransformer]] instances that generate SPARQL prequeries from Gravsearch input.
  *
- * @param typeInspectionResult the result of running type inspection on the Gravsearch input.
- * @param querySchema          the ontology schema used in the input Gravsearch query.
+ * @param typeInspectionResult  the result of running type inspection on the Gravsearch input.
+ * @param querySchema           the ontology schema used in the input Gravsearch query.
+ * @param searchValueMinLength  the minimum length required for a `matchFulltext` search term
+ *                              (`appConfig.v2.fulltextSearch.searchValueMinLength`).
  */
 abstract class AbstractPrequeryGenerator(
   constructClause: ConstructClause,
   typeInspectionResult: GravsearchTypeInspectionResult,
   querySchema: ApiV2Schema,
+  searchValueMinLength: Int,
 ) extends WhereTransformer {
 
   /**
@@ -1915,6 +1918,268 @@ abstract class AbstractPrequeryGenerator(
       ),
     )
 
+  // Fixed suffix for the internal variables introduced by the matchFulltext expansion. A fixed suffix
+  // is safe because at most one matchFulltext call is allowed per query (D5 below), so there is never
+  // more than one expansion whose internal variables could collide.
+  private val matchFulltextVariableSuffix = "__matchFulltext"
+
+  // Set once handleMatchFulltextFunction has processed a call, so a second call in the same query can
+  // be rejected: the performance spike for DEV-6715 measured a second call at 17-38s, since Jena
+  // substitution-joins the second block, re-running its Lucene lookups per candidate row of the first.
+  private var matchFulltextFunctionCalled = false
+
+  /**
+   * Checks that the query is in the simple schema, then calls `handleMatchFulltextFunction`.
+   *
+   * @param functionCallExpression the function call to be handled.
+   * @param typeInspectionResult   the type inspection results.
+   * @param isTopLevel             if `true`, this is the top-level expression in the `FILTER`.
+   * @return a [[TransformedFilterPattern]].
+   */
+  private def handleMatchFulltextFunctionInSimpleSchema(
+    functionCallExpression: FunctionCallExpression,
+    typeInspectionResult: GravsearchTypeInspectionResult,
+    isTopLevel: Boolean,
+  ): TransformedFilterPattern = {
+    val functionIri: SmartIri = functionCallExpression.functionIri.iri
+
+    if (querySchema == ApiV2Complex) {
+      throw GravsearchException(
+        s"Function ${functionIri.toSparql} cannot be used in a Gravsearch query written in the complex schema; use ${OntologyConstants.KnoraApiV2Complex.MatchFulltextFunction.toSmartIri.toSparql} instead",
+      )
+    }
+
+    handleMatchFulltextFunction(
+      functionCallExpression = functionCallExpression,
+      typeInspectionResult = typeInspectionResult,
+      isTopLevel = isTopLevel,
+    )
+  }
+
+  /**
+   * Checks that the query is in the complex schema, then calls `handleMatchFulltextFunction`.
+   *
+   * @param functionCallExpression the function call to be handled.
+   * @param typeInspectionResult   the type inspection results.
+   * @param isTopLevel             if `true`, this is the top-level expression in the `FILTER`.
+   * @return a [[TransformedFilterPattern]].
+   */
+  private def handleMatchFulltextFunctionInComplexSchema(
+    functionCallExpression: FunctionCallExpression,
+    typeInspectionResult: GravsearchTypeInspectionResult,
+    isTopLevel: Boolean,
+  ): TransformedFilterPattern = {
+    val functionIri: SmartIri = functionCallExpression.functionIri.iri
+
+    if (querySchema == ApiV2Simple) {
+      throw GravsearchException(
+        s"Function ${functionIri.toSparql} cannot be used in a Gravsearch query written in the simple schema; use ${OntologyConstants.KnoraApiV2Simple.MatchFulltextFunction.toSmartIri.toSparql} instead",
+      )
+    }
+
+    handleMatchFulltextFunction(
+      functionCallExpression = functionCallExpression,
+      typeInspectionResult = typeInspectionResult,
+      isTopLevel = isTopLevel,
+    )
+  }
+
+  /**
+   * Handles the function `knora-api:matchFulltext` in either schema. Replaces the FILTER with an
+   * index-anchored expansion giving exact match-semantics parity with `GET /v2/search/{term}`:
+   * the resource variable is bound only to resources for which the fulltext index matches the
+   * resource's label, one of its text values, one of its value comments, or a list node (including
+   * sub-nodes) referenced by one of its list values.
+   *
+   * @param functionCallExpression the function call to be handled.
+   * @param typeInspectionResult   the type inspection results.
+   * @param isTopLevel             if `true`, this is the top-level expression in the `FILTER`.
+   * @return a [[TransformedFilterPattern]].
+   */
+  private def handleMatchFulltextFunction(
+    functionCallExpression: FunctionCallExpression,
+    typeInspectionResult: GravsearchTypeInspectionResult,
+    isTopLevel: Boolean,
+  ): TransformedFilterPattern = {
+    val functionIri: SmartIri = functionCallExpression.functionIri.iri
+
+    // The matchFulltext function must be the top-level expression, otherwise boolean logic won't work properly.
+    if (!isTopLevel) {
+      throw GravsearchException(s"Function ${functionIri.toSparql} must be the top-level expression in a FILTER")
+    }
+
+    if (matchFulltextFunctionCalled) {
+      throw GravsearchException(s"Function ${functionIri.toSparql} may only be used once per query")
+    }
+    matchFulltextFunctionCalled = true
+
+    // Two arguments are expected:
+    // 1. a variable representing a resource
+    // 2. a string literal search term
+
+    if (functionCallExpression.args.size != 2)
+      throw GravsearchException(s"Two arguments are expected for ${functionIri.toSparql}")
+
+    // A QueryVariable expected to represent a resource.
+    val resourceVar: QueryVariable = functionCallExpression.getArgAsQueryVar(pos = 0)
+
+    typeInspectionResult.getTypeOfEntity(resourceVar) match {
+      case Some(nonPropInfo: NonPropertyTypeInfo) if nonPropInfo.isResourceType => ()
+      case _                                                                    => throw GravsearchException(s"${resourceVar.toSparql} must be a knora-api:Resource")
+    }
+
+    val searchTerm: String =
+      functionCallExpression.getArgAsLiteral(1, xsdDatatype = OntologyConstants.Xsd.String.toSmartIri).value
+
+    // Mirrors the fulltext endpoint's own search-string validation (SearchResponderV2.validateSearchString).
+    if (searchTerm.isEmpty || searchTerm.contains("\r")) {
+      throw GravsearchException(s"Invalid search string for ${functionIri.toSparql}: '$searchTerm'")
+    }
+    if (searchTerm.length < searchValueMinLength) {
+      throw GravsearchException(
+        s"A search value for ${functionIri.toSparql} is expected to have at least length of $searchValueMinLength, but '$searchTerm' given of length ${searchTerm.length}.",
+      )
+    }
+
+    // Replace the filter with the fulltext-index-anchored expansion.
+    TransformedFilterPattern(
+      None, // The FILTER has been replaced by statements.
+      Seq(matchFulltextExpansion(resourceVar, searchTerm)),
+    )
+  }
+
+  /**
+   * Escapes a string for safe embedding in a SPARQL string literal: a raw `"` or `\` in the search
+   * term would otherwise break out of the literal, since [[XsdLiteral.toSparql]] concatenates its
+   * value without escaping. The same pre-existing gap affects `matchText`/`matchLabel`; tracked
+   * separately (fixing it here only protects `matchFulltext`).
+   */
+  private def escapeForSparqlLiteral(s: String): String =
+    s.replace("\\", "\\\\").replace("\"", "\\\"")
+
+  /**
+   * Builds the fulltext-index-anchored expansion for `matchFulltext`, mirroring the WHERE core of
+   * [[org.knora.webapi.slice.search.repo.SearchFulltextQuery]]: a Lucene hit anchors the match, and
+   * two OPTIONAL blocks resolve it to a containing resource — either the resource that owns the
+   * matched value (a text value or a value comment; the match may also be the resource itself via its
+   * label, handled by the final COALESCE fallback), or the resource that references the matched list
+   * node (including sub-nodes) via a list value. COALESCE picks whichever resolved.
+   *
+   * The whole block is wrapped in an opaque [[GroupPattern]] so it survives unmodified: the group's
+   * `rdf:type ?var` statements (a variable object) would otherwise be rejected by the inference pass,
+   * and its `BIND` would otherwise be hoisted above the `OPTIONAL`s it depends on by the optimizer
+   * passes. See docs/05-internals/design/api-v2/gravsearch.md for the full rationale.
+   *
+   * @param resourceVar the user's resource variable, bound by the group's closing `BIND`.
+   * @param searchTerm  the raw (unescaped) Lucene query string, exactly as passed to `matchFulltext`.
+   */
+  private def matchFulltextExpansion(resourceVar: QueryVariable, searchTerm: String): GroupPattern = {
+    def internalVar(name: String): QueryVariable = QueryVariable(name + matchFulltextVariableSuffix)
+
+    val matchVar          = internalVar("match")
+    val valTypeVar        = internalVar("valType")
+    val containingResVar  = internalVar("containingRes")
+    val propVar           = internalVar("prop")
+    val subNodeVar        = internalVar("subNode")
+    val listValVar        = internalVar("listVal")
+    val resWithListValVar = internalVar("resWithListVal")
+    val predVar           = internalVar("pred")
+    val resClassVar       = internalVar("resClass")
+
+    def isNotDeleted(subj: Entity): FilterNotExistsPattern =
+      FilterNotExistsPattern(
+        Seq(
+          StatementPattern(
+            subj = subj,
+            pred = IriRef(OntologyConstants.KnoraBase.IsDeleted.toSmartIri),
+            obj = XsdLiteral(value = "true", datatype = OntologyConstants.Xsd.Boolean.toSmartIri),
+          ),
+        ),
+      )
+
+    val luceneStatement = StatementPattern(
+      subj = matchVar,
+      pred = IriRef(OntologyConstants.Fuseki.luceneQueryPredicate.toSmartIri),
+      obj = XsdLiteral(
+        value = escapeForSparqlLiteral(searchTerm),
+        datatype = OntologyConstants.Xsd.String.toSmartIri,
+      ),
+    )
+
+    // A text value or value comment containing the match, and the resource that owns it.
+    val valueBranch = OptionalPattern(
+      Seq(
+        StatementPattern(subj = matchVar, pred = IriRef(OntologyConstants.Rdf.Type.toSmartIri), obj = valTypeVar),
+        StatementPattern(
+          subj = valTypeVar,
+          pred = IriRef(OntologyConstants.Rdfs.SubClassOf.toSmartIri, propertyPathOperator = Some('*')),
+          obj = IriRef(OntologyConstants.KnoraBase.Value.toSmartIri),
+        ),
+        FilterPattern(
+          AndExpression(
+            CompareExpression(
+              valTypeVar,
+              CompareExpressionOperator.NOT_EQUALS,
+              IriRef(OntologyConstants.KnoraBase.LinkValue.toSmartIri),
+            ),
+            CompareExpression(
+              valTypeVar,
+              CompareExpressionOperator.NOT_EQUALS,
+              IriRef(OntologyConstants.KnoraBase.ListValue.toSmartIri),
+            ),
+          ),
+        ),
+        StatementPattern(subj = containingResVar, pred = propVar, obj = matchVar),
+        StatementPattern(
+          subj = propVar,
+          pred = IriRef(OntologyConstants.Rdfs.SubPropertyOf.toSmartIri, propertyPathOperator = Some('*')),
+          obj = IriRef(OntologyConstants.KnoraBase.HasValue.toSmartIri),
+        ),
+        isNotDeleted(matchVar),
+      ),
+    )
+
+    // A list node (or one of its sub-nodes) containing the match, and the resource referencing it via a list value.
+    val listBranch = OptionalPattern(
+      Seq(
+        StatementPattern(
+          subj = matchVar,
+          pred = IriRef(OntologyConstants.Rdf.Type.toSmartIri),
+          obj = IriRef(OntologyConstants.KnoraBase.ListNode.toSmartIri),
+        ),
+        StatementPattern(
+          subj = matchVar,
+          pred = IriRef(OntologyConstants.KnoraBase.HasSubListNode.toSmartIri, propertyPathOperator = Some('*')),
+          obj = subNodeVar,
+        ),
+        StatementPattern(
+          subj = listValVar,
+          pred = IriRef(OntologyConstants.KnoraBase.ValueHasListNode.toSmartIri),
+          obj = subNodeVar,
+        ),
+        StatementPattern(subj = resWithListValVar, pred = predVar, obj = listValVar),
+        isNotDeleted(matchVar),
+      ),
+    )
+
+    // Fall back to the match itself, which covers a direct label hit (the resource is its own label's subject).
+    val bindResource = BindPattern(
+      variable = resourceVar,
+      expression = CoalesceFunction(Seq(containingResVar, resWithListValVar, matchVar)),
+    )
+
+    val resourceClassCheck = Seq(
+      StatementPattern(subj = resourceVar, pred = IriRef(OntologyConstants.Rdf.Type.toSmartIri), obj = resClassVar),
+      StatementPattern(
+        subj = resClassVar,
+        pred = IriRef(OntologyConstants.Rdfs.SubClassOf.toSmartIri, propertyPathOperator = Some('*')),
+        obj = IriRef(OntologyConstants.KnoraBase.Resource.toSmartIri),
+      ),
+    )
+
+    GroupPattern(Seq(luceneStatement, valueBranch, listBranch, bindResource) ++ resourceClassCheck)
+  }
+
   /**
    * Handles the function `knora-api:StandoffLink`.
    *
@@ -2036,6 +2301,8 @@ abstract class AbstractPrequeryGenerator(
         case OntologyConstants.KnoraApiV2Complex.MatchTextFunction           => handleMatchTextFunctionInComplexSchema
         case OntologyConstants.KnoraApiV2Simple.MatchLabelFunction           => handleMatchLabelFunctionInSimpleSchema
         case OntologyConstants.KnoraApiV2Complex.MatchLabelFunction          => handleMatchLabelFunctionInComplexSchema
+        case OntologyConstants.KnoraApiV2Simple.MatchFulltextFunction        => handleMatchFulltextFunctionInSimpleSchema
+        case OntologyConstants.KnoraApiV2Complex.MatchFulltextFunction       => handleMatchFulltextFunctionInComplexSchema
         case OntologyConstants.KnoraApiV2Complex.MatchTextInStandoffFunction => handleMatchTextInStandoffFunction
         case OntologyConstants.KnoraApiV2Complex.StandoffLinkFunction        => handleStandoffLinkFunction
         case OntologyConstants.KnoraApiV2Complex.ToSimpleDateFunction        =>

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -2099,15 +2099,7 @@ abstract class AbstractPrequeryGenerator(
   private def matchFulltextVar(name: String): QueryVariable = QueryVariable(name + matchFulltextVariableSuffix)
 
   private def matchFulltextIsNotDeleted(subj: Entity): FilterNotExistsPattern =
-    FilterNotExistsPattern(
-      Seq(
-        StatementPattern(
-          subj = subj,
-          pred = IriRef(OntologyConstants.KnoraBase.IsDeleted.toSmartIri),
-          obj = XsdLiteral(value = "true", datatype = OntologyConstants.Xsd.Boolean.toSmartIri),
-        ),
-      ),
-    )
+    SparqlTransformer.notDeletedFilter(subj)
 
   private def matchFulltextLuceneStatement(matchVar: QueryVariable, searchTerm: String): StatementPattern =
     StatementPattern(

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToCountPrequeryTransformer.scala
@@ -20,15 +20,18 @@ import org.knora.webapi.messages.util.search.gravsearch.types.GravsearchTypeInsp
  * @param constructClause      the CONSTRUCT clause from the input query.
  * @param typeInspectionResult the result of type inspection of the input query.
  * @param querySchema          the ontology schema used in the input query.
+ * @param searchValueMinLength the minimum length required for a `matchFulltext` search term.
  */
 class GravsearchToCountPrequeryTransformer(
   constructClause: ConstructClause,
   typeInspectionResult: GravsearchTypeInspectionResult,
   querySchema: ApiV2Schema,
+  searchValueMinLength: Int,
 ) extends AbstractPrequeryGenerator(
       constructClause = constructClause,
       typeInspectionResult = typeInspectionResult,
       querySchema = querySchema,
+      searchValueMinLength = searchValueMinLength,
     ) {
 
   override def getSelectColumns: Task[Seq[SelectQueryColumn]] =

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/GravsearchToPrequeryTransformer.scala
@@ -39,6 +39,7 @@ class GravsearchToPrequeryTransformer(
       constructClause = constructClause,
       typeInspectionResult = typeInspectionResult,
       querySchema = querySchema,
+      searchValueMinLength = appConfig.v2.fulltextSearch.searchValueMinLength,
     ) {
 
   /**

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SelectTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SelectTransformer.scala
@@ -27,16 +27,26 @@ class SelectTransformer(
 
   override def transformFilter(filterPattern: FilterPattern): Task[Seq[QueryPattern]] = ZIO.succeed(Seq(filterPattern))
 
+  // Gives each statement a unique suffix for the VALUES variables the inference pass may introduce
+  // (e.g. `?resTypes0`, `?resTypes1`, ...), instead of the random one `OntologyInferencer` falls back
+  // to. Determinism lets prequery golden-snapshot tests assert on the rendered SPARQL; a *constant*
+  // suffix would be wrong here, since it would give unrelated statements (e.g. `?mainRes a Resource`
+  // and `?val a Value`) the same VALUES variable, intersecting their blocks into empty results.
+  private var statementCounter = 0
+
   override def transformStatementInWhere(
     statementPattern: StatementPattern,
     inputOrderBy: Seq[OrderCriterion],
     limitInferenceToOntologies: Option[Set[SmartIri]] = None,
-  ): Task[Seq[QueryPattern]] =
+  ): Task[Seq[QueryPattern]] = {
+    statementCounter += 1
     inferencer.transformStatementInWhere(
       statementPattern = statementPattern,
       simulateInference = simulateInference,
       limitInferenceToOntologies = limitInferenceToOntologies,
+      queryVariableSuffix = Some(statementCounter.toString),
     )
+  }
   override def optimiseQueryPatterns(patterns: Seq[QueryPattern]): Task[Seq[QueryPattern]] = ZIO.attempt {
     moveBindToBeginning(optimiseIsDeletedWithFilter(moveLuceneToBeginning(patterns)))
   }

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SelectTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SelectTransformer.scala
@@ -38,15 +38,18 @@ class SelectTransformer(
     statementPattern: StatementPattern,
     inputOrderBy: Seq[OrderCriterion],
     limitInferenceToOntologies: Option[Set[SmartIri]] = None,
-  ): Task[Seq[QueryPattern]] = {
-    statementCounter += 1
-    inferencer.transformStatementInWhere(
-      statementPattern = statementPattern,
-      simulateInference = simulateInference,
-      limitInferenceToOntologies = limitInferenceToOntologies,
-      queryVariableSuffix = Some(statementCounter.toString),
-    )
-  }
+  ): Task[Seq[QueryPattern]] =
+    // Defer the counter increment into the returned effect (matching AbstractPrequeryGenerator's
+    // ZIO.attempt-wrapped state updates), so the suffix is derived when the effect runs rather than
+    // as a bare side effect of building it.
+    ZIO.succeed { statementCounter += 1; statementCounter.toString }.flatMap { suffix =>
+      inferencer.transformStatementInWhere(
+        statementPattern = statementPattern,
+        simulateInference = simulateInference,
+        limitInferenceToOntologies = limitInferenceToOntologies,
+        queryVariableSuffix = Some(suffix),
+      )
+    }
   override def optimiseQueryPatterns(patterns: Seq[QueryPattern]): Task[Seq[QueryPattern]] = ZIO.attempt {
     moveBindToBeginning(optimiseIsDeletedWithFilter(moveLuceneToBeginning(patterns)))
   }

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SparqlTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SparqlTransformer.scala
@@ -140,16 +140,29 @@ object SparqlTransformer {
   }
 
   /**
-   * Optimises a query by moving Lucene query patterns to the beginning of a block.
+   * `true` if the pattern is a Lucene query statement, or a [[GroupPattern]] containing one at its
+   * top level (e.g. the `matchFulltext` expansion) — used by [[moveLuceneToBeginning]].
+   */
+  private def containsLuceneQuery(pattern: QueryPattern): Boolean = pattern match {
+    case StatementPattern(_, IriRef(pred, _), _) => pred.toIri == OntologyConstants.Fuseki.luceneQueryPredicate
+    case groupPattern: GroupPattern              => groupPattern.patterns.exists(containsLuceneQuery)
+    case _                                       => false
+  }
+
+  /**
+   * Optimises a query by moving Lucene query patterns to the beginning of a block. This also hoists a
+   * [[GroupPattern]] whose contents include a Lucene query statement (e.g. the `matchFulltext`
+   * expansion): leaving it in place risks a class-first join order, since document order is otherwise
+   * whatever position the FILTER it replaced happened to end up in. For a classless query this is not
+   * just slow but catastrophic — the ontology-cache VALUES block for `?mainRes a knora-api:Resource`
+   * enumerates every resource class in the repository, and evaluating that before the (cheap,
+   * index-anchored) Lucene lookup measured ~300x slower in the performance spike for DEV-6715.
    *
    * @param patterns the block of patterns to be optimised.
    * @return the result of the optimisation.
    */
   def moveLuceneToBeginning(patterns: Seq[QueryPattern]): Seq[QueryPattern] = {
-    val (luceneQueryPatterns, otherPatterns) = patterns.partition {
-      case StatementPattern(_, IriRef(pred, _), _) => pred.toIri == OntologyConstants.Fuseki.luceneQueryPredicate
-      case _                                       => false
-    }
+    val (luceneQueryPatterns, otherPatterns) = patterns.partition(containsLuceneQuery)
 
     luceneQueryPatterns ++ otherPatterns
   }

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SparqlTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SparqlTransformer.scala
@@ -87,6 +87,26 @@ object SparqlTransformer {
     createUniqueVariableFromStatement(baseStatement, "LinkValue")
 
   /**
+   * Builds the canonical `FILTER NOT EXISTS { subj knora-base:isDeleted true }` guard for the given
+   * subject. Shared by [[optimiseIsDeletedWithFilter]] (which rewrites `isDeleted false` statements)
+   * and the `matchFulltext` expansion in
+   * [[org.knora.webapi.messages.util.search.gravsearch.prequery.AbstractPrequeryGenerator]], so both
+   * emit the same AST shape and a change to how deletion is represented lives in one place.
+   */
+  def notDeletedFilter(subj: Entity): FilterNotExistsPattern = {
+    implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
+    FilterNotExistsPattern(
+      Seq(
+        StatementPattern(
+          subj = subj,
+          pred = IriRef(OntologyConstants.KnoraBase.IsDeleted.toSmartIri),
+          obj = XsdLiteral(value = "true", datatype = OntologyConstants.Xsd.Boolean.toSmartIri),
+        ),
+      ),
+    )
+  }
+
+  /**
    * Optimises a query by replacing `knora-base:isDeleted false` with a `FILTER NOT EXISTS` pattern
    * placed at the end of the block.
    *
@@ -94,8 +114,6 @@ object SparqlTransformer {
    * @return the result of the optimisation.
    */
   def optimiseIsDeletedWithFilter(patterns: Seq[QueryPattern]): Seq[QueryPattern] = {
-    implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
-
     // Separate the knora-base:isDeleted statements from the rest of the block.
     val (isDeletedPatterns: Seq[QueryPattern], otherPatterns: Seq[QueryPattern]) = patterns.partition {
       case StatementPattern(
@@ -109,16 +127,7 @@ object SparqlTransformer {
 
     // Replace the knora-base:isDeleted statements with FILTER NOT EXISTS patterns.
     val filterPatterns: Seq[FilterNotExistsPattern] = isDeletedPatterns.collect {
-      case statementPattern: StatementPattern =>
-        FilterNotExistsPattern(
-          Seq(
-            StatementPattern(
-              subj = statementPattern.subj,
-              pred = IriRef(OntologyConstants.KnoraBase.IsDeleted.toSmartIri),
-              obj = XsdLiteral(value = "true", datatype = OntologyConstants.Xsd.Boolean.toSmartIri),
-            ),
-          ),
-        )
+      case statementPattern: StatementPattern => notDeletedFilter(statementPattern.subj)
     }
 
     otherPatterns ++ filterPatterns

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
@@ -250,5 +250,7 @@ object GravsearchTypeInspectionUtil {
       case statementPattern: StatementPattern =>
         if (mustBeAnnotationStatement(statementPattern)) Seq.empty[QueryPattern]
         else Seq(statementPattern)
+      // Opaque: cannot contain a type annotation, and never appears before function expansion anyway.
+      case groupPattern: GroupPattern => Seq(groupPattern)
     }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
@@ -1516,6 +1516,28 @@ final class InferringGravsearchTypeInspector(
               (resourceVar -> (currentResourceVarTypesFromFilters + OntologyConstants.KnoraApiV2Complex.Resource.toSmartIri)),
           )
 
+        case OntologyConstants.KnoraApiV2Simple.MatchFulltextFunction =>
+          // The first argument is a variable representing a resource.
+          val resourceVar                                       = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
+          val currentResourceVarTypesFromFilters: Set[SmartIri] =
+            usageIndex.typedEntitiesInFilters.getOrElse(resourceVar, Set.empty)
+
+          usageIndex.copy(
+            typedEntitiesInFilters = usageIndex.typedEntitiesInFilters +
+              (resourceVar -> (currentResourceVarTypesFromFilters + OntologyConstants.KnoraApiV2Simple.Resource.toSmartIri)),
+          )
+
+        case OntologyConstants.KnoraApiV2Complex.MatchFulltextFunction =>
+          // The first argument is a variable representing a resource.
+          val resourceVar                                       = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
+          val currentResourceVarTypesFromFilters: Set[SmartIri] =
+            usageIndex.typedEntitiesInFilters.getOrElse(resourceVar, Set.empty)
+
+          usageIndex.copy(
+            typedEntitiesInFilters = usageIndex.typedEntitiesInFilters +
+              (resourceVar -> (currentResourceVarTypesFromFilters + OntologyConstants.KnoraApiV2Complex.Resource.toSmartIri)),
+          )
+
         case OntologyConstants.KnoraApiV2Complex.MatchTextInStandoffFunction =>
           // The first argument is a variable representing a text value.
           val textVar                                       = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -721,6 +721,7 @@ final class SearchResponderV2Live(
                                constructClause = query.constructClause,
                                typeInspectionResult = typeInspectionResult,
                                querySchema = querySchema,
+                               searchValueMinLength = appConfig.v2.fulltextSearch.searchValueMinLength,
                              ),
                            )
                          prequery <-

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2Module.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2Module.scala
@@ -29,8 +29,8 @@ object SearchResponderV2Module {
   type Dependencies = StandoffTagUtilV2 & AppConfig & TriplestoreService & ConstructResponseUtilV2 & OntologyCache &
     OntologyCacheHelpers & OntologyRepo & IriConverter & StringFormatter & ProjectService & Tracing
 
-  type Provided = GravsearchTypeInspectionRunner & InferringGravsearchTypeInspector & OntologyInferencer &
-    QueryTraverser & SearchResponderV2Live
+  type Provided = GravsearchTypeInspectionRunner & InferenceOptimizationService & InferringGravsearchTypeInspector &
+    OntologyInferencer & QueryTraverser & SearchResponderV2Live
 
   val layer: URLayer[Dependencies, Provided] =
     (OntologyInferencer.layer ++ QueryTraverser.layer ++ InferenceOptimizationService.layer) >+>

--- a/modules/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SparqlTransformerSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/transformers/SparqlTransformerSpec.scala
@@ -147,5 +147,30 @@ object SparqlTransformerSpec extends ZIOSpecDefault {
       )
       assertTrue(optimisedPatterns == expectedPatterns)
     },
+    test("move a GroupPattern containing a Lucene query pattern to the beginning of a block") {
+      // Simulates the classless-query pathology from the DEV-6715 spike: a plain rdf:type statement
+      // (which the inference pass later expands into a repo-wide VALUES block of every resource class)
+      // sitting before the matchFulltext expansion in document order would otherwise force that
+      // expensive VALUES join to run before the cheap, index-anchored Lucene lookup.
+      val resourceTypeStatement = StatementPattern(
+        subj = QueryVariable("mainRes"),
+        pred = IriRef(OntologyConstants.Rdf.Type.toSmartIri),
+        obj = IriRef(thingIRI),
+      )
+      val luceneQueryPattern = StatementPattern(
+        subj = QueryVariable("match__matchFulltext"),
+        pred = IriRef(OntologyConstants.Fuseki.luceneQueryPredicate.toSmartIri),
+        obj = XsdLiteral(value = "term", datatype = OntologyConstants.Xsd.String.toSmartIri),
+      )
+      val bindResource = BindPattern(
+        variable = QueryVariable("mainRes"),
+        expression = QueryVariable("match__matchFulltext"),
+      )
+      val groupPattern                        = GroupPattern(Seq(luceneQueryPattern, bindResource))
+      val patterns: Seq[QueryPattern]         = Seq(resourceTypeStatement, groupPattern)
+      val optimisedPatterns                   = SparqlTransformer.moveLuceneToBeginning(patterns)
+      val expectedPatterns: Seq[QueryPattern] = Seq(groupPattern, resourceTypeStatement)
+      assertTrue(optimisedPatterns == expectedPatterns)
+    },
   )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/util/search/gravsearch/GravsearchParserSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/util/search/gravsearch/GravsearchParserSpec.scala
@@ -520,6 +520,19 @@ object GravsearchParserSpec extends ZIOSpecDefault {
       |}
         """.stripMargin
 
+  private val QueryWithMatchFulltextFunction: String =
+    """
+      |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+      |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+      |
+      |CONSTRUCT {
+      |    ?thing knora-api:isMainResource true .
+      |} WHERE {
+      |    ?thing a anything:Thing .
+      |    FILTER(knora-api:matchFulltext(?thing, "foo"))
+      |}
+        """.stripMargin
+
   private val QueryWithFilterContainingLang: String =
     """
       |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
@@ -1774,6 +1787,74 @@ object GravsearchParserSpec extends ZIOSpecDefault {
     ),
   )
 
+  private val ParsedQueryWithMatchFulltextFunction = ConstructQuery(
+    constructClause = ConstructClause(
+      statements = Vector(
+        StatementPattern(
+          subj = QueryVariable(variableName = "thing"),
+          pred = IriRef(
+            iri = "http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri,
+            propertyPathOperator = None,
+          ),
+          obj = XsdLiteral(
+            value = "true",
+            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri,
+          ),
+        ),
+      ),
+      querySchema = Some(ApiV2Simple),
+    ),
+    querySchema = Some(ApiV2Simple),
+    offset = 0,
+    orderBy = Nil,
+    whereClause = WhereClause(
+      patterns = Vector(
+        StatementPattern(
+          subj = QueryVariable(variableName = "thing"),
+          pred = IriRef(
+            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+            propertyPathOperator = None,
+          ),
+          obj = IriRef(
+            iri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
+            propertyPathOperator = None,
+          ),
+        ),
+        FilterPattern(
+          expression = FunctionCallExpression(
+            functionIri = IriRef(
+              iri = "http://api.knora.org/ontology/knora-api/simple/v2#matchFulltext".toSmartIri,
+              propertyPathOperator = None,
+            ),
+            args = Vector(
+              QueryVariable(variableName = "thing"),
+              XsdLiteral(
+                value = "foo",
+                datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri,
+              ),
+            ),
+          ),
+        ),
+      ),
+      positiveEntities = Set(
+        QueryVariable(variableName = "thing"),
+        IriRef(
+          iri = "http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri,
+          propertyPathOperator = None,
+        ),
+        IriRef(
+          iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+          propertyPathOperator = None,
+        ),
+        IriRef(
+          iri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
+          propertyPathOperator = None,
+        ),
+      ),
+      querySchema = Some(ApiV2Simple),
+    ),
+  )
+
   private val ParsedQueryWithLangFunction = ConstructQuery(
     constructClause = ConstructClause(
       statements = Vector(
@@ -2197,6 +2278,12 @@ object GravsearchParserSpec extends ZIOSpecDefault {
       val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
 
       assertTrue(parsed == ParsedQueryWithMatchTextFunction, reparsed == parsed)
+    },
+    test("accept a custom 'matchFulltext' function in a FILTER") {
+      val parsed   = GravsearchParser.parseQuery(QueryWithMatchFulltextFunction)
+      val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+
+      assertTrue(parsed == ParsedQueryWithMatchFulltextFunction, reparsed == parsed)
     },
     test("parse a Gravsearch query with a FILTER containing a lang function") {
       val parsed   = GravsearchParser.parseQuery(QueryWithFilterContainingLang)

--- a/test_data/generated_test_data/e2e.v2.MatchFulltextE2ESpec/matchfulltext-data.ttl
+++ b/test_data/generated_test_data/e2e.v2.MatchFulltextE2ESpec/matchfulltext-data.ttl
@@ -1,0 +1,191 @@
+@prefix xsd:         <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:        <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix knora-base:  <http://www.knora.org/ontology/knora-base#> .
+@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+@prefix anything:    <http://www.knora.org/ontology/0001/anything#> .
+
+# Self-contained fixture for matchFulltext E2E tests (DEV-6715). Reuses the existing "anything"
+# project (0001), its default users, and the anything:Thing/anything:hasText ontology terms —
+# no new project/ontology registration needed — but is its own data file/graph so it never
+# touches the shared test_data/project_data/anything-data.ttl (per CLAUDE.md: shared datasets are
+# loaded by many tests; a new record there can cause cascading failures across unrelated specs).
+#
+# Every resource/value/list-node below carries a token from the "Zqxvnonce7f3" nonce family, each
+# with a distinct suffix so tests can search for one distinguishing token and know exactly which
+# match path (label / text value / value comment / list node) fired.
+
+# --- List: one root with two children, giving matchfulltextA and matchfulltextE a list to point to.
+
+<http://rdfh.ch/lists/0001/matchfulltextListRoot>
+    a                            knora-base:ListNode ;
+    knora-base:isRootNode        true ;
+    knora-base:listNodeName      "matchfulltextListRoot" ;
+    rdfs:label                   "matchFulltext test list root"@en ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:hasSubListNode    <http://rdfh.ch/lists/0001/matchfulltextListChildA>,
+                                  <http://rdfh.ch/lists/0001/matchfulltextListChildE> .
+
+<http://rdfh.ch/lists/0001/matchfulltextListChildA>
+    a                            knora-base:ListNode ;
+    knora-base:listNodeName      "matchfulltextListChildA" ;
+    knora-base:hasRootNode       <http://rdfh.ch/lists/0001/matchfulltextListRoot> ;
+    knora-base:listNodePosition  0 ;
+    rdfs:label                   "Zqxvnonce7f3Listnode"@en .
+
+<http://rdfh.ch/lists/0001/matchfulltextListChildE>
+    a                            knora-base:ListNode ;
+    knora-base:listNodeName      "matchfulltextListChildE" ;
+    knora-base:hasRootNode       <http://rdfh.ch/lists/0001/matchfulltextListRoot> ;
+    knora-base:listNodePosition  1 ;
+    rdfs:label                   "Zqxvnonce7f3D11List"@en .
+
+# --- Resource A: matches via all four paths (label, text value, value comment, list node).
+
+<http://rdfh.ch/0001/matchfulltextA>
+    a                            anything:Thing ;
+    rdfs:label                   "Zqxvnonce7f3Label" ;
+    knora-base:isDeleted         false ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:creationDate      "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+    anything:hasText             <http://rdfh.ch/0001/matchfulltextA/values/text1> ;
+    anything:hasListItem         <http://rdfh.ch/0001/matchfulltextA/values/list1> .
+
+<http://rdfh.ch/0001/matchfulltextA/values/text1>
+    a                            knora-base:TextValue ;
+    knora-base:valueHasUUID      "mftA0text1UUID000000"^^xsd:string ;
+    knora-base:isDeleted         false ;
+    knora-base:valueCreationDate "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:valueHasOrder     0 ;
+    knora-base:valueHasString    "Zqxvnonce7f3Text" ;
+    knora-base:valueHasComment   "Zqxvnonce7f3Comment" ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
+
+<http://rdfh.ch/0001/matchfulltextA/values/list1>
+    a                            knora-base:ListValue ;
+    knora-base:valueHasUUID      "mftA0list1UUID000000"^^xsd:string ;
+    knora-base:isDeleted         false ;
+    knora-base:valueCreationDate "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:valueHasListNode  <http://rdfh.ch/lists/0001/matchfulltextListChildA> ;
+    knora-base:valueHasOrder     0 ;
+    knora-base:valueHasString    "http://rdfh.ch/lists/0001/matchfulltextListChildA" ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
+
+# --- Resource B: matches via label only.
+
+<http://rdfh.ch/0001/matchfulltextB>
+    a                            anything:Thing ;
+    rdfs:label                   "Zqxvnonce7f3OnlyLabel" ;
+    knora-base:isDeleted         false ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:creationDate      "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
+
+# --- Resource C: the same token in both its label and its text value, to prove a resource that
+# matches via two independent index hits is still counted (and returned) exactly once.
+
+<http://rdfh.ch/0001/matchfulltextC>
+    a                            anything:Thing ;
+    rdfs:label                   "Zqxvnonce7f3Dedup" ;
+    knora-base:isDeleted         false ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:creationDate      "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+    anything:hasText             <http://rdfh.ch/0001/matchfulltextC/values/text1> .
+
+<http://rdfh.ch/0001/matchfulltextC/values/text1>
+    a                            knora-base:TextValue ;
+    knora-base:valueHasUUID      "mftC0text1UUID000000"^^xsd:string ;
+    knora-base:isDeleted         false ;
+    knora-base:valueCreationDate "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:valueHasOrder     0 ;
+    knora-base:valueHasString    "Zqxvnonce7f3Dedup" ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
+
+# --- Resource D: a deleted text value. Its own token must never be found (D6/D-value-drop-path):
+# a hit on a deleted value alone must not resurface the resource, even if the resource itself has
+# an explicit (irrelevant) isDeleted statement asserted in a test query.
+
+<http://rdfh.ch/0001/matchfulltextD>
+    a                            anything:Thing ;
+    rdfs:label                   "matchfulltextD (deleted-value fixture, not itself a match target)" ;
+    knora-base:isDeleted         false ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:creationDate      "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+    anything:hasText             <http://rdfh.ch/0001/matchfulltextD/values/text1> .
+
+<http://rdfh.ch/0001/matchfulltextD/values/text1>
+    a                            knora-base:TextValue ;
+    knora-base:valueHasUUID      "mftD0text1UUID000000"^^xsd:string ;
+    knora-base:isDeleted         true ;
+    knora-base:deleteDate        "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:deletedBy         <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+    knora-base:valueCreationDate "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:valueHasOrder     0 ;
+    knora-base:valueHasString    "Zqxvnonce7f3DeletedText" ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
+
+# --- Resource E: an active list node (matchfulltextListChildE) referenced by a DELETED list
+# value. Per D11, deletion for the list path is checked on the matched list NODE, not the list
+# VALUE, so this resource must still be found.
+
+<http://rdfh.ch/0001/matchfulltextE>
+    a                            anything:Thing ;
+    rdfs:label                   "matchfulltextE (deleted-list-value fixture for D11)" ;
+    knora-base:isDeleted         false ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:creationDate      "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+    anything:hasListItem         <http://rdfh.ch/0001/matchfulltextE/values/list1> .
+
+<http://rdfh.ch/0001/matchfulltextE/values/list1>
+    a                            knora-base:ListValue ;
+    knora-base:valueHasUUID      "mftE0list1UUID000000"^^xsd:string ;
+    knora-base:isDeleted         true ;
+    knora-base:deleteDate        "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:deletedBy         <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+    knora-base:valueCreationDate "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:valueHasListNode  <http://rdfh.ch/lists/0001/matchfulltextListChildE> ;
+    knora-base:valueHasOrder     0 ;
+    knora-base:valueHasString    "http://rdfh.ch/lists/0001/matchfulltextListChildE" ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
+
+# --- Resource F: links to matchfulltextA via anything:hasOtherThing, for testing matchFulltext on
+# a non-main-resource (linked) variable.
+
+<http://rdfh.ch/0001/matchfulltextF>
+    a                            anything:Thing ;
+    rdfs:label                   "matchfulltextF (links to matchfulltextA)" ;
+    knora-base:isDeleted         false ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:creationDate      "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+    anything:hasOtherThing       <http://rdfh.ch/0001/matchfulltextA> ;
+    anything:hasOtherThingValue  <http://rdfh.ch/0001/matchfulltextF/values/link1> .
+
+<http://rdfh.ch/0001/matchfulltextF/values/link1>
+    a                            knora-base:LinkValue ;
+    knora-base:valueHasUUID      "mftF0link1UUID000000"^^xsd:string ;
+    knora-base:isDeleted         false ;
+    rdf:subject                  <http://rdfh.ch/0001/matchfulltextF> ;
+    rdf:predicate                anything:hasOtherThing ;
+    rdf:object                   <http://rdfh.ch/0001/matchfulltextA> ;
+    knora-base:valueCreationDate "2026-07-01T00:00:00.000000Z"^^xsd:dateTime ;
+    knora-base:valueHasOrder     0 ;
+    knora-base:valueHasRefCount  1 ;
+    knora-base:valueHasString    "http://rdfh.ch/0001/matchfulltextA" ;
+    knora-base:hasPermissions    "V knora-admin:UnknownUser|M knora-admin:ProjectMember" ;
+    knora-base:attachedToUser    <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .


### PR DESCRIPTION
## What

Adds a new Gravsearch filter function `knora-api:matchFulltext(?resource, "terms")` that searches everywhere the full-text index covers for a resource — its `rdfs:label`, any text value, any value comment, or a list node (incl. sub-nodes) referenced by one of its list values. It gives the same result set as `GET /v2/search/{term}`, but expressed as a Gravsearch function so it can be combined with structured criteria in a single query.

Implements [DEV-6715](https://linear.app/dasch/issue/DEV-6715).

## How

- New AST nodes: an opaque `GroupPattern` (survives all optimizer/inference passes unchanged) and a `CoalesceFunction`.
- The `matchFulltext` handler expands the FILTER into an index-anchored block: a Lucene hit anchors the match, two `OPTIONAL`s resolve it to the containing resource (value path / list path), and a `COALESCE` + closing `BIND` bind the user's resource variable.
- Type-inference support so the resource argument is recognised as a `knora-api:Resource`.
- Constraints mirroring the semantics: must be the top-level FILTER expression, at most once per query, search-string validation mirroring the fulltext endpoint, and SPARQL-literal escaping of the search term (`"`, `\`, LF, CR).
- Deterministic inferencer variable suffixes in `SelectTransformer` so the generated SPARQL is golden-snapshot-testable.

## Testing

- Golden-snapshot prequery + count-prequery tests for the classless, class-restricted, and in-UNION expansions.
- E2E coverage asserting parity with `GET /v2/search`, plus deletion edge cases and embedded-newline escaping.
- Parser and type-inference unit tests.

## Notes

- A pre-existing SPARQL-literal escaping gap in the sibling `matchText`/`matchLabel` functions was surfaced during this work and is tracked separately in [DEV-6725](https://linear.app/dasch/issue/DEV-6725); `matchFulltext` itself is not affected.
- The last four commits are code-review follow-ups (shared `notDeletedFilter` helper, deferred counter mutation, test dedup, doc corrections); all golden snapshots are unchanged, confirming the refactors are behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwwhWDuecVQitC11zWnosQ