### PR TITLE
fix(ci): retry docker publish on transient RBE handshake failures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,9 +35,31 @@ jobs:
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
           client-key: ${{ secrets.REMOTEBUILD_CLIENT_KEY }}
       - name: Build and publish dsp-api/dsp-ingest/sipi image to Dockerhub
+        env:
+          RBE_FLAGS: ${{ steps.rbe.outputs.flags }}
         run: |
           echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
-          nix develop --command just docker-publish ${{ steps.rbe.outputs.flags }}
+          # The Bazel <-> NativeLink RBE mTLS handshake at "query remote execution capabilities"
+          # intermittently drops (General OpenSslEngine problem / handshake timed out) and hard-fails
+          # the whole publish, even though the backend is healthy (concurrent build-and-test runs on
+          # the same commit succeed). --remote_local_fallback does not cover this startup capabilities
+          # query, so retry the publish; a warm remote cache keeps each retry fast and re-pushing
+          # already-published tags is idempotent. See docs/development/dsp-api-rbe.md.
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            echo "::group::just docker-publish (attempt ${attempt}/${attempts})"
+            if nix develop --command just docker-publish $RBE_FLAGS; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "docker-publish attempt ${attempt}/${attempts} failed"
+            if [ "$attempt" -lt "$attempts" ]; then
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::docker-publish failed after ${attempts} attempts"
+          exit 1
       - name: Output docker image tag
         id: output_docker_image_tag
         run: echo "tag=$(nix develop --command just docker-image-tag | tr -d '\n')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The **Docker publish** job (`docker-publish.yml`) has hard-failed **3 times in ~27h** on `main`, always at the same choke point — Bazel's startup *"Failed to query remote execution capabilities"* step, ~40s in, before any build work:

| When | Error | Run |
|------|-------|-----|
| Jul 22 12:45 | `handshake timed out after 10000ms` | 29920745355 |
| Jul 23 13:45 | `General OpenSslEngine problem` | 30012427333 |
| Jul 23 15:16 | `General OpenSslEngine problem` | 30018292741 |

All exit with code 34 (`recipe docker-publish-dsp-api-image failed`).

## Root cause

A dropped mTLS handshake to the NativeLink RBE backend (`dasch-remotebuild-prod-01`) — **not a backend outage**. Each time publish failed, the concurrent `build-and-test` job for the *same commit* reached the *same* backend successfully (e.g. Jul 23: build-and-test ran 14:57–15:23 against the executor while publish's handshake died at 15:16). So the backend is healthy; it's a per-connection transient on publish's single handshake.

It hard-fails instead of degrading because `--remote_local_fallback` only covers *action execution* (remote executor unreachable), not the startup *capabilities query* to the cache endpoint — which gates the whole invocation and aborts before any action runs. Bazel's default `--remote_retries` does not retry a TLS-handshake failure at `GetCapabilities`, and the step has no CI-level retry.

**Impact:** a failed publish also **skips the DEV deployment** and doesn't push images, leaving DEV on stale builds until a publish run goes green.

## Fix

Wrap `just docker-publish` in a bounded retry (3 attempts, linear backoff). A warm remote cache keeps retries fast, and re-pushing already-published tags (`latest` + version) is idempotent.

This is the pragmatic stopgap that stops transient handshakes from red-failing `main`. A deeper root-cause look at the backend/network (VM accept-queue saturation under executor load is the leading hypothesis) is a separate ops follow-up in `ops-tf`/`ops-infra`.

## Notes
- Change is scoped to the one flaky step; `docker-image-tag` runs locally (no RBE) and needs no retry.
- Verified the YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)