### PR TITLE
feat: eliminate redundant asset compression in project-migration export (DEV-6592)

### DIFF
--- a/docs/03-endpoints/api-v3/project-migration.md
+++ b/docs/03-endpoints/api-v3/project-migration.md
@@ -55,6 +55,10 @@ data/
 
 All RDF data is serialized as N-Quads and uses the internal knora-base schema.
 
+Within the archive, the `data/rdf/` N-Quads are DEFLATE-compressed, while `data/assets/assets.zip` is stored
+without effective compression: its contents are already-compressed media, so re-compressing them only wastes
+CPU. This is why `assets.zip` does not shrink relative to its source.
+
 The `bag-info.txt` file includes metadata fields:
 
 | Field                  | Description                                     |

--- a/modules/bagit/src/main/scala/org/knora/bagit/domain/PayloadEntry.scala
+++ b/modules/bagit/src/main/scala/org/knora/bagit/domain/PayloadEntry.scala
@@ -7,7 +7,21 @@ package org.knora.bagit.domain
 
 import zio.nio.file.Path
 
+enum Compression {
+
+  /** DEFLATE at the default level (~6). */
+  case Deflate
+
+  /**
+   * No effective compression: written as DEFLATE level 0 (`Deflater.NO_COMPRESSION`), NOT the ZIP `STORED`
+   * method — the entry method stays `DEFLATED`. Chosen over true STORED to keep the single-pass streaming
+   * writer: STORED requires the CRC-32 and size up front, which would force a second read pass over every
+   * file. The observable effect is compressed size ~= uncompressed size, not a `STORED` method flag.
+   */
+  case Store
+}
+
 enum PayloadEntry {
-  case File(relativePath: String, sourcePath: Path)
-  case Directory(prefix: String, sourcePath: Path)
+  case File(relativePath: String, sourcePath: Path, compression: Compression)
+  case Directory(prefix: String, sourcePath: Path, compression: Compression)
 }

--- a/modules/bagit/src/main/scala/org/knora/bagit/internal/BagCreator.scala
+++ b/modules/bagit/src/main/scala/org/knora/bagit/internal/BagCreator.scala
@@ -13,6 +13,7 @@ import java.io.File
 import java.io.IOException
 import java.security.MessageDigest
 import java.time.LocalDate
+import java.util.zip.Deflater
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -26,6 +27,12 @@ object BagCreator {
 
   /** Emit a progress line at least this often (evaluated after each file) even if no new step was crossed. */
   private val ProgressMaxGap = 5.minutes
+
+  /** Maps the per-entry [[Compression]] to a `Deflater` level. `Store` is level 0 (see [[Compression.Store]]). */
+  private def deflateLevel(c: Compression): Int = c match {
+    case Compression.Deflate => Deflater.DEFAULT_COMPRESSION // -1 -> ~level 6
+    case Compression.Store   => Deflater.NO_COMPRESSION      // 0  -> no effective compression
+  }
 
   def createBag(
     payloadEntries: List[PayloadEntry],
@@ -48,12 +55,15 @@ object BagCreator {
     zipPath: String,
     sourceFile: File,
     algorithms: List[ChecksumAlgorithm],
+    compression: Compression,
   ): IO[IOException, (String, Map[ChecksumAlgorithm, String], Long)] =
     ZIO.scoped {
       for {
         fis    <- JioHelper.bufferedFileInputStream(sourceFile)
         result <- ZIO.attemptBlocking {
                     val digests = algorithms.map(a => a -> MessageDigest.getInstance(a.javaName))
+                    // setLevel applies to subsequent entries, so it must be set before putNextEntry.
+                    zos.setLevel(deflateLevel(compression))
                     zos.putNextEntry(new ZipEntry(zipPath))
                     val buffer     = new Array[Byte](8192)
                     var bytesTotal = 0L
@@ -73,17 +83,17 @@ object BagCreator {
       } yield result
     }
 
-  /** Flattens the payload entries into the concrete (zip path, source file) pairs to be written. */
-  private def collectFiles(entries: List[PayloadEntry]): List[(String, File)] =
+  /** Flattens the payload entries into the concrete (zip path, source file, compression) tuples to be written. */
+  private def collectFiles(entries: List[PayloadEntry]): List[(String, File, Compression)] =
     entries.flatMap {
-      case PayloadEntry.File(relativePath, sourcePath) =>
-        List((s"data/$relativePath", sourcePath.toFile))
-      case PayloadEntry.Directory(prefix, sourcePath) =>
+      case PayloadEntry.File(relativePath, sourcePath, compression) =>
+        List((s"data/$relativePath", sourcePath.toFile, compression))
+      case PayloadEntry.Directory(prefix, sourcePath, compression) =>
         val baseDir = sourcePath.toFile
         JioHelper.walkDirectory(baseDir).map { file =>
           val rel     = baseDir.toPath.relativize(file.toPath).toString.replace('\\', '/')
           val zipPath = if (prefix.isEmpty) s"data/$rel" else s"data/$prefix/$rel"
-          (zipPath, file)
+          (zipPath, file, compression)
         }
     }
 
@@ -100,8 +110,10 @@ object BagCreator {
       _          <- ZIO.logDebug(BagProgress.startLine(totalFiles, totalBytes))
       progress   <- Ref.make(BagProgress.ReporterState(start, 0))
       bytesDone  <- Ref.make(0L)
-      results    <- ZIO.foreach(files.zipWithIndex) { case ((zipPath, file), idx) =>
-                   writePayloadFile(zos, zipPath, file, algorithms).tap { case (_, _, fileBytes) =>
+      // Must stay sequential (ZIO.foreach, not foreachPar): per-entry setLevel mutates the single shared
+      // Deflater in `zos`, and ZIP entry framing is inherently sequential -- parallelizing would corrupt the bag.
+      results <- ZIO.foreach(files.zipWithIndex) { case ((zipPath, file, compression), idx) =>
+                   writePayloadFile(zos, zipPath, file, algorithms, compression).tap { case (_, _, fileBytes) =>
                      logProgress(progress, bytesDone, fileBytes, idx + 1L, totalFiles, totalBytes, start)
                    }
                  }
@@ -150,6 +162,10 @@ object BagCreator {
     fileCount: Long,
   ): IO[IOException, Map[String, Array[Byte]]] =
     ZIO.attemptBlocking {
+      // Payload entries may have left the deflate level at 0 (Store); tag files are tiny but should be
+      // written at the default level. This single reset also covers writeTagManifests, which runs afterward.
+      zos.setLevel(Deflater.DEFAULT_COMPRESSION)
+
       val bagitTxtContent = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n"
       val bagitTxtBytes   = bagitTxtContent.getBytes("UTF-8")
       zos.putNextEntry(new ZipEntry("bagit.txt"))

--- a/modules/bagit/src/test/scala/org/knora/bagit/BagItSpec.scala
+++ b/modules/bagit/src/test/scala/org/knora/bagit/BagItSpec.scala
@@ -15,6 +15,7 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.security.MessageDigest
 import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 
@@ -45,8 +46,8 @@ object BagItSpec extends ZIOSpecDefault {
           setup                         <- createTestFiles
           (filePath, dirPath, outputZip) = setup
           entries                        = List(
-                      PayloadEntry.File("readme.txt", filePath),
-                      PayloadEntry.Directory("content", dirPath),
+                      PayloadEntry.File("readme.txt", filePath, Compression.Deflate),
+                      PayloadEntry.Directory("content", dirPath, Compression.Deflate),
                     )
           _ <- BagIt.create(
                  entries,
@@ -64,8 +65,8 @@ object BagItSpec extends ZIOSpecDefault {
           setup                         <- createTestFiles
           (filePath, dirPath, outputZip) = setup
           entries                        = List(
-                      PayloadEntry.File("readme.txt", filePath),
-                      PayloadEntry.Directory("content", dirPath),
+                      PayloadEntry.File("readme.txt", filePath, Compression.Deflate),
+                      PayloadEntry.Directory("content", dirPath, Compression.Deflate),
                     )
           // Read original file contents before bagging
           originalFiles  <- collectRelativeFiles(dirPath, dirPath)
@@ -98,7 +99,7 @@ object BagItSpec extends ZIOSpecDefault {
         for {
           setup                   <- createTestFiles
           (filePath, _, outputZip) = setup
-          entries                  = List(PayloadEntry.File("readme.txt", filePath))
+          entries                  = List(PayloadEntry.File("readme.txt", filePath, Compression.Deflate))
           _                       <- BagIt.create(entries, outputZip)
           zipEntryNames           <- listZipEntryNames(outputZip)
         } yield assertTrue(
@@ -112,7 +113,7 @@ object BagItSpec extends ZIOSpecDefault {
         for {
           setup                   <- createTestFiles
           (filePath, _, outputZip) = setup
-          entries                  = List(PayloadEntry.File("readme.txt", filePath))
+          entries                  = List(PayloadEntry.File("readme.txt", filePath, Compression.Deflate))
           _                       <- BagIt.create(entries, outputZip, algorithms = List(ChecksumAlgorithm.SHA256))
           zipEntryNames           <- listZipEntryNames(outputZip)
         } yield assertTrue(
@@ -162,13 +163,99 @@ object BagItSpec extends ZIOSpecDefault {
           _        <- Files.writeBytes(filePath, Chunk.fromArray("percent test".getBytes("UTF-8")))
           outputZip = tempDir / "pct-bag.zip"
           // Use a relativePath that contains a literal percent sign
-          entries = List(PayloadEntry.File("100%done.txt", filePath))
+          entries = List(PayloadEntry.File("100%done.txt", filePath, Compression.Deflate))
           _      <- BagIt.create(entries, outputZip)
           _      <- BagIt.readAndValidateZip(outputZip)
           // Verify the manifest inside the ZIP contains the encoded path
           zipEntryNames   <- listZipEntryNames(outputZip)
           manifestContent <- readZipEntry(outputZip, zipEntryNames.find(_.startsWith("manifest-")).get)
         } yield assertTrue(manifestContent.contains("data/100%25done.txt"))
+      }
+    },
+    test("compression: a Store entry is written without effective compression while a Deflate entry shrinks") {
+      ZIO.scoped {
+        for {
+          tempDir <- Files.createTempDirectoryScoped(Some("bagit-compression-test"), Seq.empty)
+          oneMb    = 1024 * 1024
+          probe    = tempDir / "probe.bin"
+          // 1 MB of zeros: highly compressible, so Store vs Deflate is clearly distinguishable
+          _        <- Files.writeBytes(probe, Chunk.fromArray(new Array[Byte](oneMb)))
+          outputZip = tempDir / "compression-bag.zip"
+          entries   = List(
+                      PayloadEntry.File("stored.bin", probe, Compression.Store),
+                      PayloadEntry.File("deflated.bin", probe, Compression.Deflate),
+                    )
+          _                           <- BagIt.create(entries, outputZip)
+          sizes                       <- zipEntrySizes(outputZip)
+          (storedSize, storedComp)     = sizes("data/stored.bin")
+          (deflatedSize, deflatedComp) = sizes("data/deflated.bin")
+        } yield assertTrue(
+          storedSize == oneMb.toLong,
+          deflatedSize == oneMb.toLong,
+          // Store = DEFLATE level 0: compressed size ~= uncompressed size (only ~0.03% wrapper overhead)
+          storedComp >= storedSize,
+          storedComp < storedSize * 101 / 100,
+          // Deflate: 1 MB of zeros collapses to a tiny fraction of its size
+          deflatedComp < storedSize / 10,
+        )
+      }
+    },
+    test("nested Store: a stored assets.zip (itself stored-inside) round-trips byte-for-byte and stays valid") {
+      ZIO.scoped {
+        for {
+          tempDir <- Files.createTempDirectoryScoped(Some("bagit-nested-store-test"), Seq.empty)
+          // Inner bag = the ingest-produced assets.zip: all asset entries Stored.
+          assetsDir = tempDir / "assets"
+          _        <- Files.createDirectory(assetsDir)
+          _        <- Files.writeBytes(
+                 assetsDir / "image.jp2",
+                 Chunk.fromArray("pretend-already-compressed-jp2".getBytes("UTF-8")),
+               )
+          _          <- Files.writeBytes(assetsDir / "video.mp4", Chunk.fromArray(new Array[Byte](64 * 1024)))
+          innerZip    = tempDir / "assets.zip"
+          _          <- BagIt.create(List(PayloadEntry.Directory("", assetsDir, Compression.Store)), innerZip)
+          innerBytes <- Files.readAllBytes(innerZip)
+          // Outer migration bag: rdf compressed, the inner assets.zip stored.
+          rdfDir       = tempDir / "rdf"
+          _           <- Files.createDirectory(rdfDir)
+          _           <- Files.writeBytes(rdfDir / "admin.nq", Chunk.fromArray(("<a> <b> <c> .\n" * 5000).getBytes("UTF-8")))
+          outerZip     = tempDir / "outer.zip"
+          outerEntries = List(
+                           PayloadEntry.Directory("rdf", rdfDir, Compression.Deflate),
+                           PayloadEntry.File("assets/assets.zip", innerZip, Compression.Store),
+                         )
+          _              <- BagIt.create(outerEntries, outerZip)
+          outerResult    <- BagIt.readAndValidateZip(outerZip)
+          (_, outerRoot)  = outerResult
+          extractedInner  = outerRoot / "data" / "assets" / "assets.zip"
+          extractedBytes <- Files.readAllBytes(extractedInner)
+          // The extracted inner zip must itself still validate as a bag (Store-inside-Store).
+          _ <- BagIt.readAndValidateZip(extractedInner)
+        } yield assertTrue(extractedBytes == innerBytes)
+      }
+    },
+    test("backward compatibility: an all-Deflate bag (old policy) still validates and extracts byte-for-byte") {
+      ZIO.scoped {
+        for {
+          tempDir  <- Files.createTempDirectoryScoped(Some("bagit-deflate-compat-test"), Seq.empty)
+          filePath  = tempDir / "notes.txt"
+          _        <- Files.writeBytes(filePath, Chunk.fromArray(("some repeated text\n" * 1000).getBytes("UTF-8")))
+          dirPath   = tempDir / "docs"
+          _        <- Files.createDirectory(dirPath)
+          _        <- Files.writeBytes(dirPath / "a.txt", Chunk.fromArray("aaaa".getBytes("UTF-8")))
+          original <- Files.readAllBytes(filePath)
+          outputZip = tempDir / "old-policy-bag.zip"
+          // The old policy was all-DEFLATE; passing Deflate everywhere reproduces it. Assert the bag still
+          // validates and its payload extracts byte-for-byte.
+          entries = List(
+                      PayloadEntry.File("notes.txt", filePath, Compression.Deflate),
+                      PayloadEntry.Directory("docs", dirPath, Compression.Deflate),
+                    )
+          _           <- BagIt.create(entries, outputZip)
+          result      <- BagIt.readAndValidateZip(outputZip)
+          (_, bagRoot) = result
+          extracted   <- Files.readAllBytes(bagRoot / "data" / "notes.txt")
+        } yield assertTrue(extracted == original)
       }
     },
     test("corruption: tampered file produces ChecksumMismatch") {
@@ -179,7 +266,7 @@ object BagItSpec extends ZIOSpecDefault {
           _        <- Files.writeBytes(filePath, Chunk.fromArray("Original content".getBytes("UTF-8")))
           outputZip = tempDir / "bag.zip"
           _        <- BagIt.create(
-                 List(PayloadEntry.File("original.txt", filePath)),
+                 List(PayloadEntry.File("original.txt", filePath, Compression.Deflate)),
                  outputZip,
                )
           // Tamper: extract, modify a payload file, re-zip
@@ -189,6 +276,21 @@ object BagItSpec extends ZIOSpecDefault {
       }
     },
   )
+
+  /** Reads each non-directory entry's (uncompressed size, compressed size) from the ZIP central directory. */
+  private def zipEntrySizes(zipPath: Path): Task[Map[String, (Long, Long)]] =
+    ZIO.attemptBlocking {
+      val zf = new ZipFile(zipPath.toFile)
+      try {
+        var sizes   = Map.empty[String, (Long, Long)]
+        val entries = zf.entries()
+        while (entries.hasMoreElements) {
+          val e = entries.nextElement()
+          if (!e.isDirectory) sizes = sizes + (e.getName -> (e.getSize, e.getCompressedSize))
+        }
+        sizes
+      } finally zf.close()
+    }
 
   private def listZipEntryNames(zipPath: Path): Task[List[String]] =
     ZIO.attemptBlocking {

--- a/modules/bagit/src/test/scala/org/knora/bagit/internal/BagCreatorSpec.scala
+++ b/modules/bagit/src/test/scala/org/knora/bagit/internal/BagCreatorSpec.scala
@@ -69,7 +69,7 @@ object BagCreatorSpec extends ZIOSpecDefault {
           nonExistent = tempDir / "does-not-exist"
           result     <- BagCreator
                       .createBag(
-                        List(PayloadEntry.Directory("missing", nonExistent)),
+                        List(PayloadEntry.Directory("missing", nonExistent, Compression.Deflate)),
                         List(ChecksumAlgorithm.SHA256),
                         Some(BagInfo(sourceOrganization = Some("Test"))),
                         outputZip,
@@ -86,8 +86,8 @@ object BagCreatorSpec extends ZIOSpecDefault {
           setup                         <- createTempSetup
           (filePath, dirPath, outputZip) = setup
           entries                        = List(
-                      PayloadEntry.File("single-file.txt", filePath),
-                      PayloadEntry.Directory("test-dir", dirPath),
+                      PayloadEntry.File("single-file.txt", filePath, Compression.Deflate),
+                      PayloadEntry.Directory("test-dir", dirPath, Compression.Deflate),
                     )
           result <- BagCreator.createBag(
                       entries,
@@ -138,7 +138,7 @@ object BagCreatorSpec extends ZIOSpecDefault {
           _        <- Files.createFile(dirPath / "b.txt")
           outputZip = tempDir / "empty-bag.zip"
           result   <- BagCreator.createBag(
-                      List(PayloadEntry.Directory("data-dir", dirPath)),
+                      List(PayloadEntry.Directory("data-dir", dirPath, Compression.Deflate)),
                       List(ChecksumAlgorithm.SHA256),
                       Some(BagInfo(sourceOrganization = Some("Test"))),
                       outputZip,

--- a/modules/bagit/src/test/scala/org/knora/bagit/internal/BagReaderSpec.scala
+++ b/modules/bagit/src/test/scala/org/knora/bagit/internal/BagReaderSpec.scala
@@ -29,7 +29,7 @@ object BagReaderSpec extends ZIOSpecDefault {
       _        <- Files.writeBytes(filePath, Chunk.fromArray("Test content".getBytes("UTF-8")))
       outputZip = tempDir / "test.zip"
       _        <- BagCreator.createBag(
-             List(PayloadEntry.File("test-file.txt", filePath)),
+             List(PayloadEntry.File("test-file.txt", filePath, Compression.Deflate)),
              List(ChecksumAlgorithm.SHA256),
              Some(BagInfo(sourceOrganization = Some("Test Org"))),
              outputZip,
@@ -354,7 +354,7 @@ object BagReaderSpec extends ZIOSpecDefault {
           outputZip = tempDir / "o.zip"
           nestedDir = tempDir / "d"
           _        <- BagCreator.createBag(
-                 List(PayloadEntry.Directory("n", nestedDir)),
+                 List(PayloadEntry.Directory("n", nestedDir, Compression.Deflate)),
                  List(ChecksumAlgorithm.SHA256),
                  None,
                  outputZip,
@@ -393,7 +393,7 @@ object BagReaderSpec extends ZIOSpecDefault {
                }
           outputZip = tempDir / "flat.zip"
           _        <- BagCreator.createBag(
-                 List(PayloadEntry.Directory("", flatDir)),
+                 List(PayloadEntry.Directory("", flatDir, Compression.Deflate)),
                  List(ChecksumAlgorithm.SHA256),
                  None,
                  outputZip,
@@ -429,7 +429,7 @@ object BagReaderSpec extends ZIOSpecDefault {
                }
           outputZip = tempDir / "mixed.zip"
           _        <- BagCreator.createBag(
-                 List(PayloadEntry.Directory("", mixedDir)),
+                 List(PayloadEntry.Directory("", mixedDir, Compression.Deflate)),
                  List(ChecksumAlgorithm.SHA256),
                  None,
                  outputZip,

--- a/modules/bagit/src/test/scala/org/knora/bagit/internal/BagValidatorSpec.scala
+++ b/modules/bagit/src/test/scala/org/knora/bagit/internal/BagValidatorSpec.scala
@@ -24,7 +24,7 @@ object BagValidatorSpec extends ZIOSpecDefault {
       _        <- Files.writeBytes(filePath, Chunk.fromArray("Payload content".getBytes("UTF-8")))
       outputZip = tempDir / "test.zip"
       _        <- BagCreator.createBag(
-             List(PayloadEntry.File("payload.txt", filePath)),
+             List(PayloadEntry.File("payload.txt", filePath, Compression.Deflate)),
              List(ChecksumAlgorithm.SHA256),
              Some(BagInfo(sourceOrganization = Some("Test"))),
              outputZip,
@@ -143,7 +143,7 @@ object BagValidatorSpec extends ZIOSpecDefault {
                        Files
                          .writeBytes(path, Chunk.fromArray(content.getBytes("UTF-8")))
                          .as(
-                           PayloadEntry.File(name, path),
+                           PayloadEntry.File(name, path, Compression.Deflate),
                          )
                      }
           outputZip = tempDir / "many-files.zip"

--- a/modules/ingest/src/main/scala/swiss/dasch/domain/ProjectService.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/domain/ProjectService.scala
@@ -20,6 +20,7 @@ import scala.language.implicitConversions
 
 import org.knora.bagit.BagIt
 import org.knora.bagit.domain.BagInfo
+import org.knora.bagit.domain.Compression
 import org.knora.bagit.domain.PayloadEntry
 
 final case class ProjectService(
@@ -83,8 +84,10 @@ final case class ProjectService(
                   externalIdentifier = Some(shortcode.value),
                   additionalFields = List("Ingest-Export-Version" -> "1"),
                 )
-      payloadEntries = List(PayloadEntry.Directory(prefix = "", sourcePath = projectPath.path))
-      resultPath    <- BagIt.create(payloadEntries, outputPath, bagInfo = Some(bagInfo))
+      // Assets are already-compressed media; store them (DEFLATE level 0) instead of wasting CPU re-compressing.
+      payloadEntries =
+        List(PayloadEntry.Directory(prefix = "", sourcePath = projectPath.path, compression = Compression.Store))
+      resultPath <- BagIt.create(payloadEntries, outputPath, bagInfo = Some(bagInfo))
     } yield Some(resultPath)
 
   def deleteProject(shortcode: ProjectShortcode): IO[IOException | SQLException, Unit] =

--- a/modules/ingest/src/test/scala/swiss/dasch/api/ProjectsEndpointSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/api/ProjectsEndpointSpec.scala
@@ -46,6 +46,7 @@ import java.text.Normalizer
 import scala.language.implicitConversions
 
 import org.knora.bagit.BagIt
+import org.knora.bagit.domain.Compression
 import org.knora.bagit.domain.PayloadEntry
 
 object ProjectsEndpointSpec extends ZIOSpecDefault {
@@ -176,9 +177,12 @@ object ProjectsEndpointSpec extends ZIOSpecDefault {
                         .attemptBlockingIO(java.nio.file.Files.createTempDirectory("bagit-test"))
                         .map(zio.nio.file.Path.fromJava),
                     )(p => ZIO.attemptBlockingIO(org.apache.commons.io.FileUtils.deleteDirectory(p.toFile)).ignore)
-          bagitZipPath  = tmpDir / "test-import.bagit.zip"
-          sourceDir     = SpecPaths.testFolder / "0001" / "fg"
-          _            <- BagIt.create(List(PayloadEntry.Directory(prefix = "fg", sourcePath = sourceDir)), bagitZipPath)
+          bagitZipPath = tmpDir / "test-import.bagit.zip"
+          sourceDir    = SpecPaths.testFolder / "0001" / "fg"
+          _           <- BagIt.create(
+                 List(PayloadEntry.Directory(prefix = "fg", sourcePath = sourceDir, compression = Compression.Deflate)),
+                 bagitZipPath,
+               )
           body         <- Body.fromFile(bagitZipPath.toFile)
           response     <- postImport(emptyProject, body, validContentTypeHeaders)
           importExists <- Files.isDirectory(storageConfig.assetPath / emptyProject.toString)

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/ImportServiceSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/ImportServiceSpec.scala
@@ -22,6 +22,7 @@ import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 
 import org.knora.bagit.BagIt
+import org.knora.bagit.domain.Compression
 import org.knora.bagit.domain.PayloadEntry
 
 object ImportServiceSpec extends ZIOSpecDefault {
@@ -46,7 +47,13 @@ object ImportServiceSpec extends ZIOSpecDefault {
             tmpDir        <- Files.createTempDirectoryScoped(None, List.empty)
             validZip       = tmpDir / "valid.bagit.zip"
             _             <- BagIt.create(
-                   List(PayloadEntry.Directory(prefix = "", sourcePath = projectFolder.path)),
+                   List(
+                     PayloadEntry.Directory(
+                       prefix = "",
+                       sourcePath = projectFolder.path,
+                       compression = Compression.Deflate,
+                     ),
+                   ),
                    validZip,
                  )
             corruptedZip = tmpDir / "corrupted.bagit.zip"

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportService.scala
@@ -15,6 +15,7 @@ import zio.stream.ZStream
 
 import org.knora.bagit.BagIt
 import org.knora.bagit.domain.BagInfo
+import org.knora.bagit.domain.Compression
 import org.knora.bagit.domain.PayloadEntry
 import org.knora.webapi.KnoraBaseVersion
 import org.knora.webapi.config.AppConfig
@@ -199,9 +200,11 @@ final class ProjectMigrationExportService(
       zipFile      <- storage.exportBagItZipPath(taskId)
       externalHost <- AppConfig.knoraApi(_.externalHost)
       _            <- ZIO.logInfo(s"$taskId: Writing export $zipFile")
-      assetEntries  = assetZipPath.map(p => PayloadEntry.File("assets/assets.zip", p)).toList
-      _            <- BagIt.create(
-             PayloadEntry.Directory("rdf", rdfPath) :: assetEntries,
+      // The inner assets.zip is already compressed, so store it (kills the double-deflate); rdf/ N-Quads
+      // are verbose and compress well, so keep them on Deflate.
+      assetEntries = assetZipPath.map(p => PayloadEntry.File("assets/assets.zip", p, Compression.Store)).toList
+      _           <- BagIt.create(
+             PayloadEntry.Directory("rdf", rdfPath, Compression.Deflate) :: assetEntries,
              zipFile,
              bagInfo = Some(
                BagInfo(

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportServiceSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectMigrationExportServiceSpec.scala
@@ -15,6 +15,7 @@ import zio.nio.file.Path
 import zio.test.*
 
 import java.io.IOException
+import java.util.zip.ZipFile
 import scala.jdk.CollectionConverters.*
 
 import org.knora.bagit.BagIt
@@ -54,8 +55,10 @@ object ProjectMigrationExportServiceSpec extends ZIOSpecDefault {
     override def getAssetInfo(shortcode: Shortcode, assetId: AssetId): Task[AssetInfoResponse] =
       ZIO.die(new UnsupportedOperationException("not used in export tests"))
     override def exportProject(shortcode: Shortcode, outputFile: Path): Task[Option[Path]] =
+      // A sizeable, highly-compressible stand-in for the inner assets.zip (1 MB of zeros). This makes the
+      // outer-bag compression-policy assertions non-vacuous: were it re-compressed, its size would collapse.
       exportProjectCalled.set(true) *> Files.createDirectories(outputFile.parent.get) *>
-        Files.writeBytes(outputFile, Chunk.fromArray("fake-zip".getBytes)).as(Some(outputFile))
+        Files.writeBytes(outputFile, Chunk.fromArray(new Array[Byte](1024 * 1024))).as(Some(outputFile))
     override def eraseProject(shortcode: Shortcode): Task[Unit] =
       ZIO.die(new UnsupportedOperationException("not used in export tests"))
     override def importProject(shortcode: Shortcode, fileToImport: Path): Task[Path] =
@@ -190,6 +193,21 @@ object ProjectMigrationExportServiceSpec extends ZIOSpecDefault {
       } yield new String(bytes.toArray)
     }
 
+  /** Reads each non-directory entry's (uncompressed size, compressed size) from a ZIP's central directory. */
+  private def zipEntrySizes(zipPath: Path): Task[Map[String, (Long, Long)]] =
+    ZIO.attemptBlocking {
+      val zf = new ZipFile(zipPath.toFile)
+      try {
+        var sizes   = Map.empty[String, (Long, Long)]
+        val entries = zf.entries()
+        while (entries.hasMoreElements) {
+          val e = entries.nextElement()
+          if (!e.isDirectory) sizes = sizes + (e.getName -> (e.getSize, e.getCompressedSize))
+        }
+        sizes
+      } finally zf.close()
+    }
+
   /** Parses N-Quads content into a Jena `Model` (unions all named graphs). */
   private def parseNQuads(content: String): Model = {
     val dataset = org.apache.jena.query.DatasetFactory.create()
@@ -273,6 +291,41 @@ object ProjectMigrationExportServiceSpec extends ZIOSpecDefault {
         result.status == DataTaskStatus.Completed,
         bagResult._1, // assets/assets.zip exists
         bagResult._2, // rdf directory exists
+      )
+    },
+    test("export with skipAssets=false stores assets.zip and compresses rdf in the outer bag") {
+      val ka         = "http://www.knora.org/ontology/knora-admin#"
+      val projectIri = testProject.id.value
+      // A sizeable, highly-compressible admin graph so the rdf compression assertion is non-vacuous.
+      val users = (1 to 1500)
+        .map(i => s"""<http://rdfh.ch/users/user$i> a knora-admin:User ;
+                     |  knora-admin:username "user$i" ;
+                     |  knora-admin:email "user$i@example.com" ;
+                     |  knora-admin:isInProject <$projectIri> .""".stripMargin)
+        .mkString("\n")
+      val constructResult =
+        s"""@prefix knora-admin: <$ka> .
+           |<$projectIri> a knora-admin:knoraProject ;
+           |  knora-admin:projectShortcode "0001" .
+           |$users
+           |""".stripMargin
+      for {
+        env                     <- makeTestEnv
+        _                       <- env.constructRdfRef.set(constructResult)
+        task                    <- env.service.createExport(testProject, testUser, skipAssets = false)
+        result                  <- pollUntilDone(env.service, task.id)
+        zipFile                 <- env.storage.exportBagItZipPath(task.id)
+        sizes                   <- zipEntrySizes(zipFile)
+        _                       <- env.service.deleteExport(task.id).catchAllCause(_ => ZIO.unit)
+        (assetsSize, assetsComp) = sizes("data/assets/assets.zip")
+        (rdfSize, rdfComp)       = sizes("data/rdf/admin.nq")
+      } yield assertTrue(
+        result.status == DataTaskStatus.Completed,
+        // assets/assets.zip is stored (DEFLATE level 0): compressed size ~= uncompressed size
+        assetsComp >= assetsSize,
+        assetsComp < assetsSize * 101 / 100,
+        // rdf/admin.nq stays compressed: N-Quads shrink well under DEFLATE
+        rdfComp * 2 < rdfSize,
       )
     },
     suite("collectAdminGraphData with referenced users")(

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectMigrationImportServiceSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectMigrationImportServiceSpec.scala
@@ -15,6 +15,7 @@ import java.nio.charset.StandardCharsets
 
 import org.knora.bagit.BagIt
 import org.knora.bagit.domain.BagInfo
+import org.knora.bagit.domain.Compression
 import org.knora.bagit.domain.PayloadEntry
 import org.knora.webapi.KnoraBaseVersion
 import org.knora.webapi.TestDataFactory
@@ -97,7 +98,7 @@ object ProjectMigrationImportServiceSpec extends ZIOSpecDefault {
                   additionalFields = bagInfoFields,
                 )
       allNames = payloadFiles.keys ++ binaryPayloadFiles.keys
-      entries  = allNames.map(name => PayloadEntry.File(name, tempDir / name)).toList
+      entries  = allNames.map(name => PayloadEntry.File(name, tempDir / name, Compression.Deflate)).toList
       zipPath  = tempDir / "output.zip"
       _       <- BagIt.create(entries, zipPath, bagInfo = Some(bagInfo))
     } yield ZStream.fromFile(zipPath.toFile)


### PR DESCRIPTION
[DEV-6592](https://linear.app/dasch/issue/DEV-6592)

## Summary

- The shared BagIt writer (`modules/bagit`) always DEFLATE-compressed every entry, so the project-migration export compressed incompressible media **twice**: once when ingest bags assets into `assets.zip`, and again when webapi wraps that already-compressed zip in the outer bag (the "double-deflate").
- This adds a per-entry `Compression { Deflate, Store }` knob and uses it: assets are stored in **both** passes, while the compressible `rdf/` N-Quads stay DEFLATEd.
- `Store` is implemented as **DEFLATE level 0** (`Deflater.NO_COMPRESSION`), **not** true `STORED` — it drops into the existing single-pass streaming writer with no CRC pre-pass. The ZIP entry method stays `DEFLATED` and the level is not recorded in the archive, so old and new bags remain interchangeable in **both** directions and the read/import/validation path is untouched.

## Changes

- **`modules/bagit`**: new `Compression` enum (with mandatory scaladoc on `Store`); required, no-default `compression` field on `PayloadEntry.File`/`.Directory`; `BagCreator` threads it through `collectFiles`/`writePayloadEntries`, sets the deflate level per entry before `putNextEntry`, and resets to the default level before the tag files.
- **ingest**: `ProjectService.exportProjectAsBagIt` stores assets (`Compression.Store`).
- **webapi**: `ProjectMigrationExportService.createBagItZip` stores `assets/assets.zip` and keeps `rdf/` on `Deflate` — killing the double-deflate.
- All 21 `PayloadEntry` construction sites updated to pass `Compression` explicitly (compile-enforced by the no-default field).
- **Docs**: note the compression policy in the migration export-format section.

## Test Plan

Built test-first (red -> green per behavior):

- `BagItSpec` — a `Store` entry is written uncompressed while a `Deflate` entry shrinks (1 MB-of-zeros probe, entry sizes read via `java.util.zip.ZipFile`); a nested `Store`-in-`Store` bag round-trips byte-for-byte and validates; a backward-compat all-`Deflate` bag validates and extracts.
- `ProjectMigrationExportServiceSpec` — the outer migration bag stores `data/assets/assets.zip` and compresses `data/rdf/admin.nq` (enlarged the stubbed `assets.zip` and injected a sizeable compressible RDF payload so the assertions are not vacuous).
- `ImportServiceSpec` (ingest) — the real export -> import SHA-512 round-trip now exercises `Store`.
- `sbt check` clean (scalafmt + scalafix + headers); `bagit` 128 / `ingest` 28 / `webapi` export+import 48 tests green.
- Adversarial review (scala-zio, consistency, simplicity, performance): no critical/warning findings.

**Pending (separate step):** the `main`-vs-branch before/after A/B on the Alice in DaSCHland fixture (REQ-3.1/3.2 — packing throughput / CPU / bag size), to be run end-to-end on a local stack and recorded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZqH2kNsewQK9L4q6UvLrY