### PR TITLE
docs: prefer opt.fold over opt.map(...).getOrElse in Scala conventions

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -54,6 +54,10 @@ Never concatenate query strings. Use rdf4j SparqlBuilder via the helpers in `sli
 
 When adding or changing tracing/telemetry (spans, span attributes, metrics), read `docs/observability/` first — don't re-derive the pattern. Follow `docs/observability/instrumentation-recipe.md`: one root `INTERNAL` span per vertical plus bounded-name stage spans, a **bounded** query shape on the root (never raw query text, instance IRIs, or user IDs as attributes), and the load-bearing `UNSET` failure status-mapper that keeps `cause.prettyPrint` (user data) out of the span status. `docs/observability/using-grafana.md` covers reading/querying traces in Grafana and from Claude Code via the Grafana MCP server.
 
+### Scala idioms
+
+- Collapse an `Option` with `opt.fold(default)(f)`, not `opt.map(f).getOrElse(default)`. Details + argument-order note in `docs/development/dsp-api-conventions.md` § Scala Idioms.
+
 ### Imports & formatting
 
 - No fully-qualified class names in code bodies — import at the top of the file.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -66,6 +66,7 @@ Agent reference card for the **review phase**. Pair with `CONVENTIONS.md` (work 
 
 ## Style
 
+- [ ] `Option` collapsed with `opt.fold(default)(f)`, not `opt.map(f).getOrElse(default)` — see `CONVENTIONS.md` § Scala idioms
 - [ ] No fully-qualified class names in code bodies — import at the top of the file
 - [ ] `final class` preferred over plain `class` / `case class` for new services (non-public members surface as unused); `final case class private` for value objects
 - [ ] Naming follows `CONVENTIONS.md`: `*Service`, `*RestService`, `*Endpoints`, `*ServerEndpoints`, `*Spec`, `*Exception`

--- a/docs/development/dsp-api-conventions.md
+++ b/docs/development/dsp-api-conventions.md
@@ -298,6 +298,24 @@ When writing SPARQL queries do not use String concatenation.
 Instead use rdf4j and the query helper in dsp-api.
 For more details see `dsp-api-sparql-queries.md`.
 
+## Scala Idioms
+
+### Option: prefer `fold` over `map` + `getOrElse`
+
+Collapse an `Option` to a plain value with `fold`, not `map(...).getOrElse(...)` — one combinator instead of two, with the default sitting next to the transform:
+
+```scala
+// ✓ Correct
+opt.fold(default)(f)
+project.dataCopyrightHolder.fold("")(_.value)
+
+// ✗ Incorrect — two combinators for a single collapse
+opt.map(f).getOrElse(default)
+project.dataCopyrightHolder.map(_.value).getOrElse("")
+```
+
+Note the argument order: `fold` takes the empty-case value first, then the mapping function.
+
 ## Formatting 
 
 Run `sbt fmt` before pushing to the remote branch. Scalafmt reformats all Scala sources in-place.


### PR DESCRIPTION
Follow-up to the review on #4186 (DEV-6721).

## Motivation

On #4186, @BalduinLandolt's approving review left a nitpick: `opt.map(f).getOrElse(a)` reads better as `opt.fold(a)(f)`, and suggested recording it in the repo conventions as preferable. The code itself was already fixed in `d40e0f82` before merge; this PR records the *convention*, so the preference lives in the conventions set rather than only in a review thread.

## Summary

Documentation only. Adds the `fold`-over-`map`/`getOrElse` rule to the conventions set. No code changes.

## Key Changes

- `docs/development/dsp-api-conventions.md` — new **Scala Idioms** section with the rule and a ✓/✗ example, plus the `fold` argument-order note (authoritative detail).
- `CONVENTIONS.md` — one-line rule under **Code Conventions → Scala idioms**, pointing to the depth doc (work-phase reference card).
- `REVIEW.md` — checkbox under **Style** (review-phase reference card).

## Challenges and Decisions

- Mirrored across all three convention files, following the repo's own rule ("update `CONVENTIONS.md` / `REVIEW.md` alongside `docs/development/` whenever a convention changes"), so the new convention is not drift-prone.

## Gotchas

- None. The corresponding code (`ExportService`) already uses `fold` on `main`.

## Test Plan

- Root cards + `docs/development/dsp-api-conventions.md` linted clean with the repo's `.markdownlint.yml` (same disables as the `just markdownlint` target).
- No build/test run — documentation only.
