### PR TITLE
build(sipi): bump SIPI base image to v6.2.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -278,21 +278,21 @@ use_repo(maven, "maven", "unpinned_maven")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v6.2.1), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v6.2.2), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v6.2.1 index carries a `v8`
+# index/variant matching — the arm64 entry of the v6.2.2 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. The tag
 # is recorded in `Dependencies.sipiImage` (project/Dependencies.scala); bump both
 # together — see "Bumping the SIPI version" in CLAUDE.md.
-# Index digest: sha256:e45f25d66ad7e88018a65e6d12e2bd9651bdd98e521ddcf35e8f89ce3ff8fce4
+# Index digest: sha256:379f2a19a193bef907c4d99b4bfa49c2b76c62c44fa06cf52844aeaf14e63eac
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:e6323cfa8bc6588d9d09300f11b7f97d78f4a144fecdcd8138caa0a174ad42d0",
+    digest = "sha256:113450308ca60ec302e3dbbd4b7678a9be2509e4cadd68f4b77158fdce9c9676",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:07423f1190f8c5debfa1ab167c8aff4b2d757ec43bb9044c6fa2a89b26074a12",
+    digest = "sha256:b7280d932e381718cc3a2dd70f8475320d01143e697af94a4ea8a1dadb55c2d9",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // make sure to use the same version in ops-deploy repository when deploying new DSP releases!
   val fusekiImage = "daschswiss/apache-jena-fuseki:6.1.0-0"
   // base image the knora-sipi image is created from
-  val sipiImage = "daschswiss/sipi:v6.2.1"
+  val sipiImage = "daschswiss/sipi:v6.2.2"
 
   val ScalaVersion = "3.8.4"
 


### PR DESCRIPTION
## Summary

Bumps the SIPI base image from `v6.2.1` to `v6.2.2` (latest [SIPI release](https://github.com/dasch-swiss/sipi/releases/tag/v6.2.2)).

Both pins updated in sync per the "Bumping the SIPI version" runbook in `CLAUDE.md`:

- `project/Dependencies.scala` — `sipiImage` tag (consumed by sbt)
- `MODULE.bazel` — both `oci.pull` per-arch single-manifest digests + tag/index-digest comment (consumed by the Bazel build)

Digests pulled from the live published manifest:

| arch | digest |
|------|--------|
| linux/amd64 | `sha256:113450308ca60ec302e3dbbd4b7678a9be2509e4cadd68f4b77158fdce9c9676` |
| linux/arm64v8 | `sha256:b7280d932e381718cc3a2dd70f8475320d01143e697af94a4ea8a1dadb55c2d9` |
| index | `sha256:379f2a19a193bef907c4d99b4bfa49c2b76c62c44fa06cf52844aeaf14e63eac` |

`docker-compose.yml` needs no change (uses `knora-sipi:latest`, the derived image).

## Deploy note

Sync the same version in the **ops-deploy** repo when this DSP release deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)