### PR TITLE
chore: bump Sipi to v6.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -277,20 +277,20 @@ use_repo(maven, "maven", "unpinned_maven")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v5.0.1), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v6.0.0), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v5.0.1 index carries a `v8`
+# index/variant matching — the arm64 entry of the v6.0.0 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. The tag
 # is recorded in `Dependencies.sipiImage` (build.sbt); bump both together.
-# Index digest: sha256:aa9e049e075782cf6ec792668462088dde7e4ec644f419c3a5dca55c404d31e4
+# Index digest: sha256:a07f0b67ab04189cf4ca9c43a3d1d9880fbf549213ad2c3528796166616f5e02
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:a137157aed6284c789fe9af723beb484e5f5623ebeccd33b62dcabac4964ec56",
+    digest = "sha256:713f8009c5becedfa192729d49121db9559cb62580564efb2a86971b9e1ee19f",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:9e2e2ee1612d03bbb20746302ddd91a4ad0bc78ce43957710ab6e3f43c9faafe",
+    digest = "sha256:42e376b7816b9dcfb1215a4c20a3aff8c458ceff4889c00e66bf1e65ed08df64",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
   val fusekiImage = "daschswiss/apache-jena-fuseki:6.1.0-0"
   // base image the knora-sipi image is created from
-  val sipiImage = "daschswiss/sipi:v5.0.1"
+  val sipiImage = "daschswiss/sipi:v6.0.0"
 
   val ScalaVersion = "3.8.4"
 


### PR DESCRIPTION
## Motivation

Sipi `v6.0.0` is published (multi-arch on Docker Hub). Point dsp-api's
knora-sipi base image at it.

## Summary

- Bump the upstream Sipi base image from `v5.0.1` to `v6.0.0`.

## Key Changes

### Both SIPI pins, in lockstep (as the MODULE.bazel comment requires)
- `project/Dependencies.scala` — `sipiImage` → `daschswiss/sipi:v6.0.0`.
- `MODULE.bazel` — per-arch `oci.pull` manifest digests + the version/index-digest
  comment. The arm64 entry still carries a `v8` variant, so the direct
  per-arch-manifest pin (not the index) is retained.

Digests (`daschswiss/sipi:v6.0.0`):
- index `sha256:a07f0b67ab04189cf4ca9c43a3d1d9880fbf549213ad2c3528796166616f5e02`
- amd64 `sha256:713f8009c5becedfa192729d49121db9559cb62580564efb2a86971b9e1ee19f`
- arm64 `sha256:42e376b7816b9dcfb1215a4c20a3aff8c458ceff4889c00e66bf1e65ed08df64`

## Gotchas

- **Major version bump (5 → 6).** This PR only moves the pin; it makes no
  dsp-api code changes. If v6.0.0 changed anything dsp-api relies on (the
  knora-sipi build layered on top, or the runtime CLI/interface), CI here is
  the gate — watch the sipi-backed integration/e2e jobs. Any required code
  changes are a follow-up, not part of this bump.
- **Deployment pin lives elsewhere.** `Dependencies.scala` notes the version
  must also be updated in the `ops-deploy` repo when deploying a new DSP
  release. Not in scope here.
- `MODULE.bazel.lock` does not record these digests, so no lock regeneration
  was needed.

## Test Plan

- [ ] CI green, in particular the jobs that build/run the knora-sipi image.
- [ ] Sipi-backed integration/e2e tests pass against v6.0.0.
