### PR TITLE
fix(oai): use public dsp-ingest hostname for OAI file links (DEV-6774)

### DIFF
--- a/docs/04-publishing-deployment/configuration.md
+++ b/docs/04-publishing-deployment/configuration.md
@@ -22,6 +22,7 @@ A number of core settings is additionally configurable through system environmen
 | app.jwt.issuer                         | KNORA_WEBAPI_JWT_ISSUER                         | 0.0.0.0:3333            |
 | app.dsp-ingest.audience                | KNORA_WEBAPI_DSP_INGEST_AUDIENCE                | <http://localhost:3340> |
 | app.dsp-ingest.base-url                | KNORA_WEBAPI_DSP_INGEST_BASE_URL                | <http://localhost:3340> |
+| app.dsp-ingest.external-base-url       | KNORA_WEBAPI_DSP_INGEST_EXTERNAL_BASE_URL       | falls back to base-url  |
 | app.allow-reload-over-http             | KNORA_WEBAPI_ALLOW_RELOAD_OVER_HTTP             | false                   |
 | app.ark.resolver                       | KNORA_WEBAPI_ARK_RESOLVER_URL                   | <http://0.0.0.0:3336>   |
 | app.ark.assigned-number                | KNORA_WEBAPI_ARK_NAAN                           | 72163                   |

--- a/modules/webapi/src/main/resources/application.conf
+++ b/modules/webapi/src/main/resources/application.conf
@@ -27,6 +27,9 @@ app {
     dsp-ingest {
         base-url = "http://localhost:3340"
         base-url = ${?KNORA_WEBAPI_DSP_INGEST_BASE_URL}
+        // client-facing URL for download links; defaults to base-url, set to the public host when they differ
+        external-base-url = ${app.dsp-ingest.base-url}
+        external-base-url = ${?KNORA_WEBAPI_DSP_INGEST_EXTERNAL_BASE_URL}
         audience = "http://localhost:3340"
         audience = ${?KNORA_WEBAPI_DSP_INGEST_AUDIENCE}
     }

--- a/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -56,7 +56,11 @@ final case class JwtConfig(secret: String, expiration: Duration, issuer: Option[
   )
 }
 
-final case class DspIngestConfig(baseUrl: String, audience: String)
+/**
+ * @param baseUrl         internal URL for server-to-server communication with dsp-ingest.
+ * @param externalBaseUrl client-facing URL for download links handed to clients (e.g. OAI file links).
+ */
+final case class DspIngestConfig(baseUrl: String, externalBaseUrl: String, audience: String)
 
 final case class KnoraApi(
   internalHost: String,

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/export/api/service/ExportService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/export/api/service/ExportService.scala
@@ -133,15 +133,14 @@ final case class ExportService(
   }
 
   // A resource has at most one file value, so we expose the first one found (mirrors `typeOfDataOf`).
-  // The direct link points at the dsp-ingest "original" download endpoint, addressed by the asset id
-  // (the internal filename without its extension).
+  // The direct link points at the dsp-ingest "original" download endpoint, addressed by the asset id.
   private def fileLinkOf(project: KnoraProject, r: ReadResourceV2): Option[FileLink] =
     r.values.values.flatten.map(_.valueContent).collectFirst { case fc: FileValueContentV2 =>
       val internalFilename = fc.fileValue.internalFilename
       val assetId          = internalFilename.takeWhile(_ != '.')
       FileLink(
         mimeType = fc.fileValue.internalMimeType,
-        url = s"${appConfig.dspIngest.baseUrl}/projects/${project.shortcode.value}/assets/$assetId/original",
+        url = s"${appConfig.dspIngest.externalBaseUrl}/projects/${project.shortcode.value}/assets/$assetId/original",
       )
     }
 

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec__oai.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec__oai.txt
@@ -396,7 +396,7 @@
     "keywords" : [],
     "file" : {
       "mimeType" : "image/jp2",
-      "url" : "http://localhost:3340/projects/1612/assets/B1D0OkEgfFp-Cew2Seur7Wi/original"
+      "url" : "https://ingest.example.org/projects/1612/assets/B1D0OkEgfFp-Cew2Seur7Wi/original"
     }
   }
 ]

--- a/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
@@ -34,6 +34,7 @@ class AppConfigSpec extends ZIOSpecDefault {
           appConfig.instrumentationServerConfig.interval == Duration.ofSeconds(5),
           dspIngestConfig.audience == "http://localhost:3340",
           dspIngestConfig.baseUrl == "http://localhost:3340",
+          dspIngestConfig.externalBaseUrl == "http://localhost:3340",
           jwtConfig.expiration == java.time.Duration.ofDays(30),
           jwtConfig.issuer.contains("0.0.0.0:3333"),
           jwtConfig.issuerAsString() == "0.0.0.0:3333",

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
@@ -151,7 +151,13 @@ object DspIngestClientLiveSpecLayers {
   val dspIngestConfigLayer: ZLayer[TestPort, Nothing, DspIngestConfig] = ZLayer.fromZIO(
     ZIO
       .serviceWith[TestPort](_.value)
-      .map(port => DspIngestConfig(baseUrl = s"http://localhost:$port", audience = "audience")),
+      .map(port =>
+        DspIngestConfig(
+          baseUrl = s"http://localhost:$port",
+          externalBaseUrl = s"http://localhost:$port",
+          audience = "audience",
+        ),
+      ),
   )
 }
 

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/export/api/service/ExportServiceSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/export/api/service/ExportServiceSpec.scala
@@ -96,6 +96,9 @@ class ExportServiceSpec extends ZIOSpecDefault with GoldenTest {
   val user       = TestDataFactory.User.rootUser
   val projectIri = ProjectIri.unsafeFrom("http://rdfh.ch/projects/Vk0NruDmRyeZCZvOVwXOnw")
 
+  // distinct from base-url so the OAI test proves the file link uses external-base-url
+  val publicIngestUrl = "https://ingest.example.org"
+
   val dataSets: Set[RdfDataObject] = builtInNamedGraphs ++ List(
     RdfDataObject(
       path = "webapi/src/test/resources/org/knora/webapi/slice/export/api/service/ExportServiceSpec-1612-onto.ttl",
@@ -250,7 +253,8 @@ class ExportServiceSpec extends ZIOSpecDefault with GoldenTest {
           project       <- ZIO.serviceWithZIO[KnoraProjectService](_.findById(projectIri)).map(_.get)
           exportService <- ZIO.service[ExportService]
           json          <- exportService.exportResourcesOai(project, user)
-        } yield assertGolden(json, "oai")
+        } yield assertGolden(json, "oai") &&
+          assertTrue(json.contains(s"$publicIngestUrl/projects/"))
       },
       test("resources are exported in alphabetical label order") {
         for {
@@ -337,7 +341,9 @@ class ExportServiceSpec extends ZIOSpecDefault with GoldenTest {
       },
     ).provide(
       ConstructResponseUtilV2.layer,
-      AppConfig.layer,
+      AppConfig.layer.map(env =>
+        env.update[AppConfig](c => c.copy(dspIngest = c.dspIngest.copy(externalBaseUrl = publicIngestUrl))),
+      ),
       CacheManager.layer,
       CsvService.layer,
       emptyDataset,

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/infrastructure/JwtServiceLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/infrastructure/JwtServiceLiveSpec.scala
@@ -69,7 +69,7 @@ class JwtServiceLiveSpec extends ZIOSpecDefault {
   private val dspApiIssuer      = "https://dsp-api"
 
   private val dspIngestConfigLayer =
-    ZLayer.succeed(DspIngestConfig("https://dps-ingest", dspIngestAudience))
+    ZLayer.succeed(DspIngestConfig("https://dps-ingest", "https://dps-ingest", dspIngestAudience))
 
   private val jwtConfigLayer = ZLayer.succeed(
     JwtConfig("n76lPIwWKNeTodFfZPPPYFn7V24R14aE63A+XgS8MMA=", Duration.ofSeconds(10), Some(dspApiIssuer)),


### PR DESCRIPTION
## Problem

The OAI metadata export (`POST /v3/export/resources/oai`) builds the direct file download URL from the **internal** server-to-server dsp-ingest `base-url`. In a deployed stack that is `http://ingest:3340` (a docker-internal hostname), so the `file.url` handed to clients — e.g. consumed by DPE / dsp-repository, whose golden data expects `https://ingest.dasch.swiss/...` — points at an internal hostname unreachable from outside the stack.

`ExportService.fileLinkOf` was the only place in dsp-api that surfaces a dsp-ingest URL to clients; the normal API v2 file responses already use `sipi.externalBaseUrl`.

## Fix

- Add `app.dsp-ingest.external-base-url` config (env `KNORA_WEBAPI_DSP_INGEST_EXTERNAL_BASE_URL`), mirroring the existing internal/external split for `sipi` and `knora-api`.
- It defaults to `base-url` in `application.conf` (`external-base-url = ${app.dsp-ingest.base-url}`), so when unset the behaviour is unchanged.
- `ExportService.fileLinkOf` now builds the file link from `externalBaseUrl`.

Deployments set the env var to the public hostname (e.g. `https://ingest.<host>`).

## Testing

- `ExportServiceSpec` OAI test: the suite sets `external-base-url` to a distinct public host (`https://ingest.example.org`) and the test asserts (golden + explicit check) that the exported file link carries the public hostname, not the internal `base-url`. This exercises the fix end-to-end through `ExportService`.
- `AppConfigSpec`: verifies `external-base-url` defaults to `base-url` when the env var is unset.
- `DspIngestClientLiveSpec` / `JwtServiceLiveSpec`: updated for the new field.
- Full `webapi` compile + test compile pass with `-Werror`; scalafmt clean.