### PR TITLE
build(dsp-api): add a one-command Bazel/sbt maven-version sync

### DIFF
--- a/docs/05-internals/development/third-party.md
+++ b/docs/05-internals/development/third-party.md
@@ -1,6 +1,24 @@
 # Third-Party Dependencies
 
-Third party libraries are managed by SBT.
+Third party libraries are declared for the sbt build in `project/Dependencies.scala`.
+
+## Keeping the Bazel build in sync
+
+The Bazel build (which CI runs) declares the same Maven coordinates independently in `MODULE.bazel`'s
+`maven.install`, pinned in `maven_install.json`. These must agree with `project/Dependencies.scala`, and
+`//tools/deps:maven_versions_match_sbt` fails the build if they drift.
+
+`scala-steward` (the automated dependency-update tooling) is sbt-native and updates **only**
+`project/Dependencies.scala` — it does not touch the Bazel manifests. So after any dependency update the
+Bazel side must be brought back in line. Run:
+
+```shell
+just sync-bazel-maven-versions
+```
+
+which rewrites `MODULE.bazel` to match `project/Dependencies.scala` (via
+`tools/deps/check_maven_versions.py --fix`) and re-pins `maven_install.json` (`bazel run @unpinned_maven//:pin`).
+Commit the resulting `MODULE.bazel` and `maven_install.json` changes alongside the dependency bump.
 
 ## Defining Dependencies in `Dependencies.scala`
 

--- a/justfile
+++ b/justfile
@@ -50,6 +50,13 @@ test-ingest-integration *FLAGS='': (docker-load-test-images FLAGS)
 check:
     ./sbtx check
 
+# Sync MODULE.bazel's maven.install versions to Dependencies.scala (sbt) + re-pin the lock file.
+# scala-steward updates only the sbt side, so run this after a dependency update to clear the drift that
+# //tools/deps:maven_versions_match_sbt reports.
+sync-bazel-maven-versions:
+    python3 tools/deps/check_maven_versions.py --fix MODULE.bazel project/Dependencies.scala
+    bazel run @unpinned_maven//:pin
+
 ## Docker image build / publish
 
 # Print the docker image tag (git describe via workspace_status.sh; no sbt)

--- a/tools/deps/check_maven_versions.py
+++ b/tools/deps/check_maven_versions.py
@@ -14,6 +14,7 @@ elsewhere via `val NAME = "literal"`. Deps present on only one side (e.g.
 sbt-plugin-only or Scala-toolchain-only artifacts) are not an error -- this
 only flags shared coordinates whose versions disagree.
 """
+import argparse
 import re
 import sys
 
@@ -76,20 +77,79 @@ def parse_module_bazel(text):
     return deps
 
 
+def fix_module_bazel(text, sbt_deps, module_deps):
+    """Rewrites MODULE.bazel's version strings to match Dependencies.scala for every shared coordinate that
+    has drifted, handling both the `maven.install` artifacts list ("group:artifact:version") and the
+    standalone `maven.artifact(...)` override blocks. Returns (new_text, changes). Does NOT re-pin the lock
+    file -- that needs Bazel; the `just sync-bazel-maven-versions` recipe runs the re-pin after this."""
+    changes = []
+    new_text = text
+    for (group, artifact), want in sbt_deps.items():
+        have = module_deps.get((group, artifact))
+        if have is None or have == want:
+            continue
+        coord_old = f'"{group}:{artifact}:{have}"'
+        if coord_old in new_text:
+            new_text = new_text.replace(coord_old, f'"{group}:{artifact}:{want}"')
+            changes.append((group, artifact, have, want))
+            continue
+
+        # maven.artifact(...) override block: rewrite only the version= of the block whose group+artifact match.
+        def rewrite_block(m, group=group, artifact=artifact, want=want):
+            body = m.group(0)
+            g = re.search(r'group\s*=\s*"([^"]+)"', body)
+            a = re.search(r'artifact\s*=\s*"([^"]+)"', body)
+            if g and a and g.group(1) == group and a.group(1) == artifact:
+                return re.sub(r'(version\s*=\s*")[^"]+"', lambda vm: vm.group(1) + want + '"', body)
+            return body
+
+        replaced = MAVEN_ARTIFACT_BLOCK_RE.sub(rewrite_block, new_text)
+        if replaced != new_text:
+            new_text = replaced
+            changes.append((group, artifact, have, want))
+    return new_text, changes
+
+
 def main():
-    module_bazel_path, dependencies_scala_path = sys.argv[1], sys.argv[2]
-    with open(module_bazel_path) as f:
-        module_bazel_deps = parse_module_bazel(f.read())
-    with open(dependencies_scala_path) as f:
+    parser = argparse.ArgumentParser(
+        description="Check (or --fix) MODULE.bazel's maven versions against Dependencies.scala.",
+    )
+    parser.add_argument("module_bazel")
+    parser.add_argument("dependencies_scala")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="rewrite MODULE.bazel versions to match Dependencies.scala (does not re-pin; "
+        "run `just sync-bazel-maven-versions` for the full sync)",
+    )
+    args = parser.parse_args()
+
+    with open(args.module_bazel) as f:
+        module_bazel_text = f.read()
+    module_bazel_deps = parse_module_bazel(module_bazel_text)
+    with open(args.dependencies_scala) as f:
         sbt_deps, unresolved = parse_dependencies_scala(f.read())
 
     if unresolved:
         for group, artifact, ref in unresolved:
             print(
                 f"WARNING: could not resolve version identifier '{ref}' for "
-                f"{group}:{artifact} in {dependencies_scala_path} -- skipped",
+                f"{group}:{artifact} in {args.dependencies_scala} -- skipped",
                 file=sys.stderr,
             )
+
+    if args.fix:
+        new_text, changes = fix_module_bazel(module_bazel_text, sbt_deps, module_bazel_deps)
+        if not changes:
+            print("OK: MODULE.bazel already agrees with Dependencies.scala; nothing to fix.")
+            return 0
+        with open(args.module_bazel, "w") as f:
+            f.write(new_text)
+        print(f"Updated {len(changes)} coordinate(s) in {args.module_bazel} to match Dependencies.scala:")
+        for group, artifact, have, want in sorted(changes):
+            print(f"  {group}:{artifact} -- {have} -> {want}")
+        print("\nNow re-pin the lock file: `bazel run @unpinned_maven//:pin` (or run `just sync-bazel-maven-versions`).")
+        return 0
 
     mismatches = []
     checked = 0
@@ -108,7 +168,11 @@ def main():
                 f"  {group}:{artifact} -- sbt has {sbt_version}, MODULE.bazel has {bazel_version}",
                 file=sys.stderr,
             )
-        print("\nBump both together (MODULE.bazel's maven.install + Dependencies.scala).", file=sys.stderr)
+        print(
+            "\nRun `just sync-bazel-maven-versions` to bring MODULE.bazel in line and re-pin "
+            "(scala-steward updates only the sbt side).",
+            file=sys.stderr,
+        )
         return 1
 
     print(f"OK: {checked} shared Maven coordinates agree between MODULE.bazel and Dependencies.scala.")


### PR DESCRIPTION
> **Stacked on #4210** (base branch = `build/sync-bazel-maven-versions`). Review/merge #4210 first; GitHub will retarget this to `main` once it lands.

## Summary

`scala-steward` updates only the sbt side (`project/Dependencies.scala`); the Bazel manifests (`MODULE.bazel` / `maven_install.json`) have to be synced by hand. `//tools/deps:maven_versions_match_sbt` *catches* the resulting drift but doesn't *fix* it, so every dependency update means a manual multi-coordinate edit + re-pin (that's what #4210 had to do — 21 of them, and it even masked a real regression). This turns that chore into one command.

## Changes

- **`tools/deps/check_maven_versions.py`** — add a `--fix` mode that rewrites `MODULE.bazel`'s versions to match `Dependencies.scala`, handling both the `maven.install` artifacts list (`"group:artifact:version"`) and the standalone `maven.artifact(...)` override blocks. Default (check) behaviour is unchanged — the `py_test` still runs the same 2-positional invocation — and the failure message now points at the recipe.
- **`justfile`** — `just sync-bazel-maven-versions`: runs `--fix`, then `bazel run @unpinned_maven//:pin`.
- **`docs/05-internals/development/third-party.md`** — document the sbt+Bazel duality and the sync command (the doc was stale: "managed by SBT").

## Test Plan

- Introduced a temporary drift in both forms (a tapir coordinate in the artifacts list + the `spring-security-core` `maven.artifact` block); `--fix` corrected both and restored `MODULE.bazel` **byte-for-byte** to the synced state (empty `git diff`). The checker returns MISMATCH/exit 1 before and `OK` after.
- `markdownlint` clean on the edited doc.

## Not included (follow-up)

Full CI auto-heal — running the sync on scala-steward PRs and committing the Bazel changes back — is the real prevention, but it needs Bazel-in-a-new-workflow and push-token/loop-guard decisions the team should own. This PR makes the fix a one-liner in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHdLgHyuoxFPv8bcpaPN55
