### PR TITLE
fix(grafana): plot SIPI working set, not usage-incl-page-cache

### DIFF
--- a/grafana-dashboards/sipi/sipi-iiif-media-server.json
+++ b/grafana-dashboards/sipi/sipi-iiif-media-server.json
@@ -1229,7 +1229,7 @@
         "spec": {
           "id": 12,
           "title": "SIPI Container Memory Usage",
-          "description": "cAdvisor container metrics for the SIPI container (service DSP_iiif_iiif).",
+          "description": "cAdvisor container metrics for the SIPI container (service DSP_iiif_iiif). 'working set' is the real, non-reclaimable memory the cgroup OOM killer acts on; 'usage (incl. page cache)' additionally counts reclaimable page cache from reading image files, so it climbs under load and stays elevated after load without indicating a leak. Watch the working set for actual memory health.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -1245,7 +1245,21 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "version": "",
-                      "spec": { "expr": "sum(container_memory_usage_bytes{service=\"DSP_iiif_iiif\",environment=~\"$environment\",instance=~\"dasch-vre-$environment-01\"})", "instant": false, "legendFormat": "memory", "queryType": "range", "range": true }
+                      "spec": { "expr": "sum(container_memory_working_set_bytes{service=\"DSP_iiif_iiif\",environment=~\"$environment\",instance=~\"dasch-vre-$environment-01\"})", "instant": false, "legendFormat": "working set", "queryType": "range", "range": true }
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": { "name": "grafanacloud-prom" },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "version": "",
+                      "spec": { "expr": "sum(container_memory_usage_bytes{service=\"DSP_iiif_iiif\",environment=~\"$environment\",instance=~\"dasch-vre-$environment-01\"})", "instant": false, "legendFormat": "usage (incl. page cache)", "queryType": "range", "range": true }
                     }
                   }
                 }


### PR DESCRIPTION
## Problem

The **SIPI Container Memory Usage** panel plotted `container_memory_usage_bytes`, which includes reclaimable file-backed **page cache** from reading image files. Under load it climbs and, after load stops, stays elevated (the kernel keeps the cache until memory pressure). That reads exactly like a memory leak when it is not — it prompted a leak investigation on `vre-dev-01`.

## Investigation outcome (SIPI)

No leak. On the new Rust shell (dev), a live load burst showed every instrumented structure release fully (decode-memory budget 27 MB → 0, rate-limit client map 0 → 4 → 0, pool permits → 0). The retained container memory was reclaimable page cache (the usage-minus-working-set gap) plus glibc arena retention — both benign. Details and the allocator mitigation live in the SIPI repo.

## Change

- Make `container_memory_working_set_bytes` the **primary** series (the real, non-reclaimable memory the cgroup OOM killer acts on).
- Keep total `container_memory_usage_bytes` as a second series labelled **"usage (incl. page cache)"** for context.
- Rewrite the panel description to explain the distinction so the panel stops reading as a leak.

## Verification

- `jq .` validates; panel `id`/key and layout `ElementReference` unchanged.
- Both queries verified live against `grafanacloud-prom` via the Grafana MCP (`working_set` returns data on `dasch-vre-dev-01`).
- Git Sync pulls `main` only, so this reaches Grafana on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)