### PR TITLE
chore: bump Sipi to v6.2.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -278,21 +278,21 @@ use_repo(maven, "maven", "unpinned_maven")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v6.2.0), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v6.2.1), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v6.2.0 index carries a `v8`
+# index/variant matching — the arm64 entry of the v6.2.1 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. The tag
 # is recorded in `Dependencies.sipiImage` (project/Dependencies.scala); bump both
 # together — see "Bumping the SIPI version" in CLAUDE.md.
-# Index digest: sha256:6823baef864dd22d1f38496f4acb88b21856f8a1fa5a2e288663155d7dfab286
+# Index digest: sha256:e45f25d66ad7e88018a65e6d12e2bd9651bdd98e521ddcf35e8f89ce3ff8fce4
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:ba31c5947bcbed41b08a7062d882764423d389c7ba48c355871a8d65dbf2ff5c",
+    digest = "sha256:e6323cfa8bc6588d9d09300f11b7f97d78f4a144fecdcd8138caa0a174ad42d0",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:f3d84301fbcd3973f1d20aa9abb0cb7d0b36aa890632c612e7debad6fb11f1b1",
+    digest = "sha256:07423f1190f8c5debfa1ab167c8aff4b2d757ec43bb9044c6fa2a89b26074a12",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
   val fusekiImage = "daschswiss/apache-jena-fuseki:6.1.0-0"
   // base image the knora-sipi image is created from
-  val sipiImage = "daschswiss/sipi:v6.2.0"
+  val sipiImage = "daschswiss/sipi:v6.2.1"
 
   val ScalaVersion = "3.8.4"
 


### PR DESCRIPTION
### Description

Applies the latest SIPI release (v6.2.1) to dsp-api. Docs/CI/test-only release upstream — no server behavior change.

## Changes
- `project/Dependencies.scala` — `sipiImage` tag `v6.2.0` → `v6.2.1` (base image for the derived `knora-sipi` image; consumed by sbt).
- `MODULE.bazel` — the two `oci.pull` blocks (`sipi_base_amd64`, `sipi_base_arm64`) refreshed to the v6.2.1 per-arch single-manifest digests, plus the tag/index digest in the comment.

Digests pulled live from `daschswiss/sipi:v6.2.1` on Docker Hub. `docker-compose.yml` needs no change (uses `daschswiss/knora-sipi:latest`).

## Verification
- `bazel fetch @sipi_base_amd64 @sipi_base_arm64` — both arches resolve.
- `bazel build //modules/sipi:all` — 23 targets green; both arch images and the index build on the new bases.

Reminder: sync the same version in **ops-deploy** when deploying the DSP release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)