### PR TITLE
docs: correct stale metadata-source reference in SipiService comment

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/store/iiif/api/SipiService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/iiif/api/SipiService.scala
@@ -57,7 +57,8 @@ object FileMetadataSipiResponse {
 trait SipiService {
 
   /**
-   * Asks DSP-Ingest for metadata about a file in permanent location, served from the 'knora.json' route.
+   * Fetches metadata about a file in permanent storage from DSP-Ingest's asset-info endpoint
+   * (`/projects/{shortcode}/assets/{assetId}`).
    *
    * @param shortcode the shortcode of the project.
    * @param assetId for the file.


### PR DESCRIPTION
The Scaladoc on `SipiService.getFileMetadataFromDspIngest` described the metadata as being served from Sipi's `knora.json` route. That is no longer accurate: the live implementation (`SipiServiceLive.getFileMetadataFromDspIngest`) queries dsp-ingest's asset-info endpoint at `/projects/{shortcode}/assets/{assetId}` via `DspIngestClient.getAssetInfo`.

This corrects the comment to describe the actual behavior. Comment-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emfc7ytFoCtPDzGBwDy4Kf
