### PR TITLE
chore: group all scala-steward updates into a single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -40,9 +40,6 @@ updates.pin = [
 #
 # Default: []
 pullRequests.grouping = [
-  { name = "patch", "title" = "chore: Patch dependency updates", "filter" = [{"version" = "patch"}] },
-  { name = "minor", "title" = "chore: Minor dependency updates", "filter" = [{"version" = "minor"}] },
-  { name = "major", "title" = "chore: Major dependency updates", "filter" = [{"version" = "major"}] },
   { name = "all", "title" = "chore: Dependency updates", "filter" = [{"group" = "*"}] }
 ]
 


### PR DESCRIPTION
## What

Collapse the scala-steward `pullRequests.grouping` config so that **all** dependency updates land in a single PR instead of being split by bump type.

## Trade-off

Combining major bumps with everything else means a single incompatible update (typically a major version bump) can block the whole PR from merging. This is intentional per the request.

However, from my personal experience, these updates are usually worked at merged all at once anyway and dealing with them through separate PRs only makes the experience more complex. This seems to be a better idea.

## Before

Updates were grouped into up to four separate PRs by version bump:

- `chore: Patch dependency updates`
- `chore: Minor dependency updates`
- `chore: Major dependency updates`
- `chore: Dependency updates` (catch-all)