### PR TITLE
feat(dsp-api): cache file permission checks on the image-serving path (DEV-6806)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -148,6 +148,7 @@ maven.install(
     artifacts = [
         # -- ZIO (Scala 3 `_3`) --
         "dev.zio:zio_3:2.1.26",
+        "dev.zio:zio-cache_3:0.2.4",
         "dev.zio:zio-streams_3:2.1.26",
         "dev.zio:zio-schema_3:1.8.5",
         "dev.zio:zio-schema-derivation_3:1.8.5",

--- a/maven_install.json
+++ b/maven_install.json
@@ -25,6 +25,7 @@
     "dev.optics:monocle-core_3": 1598778482,
     "dev.optics:monocle-macro_3": 82206083,
     "dev.optics:monocle-refined_3": 485163608,
+    "dev.zio:zio-cache_3": -1303758854,
     "dev.zio:zio-config-magnolia_3": 712513304,
     "dev.zio:zio-config-typesafe_3": -1204877329,
     "dev.zio:zio-config_3": -469687121,
@@ -250,6 +251,8 @@
     "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_3:jar:sources": 343704133,
     "dev.zio:izumi-reflect_3": -655092843,
     "dev.zio:izumi-reflect_3:jar:sources": -148042695,
+    "dev.zio:zio-cache_3": 1261113174,
+    "dev.zio:zio-cache_3:jar:sources": -1899009973,
     "dev.zio:zio-config-derivation_3": -1870395090,
     "dev.zio:zio-config-derivation_3:jar:sources": -187498114,
     "dev.zio:zio-config-magnolia_3": 1373611703,
@@ -1361,6 +1364,13 @@
         "sources": "3602701b6407c8a46b78fcfb2634d64345e57e3c31b2f0c7d141a5d9b7f813b5"
       },
       "version": "3.0.9"
+    },
+    "dev.zio:zio-cache_3": {
+      "shasums": {
+        "jar": "2ebdf6c106738ffe172703387c62df5e76bfb320b841f7745809986c9f1a8177",
+        "sources": "ac7703325c285e101a054a6c001308baac51d7cc7658c8f541faf5a41b9ba221"
+      },
+      "version": "0.2.4"
     },
     "dev.zio:zio-config-derivation_3": {
       "shasums": {
@@ -3386,6 +3396,10 @@
     "dev.zio:izumi-reflect_3": [
       "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_3"
     ],
+    "dev.zio:zio-cache_3": [
+      "dev.zio:zio_3",
+      "org.scala-lang.modules:scala-collection-compat_3"
+    ],
     "dev.zio:zio-config-derivation_3": [
       "dev.zio:zio-config_3"
     ],
@@ -5253,6 +5267,9 @@
       "izumi.reflect.internal.fundamentals.platform.language",
       "izumi.reflect.internal.fundamentals.platform.strings",
       "izumi.reflect.macrortti"
+    ],
+    "dev.zio:zio-cache_3": [
+      "zio.cache"
     ],
     "dev.zio:zio-config-derivation_3": [
       "zio.config.derivation"
@@ -9188,6 +9205,8 @@
       "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_3:jar:sources",
       "dev.zio:izumi-reflect_3",
       "dev.zio:izumi-reflect_3:jar:sources",
+      "dev.zio:zio-cache_3",
+      "dev.zio:zio-cache_3:jar:sources",
       "dev.zio:zio-config-derivation_3",
       "dev.zio:zio-config-derivation_3:jar:sources",
       "dev.zio:zio-config-magnolia_3",

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsCacheE2ESpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsCacheE2ESpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.responders.admin
+
+import org.junit.runner.RunWith
+import zio.ZIO
+import zio.test.*
+
+import dsp.errors.NotFoundException
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.*
+import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
+import org.knora.webapi.slice.admin.domain.model.InternalFilename
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.api.admin.model.PermissionCodeAndProjectRestrictedViewSettings
+import org.knora.webapi.slice.api.admin.model.ProjectRestrictedViewSettingsADM
+
+/**
+ * Integration spec for the wired [[AssetPermissionsCache]] against a real triplestore. It mirrors
+ * [[AssetPermissionsResponderSpec]] so the cache is shown to reproduce the responder's decisions end-to-end, and pins
+ * the one genuine divergence: for an anonymous request the endpoint injects the hardcoded `AnonymousUser` constant,
+ * whereas the cache re-derives the user from its IRI via `findUserByIri`. Those two are asserted decision-equivalent.
+ *
+ * No cache-state isolation is needed here: each test compares the cache's decision to the direct responder decision (or
+ * to a fixed literal) for given inputs, which holds whether the entry is a hit or a miss; hit/miss/eviction accounting
+ * is covered by the pure-JVM `AssetPermissionsCacheSpec`.
+ */
+@RunWith(classOf[DspZTestJUnitRunner])
+class AssetPermissionsCacheE2ESpec extends E2EZSpec {
+
+  private val cache     = ZIO.serviceWithZIO[AssetPermissionsCache]
+  private val responder = ZIO.serviceWithZIO[AssetPermissionsResponder]
+  private val asset     = InternalFilename.unsafeFrom("incunabula_0000003328.jp2")
+
+  override val rdfDataObjects: List[RdfDataObject] = List(incunabulaRdfData)
+
+  override val e2eSpec = suite("The AssetPermissionsCache (wired, real triplestore)")(
+    test("serve a full-quality decision for an authenticated project member (code 6, no settings)") {
+      cache(
+        _.getPermissionCodeAndProjectRestrictedViewSettings(incunabulaMemberUser)(incunabulaProject.shortcode, asset),
+      ).map(actual => assertTrue(actual == PermissionCodeAndProjectRestrictedViewSettings(permissionCode = 6, None)))
+    },
+    test("serve a restricted-view decision for an anonymous request (code 1 + settings)") {
+      cache(
+        _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(incunabulaProject.shortcode, asset),
+      ).map(actual =>
+        assertTrue(
+          actual == PermissionCodeAndProjectRestrictedViewSettings(
+            permissionCode = 1,
+            Some(ProjectRestrictedViewSettingsADM(size = Some("!512,512"), watermark = false)),
+          ),
+        ),
+      )
+    },
+    test("still fail with NotFound when the file belongs to a different project than the given shortcode") {
+      cache(
+        _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(Shortcode.unsafeFrom("0001"), asset),
+      ).exit.map(exit => assert(exit)(Assertion.fails(Assertion.isSubtype[NotFoundException](Assertion.anything))))
+    },
+    test(
+      "cached anonymous decision equals the direct responder decision with the constant AnonymousUser (REQ-1.5/1.3)",
+    ) {
+      for {
+        cached <-
+          cache(
+            _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(incunabulaProject.shortcode, asset),
+          )
+        direct <-
+          responder(
+            _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(incunabulaProject.shortcode, asset),
+          )
+      } yield assertTrue(cached == direct)
+    },
+    test("cached authenticated decision equals the direct responder decision (REQ-1.3)") {
+      for {
+        cached <- cache(
+                    _.getPermissionCodeAndProjectRestrictedViewSettings(incunabulaMemberUser)(
+                      incunabulaProject.shortcode,
+                      asset,
+                    ),
+                  )
+        direct <- responder(
+                    _.getPermissionCodeAndProjectRestrictedViewSettings(incunabulaMemberUser)(
+                      incunabulaProject.shortcode,
+                      asset,
+                    ),
+                  )
+      } yield assertTrue(cached == direct)
+    },
+  )
+}

--- a/modules/webapi/BUILD.bazel
+++ b/modules/webapi/BUILD.bazel
@@ -70,6 +70,7 @@ scala_library(
         "@maven//:dev_optics_monocle_macro_3",
         "@maven//:dev_optics_monocle_refined_3",
         "@maven//:dev_zio_zio_3",
+        "@maven//:dev_zio_zio_cache_3",
         "@maven//:dev_zio_zio_config_3",
         "@maven//:dev_zio_zio_config_magnolia_3",
         "@maven//:dev_zio_zio_config_typesafe_3",
@@ -141,6 +142,7 @@ scala_junit_test(
         "//modules/test-runner",
         "//test_data:fixtures",  # RDF fixtures on the classpath (see test_data/BUILD.bazel)
         "@maven//:dev_zio_zio_3",
+        "@maven//:dev_zio_zio_cache_3",
         "@maven//:dev_zio_zio_json_3",
         "@maven//:dev_zio_zio_test_3",
         "@maven//:org_wiremock_wiremock",

--- a/modules/webapi/src/main/resources/application.conf
+++ b/modules/webapi/src/main/resources/application.conf
@@ -201,6 +201,20 @@ app {
         interval = 5 seconds
     }
 
+    // Short-lived cache for asset (file) permission checks on the IIIF tile-serving path (DEV-6806). A single tiled
+    // image fires many identical GET /admin/files/{shortcode}/{filename} checks in a short burst; caching the decision
+    // sheds the repeated triplestore round-trip and permission computation within that burst. Operational knobs,
+    // overridable per deployment via env var without a code change/release/deploy.
+    file-permission-cache {
+        // how long a computed decision is retained before it is re-resolved. Staleness (a revocation or a new grant)
+        // therefore lags by at most one ttl; keep it short.
+        ttl = 2 minutes
+        ttl = ${?KNORA_WEBAPI_FILE_PERMISSION_CACHE_TTL}
+        // maximum number of cached decisions; eviction beyond this bound is delegated to zio-cache.
+        capacity = 10000
+        capacity = ${?KNORA_WEBAPI_FILE_PERMISSION_CACHE_CAPACITY}
+    }
+
     features {
         allow-erase-projects = false
         allow-erase-projects = ${?ALLOW_ERASE_PROJECTS}

--- a/modules/webapi/src/main/resources/application.conf
+++ b/modules/webapi/src/main/resources/application.conf
@@ -207,7 +207,7 @@ app {
     // overridable per deployment via env var without a code change/release/deploy.
     file-permission-cache {
         // how long a computed decision is retained before it is re-resolved. Staleness (a revocation or a new grant)
-        // therefore lags by at most one ttl; keep it short.
+        // therefore lags by at most one ttl; keep it short. Validated at load to be > 0 and <= 10 minutes.
         ttl = 2 minutes
         ttl = ${?KNORA_WEBAPI_FILE_PERMISSION_CACHE_TTL}
         // maximum number of cached decisions; eviction beyond this bound is delegated to zio-cache.

--- a/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -54,8 +54,9 @@ final case class ExportConfig(
  *
  * `ttl` is how long a computed decision is retained before it is re-resolved (so staleness lags by at most one `ttl`);
  * `capacity` is the maximum number of cached decisions before eviction. Both live in config so they can be tuned per
- * deployment without a code change. Validated at load: `ttl` must be positive and `capacity` at least 1 (a `capacity`
- * below 1 is undefined for `zio.cache.Cache.makeWith`).
+ * deployment without a code change. Validated at load: `ttl` must be positive and at most 10 minutes (a longer window
+ * would silently widen permission staleness — this is a short-lived burst cache, not a general one), and `capacity`
+ * must be at least 1 (a `capacity` below 1 is undefined for `zio.cache.Cache.makeWith`).
  */
 final case class FilePermissionCacheConfig(
   ttl: Duration,
@@ -204,6 +205,9 @@ object AppConfig {
     )
     .validate("app.v2.resources.max-batch-size must be >= 1")(_.v2.resources.maxBatchSize >= 1)
     .validate("app.file-permission-cache.ttl must be positive")(_.filePermissionCache.ttl.compareTo(Duration.ZERO) > 0)
+    .validate("app.file-permission-cache.ttl must be at most 10 minutes (permission-staleness guard)")(
+      _.filePermissionCache.ttl.compareTo(Duration.ofMinutes(10)) <= 0,
+    )
     .validate("app.file-permission-cache.capacity must be >= 1")(_.filePermissionCache.capacity >= 1)
 
   def config[A](f: AppConfig => A): UIO[A]  = ZIO.config(config).map(f).orDie

--- a/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -32,6 +32,7 @@ final case class AppConfig(
   dspIngest: DspIngestConfig,
   features: Features,
   `export`: ExportConfig,
+  filePermissionCache: FilePermissionCacheConfig,
 ) {
   val tmpDataDirPath: zio.nio.file.Path = zio.nio.file.Path(this.tmpDatadir)
 }
@@ -46,6 +47,19 @@ final case class AppConfig(
 final case class ExportConfig(
   batchSize: Int,
   parallelism: Int,
+)
+
+/**
+ * Tuning knobs for the short-lived asset-permission cache on the IIIF tile-serving path (DEV-6806).
+ *
+ * `ttl` is how long a computed decision is retained before it is re-resolved (so staleness lags by at most one `ttl`);
+ * `capacity` is the maximum number of cached decisions before eviction. Both live in config so they can be tuned per
+ * deployment without a code change. Validated at load: `ttl` must be positive and `capacity` at least 1 (a `capacity`
+ * below 1 is undefined for `zio.cache.Cache.makeWith`).
+ */
+final case class FilePermissionCacheConfig(
+  ttl: Duration,
+  capacity: Int,
 )
 
 final case class JwtConfig(secret: String, expiration: Duration, issuer: Option[String]) {
@@ -189,6 +203,8 @@ object AppConfig {
       c.copy(jwt = c.jwt.copy(issuer = c.jwt.issuer.orElse(Some(c.knoraApi.externalKnoraApiHostPort)))),
     )
     .validate("app.v2.resources.max-batch-size must be >= 1")(_.v2.resources.maxBatchSize >= 1)
+    .validate("app.file-permission-cache.ttl must be positive")(_.filePermissionCache.ttl.compareTo(Duration.ZERO) > 0)
+    .validate("app.file-permission-cache.capacity must be >= 1")(_.filePermissionCache.capacity >= 1)
 
   def config[A](f: AppConfig => A): UIO[A]  = ZIO.config(config).map(f).orDie
   def features[A](f: Features => A): UIO[A] = ZIO.config(config.map(_.features)).map(f).orDie

--- a/modules/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -108,6 +108,7 @@ object LayersLive { self =>
       // ZLayer.Debug.mermaid,
       AdminModule.layer,
       ApiComplexV2JsonLdRequestParser.layer,
+      AssetPermissionsCache.layer,
       AssetPermissionsResponder.layer,
       AuthorizationRestService.layer,
       BaseEndpoints.layer,

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/admin/AssetPermissionsCache.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/admin/AssetPermissionsCache.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.responders.admin
+
+import zio.*
+import zio.cache.Cache
+import zio.cache.Lookup
+import zio.metrics.Metric
+import zio.metrics.PollingMetric
+
+import dsp.errors.BadRequestException
+import dsp.errors.NotFoundException
+import org.knora.webapi.config.AppConfig
+import org.knora.webapi.slice.admin.domain.model.InternalFilename
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.admin.domain.model.UserIri
+import org.knora.webapi.slice.admin.domain.service.UserService
+import org.knora.webapi.slice.api.admin.model.PermissionCodeAndProjectRestrictedViewSettings
+
+/**
+ * A short-lived, in-memory cache in front of [[AssetPermissionsResponder]] for the IIIF tile-serving path (DEV-6806).
+ *
+ * A single tiled image fires many identical `GET /admin/files/{shortcode}/{filename}` checks in a short burst; caching
+ * the decision keyed by `(UserIri, Shortcode, InternalFilename)` sheds the repeated `FileValuePermissionsQuery`
+ * round-trip and permission computation within that burst, and zio-cache's single-flight behaviour collapses the
+ * simultaneous first-tile salvo into one resolution.
+ *
+ * The responder stays a pure resolver: this is a wrapping service, so the cache is self-contained and independently
+ * testable. Only successful decisions are retained (failures re-resolve on the next request), expiry is lazy after a
+ * configured TTL, and capacity is bounded — see [[AssetPermissionsCache.makeCache]].
+ */
+final case class AssetPermissionsCache(
+  private val cache: Cache[
+    AssetPermissionsCache.CacheKey,
+    Throwable,
+    PermissionCodeAndProjectRestrictedViewSettings,
+  ],
+) {
+
+  /**
+   * Same shape as [[AssetPermissionsResponder.getPermissionCodeAndProjectRestrictedViewSettings]], so the
+   * `serverLogic(...)` binding in `FilesServerEndpoints` is unchanged.
+   */
+  def getPermissionCodeAndProjectRestrictedViewSettings(user: User)(
+    shortcode: Shortcode,
+    filename: InternalFilename,
+  ): Task[PermissionCodeAndProjectRestrictedViewSettings] =
+    // `User.id` is a `String` (only `KnoraUser.id` is a typed `UserIri`); convert per the IRI-handling convention —
+    // never `unsafeFrom`. `UserIri.from` whitelists the built-in `AnonymousUser` IRI, so both authenticated and
+    // anonymous requests produce a key; the value comes from an already-validated `User`, so the failure branch is
+    // effectively unreachable.
+    ZIO
+      .fromEither(UserIri.from(user.id))
+      .mapError(BadRequestException.apply)
+      .flatMap(iri => cache.get(AssetPermissionsCache.CacheKey(iri, shortcode, filename)))
+}
+
+object AssetPermissionsCache {
+
+  final case class CacheKey(userIri: UserIri, shortcode: Shortcode, filename: InternalFilename)
+
+  /**
+   * Testable core of the cache. Unit tests pass a counting/failing `resolve`; production passes the real one (see
+   * [[layer]]). Built with `Cache.makeWith` so that only successes are retained for the configured `ttl`, while a
+   * failure (a transient triplestore error or a definitive `NotFoundException`) is given `Duration.Zero` and thus
+   * re-resolved on the next matching request (REQ-1.6).
+   */
+  def makeCache(capacity: Int, ttl: Duration)(
+    resolve: CacheKey => Task[PermissionCodeAndProjectRestrictedViewSettings],
+  ): UIO[Cache[CacheKey, Throwable, PermissionCodeAndProjectRestrictedViewSettings]] =
+    Cache.makeWith(capacity, Lookup(resolve)) {
+      case Exit.Success(_) => ttl
+      case Exit.Failure(_) => Duration.Zero // REQ-1.6: never retain failures
+    }
+
+  val layer: URLayer[AppConfig & UserService & AssetPermissionsResponder, AssetPermissionsCache] =
+    ZLayer.scoped {
+      for {
+        config    <- ZIO.service[AppConfig]
+        users     <- ZIO.service[UserService]
+        responder <- ZIO.service[AssetPermissionsResponder]
+        cfg        = config.filePermissionCache
+        // `zio.Duration` IS `java.time.Duration` in ZIO 2, so `cfg.ttl` needs no conversion.
+        cache <- makeCache(cfg.capacity, cfg.ttl) { key =>
+                   // On a miss the lookup sees only the key, so it re-derives the `User` from the `UserIri` via the
+                   // same `findUserByIri` path the auth layer uses. `findById`'s built-in fallback resolves the
+                   // anonymous IRI, so no special-casing is needed. This introduces a benign TOCTOU divergence from
+                   // the uncached path: the uncached path receives an already-hydrated `User` and never re-checks
+                   // existence, whereas here a user deleted between requests would surface as a `NotFoundException`.
+                   users
+                     .findUserByIri(key.userIri)
+                     .someOrFail(NotFoundException(s"No user found for ${key.userIri.value}"))
+                     .flatMap(
+                       responder.getPermissionCodeAndProjectRestrictedViewSettings(_)(key.shortcode, key.filename),
+                     )
+                 }
+        _ <- registerMetrics(cache)
+      } yield AssetPermissionsCache(cache)
+    }
+
+  /**
+   * Registers `hits`/`misses`/`size` from `cache.cacheStats` as unlabeled polling gauges (REQ-3.1/3.2). `hits`/`misses`
+   * are cumulative totals surfaced as gauges-of-absolute-value (a Prometheus counter would double-count), so dashboards
+   * use `deriv`/`idelta`, not `rate()`, and the names carry no `_total` suffix. The poller runs for the lifetime of the
+   * enclosing layer's scope.
+   */
+  private def registerMetrics(
+    cache: Cache[CacheKey, Throwable, PermissionCodeAndProjectRestrictedViewSettings],
+  ): ZIO[Scope, Nothing, Unit] = {
+    val hits   = PollingMetric(Metric.gauge("file_permission_cache_hits"), cache.cacheStats.map(_.hits.toDouble))
+    val misses = PollingMetric(Metric.gauge("file_permission_cache_misses"), cache.cacheStats.map(_.misses.toDouble))
+    val size   = PollingMetric(Metric.gauge("file_permission_cache_size"), cache.cacheStats.map(_.size.toDouble))
+    PollingMetric.collectAll(Chunk(hits, misses, size)).launch(Schedule.fixed(10.seconds)).unit
+  }
+}

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/admin/AssetPermissionsCache.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/admin/AssetPermissionsCache.scala
@@ -77,6 +77,22 @@ object AssetPermissionsCache {
       case Exit.Failure(_) => Duration.Zero // REQ-1.6: never retain failures
     }
 
+  /**
+   * The miss-path resolution the production cache is built around: re-derive the `User` from the key's `UserIri` via
+   * the same `findUserByIri` path the auth layer uses (`findById`'s built-in fallback resolves the anonymous IRI, so no
+   * special-casing is needed), then delegate to the unchanged responder. The `zio.cache.Lookup` sees only the key, so
+   * this cannot reuse the request's already-hydrated `User`; that introduces a benign TOCTOU divergence from the
+   * uncached path (a user deleted between requests surfaces here as a `NotFoundException` rather than the token `User`).
+   * It depends only on `users`/`responder`, not on the built `Cache`, so it lives here rather than on the instance.
+   */
+  private def resolve(users: UserService, responder: AssetPermissionsResponder)(
+    key: CacheKey,
+  ): Task[PermissionCodeAndProjectRestrictedViewSettings] =
+    users
+      .findUserByIri(key.userIri)
+      .someOrFail(NotFoundException(s"No user found for ${key.userIri.value}"))
+      .flatMap(responder.getPermissionCodeAndProjectRestrictedViewSettings(_)(key.shortcode, key.filename))
+
   val layer: URLayer[AppConfig & UserService & AssetPermissionsResponder, AssetPermissionsCache] =
     ZLayer.scoped {
       for {
@@ -85,20 +101,8 @@ object AssetPermissionsCache {
         responder <- ZIO.service[AssetPermissionsResponder]
         cfg        = config.filePermissionCache
         // `zio.Duration` IS `java.time.Duration` in ZIO 2, so `cfg.ttl` needs no conversion.
-        cache <- makeCache(cfg.capacity, cfg.ttl) { key =>
-                   // On a miss the lookup sees only the key, so it re-derives the `User` from the `UserIri` via the
-                   // same `findUserByIri` path the auth layer uses. `findById`'s built-in fallback resolves the
-                   // anonymous IRI, so no special-casing is needed. This introduces a benign TOCTOU divergence from
-                   // the uncached path: the uncached path receives an already-hydrated `User` and never re-checks
-                   // existence, whereas here a user deleted between requests would surface as a `NotFoundException`.
-                   users
-                     .findUserByIri(key.userIri)
-                     .someOrFail(NotFoundException(s"No user found for ${key.userIri.value}"))
-                     .flatMap(
-                       responder.getPermissionCodeAndProjectRestrictedViewSettings(_)(key.shortcode, key.filename),
-                     )
-                 }
-        _ <- registerMetrics(cache)
+        cache <- makeCache(cfg.capacity, cfg.ttl)(resolve(users, responder))
+        _     <- registerMetrics(cache)
       } yield AssetPermissionsCache(cache)
     }
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/admin/AdminApiModule.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/admin/AdminApiModule.scala
@@ -9,7 +9,7 @@ import zio.URLayer
 import zio.ZLayer
 
 import org.knora.webapi.config.AppConfig
-import org.knora.webapi.responders.admin.AssetPermissionsResponder
+import org.knora.webapi.responders.admin.AssetPermissionsCache
 import org.knora.webapi.responders.admin.ListsResponder
 import org.knora.webapi.responders.admin.PermissionsResponder
 import org.knora.webapi.slice.admin.domain.service.AdministrativePermissionService
@@ -43,7 +43,7 @@ object AdminApiModule { self =>
       // format: off
       AdministrativePermissionService &
       AppConfig &
-      AssetPermissionsResponder &
+      AssetPermissionsCache &
       AuthorizationRestService &
       BaseEndpoints &
       CacheManager &

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/admin/FilesServerEndpoints.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/admin/FilesServerEndpoints.scala
@@ -8,17 +8,17 @@ package org.knora.webapi.slice.api.admin
 import sttp.tapir.ztapir.*
 import zio.*
 
-import org.knora.webapi.responders.admin.AssetPermissionsResponder
+import org.knora.webapi.responders.admin.AssetPermissionsCache
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
 
 final class FilesServerEndpoints(
   filesEndpoints: FilesEndpoints,
-  assetPermissionsResponder: AssetPermissionsResponder,
+  assetPermissionsCache: AssetPermissionsCache,
 ) {
   val serverEndpoints: List[ZServerEndpoint[Any, Any]] = List(
     filesEndpoints.getAdminFilesShortcodeFileIri.serverLogic(
-      assetPermissionsResponder.getPermissionCodeAndProjectRestrictedViewSettings,
+      assetPermissionsCache.getPermissionCodeAndProjectRestrictedViewSettings,
     ),
   )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
@@ -49,6 +49,10 @@ class AppConfigSpec extends ZIOSpecDefault {
       loadAppConfigWith("app.file-permission-cache.ttl = 0 seconds").exit
         .map(exit => assertTrue(exit.isFailure))
     },
+    test("reject a file-permission-cache ttl above the 10 minute staleness guard") {
+      loadAppConfigWith("app.file-permission-cache.ttl = 11 minutes").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
     test("reject a file-permission-cache capacity below 1") {
       loadAppConfigWith("app.file-permission-cache.capacity = 0").exit
         .map(exit => assertTrue(exit.isFailure))

--- a/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
@@ -5,8 +5,11 @@
 
 package org.knora.webapi.config
 
+import com.typesafe.config.ConfigFactory
 import org.junit.runner.RunWith
 import zio.ZIO
+import zio.config.*
+import zio.config.typesafe.TypesafeConfigProvider
 import zio.test.Spec
 import zio.test.ZIOSpecDefault
 import zio.test.assertTrue
@@ -32,6 +35,8 @@ class AppConfigSpec extends ZIOSpecDefault {
           appConfig.triplestore.gravsearchTimeout == Duration.ofSeconds(120),
           appConfig.bcryptPasswordStrength == PasswordStrength.unsafeFrom(12).value,
           appConfig.instrumentationServerConfig.interval == Duration.ofSeconds(5),
+          appConfig.filePermissionCache.ttl == Duration.ofMinutes(2),
+          appConfig.filePermissionCache.capacity == 10000,
           dspIngestConfig.audience == "http://localhost:3340",
           dspIngestConfig.baseUrl == "http://localhost:3340",
           jwtConfig.expiration == java.time.Duration.ofDays(30),
@@ -40,5 +45,21 @@ class AppConfigSpec extends ZIOSpecDefault {
         )
       }
     }.provideLayer(AppConfig.layer),
+    test("reject a file-permission-cache ttl that is not positive") {
+      loadAppConfigWith("app.file-permission-cache.ttl = 0 seconds").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
+    test("reject a file-permission-cache capacity below 1") {
+      loadAppConfigWith("app.file-permission-cache.capacity = 0").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
   )
+
+  // Loads the full application.conf, overriding the given HOCON keys, so a validation failure isolates to the override.
+  private def loadAppConfigWith(overrides: String) =
+    read(
+      AppConfig.config from TypesafeConfigProvider.fromTypesafeConfig(
+        ConfigFactory.parseString(overrides).withFallback(ConfigFactory.load()).getConfig("app").resolve,
+      ),
+    )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsCacheSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsCacheSpec.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.responders.admin
+
+import org.junit.runner.RunWith
+import zio.*
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.responders.admin.AssetPermissionsCache.CacheKey
+import org.knora.webapi.slice.admin.domain.model.InternalFilename
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.admin.domain.model.UserIri
+import org.knora.webapi.slice.api.admin.model.PermissionCodeAndProjectRestrictedViewSettings
+
+/**
+ * Pure-JVM unit spec for the cache wiring in [[AssetPermissionsCache.makeCache]] — no triplestore. A counting/failing
+ * stub `resolve` stands in for the real lookup, so these tests exercise the exact `makeWith` + failure-TTL behaviour
+ * the production layer relies on rather than generic zio-cache.
+ */
+@RunWith(classOf[DspZTestJUnitRunner])
+class AssetPermissionsCacheSpec extends ZIOSpecDefault {
+
+  private val ttl = 2.minutes
+
+  private def keyFor(
+    user: String = "http://rdfh.ch/users/aaaa",
+    shortcode: String = "0001",
+    filename: String = "test.jp2",
+  ): CacheKey =
+    CacheKey(UserIri.unsafeFrom(user), Shortcode.unsafeFrom(shortcode), InternalFilename.unsafeFrom(filename))
+
+  private def decision(code: Int): PermissionCodeAndProjectRestrictedViewSettings =
+    PermissionCodeAndProjectRestrictedViewSettings(code, restrictedViewSettings = None)
+
+  private val allow = decision(6)
+  private val deny  = decision(0)
+
+  def spec: Spec[Any, Any] = suite("AssetPermissionsCache.makeCache")(
+    test("resolves on a miss and serves from cache on a hit (REQ-1.1/1.2/3.1)") {
+      for {
+        calls <- Ref.make(0)
+        cache <- AssetPermissionsCache.makeCache(100, ttl)(_ => calls.update(_ + 1).as(allow))
+        key    = keyFor()
+        first <- cache.get(key) // miss
+        again <- cache.get(key) // hit
+        n     <- calls.get
+        stats <- cache.cacheStats
+      } yield assertTrue(
+        first == allow,
+        again == allow,
+        n == 1,
+        stats.hits == 1L,
+        stats.misses == 1L,
+      )
+    },
+    test("collapses concurrent identical misses into exactly one resolution (REQ-1.7)") {
+      for {
+        calls   <- Ref.make(0)
+        entered <- Promise.make[Nothing, Unit]
+        release <- Promise.make[Nothing, Unit]
+        cache   <- AssetPermissionsCache.makeCache(100, ttl) { _ =>
+                   calls.update(_ + 1) *> entered.succeed(()) *> release.await.as(allow)
+                 }
+        key     = keyFor()
+        fibers <- ZIO.foreach(1 to 5)(_ => cache.get(key).fork)
+        // `entered` guarantees the first fiber has reached `resolve` before we read the counter (else we could read 0);
+        // `release` keeps that lookup in-flight so the other four dedup onto it rather than hitting a completed entry.
+        _               <- entered.await
+        callsInFlight   <- calls.get
+        _               <- release.succeed(())
+        results         <- ZIO.foreach(fibers)(_.join)
+        callsAfterwards <- calls.get
+      } yield assertTrue(
+        callsInFlight == 1,
+        callsAfterwards == 1,
+        results.forall(_ == allow),
+      )
+    },
+    test("does not retain a failed resolution; the next request re-resolves (REQ-1.6)") {
+      for {
+        calls <- Ref.make(0)
+        cache <- AssetPermissionsCache.makeCache(100, ttl) { _ =>
+                   calls.updateAndGet(_ + 1).flatMap {
+                     case 1 => ZIO.fail(new RuntimeException("transient failure"))
+                     case _ => ZIO.succeed(allow)
+                   }
+                 }
+        key    = keyFor()
+        first <- cache.get(key).exit
+        // A failure is given Duration.Zero, so it expires the instant any time passes. Under the frozen TestClock the
+        // boundary is not crossed without this nudge; in production the clock always advances, so the next real request
+        // re-resolves. (Contrast the TTL test: a *success* is still valid 1ms later.)
+        _     <- TestClock.adjust(1.milli)
+        again <- cache.get(key)
+        n     <- calls.get
+      } yield assertTrue(first.isFailure, again == allow, n == 2)
+    },
+    test("re-resolves an entry once its TTL has elapsed (REQ-2.1)") {
+      for {
+        calls <- Ref.make(0)
+        cache <- AssetPermissionsCache.makeCache(100, ttl)(_ => calls.update(_ + 1).as(allow))
+        key    = keyFor()
+        _     <- cache.get(key) // miss, calls = 1
+        _     <- cache.get(key) // hit, calls = 1
+        // a hair past the TTL, to cross zio-cache's lazy-expiry boundary deterministically
+        _         <- TestClock.adjust(ttl.plusMillis(1))
+        _         <- cache.get(key) // expired -> re-resolve, calls = 2
+        callCount <- calls.get
+      } yield assertTrue(callCount == 2)
+    },
+    test("stays bounded when far more than `capacity` distinct keys are inserted (REQ-2.3)") {
+      val capacity = 10
+      for {
+        cache <- AssetPermissionsCache.makeCache(capacity, ttl)(_ => ZIO.succeed(allow))
+        _     <- ZIO.foreachDiscard(1 to 500)(i => cache.get(keyFor(filename = s"file_$i.jp2")))
+        stats <- cache.cacheStats
+      } yield assertTrue(
+        // eviction is amortized, not strictly synchronous at the boundary, so assert bounded-with-slack, not an
+        // exact ceiling; the point is the size does not grow with the number of inserts.
+        stats.size <= capacity * 2,
+        stats.size >= 1,
+      )
+    },
+    test("keeps decisions for distinct user IRIs independent; never cross-serves (REQ-1.4)") {
+      val userA = "http://rdfh.ch/users/aaaa"
+      val userB = "http://rdfh.ch/users/bbbb"
+      for {
+        cache <- AssetPermissionsCache.makeCache(100, ttl) { key =>
+                   ZIO.succeed(decision(if (key.userIri.value == userA) 6 else 2))
+                 }
+        decisionA <- cache.get(keyFor(user = userA))
+        decisionB <- cache.get(keyFor(user = userB))
+      } yield assertTrue(decisionA.permissionCode == 6, decisionB.permissionCode == 2)
+    },
+    test("caches and serves a deny decision (permissionCode = 0) as a success value (REQ-1.3, deny)") {
+      for {
+        calls <- Ref.make(0)
+        cache <- AssetPermissionsCache.makeCache(100, ttl)(_ => calls.update(_ + 1).as(deny))
+        key    = keyFor()
+        first <- cache.get(key) // miss
+        again <- cache.get(key) // hit
+        n     <- calls.get
+      } yield assertTrue(first == deny, again == deny, n == 1)
+    },
+  )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,8 +29,9 @@ object Dependencies {
   val ZioPreludeVersion = "1.0.0-RC47"
   val ZioSchemaVersion  = "1.8.5"
 
-  val ZioMockVersion = "1.0.0-RC12"
-  val ZioVersion     = "2.1.26"
+  val ZioMockVersion  = "1.0.0-RC12"
+  val ZioVersion      = "2.1.26"
+  val ZioCacheVersion = "0.2.4"
 
   // ZIO
   val zio               = "dev.zio" %% "zio"                 % ZioVersion
@@ -117,7 +118,8 @@ object Dependencies {
   val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15to18" % "1.85"
 
   // caching
-  val ehcache = "org.ehcache" % "ehcache" % "3.12.0"
+  val ehcache  = "org.ehcache" % "ehcache"   % "3.12.0"
+  val zioCache = "dev.zio"    %% "zio-cache" % ZioCacheVersion
 
   // other
   val gwtServlet     = "com.google.gwt"          % "gwt-servlet"      % "2.10.0"
@@ -218,6 +220,7 @@ object Dependencies {
     zioLoggingSlf4jBridge,
     zioNio,
     zioPrelude,
+    zioCache,
     zio,
   ) ++ zioSttpClient ++ metrics ++ tapir ++ openTelemetryWithSentry
 


### PR DESCRIPTION
[DEV-6806](https://linear.app/dasch/issue/DEV-6806)

## Summary

- A single tiled image fires many identical `GET /admin/files/{shortcode}/{filename}` permission checks in a short burst. This puts a short-lived, in-memory `zio.cache.Cache` (`AssetPermissionsCache`) in front of the unchanged `AssetPermissionsResponder`, keyed by `(UserIri, Shortcode, InternalFilename)`.
- On a hit the previously computed decision (`permissionCode` + optional `restrictedViewSettings`) is returned without a triplestore round-trip, and zio-cache's single-flight collapses the simultaneous first-tile salvo into one resolution.
- Only successful decisions are retained (failures get `Duration.Zero`), expiry is lazy after a configurable TTL (default 2 min), capacity is bounded (default 10 000), and `hits`/`misses`/`size` are exposed as unlabeled Prometheus gauges.

## Changes

**Cache & config**
- New `AssetPermissionsCache` (wrapping service, `ZLayer.scoped`) in `responders.admin`; the responder stays a pure resolver. On a miss the lookup re-derives the `User` from its IRI via `UserService.findUserByIri` (the same path the auth layer uses), so anonymous requests resolve through the built-in fallback.
- `file-permission-cache { ttl, capacity }` HOCON section with env overrides; `AppConfig.FilePermissionCacheConfig` with load-time validation (`0 < ttl <= 10 min` — a staleness guard added from security review — and `capacity >= 1`).

**Wiring**
- `FilesServerEndpoints`, `AdminApiModule.Dependencies`, and `LayersLive` now route through the cache; the responder is still produced (the cache depends on it and `AssetPermissionsResponderSpec` still uses it).

**Build**
- `dev.zio:zio-cache:0.2.4` added to sbt (`Dependencies.scala`) **and** the Bazel build (`MODULE.bazel`, `modules/webapi/BUILD.bazel`, re-pinned `maven_install.json`).

## Test Plan

- **Unit** (`AssetPermissionsCacheSpec`, pure JVM): hit/miss stats, single-flight dedup, failure-not-cached, TTL expiry (`TestClock`), capacity bound, per-user key independence, deny (`code 0`) round-trip. ✅ 7/7
- **Config** (`AppConfigSpec`): asserts `ttl`/`capacity` load from HOCON and that `ttl = 0` / `capacity = 0` fail validation. ✅
- **Integration** (`AssetPermissionsCacheE2ESpec`, real triplestore via testcontainers): authenticated code 6, anonymous code 1 + settings, cross-project not-found, and cached-vs-direct-responder equivalence for the anonymous (constant-vs-re-derived) and authenticated cases. ✅ 5/5
- `sbt check` (scalafmt + scalafix) clean; `bazel build //modules/webapi:webapi //modules/webapi:test` and `//modules/test-it:test` compile.

## Notes for the reviewer

- **Metrics (REQ-3.1) — verified live.** Ran the built image in the full local stack: after 6 anonymous requests to one file, `/metrics` (:3339) reported `file_permission_cache_hits 5.0`, `file_permission_cache_misses 1.0`, `file_permission_cache_size 1.0` — the three unlabeled gauges are exposed via the Prometheus connector and track cache activity as designed.
- **Pre-existing Bazel/sbt version drift (not from this PR).** `//tools/deps:maven_versions_match_sbt` is red on `main` for ~21 unrelated deps (tapir, HikariCP, rdf4j, opentelemetry, flyway, …) that drifted between `Dependencies.scala` and `MODULE.bazel`. This PR's `zio-cache` addition is consistent on both sides; the drift is out of scope for DEV-6806 and flagged for a separate maintenance PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHdLgHyuoxFPv8bcpaPN55
