### PR TITLE
fix(build): set dsp-api image workdir to /opt/docker so triplestore reset finds test data

### DIFF
--- a/modules/webapi/BUILD.bazel
+++ b/modules/webapi/BUILD.bazel
@@ -243,6 +243,11 @@ oci_image(
         ":otel_layer",
         ":curl_jq_layer_amd64",
     ],
+    # WORKDIR: ResetTriplestoreContent resolves test-data files relative to the
+    # CWD (../test_data -> the /opt/test_data bind-mount). sbt-native-packager
+    # set this; rules_oci does not, so without it the container runs from / and
+    # the reset endpoint 500s. See TriplestoreServiceLive.insertObjectIntoTriplestore.
+    workdir = "/opt/docker",
 )
 
 oci_image(
@@ -261,6 +266,9 @@ oci_image(
         ":otel_layer",
         ":curl_jq_layer_arm64",
     ],
+    # WORKDIR: see image_amd64 above — required so ResetTriplestoreContent can
+    # resolve test-data files relative to the /opt/test_data bind-mount.
+    workdir = "/opt/docker",
 )
 
 # Multi-arch index for publishing.


### PR DESCRIPTION
## Problem

`POST /admin/store/ResetTriplestoreContent` returns **500** on the published `daschswiss/knora-api:latest` image. It first drops all graphs, then fails to reload the seed data:

```
ERROR StoreRestService
cause=java.io.FileNotFoundException: resource 'test_data/project_ontologies/dokubib-onto.ttl'
      was not found in the classpath from the given classloader.
  at scala.io.Source$.fromResource(Source.scala:173)
  at ...TriplestoreServiceLive.insertObjectIntoTriplestore(TriplestoreServiceLive.scala:274)
```

`insertObjectIntoTriplestore` resolves each seed file relative to the container's working directory:

```scala
ZIO.readFile(Paths.get("..", path))          // ../test_data/...
  .orElse(ZIO.readFile(Paths.get(path)))     // test_data/...
  .orElse(ZIO.readFile(Paths.get("../..", path)))
  .orElse(ZIO.readFile(Paths.get("../../..", path)))
  .orElse(Source.fromResource(path))         // classpath (last resort)
```

`docker-compose.yml` bind-mounts `./test_data:/opt/test_data`, so `../test_data` only resolves when the container's **workdir is `/opt/docker`**.

## Root cause

The Bazel `rules_oci` migration (#4187) dropped the `WORKDIR /opt/docker` that sbt-native-packager used to set — the `oci_image` targets in `modules/webapi/BUILD.bazel` declared `base`/`entrypoint`/`tars` but no `workdir`, so the container inherits the temurin base default of `/`. Every relative candidate then resolves to `/test_data/…` (nonexistent) and test_data isn't on the classpath → `FileNotFoundException` → 500 (leaving the triplestore empty).

The `fuseki` image kept its `workdir`; only `webapi` lost it.

## Fix

Restore `workdir = "/opt/docker"` on both `image_amd64` and `image_arm64`. Blast radius is minimal — the entrypoint (`-cp /opt/docker/lib/*`) and healthcheck (`/opt/docker/scripts/healthcheck.sh`) use absolute paths; only runtime relative-path resolution was affected.

## Impact / how it surfaced

This broke **dsp-app**'s e2e tests, whose every spec `before all` hook resets the triplestore via this endpoint. dsp-api's own CI didn't catch it because its it/e2e tests don't reset via the published container + compose bind-mount.

## Testing

- No local build validation in this environment (Bazel image build needs the Nix dev shell + RBE); CI/RBE validates the build.
- Behavioural regression guard is dsp-app's e2e (red on the unfixed image, green once this republishes `:latest`). A dsp-api-side container-structure test asserting `WorkingDir` would close the gap in this repo's own CI — noted as a possible follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)