### PR TITLE
fix: pass explicit Lucene hit limit in search queries to prevent silent 10k truncation (DEV-6823)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -1082,5 +1082,11 @@ object OntologyConstants {
 
   object Fuseki {
     val luceneQueryPredicate = "http://jena.apache.org/text#query"
+
+    // Without an explicit limit, Jena caps text index lookups at 10'000 hits (TextIndexLucene.MAX_N) and
+    // silently discards an arbitrary subset of matches *before* the SPARQL filters apply, making resources
+    // unfindable (DEV-6822). The worst realistic prefix measured on prod-scale data yields ~95k hits, so 1M
+    // leaves ample headroom while still bounding the Lucene collector allocation.
+    val luceneHitLimit: Int = 1000000
   }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchQueries.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchQueries.scala
@@ -8,6 +8,7 @@ package org.knora.webapi.responders.v2
 import org.eclipse.rdf4j.model.vocabulary.RDFS
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.PropertyPathBuilder
 
+import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
@@ -17,6 +18,8 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 import org.knora.webapi.util.FusekiLucenceQuery
 
 object SearchQueries extends QueryBuilderHelper {
+
+  private val luceneHitLimit = OntologyConstants.Fuseki.luceneHitLimit
 
   def selectCountByLabel(
     luceneQuery: FusekiLucenceQuery,
@@ -28,7 +31,7 @@ object SearchQueries extends QueryBuilderHelper {
           |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
           |SELECT (count(distinct ?resource) as ?count)
           |WHERE {
-          |    ?resource <http://jena.apache.org/text#query> (rdfs:label "${luceneQuery.getQueryString}") ;
+          |    ?resource <http://jena.apache.org/text#query> (rdfs:label "${luceneQuery.getQueryString}" $luceneHitLimit) ;
           |        a ?resourceClass .
           |    ?resourceClass rdfs:subClassOf* knora-base:Resource .
           |    ${filterByProjectAndResourceClass(limitToProject, limitToResourceClass)}
@@ -77,7 +80,7 @@ object SearchQueries extends QueryBuilderHelper {
           |    {
           |        SELECT DISTINCT ?resource ?label
           |        WHERE {
-          |            ?resource <http://jena.apache.org/text#query> (rdfs:label "${luceneQuery.getQueryString}") ;
+          |            ?resource <http://jena.apache.org/text#query> (rdfs:label "${luceneQuery.getQueryString}" $luceneHitLimit) ;
           |                a ?resourceClass ;
           |                rdfs:label ?label .
           |            ${filterByProjectAndResourceClass(limitToProject, limitToResourceClass)}

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuery.scala
@@ -9,6 +9,7 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import zio.IO
 
 import dsp.errors.SparqlGenerationException
+import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
@@ -16,6 +17,8 @@ import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 
 object SearchFulltextQuery extends QueryBuilderHelper {
+
+  private val luceneHitLimit = OntologyConstants.Fuseki.luceneHitLimit
 
   // The overall query structure (SELECT with GROUP_CONCAT, subqueries, BIND/COALESCE, SUBSTR)
   // is assembled via string interpolation because these features are not supported by the
@@ -98,7 +101,7 @@ object SearchFulltextQuery extends QueryBuilderHelper {
          |WHERE {
          |    {
          |        SELECT DISTINCT ?matchingSubject WHERE {
-         |            ?matchingSubject <http://jena.apache.org/text#query> $searchLiteral .$standoffFilter
+         |            ?matchingSubject <http://jena.apache.org/text#query> ($searchLiteral $luceneHitLimit) .$standoffFilter
          |        }
          |    }
          |    OPTIONAL {

--- a/modules/webapi/src/test/resources/org/knora/webapi/responders/v2/SearchQueriesSpec__countNoFilters.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/responders/v2/SearchQueriesSpec__countNoFilters.txt
@@ -1,0 +1,10 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+SELECT (count(distinct ?resource) as ?count)
+WHERE {
+    ?resource <http://jena.apache.org/text#query> (rdfs:label "Anton*" 1000000) ;
+        a ?resourceClass .
+    ?resourceClass rdfs:subClassOf* knora-base:Resource .
+    
+    FILTER NOT EXISTS { ?resource knora-base:isDeleted true . }
+}

--- a/modules/webapi/src/test/resources/org/knora/webapi/responders/v2/SearchQueriesSpec__countWithProjectAndClass.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/responders/v2/SearchQueriesSpec__countWithProjectAndClass.txt
@@ -1,0 +1,11 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+SELECT (count(distinct ?resource) as ?count)
+WHERE {
+    ?resource <http://jena.apache.org/text#query> (rdfs:label "Anton*" 1000000) ;
+        a ?resourceClass .
+    ?resourceClass rdfs:subClassOf* knora-base:Resource .
+    ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> <http://rdfh.ch/projects/0001> .
+?resourceClass <http://www.w3.org/2000/01/rdf-schema#subClassOf>? <http://www.knora.org/ontology/0001/anything#Thing> .
+    FILTER NOT EXISTS { ?resource knora-base:isDeleted true . }
+}

--- a/modules/webapi/src/test/resources/org/knora/webapi/responders/v2/SearchQueriesSpec__searchWithProjectAndClass.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/responders/v2/SearchQueriesSpec__searchWithProjectAndClass.txt
@@ -1,0 +1,50 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+CONSTRUCT {
+    ?resource rdfs:label ?label ;
+        a knora-base:Resource ;
+        knora-base:isMainResource true ;
+        knora-base:isDeleted false ;
+        a ?resourceType ;
+        knora-base:attachedToUser ?resourceCreator ;
+        knora-base:hasPermissions ?resourcePermissions ;
+        knora-base:attachedToProject ?resourceProject  ;
+        knora-base:creationDate ?creationDate ;
+        knora-base:lastModificationDate ?lastModificationDate ;
+        knora-base:hasValue ?valueObject ;
+        ?resourceValueProperty ?valueObject .
+    ?valueObject ?valueObjectProperty ?valueObjectValue .
+} WHERE {
+    {
+        SELECT DISTINCT ?resource ?label
+        WHERE {
+            ?resource <http://jena.apache.org/text#query> (rdfs:label "Anton*" 1000000) ;
+                a ?resourceClass ;
+                rdfs:label ?label .
+            ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> <http://rdfh.ch/projects/0001> .
+?resourceClass <http://www.w3.org/2000/01/rdf-schema#subClassOf>? <http://www.knora.org/ontology/0001/anything#Thing> .
+            FILTER NOT EXISTS { ?resource knora-base:isDeleted true . }
+        }
+        ORDER BY ?resource
+        LIMIT 25
+        OFFSET 0
+    }
+
+    ?resource a ?resourceType ;
+        knora-base:attachedToUser ?resourceCreator ;
+        knora-base:hasPermissions ?resourcePermissions ;
+        knora-base:attachedToProject ?resourceProject ;
+        knora-base:creationDate ?creationDate ;
+        rdfs:label ?label .
+    OPTIONAL { ?resource knora-base:lastModificationDate ?lastModificationDate . }
+    OPTIONAL {
+        ?resource ?resourceValueProperty ?valueObject .
+        ?resourceValueProperty rdfs:subPropertyOf* knora-base:hasValue .
+        ?valueObject a ?valueObjectType ;
+            ?valueObjectProperty ?valueObjectValue .
+        ?valueObjectType rdfs:subClassOf* knora-base:Value .
+        FILTER(?valueObjectType != knora-base:LinkValue)
+        FILTER NOT EXISTS { ?valueObject knora-base:isDeleted true . }
+        FILTER NOT EXISTS { ?valueObjectValue a knora-base:StandoffTag . }
+    }
+}

--- a/modules/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchQueriesSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchQueriesSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.responders.v2
+
+import org.junit.runner.RunWith
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.GoldenTest
+import org.knora.webapi.messages.IriConversions.ConvertibleIri
+import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.util.FusekiLucenceQuery
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class SearchQueriesSpec extends ZIOSpecDefault with GoldenTest {
+
+  implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
+
+  private val luceneQuery      = FusekiLucenceQuery.unsafeFrom("Anton*")
+  private val projectIri       = ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001")
+  private val resourceClassIri =
+    ResourceClassIri.unsafeFrom("http://www.knora.org/ontology/0001/anything#Thing".toSmartIri)
+
+  // The golden outputs must contain an explicit hit limit in the text:query list — without one, Jena
+  // caps the Lucene lookup at 10'000 hits and silently drops matches before the project/class filters
+  // apply, making resources unfindable (DEV-6822).
+  override def spec: Spec[TestEnvironment, Any] = suite("SearchQueriesSpec")(
+    test("selectCountByLabel should produce the correct query with project and resource class filters") {
+      val query = SearchQueries.selectCountByLabel(luceneQuery, Some(projectIri), Some(resourceClassIri))
+      assertGolden(query.sparql, "countWithProjectAndClass")
+    },
+    test("selectCountByLabel should produce the correct query without filters") {
+      val query = SearchQueries.selectCountByLabel(luceneQuery, None, None)
+      assertGolden(query.sparql, "countNoFilters")
+    },
+    test("constructSearchByLabel should produce the correct query with project and resource class filters") {
+      val query =
+        SearchQueries.constructSearchByLabel(luceneQuery, Some(projectIri), Some(resourceClassIri), 25, 0)
+      assertGolden(query.sparql, "searchWithProjectAndClass")
+    },
+  )
+}

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec.scala
@@ -49,7 +49,7 @@ class SearchFulltextQuerySpec extends ZIOSpecDefault {
               |WHERE {
               |    {
               |        SELECT DISTINCT ?matchingSubject WHERE {
-              |            ?matchingSubject <http://jena.apache.org/text#query> "test" .
+              |            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
               |        }
               |    }
               |    OPTIONAL {
@@ -106,7 +106,7 @@ class SearchFulltextQuerySpec extends ZIOSpecDefault {
               |WHERE {
               |    {
               |        SELECT DISTINCT ?matchingSubject WHERE {
-              |            ?matchingSubject <http://jena.apache.org/text#query> "test" .
+              |            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
               |        }
               |    }
               |    OPTIONAL {
@@ -168,7 +168,7 @@ class SearchFulltextQuerySpec extends ZIOSpecDefault {
                |WHERE {
                |    {
                |        SELECT DISTINCT ?matchingSubject WHERE {
-               |            ?matchingSubject <http://jena.apache.org/text#query> "test" .
+               |            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
                |        }
                |    }
                |    OPTIONAL {
@@ -229,7 +229,7 @@ class SearchFulltextQuerySpec extends ZIOSpecDefault {
                |WHERE {
                |    {
                |        SELECT DISTINCT ?matchingSubject WHERE {
-               |            ?matchingSubject <http://jena.apache.org/text#query> "test search" .
+               |            ?matchingSubject <http://jena.apache.org/text#query> ("test search" 1000000) .
                |    ?matchingSubject a knora-base:TextValue ;
                |        knora-base:valueHasString ?literal ;
                |        knora-base:valueHasStandoff ?standoffNode .


### PR DESCRIPTION
Resolves [DEV-6823](https://linear.app/dasch/issue/DEV-6823) (parent: [DEV-6822](https://linear.app/dasch/issue/DEV-6822))

## Problem

Every `text:query` sent to Fuseki's Lucene text index omitted the optional limit argument, so Jena silently capped the lookup at **10,000 hits** (`TextIndexLucene.MAX_N`). The cap is applied **before** the SPARQL filters (`limitToProject`, `limitToResourceClass`, `isDeleted`), and since wildcard/prefix queries are constant-score, the surviving 10k are an arbitrary subset of all matching text in the entire database, across all projects.

Result: resources were randomly unfindable in search-by-label (link-value autocomplete, advanced search) whenever the typed prefix matched more than 10k text snippets dataset-wide. This is the root cause behind the long-standing "inconsistent search" bug family (DEV-4589, DEV-5481, DEV-4904, likely DEV-3695), previously closed as not fixable. Full analysis, stage measurements, and reproduction recipes: [DEV-6822](https://linear.app/dasch/issue/DEV-6822).

Verified on stage (prod mirror): the search-by-label query for "Anton" (Webern project, class Person) returns 0 without a limit and the correct 8 persons with one; raw hit counts confirm the cap at exactly 10,000 (true count for `Anton*`: 11,782).

## Changes

- New shared constant `OntologyConstants.Fuseki.luceneHitLimit = 1000000` (~10× headroom over the worst prefix measured on prod-scale data, `uni*` = 94,187 hits; deliberately not unbounded since Lucene pre-allocates the hit-queue).
- `SearchQueries.selectCountByLabel` / `constructSearchByLabel`: `(rdfs:label "…")` → `(rdfs:label "…" 1000000)`.
- `SearchFulltextQuery` (fulltext route + count): `text:query "…"` → `text:query ("…" 1000000)`. Same bug, same one-line fix — folded in here; the Gravsearch call sites need AST work and are tracked separately in [DEV-6824](https://linear.app/dasch/issue/DEV-6824).

## Tests

- New `SearchQueriesSpec` (golden files) pins the generated search-by-label SPARQL including the limit.
- `SearchFulltextQuerySpec` expected queries updated.
- Local test data cannot reproduce the 10k cap, so correctness on prod-scale data was verified manually against the stage DB (measurements in DEV-6822/DEV-6823).

## Latency note

With the limit, worst-case terms (`uni*`) take ~1.6 s on the search route and ~9 s on the count route on stage (join-dominated, not Lucene). Typical terms ~1.5 s. Correct-and-slower beats fast-and-empty; count-route optimization can follow up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVPsnzF7SCjCutrnQ6ioCb
