### PR TITLE
chore: bump Sipi to v6.1.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -277,20 +277,20 @@ use_repo(maven, "maven", "unpinned_maven")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v6.0.0), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v6.1.0), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v6.0.0 index carries a `v8`
+# index/variant matching — the arm64 entry of the v6.1.0 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. The tag
 # is recorded in `Dependencies.sipiImage` (build.sbt); bump both together.
-# Index digest: sha256:a07f0b67ab04189cf4ca9c43a3d1d9880fbf549213ad2c3528796166616f5e02
+# Index digest: sha256:4bed63e1720eab9b85b64aba07b5e176a75fe48621e659db9c3e44a71398c4b6
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:713f8009c5becedfa192729d49121db9559cb62580564efb2a86971b9e1ee19f",
+    digest = "sha256:a4584a6cb2378d264af1d4e253410efcd3fbfde91ab2007fd8ef6005be6290e0",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:42e376b7816b9dcfb1215a4c20a3aff8c458ceff4889c00e66bf1e65ed08df64",
+    digest = "sha256:da3c6989496aaa1e78448e4165302f451a3d810c3de3de124649c59903f40f31",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
   val fusekiImage = "daschswiss/apache-jena-fuseki:6.1.0-0"
   // base image the knora-sipi image is created from
-  val sipiImage = "daschswiss/sipi:v6.0.0"
+  val sipiImage = "daschswiss/sipi:v6.1.0"
 
   val ScalaVersion = "3.8.4"
 


### PR DESCRIPTION
## Motivation
Sipi `v6.1.0` is published (multi-arch on Docker Hub). It supersedes the v6.0.0 bump (#4205) and adds the engine-pool request queueing (replaces 503 shedding under load).

## Summary
- Bump the upstream Sipi base image from `v6.0.0` to `v6.1.0`.

## Key Changes
### Both SIPI pins, in lockstep (per the MODULE.bazel comment)
- `project/Dependencies.scala` — `sipiImage` → `daschswiss/sipi:v6.1.0`.
- `MODULE.bazel` — per-arch `oci.pull` manifest digests + the version/index-digest comment. The arm64 entry still carries a `v8` variant, so the direct per-arch-manifest pin (not the index) is retained.

Digests (`daschswiss/sipi:v6.1.0`):
- index `sha256:4bed63e1720eab9b85b64aba07b5e176a75fe48621e659db9c3e44a71398c4b6`
- amd64 `sha256:a4584a6cb2378d264af1d4e253410efcd3fbfde91ab2007fd8ef6005be6290e0`
- arm64 `sha256:da3c6989496aaa1e78448e4165302f451a3d810c3de3de124649c59903f40f31`

## Gotchas
- v6.1.0 = v6.0.0 + the queue-requests feature; no other dsp-api-facing changes expected. CI here (the sipi-backed integration/e2e jobs) is the gate.
- `ops-deploy` has its own SIPI version pin for deployment — bump there too at release time.
- `MODULE.bazel.lock` does not record these digests, so no lock regeneration needed.

## Test Plan
- [ ] CI green, especially the jobs that build/run the knora-sipi image.
- [ ] Sipi-backed integration/e2e tests pass against v6.1.0.