### PR TITLE
chore: package-cycle analysis tooling + handoff (DEV-6776)

### DIFF
--- a/SESSION-HANDOFF.md
+++ b/SESSION-HANDOFF.md
@@ -1,0 +1,133 @@
+# SESSION-HANDOFF — dsp-api modularization / dependency cleanup
+
+**Linear:** [DEV-6776](https://linear.app/dasch/issue/DEV-6776/dsp-api-modularization-dependency-cleanup-break-package-cycles)
+**Branch:** `feature/dev-6776-dsp-api-modularization-dependency-cleanup-break-package`
+**Status:** groundwork only — analysis tooling + this handoff. No refactoring done yet.
+
+## Why this work exists
+
+The Bazel build compiles each module (`webapi`, `ingest`) as **one** `scala_library`
+action. Bazel targets must be acyclic, so a strongly-connected cluster of packages is
+inherently a single compile action: touching any file recompiles the whole cluster, and
+there is no intra-module build parallelism.
+
+Current reality (run `tools/analysis/package_cycles.py` for live numbers):
+
+- **webapi** — ~430 source files collapse into **one ~429-file cyclic blob** (`core`,
+  `messages`, `store`, `responders`, `util`, and every `slice.*`). Only `config` (1 file)
+  sits outside it.
+- **ingest** — ~60 files → **one ~54-file cyclic blob** (`api`, `domain`,
+  `infrastructure`) plus `config`, `db`, `version` sinks.
+
+No build-file trick splits a cyclic blob. To get parallel Bazel targets (and, downstream,
+faster incremental rebuilds, independent testability, eventual sbt subprojects), the
+**package dependency cycles must be broken first**. That is the whole point of this issue.
+
+### Precedent that motivated it
+
+The related quick win already merged to `main`: the generated `BuildInfo.scala` used to be
+compiled *inside* each module's monolithic `scala_library` (`srcs`). Its git-stamped
+version changes every push, so the single compile action's input hash changed and the
+**entire module recompiled on every push**. Fix (commit `ee251af5f`,
+`modules/{webapi,ingest}/BUILD.bazel`): move `BuildInfo` into its own tiny `scala_library`
+that the module depends on. rules_scala hands downstream the *interface jar*
+(`buildinfo-ijar.jar`); the stamped values live only in `<clinit>` with no `ConstantValue`
+attribute, so the ijar is byte-stable and the module cache-hits. **This is the reference
+example** for how splitting a target buys cache isolation — the same mechanic is why
+breaking cycles will pay off.
+
+## The goal
+
+Refactor `webapi` (and later `ingest`) so packages form an acyclic layering, then peel the
+now-independent leaves into their own `scala_library` targets. Success is measured
+mechanically: each decoupling step shrinks the SCC set (re-run the script), and eventually
+a package can be extracted as its own target and shown to cache-hit independently.
+
+Intended layering (bottom → top; dependencies only ever point downward):
+
+```
+config
+  └─ util · messages · store            (foundation: types, domain models, persistence)
+       └─ slice.common                   (shared modern base)
+            └─ slice.admin · ontology · resources · search · standoff · security · infrastructure
+                 └─ responders · slice.api
+                      └─ core · Main
+```
+
+## The tool: `tools/analysis/package_cycles.py`
+
+stdlib-only, not a Bazel target, not a CI check. On-demand analysis helper.
+
+```
+python3 tools/analysis/package_cycles.py            # both modules: SCCs + back-edges
+python3 tools/analysis/package_cycles.py webapi      # one module
+python3 tools/analysis/package_cycles.py --detail    # + per-file, per-symbol back-edge list
+```
+
+It builds a coarse component graph (one node per top-level package + per `slice.<x>`),
+computes SCCs (Tarjan), and — for webapi, which has a declared `RANK` layering — lists the
+**back-edges**: imports pointing from a lower layer up to a higher one. Each back-edge is a
+cycle-maker; the counts are a heat map for sequencing. The layering (`WEBAPI_RANK`) is
+editable in the script as packages move.
+
+Caveat worth knowing: the parser handles Scala-3 backtick-escaped package names (the
+`export` keyword is always written `` slice.`export` ``); a naive import regex silently
+drops those edges (this bit the first draft of the analysis and made `export` look like a
+leaf when it is in the blob).
+
+## Where the cycles are (heat map, sequence foundation-first)
+
+Full file/symbol detail is in DEV-6776 and via `--detail`. Highest-leverage first:
+
+1. **`root` package-object primitives** — `IRI` (type alias) and schema enums
+   (`ApiV2Schema`, `InternalSchema`, `ApiV2Complex/Simple`, `SchemaOptions`, `Rendering`,
+   `SchemaRendering`) live at `org.knora.webapi.*` and are imported *down* into
+   `messages`/`store`/`slice.common`. Relocating them to a foundation location erases a
+   whole class of back-edges cheaply. Do this first.
+2. **`util → slice.common`** — 1 file (`util/ApacheLuceneSupport.scala`). Warm-up.
+3. **`store → slice.common` / `slice.admin`** (~37 imports) — two clusters: triplestore
+   upgrade plugins referencing `slice.admin.AdminConstants` / `slice.common...Vocabulary`,
+   and Sipi/triplestore services referencing `slice.admin`/`slice.api`/`slice.infrastructure`.
+4. **`messages → slice.*`** (~140 imports, ~37 files) — the big one. Legacy message classes
+   embed modern value objects (`ProjectIri`, `User`, `Group`, `Permission`, `KnoraIris.*`,
+   `Cardinality`, `LanguageCode`) and API DTOs (`slice.api.admin.model.Project`). Likely
+   resolved by moving those value objects into a foundation both `messages` and the slices
+   depend on downward. Worst files: `ValueMessagesV2`, `ConstructResponseUtilV2`,
+   `ResourceMessagesV2`, `OntologyMessagesV2`, `PermissionUtilADM`, `StringFormatter`,
+   the `gravsearch` utils.
+5. **`slice.common → slice.admin` / `slice.api`** (~50 imports) — invert so `common` holds
+   no feature/DTO deps; the modern-slice cycle collapses next.
+
+Note: `responders` is legacy glue. Its only *upward* edges are to the `root` package object;
+`responders → slice.*` is forward/expected. Long-term it should shrink toward deletion, not
+be re-layered — don't spend effort re-layering it.
+
+## How to make progress (suggested loop)
+
+1. Pick the next item above. Run `package_cycles.py --detail webapi` to get exact sites.
+2. Move the shared type down (or invert the dependency). Keep the change small and typed.
+3. Recompile: prefer the Metals MCP (`compile-module`) over `sbt compile`. **sbt must stay
+   green** — it remains the Scala build of record during the Bazel validation window and is
+   Zinc-incremental, so it never had the recompile problem; this work is for Bazel's benefit.
+4. Re-run `package_cycles.py`: confirm the targeted back-edge count dropped and, ideally,
+   the SCC shrank.
+5. When a package finally has no back-edges and nothing depends back on it, extract it as
+   its own `scala_library` in the module `BUILD.bazel` (pattern: the buildinfo split) and
+   confirm the ijar-isolation behaviour.
+
+## Constraints / gotchas
+
+- **Do not rename `Knora` packages/classes** (`org.knora.webapi`, `KnoraXxx`) — allowed in
+  code, but no refactoring-rename without an explicit task. Moving *types between packages*
+  for layering is in scope; wholesale renames are not.
+- **No "Knora" in human-readable text** (commits, PR text, docs) — use "dsp-api".
+- Keep the layering model (`WEBAPI_RANK`) in the script updated as packages move, or the
+  back-edge classification drifts.
+- Numbers in DEV-6776 were captured at `ee251af5f`; `main` has moved a few PRs ahead, so
+  live counts differ slightly. The script is the source of truth, not the issue snapshot.
+
+## State of this branch
+
+- `tools/analysis/package_cycles.py` — the analysis tool (new).
+- `SESSION-HANDOFF.md` — this file (new).
+- Nothing else. No source refactoring yet. Draft PR opened for continuation.

--- a/tools/analysis/package_cycles.py
+++ b/tools/analysis/package_cycles.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Analyse the internal package-dependency graph of the Scala modules.
+
+Motivation (see Linear DEV-6776): Bazel compiles each module (`webapi`, `ingest`)
+as ONE `scala_library` action, and Bazel targets must be acyclic. Any
+strongly-connected cluster of packages is therefore inherently a single compile
+action: touching any file recompiles the whole cluster, and no intra-module build
+parallelism is possible. To split a module into smaller/parallel targets, the
+package-level dependency cycles have to be broken first.
+
+This script builds a coarse component graph (one node per top-level package, and
+one per `slice.<x>` sub-package), then:
+
+  1. computes strongly-connected components (Tarjan) — the "blobs" that cannot be
+     split until their internal cycles are broken; and
+  2. for a module with a declared layering (RANK below), lists the *back-edges* —
+     imports that point from a lower layer UP to a higher one. Each back-edge is a
+     cycle-maker; removing them turns a lower layer into a peelable foundation.
+
+It is intentionally NOT a Bazel target and NOT a CI check — it's an on-demand
+analysis helper. stdlib only, no third-party deps.
+
+Usage:
+    python3 tools/analysis/package_cycles.py            # both modules
+    python3 tools/analysis/package_cycles.py webapi     # one module
+    python3 tools/analysis/package_cycles.py --detail   # + per-file back-edge list
+
+Re-run after each decoupling step: the SCC set should shrink and new leaf
+packages become extractable as their own `scala_library` targets.
+"""
+
+from __future__ import annotations
+
+import collections
+import os
+import re
+import sys
+
+# Top-level packages that are their own component (everything else directly under
+# the module root collapses to "root", e.g. Main.scala, the package object).
+WEBAPI_TOPLEVELS = {"messages", "store", "responders", "util", "core", "config"}
+INGEST_TOPLEVELS = {"domain", "api", "infrastructure", "db", "config", "version"}
+
+# Intended layering for webapi (lower rank = more foundational). A dependency
+# should only ever point downward (to an equal-or-lower rank). An import whose
+# target has a HIGHER rank than its source is a back-edge = a layering violation
+# = a cycle-maker. `ingest` has no declared layering yet, so it gets SCC-only.
+WEBAPI_RANK = {
+    "config": 0,
+    "util": 1, "messages": 1, "store": 1,
+    "slice.common": 2, "slice.infrastructure": 2,
+    "slice.security": 3, "slice.admin": 3, "slice.ontology": 3,
+    "slice.resources": 3, "slice.search": 3, "slice.standoff": 3, "slice.export": 3,
+    "responders": 4, "slice.api": 4,
+    "core": 5, "root": 5,
+}
+
+MODULES = {
+    "webapi": {
+        "root": "modules/webapi/src/main/scala/org/knora/webapi",
+        "prefix": "org.knora.webapi",
+        "toplevels": WEBAPI_TOPLEVELS,
+        "rank": WEBAPI_RANK,
+    },
+    "ingest": {
+        "root": "modules/ingest/src/main/scala/swiss/dasch",
+        "prefix": "swiss.dasch",
+        "toplevels": INGEST_TOPLEVELS,
+        "rank": None,
+    },
+}
+
+
+def component_of_path(path: str, root: str, toplevels: set[str]) -> str:
+    parts = path[len(root) + 1:].split(os.sep)
+    if parts[0] == "slice" and len(parts) > 1:
+        return "slice." + parts[1]
+    if parts[0] in toplevels:
+        return parts[0]
+    return "root" if len(parts) == 1 else parts[0]
+
+
+def component_of_fqn(fqn: str, prefix: str, toplevels: set[str]) -> str:
+    # Strip Scala-3 backtick escaping (e.g. the `export` package is a keyword and
+    # is always written `slice.`export``); a naive parser silently drops it.
+    seg = [s.strip("`") for s in fqn[len(prefix) + 1:].split(".")]
+    if seg[0] == "slice" and len(seg) > 1 and seg[1]:
+        return "slice." + seg[1]
+    if seg[0] in toplevels:
+        return seg[0]
+    return "root"
+
+
+def build_graph(cfg: dict):
+    root, prefix, toplevels = cfg["root"], cfg["prefix"], cfg["toplevels"]
+    imp = re.compile(
+        r"import\s+(" + re.escape(prefix) + r"(?:\.(?:`[^`]+`|[A-Za-z0-9_]+))+)"
+    )
+    files = [
+        os.path.join(dp, fn)
+        for dp, _, fns in os.walk(root)
+        for fn in fns
+        if fn.endswith(".scala")
+    ]
+    adj = collections.defaultdict(set)                 # component -> {component}
+    detail = collections.defaultdict(list)             # (src,dst) -> [(file, symbol)]
+    for f in files:
+        src = component_of_path(f, root, toplevels)
+        with open(f, encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                for m in imp.finditer(line):
+                    fqn = m.group(1)
+                    dst = component_of_fqn(fqn, prefix, toplevels)
+                    if dst != src:
+                        adj[src].add(dst)
+                        detail[(src, dst)].append(
+                            (f[len(root) + 1:], fqn[len(prefix) + 1:])
+                        )
+    return adj, detail, len(files)
+
+
+def sccs(adj: dict) -> list[list[str]]:
+    """Tarjan's strongly-connected components (iterative, no recursion limit)."""
+    index: dict[str, int] = {}
+    low: dict[str, int] = {}
+    on_stack: dict[str, bool] = {}
+    stack: list[str] = []
+    out: list[list[str]] = []
+    counter = [0]
+    nodes = set(adj) | {d for s in adj for d in adj[s]}
+
+    def strongconnect(root_node: str):
+        work = [(root_node, iter(sorted(adj.get(root_node, ()))))]
+        index[root_node] = low[root_node] = counter[0]
+        counter[0] += 1
+        stack.append(root_node)
+        on_stack[root_node] = True
+        while work:
+            v, it = work[-1]
+            advanced = False
+            for w in it:
+                if w not in index:
+                    index[w] = low[w] = counter[0]
+                    counter[0] += 1
+                    stack.append(w)
+                    on_stack[w] = True
+                    work.append((w, iter(sorted(adj.get(w, ())))))
+                    advanced = True
+                    break
+                elif on_stack.get(w):
+                    low[v] = min(low[v], index[w])
+            if advanced:
+                continue
+            if low[v] == index[v]:
+                comp = []
+                while True:
+                    w = stack.pop()
+                    on_stack[w] = False
+                    comp.append(w)
+                    if w == v:
+                        break
+                out.append(comp)
+            work.pop()
+            if work:
+                parent = work[-1][0]
+                low[parent] = min(low[parent], low[v])
+
+    for n in sorted(nodes):
+        if n not in index:
+            strongconnect(n)
+    return out
+
+
+def report(name: str, cfg: dict, show_detail: bool):
+    adj, detail, nfiles = build_graph(cfg)
+    comps = sccs(adj)
+    print(f"\n{'=' * 72}\n{name.upper()}: {nfiles} source files, {len(comps)} SCCs\n{'=' * 72}")
+    for comp in sorted(comps, key=len, reverse=True):
+        tag = "   <-- CYCLIC BLOB (one Bazel compile action)" if len(comp) > 1 else ""
+        print(f"  size {len(comp):2d}: {sorted(comp)}{tag}")
+
+    rank = cfg["rank"]
+    if not rank:
+        print(f"\n  ({name} has no declared layering — SCC only.)")
+        return
+
+    print(f"\n  --- back-edges (source depends UP on a higher layer) ---")
+    # group by source component, foundation-first
+    srcs = sorted({s for (s, _) in detail}, key=lambda c: rank.get(c, 9))
+    for src in srcs:
+        be = [
+            (d, detail[(src, d)])
+            for (s, d) in detail
+            if s == src and rank.get(d, 9) > rank.get(src, 0)
+        ]
+        if not be:
+            continue
+        total = sum(len(l) for _, l in be)
+        nf = len({f for _, l in be for f, _ in l})
+        print(f"\n  {src} (rank {rank[src]}): {total} back-edge imports across {nf} files")
+        for d, lst in sorted(be, key=lambda r: -len(r[1])):
+            files_hit = len({f for f, _ in lst})
+            print(f"      -> {d} (rank {rank[d]}): {len(lst)} imports / {files_hit} files")
+        if show_detail:
+            by_file = collections.defaultdict(set)
+            for d, lst in be:
+                for f, sym in lst:
+                    by_file[f].add(sym)
+            for f in sorted(by_file):
+                print(f"        {f}")
+                for sym in sorted(by_file[f]):
+                    print(f"            -> {sym}")
+
+
+def main(argv: list[str]):
+    show_detail = "--detail" in argv
+    wanted = [a for a in argv[1:] if not a.startswith("-")]
+    targets = wanted or list(MODULES)
+    for name in targets:
+        if name not in MODULES:
+            print(f"unknown module '{name}'; known: {', '.join(MODULES)}", file=sys.stderr)
+            return 2
+        report(name, MODULES[name], show_detail)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
Groundwork for **DEV-6776** — breaking the `webapi`/`ingest` package dependency cycles so the modules can eventually be split into smaller, parallelizable Bazel targets.

## What's here

- `tools/analysis/package_cycles.py` — stdlib-only helper (not a Bazel target, not a CI check) that builds the internal package import graph, computes strongly-connected components (Tarjan), and lists the **back-edges** that fuse each module into a single cyclic compile action. Re-run it to track decoupling progress.
- `SESSION-HANDOFF.md` — state, goal, the intended layering model, a heat-map of where the cycles are (foundation-first), and the suggested decoupling loop for continuing in a later session.

**No source refactoring yet** — this PR is intentionally just the tooling + plan, opened as a draft so the actual decoupling work can land on top.

## Why

Bazel compiles each module as one `scala_library` action and targets must be acyclic, so a strongly-connected package cluster is inherently one compile action (any change recompiles the whole module; no intra-module parallelism). SCC analysis shows `webapi` is a single ~429-file blob (only `config` sits outside) and `ingest` a ~54-file blob. The cycles must be broken before any split is possible. Full back-edge catalog and sequencing live in DEV-6776 and `SESSION-HANDOFF.md`.

Builds on the already-merged buildinfo split (`ee251af5f`), which is the reference example of how isolating a target buys compile-cache isolation via interface jars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)