### PR TITLE
fix: place selective pattern before OPTIONAL blocks in generated entity queries (DEV-6796)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/AbstractEntityRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/AbstractEntityRepo.scala
@@ -87,9 +87,12 @@ abstract class AbstractEntityRepo[E <: EntityWithId[Id], Id <: StringValue](
       p.andHas(iri, variable(s"n$index"))
     }
 
-  private def graphP(sub: RdfSubject): GraphPattern = {
-    val req: GraphPattern = requiredTriples(sub.isA(Rdf.iri(resourceClass.toString)))
-    self.entityProperties.opt.zipWithIndex.foldLeft(req) { case (p, (iri, index)) =>
+  private def graphP(sub: RdfSubject): GraphPattern = graphP(sub, leading = None)
+
+  private def graphP(sub: RdfSubject, leading: Option[GraphPattern]): GraphPattern = {
+    val req: GraphPattern  = requiredTriples(sub.isA(Rdf.iri(resourceClass.toString)))
+    val base: GraphPattern = leading.fold(req)(_.and(req))
+    self.entityProperties.opt.zipWithIndex.foldLeft(base) { case (p, (iri, index)) =>
       p.and(sub.has(iri, variable(s"n${index + self.entityProperties.req.size}")).optional())
     }
   }
@@ -100,9 +103,13 @@ abstract class AbstractEntityRepo[E <: EntityWithId[Id], Id <: StringValue](
   protected def findAllByPattern(pattern: RdfSubject => GraphPattern): Task[Chunk[E]] =
     findAllByQuery(findByPatternQuery(pattern))
 
-  private def findByPatternQuery(pattern: RdfSubject => GraphPattern) = {
-    val s             = variable("s")
-    val query: String = entityQuery(tripleP(s), graphP(s).and(pattern(s))).getQueryString
+  private[service] def findByPatternQuery(pattern: RdfSubject => GraphPattern): Construct = {
+    val s = variable("s")
+    // The caller's pattern is the most selective part of the query (e.g. a shortcode lookup) and must
+    // precede the OPTIONAL blocks within the same group: OPTIONALs are left-joins evaluated in document
+    // order, so with the pattern at the end the triplestore computes them for every entity of the class
+    // before restricting.
+    val query: String = entityQuery(tripleP(s), graphP(s, leading = Some(pattern(s)))).getQueryString
     Construct(query)
   }
 

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
@@ -34,6 +34,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.Status
 import org.knora.webapi.slice.admin.domain.model.LicenseIri
 import org.knora.webapi.slice.admin.domain.model.RestrictedView
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectRepo
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary
 import org.knora.webapi.slice.infrastructure.CacheManager
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory
 
@@ -183,6 +184,54 @@ class KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
           }
         },
       ),
+    ),
+    suite("findByPatternQuery")(
+      // Pins the generated SPARQL. The selective pattern must precede the OPTIONAL blocks: OPTIONALs are
+      // left-joins evaluated in document order, so a trailing pattern makes the triplestore compute them
+      // for every entity of the class first (DEV-6796, prod tile-loading regression).
+      test("place the selective pattern before the OPTIONAL blocks") {
+        for {
+          repo    <- ZIO.service[KnoraProjectRepoLive]
+          query    = repo.findByPatternQuery(_.has(Vocabulary.KnoraAdmin.projectShortcode, "1234"))
+          expected =
+            """PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+              |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+              |CONSTRUCT { ?s a knora-admin:knoraProject ;
+              |    knora-admin:hasSelfJoinEnabled ?n0 ;
+              |    knora-admin:projectDescription ?n1 ;
+              |    knora-admin:projectShortcode ?n2 ;
+              |    knora-admin:projectShortname ?n3 ;
+              |    knora-admin:status ?n4 ;
+              |    knora-admin:projectKeyword ?n5 ;
+              |    knora-admin:projectLogo ?n6 ;
+              |    knora-admin:projectLongname ?n7 ;
+              |    knora-admin:projectRestrictedViewSize ?n8 ;
+              |    knora-admin:projectRestrictedViewWatermark ?n9 ;
+              |    knora-admin:hasAllowedCopyrightHolder ?n10 ;
+              |    knora-admin:hasEnabledLicense ?n11 ;
+              |    knora-admin:hasDataLicense ?n12 ;
+              |    knora-admin:hasDataCopyrightHolder ?n13 ;
+              |    knora-admin:hasDefaultDataAuthorship ?n14 . }
+              |WHERE { GRAPH <http://www.knora.org/data/admin> { ?s knora-admin:projectShortcode "1234" .
+              |?s a knora-admin:knoraProject ;
+              |    knora-admin:hasSelfJoinEnabled ?n0 ;
+              |    knora-admin:projectDescription ?n1 ;
+              |    knora-admin:projectShortcode ?n2 ;
+              |    knora-admin:projectShortname ?n3 ;
+              |    knora-admin:status ?n4 .
+              |OPTIONAL { ?s knora-admin:projectKeyword ?n5 . }
+              |OPTIONAL { ?s knora-admin:projectLogo ?n6 . }
+              |OPTIONAL { ?s knora-admin:projectLongname ?n7 . }
+              |OPTIONAL { ?s knora-admin:projectRestrictedViewSize ?n8 . }
+              |OPTIONAL { ?s knora-admin:projectRestrictedViewWatermark ?n9 . }
+              |OPTIONAL { ?s knora-admin:hasAllowedCopyrightHolder ?n10 . }
+              |OPTIONAL { ?s knora-admin:hasEnabledLicense ?n11 . }
+              |OPTIONAL { ?s knora-admin:hasDataLicense ?n12 . }
+              |OPTIONAL { ?s knora-admin:hasDataCopyrightHolder ?n13 . }
+              |OPTIONAL { ?s knora-admin:hasDefaultDataAuthorship ?n14 . } } }
+              |""".stripMargin
+        } yield assertTrue(query.sparql == expected)
+      },
     ),
   ).provide(KnoraProjectRepoLive.layer, TriplestoreServiceInMemory.emptyLayer, CacheManager.layer, StringFormatter.test)
 }


### PR DESCRIPTION
## Problem

Since v37.0.0, IIIF tile loading on prod degraded from ~150ms to ~700ms end-to-end, with >99% of the time spent in Fuseki (DEV-6796).

The per-tile permission check (`GET /admin/files/{shortcode}/{filename}`) runs a project lookup by shortcode. `AbstractEntityRepo.findByPatternQuery` appends the caller's restriction pattern (e.g. the shortcode triple) **after** the required-property BGP and all `OPTIONAL` blocks. `OPTIONAL`s are left-joins evaluated in document order, so Fuseki computes them for **every** project — with multi-valued properties forming a per-project cross product — before the restriction throws all but one away.

DEV-6661 added three more `OPTIONAL`s (`hasDataLicense`, `hasDataCopyrightHolder`, `hasDefaultDataAuthorship`) to this query, which took it from ~150ms to ~700ms (measured against prod Fuseki).

## Fix

Emit the caller's pattern as the **leading** element inside the same graph pattern group, so the subject is bound before any left-join runs. Care is taken to keep the group flat: naively prepending via `pattern.and(graphP)` nests the existing block in a braced sub-group, which would leave the OPTIONAL evaluation scoped away from the binding.

Measured against prod Fuseki with the new query shape: ~700ms → ~30ms.

This fixes all `findOneByPattern`/`findAllByPattern` callers (`findByShortcode`, `findByShortname`, and the other entity repos), not just the tile path.

## Tests

- New pinned-query test in `KnoraProjectRepoLiveSpec` asserts the generated SPARQL verbatim, guarding the pattern-before-OPTIONALs order (the regression guard this query was missing).
- Existing behavioral tests (`findByShortcode`/`findByShortname`/`findAll` against the in-memory triplestore) cover semantics.

Resolves DEV-6796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cRYN8pdJTmWkPti7xTxbY
