### PR TITLE
chore: bump Sipi to v6.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,32 @@ caveats see `docs/development/dsp-api-metals-mcp.md`.
 3. Register in `CompleteApiServerEndpoints.scala`
 4. Add unit/integration tests mirroring the main structure
 
+### Bumping the SIPI version
+
+When applying a new `daschswiss/sipi` release, update **both** pins (they must
+stay in sync — the Bazel build consumes `MODULE.bazel`, sbt consumes
+`Dependencies.scala`):
+
+1. `project/Dependencies.scala` — `sipiImage` tag, e.g. `"daschswiss/sipi:v6.2.0"`.
+2. `MODULE.bazel` — the two `oci.pull` blocks (`sipi_base_amd64`,
+   `sipi_base_arm64`) are pinned by **per-arch single-manifest digest**, not the
+   tag. The arm64 index entry carries a `v8` variant that a bare `linux/arm64`
+   request does not match, so pull each platform's manifest directly. Also update
+   the tag and the index digest in the comment above them.
+
+Get the digests for the target tag with:
+
+```bash
+docker buildx imagetools inspect daschswiss/sipi:vX.Y.Z --raw \
+  | jq -r '.manifests[] | "\(.platform.os)/\(.platform.architecture)\(.platform.variant // "") \(.digest)"'
+docker buildx imagetools inspect daschswiss/sipi:vX.Y.Z | grep -i digest   # index digest
+```
+
+`docker-compose.yml` needs no change — it uses `daschswiss/knora-sipi:latest`
+(the derived image built from this base), not a pinned version. After bumping,
+remember to sync the same version in the **ops-deploy** repo when deploying the
+DSP release.
+
 ### Code Style
 
 - Use Scalafmt for formatting

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -278,20 +278,21 @@ use_repo(maven, "maven", "unpinned_maven")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v6.1.0), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v6.2.0), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v6.1.0 index carries a `v8`
+# index/variant matching — the arm64 entry of the v6.2.0 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. The tag
-# is recorded in `Dependencies.sipiImage` (build.sbt); bump both together.
-# Index digest: sha256:4bed63e1720eab9b85b64aba07b5e176a75fe48621e659db9c3e44a71398c4b6
+# is recorded in `Dependencies.sipiImage` (project/Dependencies.scala); bump both
+# together — see "Bumping the SIPI version" in CLAUDE.md.
+# Index digest: sha256:6823baef864dd22d1f38496f4acb88b21856f8a1fa5a2e288663155d7dfab286
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:a4584a6cb2378d264af1d4e253410efcd3fbfde91ab2007fd8ef6005be6290e0",
+    digest = "sha256:ba31c5947bcbed41b08a7062d882764423d389c7ba48c355871a8d65dbf2ff5c",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:da3c6989496aaa1e78448e4165302f451a3d810c3de3de124649c59903f40f31",
+    digest = "sha256:f3d84301fbcd3973f1d20aa9abb0cb7d0b36aa890632c612e7debad6fb11f1b1",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
   val fusekiImage = "daschswiss/apache-jena-fuseki:6.1.0-0"
   // base image the knora-sipi image is created from
-  val sipiImage = "daschswiss/sipi:v6.1.0"
+  val sipiImage = "daschswiss/sipi:v6.2.0"
 
   val ScalaVersion = "3.8.4"
 


### PR DESCRIPTION
Applies the latest SIPI release (v6.2.0) to dsp-api.

## Changes
- `project/Dependencies.scala` — `sipiImage` tag `v6.1.0` → `v6.2.0` (base image for the derived `knora-sipi` image; consumed by sbt).
- `MODULE.bazel` — the two `oci.pull` blocks (`sipi_base_amd64`, `sipi_base_arm64`) refreshed to the v6.2.0 per-arch single-manifest digests, plus the tag/index digest in the comment.
- `CLAUDE.md` — documents the two-pin bump procedure so both pins stay in sync next time.

Digests pulled live from `daschswiss/sipi:v6.2.0` on Docker Hub. `docker-compose.yml` needs no change (uses `daschswiss/knora-sipi:latest`).

Reminder: sync the same version in **ops-deploy** when deploying the DSP release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)