### PR TITLE
chore: remove broken direct-DB-access recipes and docs (DEV-6734)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,6 @@ Each slice typically contains:
 3. Run the API locally via IDE or `sbt run`
 4. API will be available at <http://localhost:3333>
 
-### Testing Against the Dev Database
-
-When changes are hard to test with local test data (e.g. they need realistic data), run the API against the remote dev Fuseki:
-
-1. Create a `.env` file in the repo root with `DEV_DB_PASSWORD=<password>` (this file is git-ignored). Passwords can be found in [ops-deploy/host_vars](https://github.com/dasch-swiss/ops-deploy/tree/main/host_vars).
-2. Run `just run-with-dev-db`
-3. The API will start connected to `db.dev.dasch.swiss` via HTTPS
-
 ### Configuration
 
 - Main config: `modules/webapi/src/main/resources/application.conf`

--- a/Makefile
+++ b/Makefile
@@ -242,62 +242,6 @@ init-db-test-minimal: stack-down-delete-volumes stack-db-only ## initializes the
 init-db-test-empty: stack-down-delete-volumes stack-db-only ## initializes the dsp-repo repository with minimal data
 	@echo $@
 
-.PHONY: init-db-from-test
-init-db-from-test: ## init local database with data from test server. Use as `make init-db-from-test PW=database-password`
-	@echo $@
-	${MAKE} init-db-from-env ENV=db.test.dasch.swiss
-
-.PHONY: init-db-from-test-dump
-init-db-from-test-dump: ## init local database with data from local dump file of test server. Use as `make init-db-from-test-dump`
-	@echo $@
-	${MAKE} init-db-from-dump-file DUMP=db.test.dasch.swiss.trig
-
-.PHONY: init-db-from-stage
-init-db-from-stage: ## init local database with data from stage server. Use as `make init-db-from-stage PW=database-password`
-	@echo $@
-	${MAKE} init-db-from-env ENV=db.stage.dasch.swiss
-
-.PHONY: init-db-from-stage-dump
-init-db-from-stage-dump: ## init local database with data from local dump file of stage server. Use as `make init-db-from-stage-dump`
-	@echo $@
-	${MAKE} init-db-from-dump-file DUMP=db.stage.dasch.swiss.trig
-
-.PHONY: init-db-from-prod
-init-db-from-prod: ## init local database with data from prod server. Use as `make init-db-from-prod PW=database-password`
-	@echo $@
-	${MAKE} init-db-from-env ENV=db.dasch.swiss
-
-.PHONY: init-db-from-prod-dump
-init-db-from-prod-dump: ## init local database with data from local dump file of prod server. Use as `make init-db-from-prod-dump`
-	@echo $@
-	${MAKE} init-db-from-dump-file DUMP=db.dasch.swiss.trig
-
-.PHONY: init-db-from-dev
-init-db-from-dev: ## init local database with data from dev. Use as `make init-db-from-dev PW=database-password`
-	@echo $@
-	${MAKE} init-db-from-env ENV=db.dev.dasch.swiss
-
-.PHONY: init-db-from-dev-dump
-init-db-from-dev-dump: ## init local database with data from local dump file of dev server. Use as `make init-db-from-dev-dump`
-	@echo $@
-	${MAKE} init-db-from-dump-file DUMP=db.dev.dasch.swiss.trig
-
-.PHONY: init-db-from-ls-test-server
-init-db-from-ls-test-server: ## init local database with data from ls-test-server. Use as `make init-db-from-ls-test-server PW=database-password`
-	@echo $@
-	${MAKE} init-db-from-env ENV=db.ls-test-server.dasch.swiss
-
-.PHONY: init-db-from-ls-test-server-dump
-init-db-from-ls-test-server-dump: ## init local database with data from local dump file of ls-test-server server. Use as `make init-db-from-ls-test-server-dump`
-	@echo $@
-	${MAKE} init-db-from-dump-file DUMP=db.ls-test-server.dasch.swiss.trig
-
-.PHONY: db-dump
-db-dump: ## Dump data from an env. Use as `make db-dump PW=database-password ENV=db.0000-test-server.dasch.swiss`
-	@echo $@
-	@echo dumping environment ${ENV}
-	@curl -f -X GET -H "Accept: application/trig" -u "admin:${PW}" "https://${ENV}/dsp-repo" > "${ENV}.trig"
-
 .PHONY: init-db-from-dump-file
 init-db-from-dump-file: ## init local database from a specified dump file. Use as `make init-db-from-dump-file DUMP=some-dump-file.trig`
 	@echo $@
@@ -305,13 +249,6 @@ init-db-from-dump-file: ## init local database from a specified dump file. Use a
 	${MAKE} init-db-test-empty
 	@curl -X POST -H "Content-Type: application/sparql-update" -d "DROP ALL" -u "admin:test" "http://localhost:3030/dsp-repo"
 	@curl -X POST -H "Content-Type: application/trig" -T "${CURRENT_DIR}/${DUMP}" -u "admin:test" "http://localhost:3030/dsp-repo"
-
-.PHONY: init-db-from-env
-init-db-from-env: ## ## Dump data from an env and upload it to the local DB. Use as `make init-db-from-env PW=database-password ENV=db.0000-test-server.dasch.swiss`
-	@echo $@
-	${MAKE} db-dump
-	${MAKE} init-db-from-dump-file DUMP=${ENV}.trig
-
 
 #################################
 ## Other

--- a/docs/05-internals/development/building-and-running.md
+++ b/docs/05-internals/development/building-and-running.md
@@ -117,19 +117,6 @@ docker logs to the terminal window of the editor.
 The docker plugin also allows for a number of other useful features, like inspecting the container's file system or
 attaching a shell to the container.
 
-## Running against the dev database
-
-When changes are hard to test with local test data (e.g. they need realistic data), you can run the API locally against the remote dev Fuseki triplestore:
-
-1. Create a `.env` file in the repo root with `DEV_DB_PASSWORD=<password>` (this file is git-ignored). Passwords can be found in [ops-deploy/host_vars](https://github.com/dasch-swiss/ops-deploy/tree/main/host_vars).
-2. Run:
-
-   ```bash
-   just run-with-dev-db
-   ```
-
-3. The API will start connected to `db.dev.dasch.swiss` via HTTPS.
-
 ## Running the automated tests
 
 To run all test targets, use the following in the command line:

--- a/docs/05-internals/development/building-and-running.md
+++ b/docs/05-internals/development/building-and-running.md
@@ -117,6 +117,26 @@ docker logs to the terminal window of the editor.
 The docker plugin also allows for a number of other useful features, like inspecting the container's file system or
 attaching a shell to the container.
 
+## Testing against realistic data
+
+Direct access to the remote dev/stage triplestore — the former `just run-with-dev-db`
+and `make init-db-from-<env>` recipes — has been **retired**: shared DB passwords are
+gone and the DB network is locked down. An API-based replacement is planned (tracked
+internally as DEV-6734).
+
+For reference — useful when building that replacement — the retired workflows worked
+like this:
+
+- **Dump a dataset:** `GET https://<host>/dsp-repo` with `Accept: application/trig` and
+  HTTP basic auth returns a TriG file of all named graphs.
+- **Load a dump into local Fuseki:** `DROP ALL` via a SPARQL update, then `POST` the
+  TriG to `http://localhost:3030/dsp-repo` with `Content-Type: application/trig`
+  (per-graph loads use `PUT .../dsp-repo/data?graph=<iri>`).
+- **Point a local API at a remote store:** set `KNORA_WEBAPI_TRIPLESTORE_HOST`,
+  `KNORA_WEBAPI_TRIPLESTORE_USE_HTTPS`, `KNORA_WEBAPI_TRIPLESTORE_FUSEKI_PORT`,
+  `KNORA_WEBAPI_TRIPLESTORE_FUSEKI_USERNAME` / `_PASSWORD`, plus the matching
+  `KNORA_WEBAPI_SIPI_INTERNAL_HOST` / `_PROTOCOL` / `_PORT` for assets.
+
 ## Running the automated tests
 
 To run all test targets, use the following in the command line:

--- a/justfile
+++ b/justfile
@@ -78,24 +78,6 @@ stack-destroy:
 stack-init-test: && stack-start
     make init-db-test
 
-# Run API locally against the dev Fuseki (requires VPN)
-run-with-dev-db:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ ! -f .env ]; then
-        main=$(git worktree list --porcelain | awk 'NR==1{sub(/^worktree /, ""); print}')
-        ln -s "$main/.env" .env
-    fi
-    source .env
-    export KNORA_WEBAPI_TRIPLESTORE_HOST=db.dev.dasch.swiss
-    export KNORA_WEBAPI_TRIPLESTORE_USE_HTTPS=true
-    export KNORA_WEBAPI_TRIPLESTORE_FUSEKI_PORT=443
-    export KNORA_WEBAPI_TRIPLESTORE_FUSEKI_USERNAME=admin
-    export KNORA_WEBAPI_TRIPLESTORE_FUSEKI_PASSWORD=$DEV_DB_PASSWORD
-    export KNORA_WEBAPI_SIPI_INTERNAL_HOST=iiif.dev.dasch.swiss                                                             
-    export KNORA_WEBAPI_SIPI_INTERNAL_PROTOCOL=https                                                                        
-    export KNORA_WEBAPI_SIPI_INTERNAL_PORT=443
-    ./sbtx "webapi/run"
 
 ## Documentation
 


### PR DESCRIPTION
Removes recipes and docs that assume direct triplestore access via shared DB passwords. That access has been retired (encrypted-only passwords, network lockdown), so these no longer work and only mislead.

## Removed
- **Makefile:** `init-db-from-{test,stage,prod,dev,ls-test-server}` and their `-dump` wrappers, plus `db-dump` and `init-db-from-env` — all fetch a remote `.trig` via the Fuseki admin password.
- **justfile:** `run-with-dev-db` — ran a local API against the remote dev Fuseki.
- **CLAUDE.md** and **docs/05-internals/development/building-and-running.md:** the "dev database" testing sections documenting the above.

## Kept
- `make init-db-from-dump-file` — honestly loads any dump file you supply, and the natural target for a future API-produced export.

Related to DEV-6734 (API-based replacement for direct triplestore access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d72UUGnL7xXpynE7fjrgM