### PR TITLE
chore(ci): attach the Bazel build event JSON to the test jobs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,21 @@ jobs:
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
           client-key: ${{ secrets.REMOTEBUILD_CLIENT_KEY }}
       - name: Run all unit tests
-        run: nix develop --command just test-unit ${{ steps.rbe.outputs.flags }}
+        run: nix develop --command just test-unit ${{ steps.rbe.outputs.flags }} --build_event_json_file=bep-unit.json
+      # Attach the Build Event Protocol JSON so the remote/action cache hit
+      # rate on the NativeLink RBE backend can be analyzed offline. Bazel
+      # emits one BuildMetrics event per invocation whose
+      # actionSummary.runnerCount[] breaks actions down by runner type
+      # (total / remote cache hit / remote / local / internal). `always()`
+      # so a failed build's breakdown (often the most interesting) is still
+      # captured.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-unit
+          path: bep-unit.json
+          retention-days: 30
       - name: Collect Bazel test XML
         if: success() || failure()
         run: |
@@ -118,7 +132,17 @@ jobs:
         # `just test-it` loads the PR's sipi/ingest/fuseki images (via its
         # docker-load-test-images prerequisite) before running the Bazel tests,
         # so the PR's own images are exercised, not the registry's lagging :latest.
-        run: nix develop --command just test-it ${{ steps.rbe.outputs.flags }}
+        run: nix develop --command just test-it ${{ steps.rbe.outputs.flags }} --build_event_json_file=bep-it.json
+      # BEP for offline RBE cache-hit-rate analysis (cf. the unit-tests job).
+      # The `:load` prerequisites overwrite this file in turn, so it ends up
+      # holding the `bazel test` invocation's metrics — the one that matters.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-it
+          path: bep-it.json
+          retention-days: 30
       - name: Collect Bazel test XML
         if: success() || failure()
         run: |
@@ -167,7 +191,17 @@ jobs:
       - name: Run end-to-end tests
         # `just test-e2e` loads the PR's sipi/ingest/fuseki images (via its
         # docker-load-test-images prerequisite) before running the Bazel tests.
-        run: nix develop --command just test-e2e ${{ steps.rbe.outputs.flags }}
+        run: nix develop --command just test-e2e ${{ steps.rbe.outputs.flags }} --build_event_json_file=bep-e2e.json
+      # BEP for offline RBE cache-hit-rate analysis (cf. the unit-tests job).
+      # The `:load` prerequisites overwrite this file in turn, so it ends up
+      # holding the `bazel test` invocation's metrics — the one that matters.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-e2e
+          path: bep-e2e.json
+          retention-days: 30
       - name: Collect Bazel test XML
         if: success() || failure()
         run: |
@@ -216,7 +250,17 @@ jobs:
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
           client-key: ${{ secrets.REMOTEBUILD_CLIENT_KEY }}
       - name: Run integration tests
-        run: nix develop --command just test-ingest-integration ${{ steps.rbe.outputs.flags }}
+        run: nix develop --command just test-ingest-integration ${{ steps.rbe.outputs.flags }} --build_event_json_file=bep-ingest-integration.json
+      # BEP for offline RBE cache-hit-rate analysis (cf. the unit-tests job).
+      # The `:load` prerequisites overwrite this file in turn, so it ends up
+      # holding the `bazel test` invocation's metrics — the one that matters.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-ingest-integration
+          path: bep-ingest-integration.json
+          retention-days: 30
       - name: Collect Bazel test XML
         if: success() || failure()
         run: |


### PR DESCRIPTION
## Motivation
The sipi repo attaches each Bazel invocation's Build Event Protocol (BEP) JSON as an artifact so the NativeLink RBE cache-hit rate can be analyzed offline. dsp-api drives its build/test through Bazel on the same RBE backend but produced no such artifact, leaving a blind spot for per-PR cache behavior.

## Summary
- The four RBE-backed test jobs in `build-and-test.yml` (`unit-tests`, `test-it`, `test-e2e`, `test-ingest-integration`) now emit their `bazel test` BEP JSON and upload it as a `bep-<job>` artifact.

## Key Changes
### build-and-test.yml
- Append `--build_event_json_file=bep-<job>.json` to each test job's `just test-*` invocation (the recipes forward extra flags positionally into `bazel test`).
- Add an `actions/upload-artifact@v7` step per job (`if: always()`, 30-day retention).

## Challenges and Decisions
### Chained recipes and single-file BEP
**Problem:** `test-it`/`test-e2e`/`test-ingest-integration` first run three `bazel run :load` invocations (via `docker-load-test-images`) before `bazel test`. A single `--build_event_json_file` path is written by every invocation in turn.
**Solution:** Last-write-wins means the file ends up holding the `bazel test` invocation's metrics — exactly the RBE-heavy invocation worth analyzing. The trivial `:load` BEPs are intentionally not retained.

### Scope
Instrumented only the per-PR test jobs (the direct analog of sipi's ci.yml). The tag/release publish workflows chain multiple `:push` invocations where single-file BEP would be lossy and the frequency is low, so they were left out.

## Gotchas
- dsp-api's PR-title check disallows a `ci:` type, so this is `chore(ci):`.
- BEP files are per-invocation; to capture a load/push invocation separately, give it its own distinct `--build_event_json_file` path.

## Test Plan
- [ ] PR CI run produces `bep-unit`, `bep-it`, `bep-e2e`, and `bep-ingest-integration` artifacts on their respective jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)