### PR TITLE
chore: fix misleading object-class-constraint error message

### DIFF
--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -1459,9 +1459,21 @@ class ResourcesResponderV2Spec extends E2EZSpec { self =>
           projectADM = anythingProject,
         )
 
-        resourceResponder(_.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID))).exit.map(
-          actual => assert(actual)(failsWithA[OntologyConstraintException]),
-        )
+        // objectClassConstraint of hasOtherThing is anything:Thing, which has subclasses. The error must
+        // list the acceptable classes with each IRI in its own angle brackets (no malformed `<A,B>` token)
+        // and the constraint class must appear only once (it is a subclass of itself in the ontology cache).
+        val thingIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"
+        resourceResponder(
+          _.createResource(CreateResourceRequestV2(inputResource, anythingUser2, randomUUID)),
+        ).exit.map { actual =>
+          val message = actual.causeOption.flatMap(_.failureOption).map(_.getMessage).getOrElse("")
+          assert(actual)(failsWithA[OntologyConstraintException]) &&
+          assertTrue(
+            message.contains("does not belong to any of the following classes:"),
+            !message.contains(",http"),
+            message.split(java.util.regex.Pattern.quote(s"<$thingIri>"), -1).length - 1 == 1,
+          )
+        }
       },
       test("not create a resource with invalid custom permissions") {
         val resourceIri   = ResourceIri.makeNew(anythingProject.shortcode)

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CheckObjectClassConstraints.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/resources/CheckObjectClassConstraints.scala
@@ -136,7 +136,10 @@ object CheckObjectClassConstraints {
           .orElseFail(objectTypeMissing(propertyInfoLinked.entityInfoContent.propertyIri))
 
       objectConstraintInfos <- ontologyRepo.findDirectSubclassesBy(objectConstraint.toInternalIri)
-    } yield objectConstraint +: (objectConstraintInfos.map(_.entityInfoContent.classIri))
+      // `findDirectSubclassesBy` already includes the class itself (a class is a subclass of itself in
+      // the ontology cache), so prepending `objectConstraint` would list it twice. Dedup to keep the
+      // list of acceptable classes free of duplicates.
+    } yield (objectConstraint +: objectConstraintInfos.map(_.entityInfoContent.classIri)).distinct
   }
 
   private def invalidPropUseLinkProp(
@@ -152,18 +155,19 @@ object CheckObjectClassConstraints {
   ): InconsistentRepositoryDataException =
     InconsistentRepositoryDataException(s"Property <$property> has no knora-api:objectType")
 
+  private[resources] def formatObjectClassConstraints(objectClassConstraints: List[SmartIri]): String =
+    objectClassConstraints.map(iri => s"<${iri.toComplexSchema}>").mkString(", ")
+
   private def propertyRequiresValue(
     resourceIdForErrorMsg: IRI,
     propertyIri: SmartIri,
     objectClassConstraints: List[SmartIri],
-  ): Task[OntologyConstraintException] = {
-    val constraints = objectClassConstraints.map(_.toComplexSchema).mkString(",")
+  ): Task[OntologyConstraintException] =
     ZIO.fail(
       OntologyConstraintException(
-        s"${resourceIdForErrorMsg}Property <${propertyIri.toComplexSchema}> requires a value of types: <${constraints}>",
+        s"${resourceIdForErrorMsg}Property <${propertyIri.toComplexSchema}> requires a value of one of the following types: ${formatObjectClassConstraints(objectClassConstraints)}",
       ),
     )
-  }
 
   private def propertyInvalid(
     resourceIdForErrorMsg: IRI,
@@ -178,9 +182,8 @@ object CheckObjectClassConstraints {
       s"'${clientResourceIDs.apply(linkValueContentV2.referredResourceIri.value)}'" // unsafe apply, present before refactoring
     }
 
-    val constraints = objectClassConstraints.map(_.toComplexSchema).mkString(",")
     OntologyConstraintException(
-      s"${resourceIdForErrorMsg}Resource $resourceID cannot be the object of property <${propertyIriForObjectClassConstraint.toComplexSchema}>, because it does not belong to class <$constraints>",
+      s"${resourceIdForErrorMsg}Resource $resourceID cannot be the object of property <${propertyIriForObjectClassConstraint.toComplexSchema}>, because it does not belong to any of the following classes: ${formatObjectClassConstraints(objectClassConstraints)}",
     )
   }
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/responders/v2/resources/CheckObjectClassConstraintsSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/responders/v2/resources/CheckObjectClassConstraintsSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.responders.v2.resources
+
+import org.junit.runner.RunWith
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.messages.IriConversions.*
+import org.knora.webapi.messages.StringFormatter
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class CheckObjectClassConstraintsSpec extends ZIOSpecDefault {
+
+  private implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
+
+  private val thing     = "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri
+  private val blueThing = "http://www.knora.org/ontology/0001/anything#BlueThing".toSmartIri
+
+  override val spec = suite("CheckObjectClassConstraints.formatObjectClassConstraints")(
+    test("wrap a single class IRI in its own angle brackets") {
+      val actual = CheckObjectClassConstraints.formatObjectClassConstraints(List(thing))
+      assertTrue(actual == s"<${thing.toComplexSchema}>")
+    },
+    test("wrap each class IRI in its own angle brackets and separate them with a comma and a space") {
+      val actual = CheckObjectClassConstraints.formatObjectClassConstraints(List(thing, blueThing))
+      assertTrue(actual == s"<${thing.toComplexSchema}>, <${blueThing.toComplexSchema}>")
+    },
+    test("never join two IRIs with a bare comma inside a single pair of angle brackets") {
+      // Regression guard for the malformed `<A,B>` / `<A,A>` output: even with duplicate IRIs the
+      // rendered fragment must not contain a comma directly preceding an IRI scheme.
+      val actual = CheckObjectClassConstraints.formatObjectClassConstraints(List(thing, thing))
+      assertTrue(!actual.contains(",http"), actual == s"<${thing.toComplexSchema}>, <${thing.toComplexSchema}>")
+    },
+    test("render an empty list as an empty string") {
+      val actual = CheckObjectClassConstraints.formatObjectClassConstraints(Nil)
+      assertTrue(actual.isEmpty)
+    },
+  )
+}


### PR DESCRIPTION
### Description

**What kind of change does this PR introduce?** Bug fix to a user-facing error message (no change to validation behaviour).

**What is the current behavior?**

When a resource is created/updated with a link (or value) whose target does not satisfy the property's `objectClassConstraint`, the API returns an `OntologyConstraintException` whose message lists the acceptable classes in a confusing way:

```
Resource <...> cannot be the object of property <...#isPartOfChapterValue>,
because it does not belong to class <...#Chapter,...#Chapter>
```

Two problems combine:

1. **Malformed formatting** — the list of acceptable classes is joined with a bare comma and wrapped in a single pair of angle brackets, so it reads like one broken IRI `<A,B>` instead of "one of `<A>`, `<B>`". (`mkString(",")` inside `<...>`.)
2. **Duplication** — the constraint class appears twice (`<Chapter,Chapter>`). The acceptable-class list is built as `objectConstraint +: findDirectSubclassesBy(objectConstraint)`, but `findDirectSubclassesBy` already includes the class itself (a class is registered as a subclass of itself in the ontology cache — see the `subclassesWithSelf` naming in `OntologyRepoLive.findAllSubclassesBy`). So the constraint class is contributed once by the prepend and once by the self-inclusive lookup.

**What is the new behavior?**

Same message for both affected paths (`propertyInvalid`, `propertyRequiresValue`), now readable:

```
Resource <...> cannot be the object of property <...#isPartOfChapterValue>,
because it does not belong to any of the following classes: <...#Chapter>
```

- Each acceptable class IRI is wrapped in its own angle brackets and separated by `, ` (extracted into a small `formatObjectClassConstraints` helper).
- The constraint list is de-duplicated at the source in `propertysObjectConstraint`.

The validation logic itself is unchanged — only the human-readable error text.

**Does this PR introduce a breaking change?** No. Only the wording of an error message changes; there is no stable contract on error-message text.

### Tests

- New unit spec `CheckObjectClassConstraintsSpec` covering the formatting helper (each IRI individually bracketed, comma-space separated, empty list, and a regression guard that duplicates never produce a `<A,B>`-style token).
- Strengthened the existing integration test in `ResourcesResponderV2Spec` ("not create a resource with a link to a resource of the wrong class for the link property") to assert the message end-to-end: the new phrasing is present, no bare-comma-joined IRIs (`,http`), and the constraint class is listed exactly once. Kept order-independent because `findDirectSubclassesBy` iterates a map (unstable subclass order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)