### PR TITLE
fix(search): fix HTTP 500 on common fulltext search terms (DEV-6864)

### DIFF
--- a/docs/03-endpoints/api-v2/query-language.md
+++ b/docs/03-endpoints/api-v2/query-language.md
@@ -703,9 +703,13 @@ FILTER knora-api:matchLabel(?book, "Zeitglöcklein")
 The function `knora-api:matchFulltext` searches for matching words anywhere the
 full-text index covers for a resource: its `rdfs:label`, any of its text values, any
 of its value comments, or a list node (including sub-nodes) referenced by one of its
-list values. It gives the same result set as the `GET /v2/search/{term}` endpoint,
-expressed as a Gravsearch function so it can be combined with structured criteria in
-one query.
+list values. It is expressed as a Gravsearch function so it can be combined with
+structured criteria in one query.
+
+`matchFulltext` covers the same fields as the `GET /v2/search/{term}` endpoint, but the
+two do not necessarily return the same result set on large data: `matchFulltext` still
+inherits Jena's silent ~10,000-hit Lucene cap, whereas `/v2/search` passes an explicit
+hit limit and returns the full set (DEV-6824). For a term below the cap the results match.
 
 The first argument is a variable representing a resource (main or linked). The
 second argument is a string literal containing the search terms, with the same

--- a/docs/development/dsp-api-fuseki-query-execution.md
+++ b/docs/development/dsp-api-fuseki-query-execution.md
@@ -15,8 +15,10 @@ clause span the union of all named graphs), a **Lucene text index** over `rdfs:l
 Lucene field, which has consequences (Fact 10) — (`modules/fuseki/dsp-repo.ttl`),
 and **no `stats.opt` statistics file** — so the BGP optimizer runs on the `fixed`
 variable-counting heuristic, not cost estimates. The API sends every query with a server-side
-`timeout` form parameter in three tiers (Standard 20s, Maintenance 120s, Gravsearch 120s;
-`application.conf`).
+`timeout` form parameter in tiers (Standard 20s, Maintenance 120s, Gravsearch 120s, Search 60s;
+`application.conf`). The fulltext prequery and count run on the Search tier; the fulltext breadth probe
+(DEV-6864) reuses the Search timeout value under a distinct `SearchProbe` tier so its samples stay out of
+the Search-tier metric.
 
 ## Fact 1 — Reordering is BGP-local and heuristic
 
@@ -148,6 +150,12 @@ probing the path once per Lucene hit. (That rewrite was not semantically equival
 of the cautionary tale.) The fastest form was neither: a single bound-subject probe for a
 property present on exactly the wanted subjects (`?resource knora-base:creationDate ?d`) at
 **1.8s** for the correct 13,051 (DEV-6833, DEV-6850).
+
+The fulltext query carried the same per-hit walks, and the same substitution reproduced the win at
+scale: replacing `?resourceClass rdfs:subClassOf* knora-base:Resource` (plus the value branch's
+`?valueObjectType rdfs:subClassOf* knora-base:Value` and `?property rdfs:subPropertyOf*
+knora-base:hasValue` walks) with `creationDate` / `valueCreationDate` existence probes took
+`count/der` from **82.50s to 13.09s** on stage — 6.3× for byte-identical counts (DEV-6864).
 
 Rule: benchmark a simplification in place, using the query as actually generated, before trusting
 it. This is the same discipline as the equivalence check below — and for the same reason.

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
@@ -122,6 +122,100 @@ class SearchResponderV2Spec extends E2EZSpec {
           }
       } yield assertTrue(hasImageFileValues)
     },
+
+    // DEV-6864 / DEV-6833. The fulltext class restriction must walk the whole subclass closure
+    // (rdfs:subClassOf*), never one hop. anything:BlueThing sits two hops below knora-base:Resource
+    // (BlueThing -> Thing -> Resource), so a `subClassOf?` would silently drop it. These tests are the
+    // regression net for the query rewrite that makes the resource-type join conditional: they pass
+    // against the current query and must keep passing after `?resource a ?resourceClass` moves behind
+    // the class-restriction flag. "blue" occurs in exactly one anything label ("A blue thing").
+    test("fulltext search restricted to a class two hops above the matched resource's class returns the match") {
+      for {
+        result <- searchResponder(
+                    _.fulltextSearchV2(
+                      searchValue = "blue",
+                      offset = 0,
+                      limitToProject = None,
+                      limitToResourceClass = Some(resourceBaseClassIri),
+                      limitToStandoffClass = None,
+                      returnFiles = false,
+                      apiV2SchemaWithOption(MarkupRendering.Xml),
+                      requestingUser = anythingUser1,
+                    ),
+                  )
+      } yield assertTrue(result.resources.map(_.resourceIri.value).contains("http://rdfh.ch/0001/a-blue-thing"))
+    },
+    test("fulltext count restricted to a class two hops above the matched resource's class counts the match") {
+      for {
+        result <- searchResponder(
+                    _.fulltextSearchCountV2(
+                      searchValue = "blue",
+                      limitToProject = None,
+                      limitToResourceClass = Some(resourceBaseClassIri),
+                      limitToStandoffClass = None,
+                    ),
+                  )
+      } yield assertTrue(result.numberOfResources >= 1)
+    },
+
+    // DEV-6864. Project restriction must keep results inside the given project. "Narr" matches only
+    // incunabula resources (413 occurrences there, none in anything), so restricting it to incunabula
+    // returns those matches and restricting it to anything returns nothing — a discriminating filter,
+    // not a no-op.
+    test("fulltext search restricted to a project returns only that project's resources") {
+      for {
+        inIncunabula <- searchResponder(
+                          _.fulltextSearchV2(
+                            searchValue = "Narr",
+                            offset = 0,
+                            limitToProject = Some(incunabulaProjectIri),
+                            limitToResourceClass = None,
+                            limitToStandoffClass = None,
+                            returnFiles = false,
+                            apiV2SchemaWithOption(MarkupRendering.Xml),
+                            requestingUser = anonymousUser,
+                          ),
+                        )
+        inAnything <- searchResponder(
+                        _.fulltextSearchV2(
+                          searchValue = "Narr",
+                          offset = 0,
+                          limitToProject = Some(anythingProjectIri),
+                          limitToResourceClass = None,
+                          limitToStandoffClass = None,
+                          returnFiles = false,
+                          apiV2SchemaWithOption(MarkupRendering.Xml),
+                          requestingUser = anonymousUser,
+                        ),
+                      )
+      } yield assertTrue(
+        inIncunabula.resources.nonEmpty,
+        inIncunabula.resources.forall(_.resourceIri.value.startsWith("http://rdfh.ch/0803/")),
+        inAnything.resources.isEmpty,
+      )
+    },
+
+    // DEV-6864. Project and class restriction combined, again with a class two hops up, must still
+    // return the match and nothing outside the project.
+    test("fulltext search restricted to both a project and a class two hops up returns the match") {
+      for {
+        result <- searchResponder(
+                    _.fulltextSearchV2(
+                      searchValue = "blue",
+                      offset = 0,
+                      limitToProject = Some(anythingProjectIri),
+                      limitToResourceClass = Some(resourceBaseClassIri),
+                      limitToStandoffClass = None,
+                      returnFiles = false,
+                      apiV2SchemaWithOption(MarkupRendering.Xml),
+                      requestingUser = anythingUser1,
+                    ),
+                  )
+      } yield assertTrue(
+        result.resources.map(_.resourceIri.value).contains("http://rdfh.ch/0001/a-blue-thing"),
+        result.resources.forall(_.resourceIri.value.startsWith("http://rdfh.ch/0001/")),
+      )
+    },
     test("perform an extended search for books that have the title 'Zeitglöcklein des Lebens'") {
       for {
         searchResult <- searchResponder(

--- a/modules/webapi/src/main/resources/application.conf
+++ b/modules/webapi/src/main/resources/application.conf
@@ -125,6 +125,17 @@ app {
         },
         fulltext-search {
             search-value-min-length = 3
+            // DEV-6864 PROBE: refuse a fulltext search whose Lucene candidate count exceeds `cap`, measured by a
+            // fast COUNT raced against the real query so an admitted term pays no tax and a refused one returns
+            // fast. 250,000 fits the 60s search tier with headroom (Spike A). `cache-*` bound the measured-breadth
+            // cache; `max-concurrent` bounds probes in flight against Fuseki.
+            probe {
+                cap = 250000
+                cap = ${?KNORA_WEBAPI_FULLTEXT_PROBE_CAP}
+                cache-capacity = 1024
+                cache-ttl = 10 minutes
+                max-concurrent = 8
+            }
         },
         graph-route {
             default-graph-depth = 4

--- a/modules/webapi/src/main/resources/application.conf
+++ b/modules/webapi/src/main/resources/application.conf
@@ -176,6 +176,12 @@ app {
         // timeout for Gravsearch queries.
         gravsearch-timeout = 120 seconds
 
+        // timeout for the fulltext search prequery and count (DEV-6864). Longer than query-timeout so the
+        // prequery is not cut before the 120s main query that follows it, but shorter than gravsearch-timeout
+        // so a broad query still sheds load. Overridable so a bad value can be corrected without a release.
+        search-timeout = 60 seconds
+        search-timeout = ${?KNORA_WEBAPI_TRIPLESTORE_SEARCH_TIMEOUT}
+
         fuseki {
             port = 3030
             port = ${?KNORA_WEBAPI_TRIPLESTORE_FUSEKI_PORT}

--- a/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -239,13 +239,19 @@ object AppConfig {
       _.filePermissionCache.ttl.compareTo(Duration.ofMinutes(10)) <= 0,
     )
     .validate("app.file-permission-cache.capacity must be >= 1")(_.filePermissionCache.capacity >= 1)
-    // The probe knobs feed FulltextBreadthGuard's cap check, Cache.makeWith and Semaphore.make. cap is
-    // env-injectable (KNORA_WEBAPI_FULLTEXT_PROBE_CAP), so a bad value refuses every probed search (cap < 1),
-    // hangs it (max-concurrent = 0 -> a zero-permit semaphore) or is undefined (cache-capacity < 1); guard all
-    // three, as the sibling file-permission-cache.capacity guard does (DEV-6864).
+    // The probe knobs feed FulltextBreadthGuard's cap check, Cache.makeWith and Semaphore.make, so guard each
+    // against a value that silently breaks the guard. cap is env-injectable (KNORA_WEBAPI_FULLTEXT_PROBE_CAP):
+    // cap < 1 refuses every probed search; cache-capacity < 1 is undefined; max-concurrent = 0 is a zero-permit
+    // semaphore, so the probe never completes and — because `guarded` races it against the query — the query
+    // always wins and every probed search silently runs unguarded (plus a per-request daemon leaks); cache-ttl
+    // <= 0 expires each result instantly, defeating the single-flight cache so every request re-probes. Guard all
+    // four, as the sibling file-permission-cache guards do (DEV-6864).
     .validate("app.v2.fulltext-search.probe.cap must be >= 1")(_.v2.fulltextSearch.probe.cap >= 1)
     .validate("app.v2.fulltext-search.probe.cache-capacity must be >= 1")(
       _.v2.fulltextSearch.probe.cacheCapacity >= 1,
+    )
+    .validate("app.v2.fulltext-search.probe.cache-ttl must be positive")(
+      _.v2.fulltextSearch.probe.cacheTtl.compareTo(Duration.ZERO) > 0,
     )
     .validate("app.v2.fulltext-search.probe.max-concurrent must be >= 1")(
       _.v2.fulltextSearch.probe.maxConcurrent >= 1,

--- a/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -155,6 +155,22 @@ final case class Resources(
 
 final case class FulltextSearch(
   searchValueMinLength: Int,
+  probe: FulltextSearchProbe,
+)
+
+/**
+ * Tuning knobs for the fulltext breadth probe (DEV-6864, PROBE).
+ *
+ * `cap` is the Lucene candidate count above which a fulltext search is refused (raced against the real query so
+ * an admitted term pays no tax). `cacheCapacity` / `cacheTtl` bound the measured-breadth cache, and `maxConcurrent`
+ * bounds how many probes run against Fuseki at once. All live in config so they can be tuned per deployment
+ * without a code change; `cap` also has a `KNORA_WEBAPI_FULLTEXT_PROBE_CAP` override.
+ */
+final case class FulltextSearchProbe(
+  cap: Int,
+  cacheCapacity: Int,
+  cacheTtl: Duration,
+  maxConcurrent: Int,
 )
 
 final case class GraphRoute(

--- a/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -240,12 +240,11 @@ object AppConfig {
     )
     .validate("app.file-permission-cache.capacity must be >= 1")(_.filePermissionCache.capacity >= 1)
     // The probe knobs feed FulltextBreadthGuard's cap check, Cache.makeWith and Semaphore.make, so guard each
-    // against a value that silently breaks the guard. cap is env-injectable (KNORA_WEBAPI_FULLTEXT_PROBE_CAP):
-    // cap < 1 refuses every probed search; cache-capacity < 1 is undefined; max-concurrent = 0 is a zero-permit
-    // semaphore, so the probe never completes and — because `guarded` races it against the query — the query
-    // always wins and every probed search silently runs unguarded (plus a per-request daemon leaks); cache-ttl
-    // <= 0 expires each result instantly, defeating the single-flight cache so every request re-probes. Guard all
-    // four, as the sibling file-permission-cache guards do (DEV-6864).
+    // against a value that breaks the guard. cap is env-injectable (KNORA_WEBAPI_FULLTEXT_PROBE_CAP): cap < 1
+    // refuses every probed search; cache-capacity < 1 is undefined; max-concurrent = 0 is a zero-permit semaphore,
+    // so the probe lookup never completes and `guarded` — which awaits it before deciding — hangs every probed
+    // search; cache-ttl <= 0 expires each result instantly, defeating the single-flight cache so every request
+    // re-probes. Guard all four, as the sibling file-permission-cache guards do (DEV-6864).
     .validate("app.v2.fulltext-search.probe.cap must be >= 1")(_.v2.fulltextSearch.probe.cap >= 1)
     .validate("app.v2.fulltext-search.probe.cache-capacity must be >= 1")(
       _.v2.fulltextSearch.probe.cacheCapacity >= 1,

--- a/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -239,6 +239,17 @@ object AppConfig {
       _.filePermissionCache.ttl.compareTo(Duration.ofMinutes(10)) <= 0,
     )
     .validate("app.file-permission-cache.capacity must be >= 1")(_.filePermissionCache.capacity >= 1)
+    // The probe knobs feed FulltextBreadthGuard's cap check, Cache.makeWith and Semaphore.make. cap is
+    // env-injectable (KNORA_WEBAPI_FULLTEXT_PROBE_CAP), so a bad value refuses every probed search (cap < 1),
+    // hangs it (max-concurrent = 0 -> a zero-permit semaphore) or is undefined (cache-capacity < 1); guard all
+    // three, as the sibling file-permission-cache.capacity guard does (DEV-6864).
+    .validate("app.v2.fulltext-search.probe.cap must be >= 1")(_.v2.fulltextSearch.probe.cap >= 1)
+    .validate("app.v2.fulltext-search.probe.cache-capacity must be >= 1")(
+      _.v2.fulltextSearch.probe.cacheCapacity >= 1,
+    )
+    .validate("app.v2.fulltext-search.probe.max-concurrent must be >= 1")(
+      _.v2.fulltextSearch.probe.maxConcurrent >= 1,
+    )
 
   def config[A](f: AppConfig => A): UIO[A]  = ZIO.config(config).map(f).orDie
   def features[A](f: Features => A): UIO[A] = ZIO.config(config.map(_.features)).map(f).orDie

--- a/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/config/AppConfig.scala
@@ -169,6 +169,7 @@ final case class Triplestore(
   host: String,
   queryTimeout: Duration,
   gravsearchTimeout: Duration,
+  searchTimeout: Duration,
   maintenanceTimeout: Duration,
   fuseki: Fuseki,
   profileQueries: Boolean,
@@ -208,6 +209,15 @@ object AppConfig {
       c.copy(jwt = c.jwt.copy(issuer = c.jwt.issuer.orElse(Some(c.knoraApi.externalKnoraApiHostPort)))),
     )
     .validate("app.v2.resources.max-batch-size must be >= 1")(_.v2.resources.maxBatchSize >= 1)
+    .validate("app.triplestore.search-timeout must be positive")(
+      _.triplestore.searchTimeout.compareTo(Duration.ZERO) > 0,
+    )
+    // The search tier must never exceed Gravsearch, or the DEV-6864 load-shed rationale inverts: the whole
+    // point is that the fulltext prequery sheds load *before* the 120s main query would. An env override
+    // (KNORA_WEBAPI_TRIPLESTORE_SEARCH_TIMEOUT) makes a bad value injectable at deploy time, so guard it.
+    .validate("app.triplestore.search-timeout must be <= app.triplestore.gravsearch-timeout")(c =>
+      c.triplestore.searchTimeout.compareTo(c.triplestore.gravsearchTimeout) <= 0,
+    )
     .validate("app.file-permission-cache.ttl must be positive")(_.filePermissionCache.ttl.compareTo(Duration.ZERO) > 0)
     .validate("app.file-permission-cache.ttl must be at most 10 minutes (permission-staleness guard)")(
       _.filePermissionCache.ttl.compareTo(Duration.ofMinutes(10)) <= 0,

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -62,6 +62,7 @@ import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.resources.repo.GetResourcePropertiesAndValuesQuery
 import org.knora.webapi.slice.resources.repo.GetResourcesByClassInProjectPrequery
+import org.knora.webapi.slice.search.FulltextSearchTerms
 import org.knora.webapi.slice.search.repo.SearchFulltextQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
@@ -548,6 +549,7 @@ final class SearchResponderV2Live(
     for {
       _                    <- ensureIsFulltextSearch(searchValue)
       _                    <- validateSearchString(searchValue)
+      _                    <- ensureWildcardTermsLongEnough(searchValue)
       limitToStandoffClass <- ZIO.foreach(limitToStandoffClass)(ensureStandoffClass)
       countSparql          <- SearchFulltextQuery.build(
                        searchTerms = LuceneQueryString(searchValue),
@@ -597,6 +599,7 @@ final class SearchResponderV2Live(
     for {
       _                    <- ensureIsFulltextSearch(searchValue)
       _                    <- validateSearchString(searchValue)
+      _                    <- ensureWildcardTermsLongEnough(searchValue)
       limitToStandoffClass <- ZIO.foreach(limitToStandoffClass)(ensureStandoffClass)
       searchSparql         <- SearchFulltextQuery.build(
                         searchTerms = LuceneQueryString(searchValue),
@@ -1215,6 +1218,24 @@ final class SearchResponderV2Live(
           )
           .when(searchStr.length < searchValueMinLength)
     } yield ()
+  }
+
+  // Fulltext-only rule (LITERAL-LENGTH, DEV-6864): a wildcard term must carry at least the same number of
+  // *literal* characters as the whole-string minimum. `de*` matches 374k candidates and blows the timeout; the
+  // literal-length floor is a cheap, explainable proxy that rejects it before any query runs. Deliberately not in
+  // validateSearchString, whose other two call sites are searchbylabel, where a typed `*` is an escaped literal.
+  private def ensureWildcardTermsLongEnough(searchStr: String): Task[Unit] = {
+    val minLength = appConfig.v2.fulltextSearch.searchValueMinLength
+    val tooShort  = FulltextSearchTerms.tooShortWildcardTerms(LuceneQueryString(searchStr), minLength)
+    ZIO
+      .fail(
+        BadRequestException(
+          s"A wildcard search term must contain at least $minLength characters besides the wildcard, " +
+            s"but the following do not: ${tooShort.mkString(", ")}.",
+        ),
+      )
+      .when(tooShort.nonEmpty)
+      .unit
   }
 
   override def searchResourcesByLabelV2(

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -562,7 +562,7 @@ final class SearchResponderV2Live(
                        offset = 0,
                        countQuery = true, // do not get the resources themselves, but the sum of results
                      )
-      bindings <- triplestore.query(Select(countSparql)).map(_.results.bindings)
+      bindings <- triplestore.query(Select.search(countSparql)).map(_.results.bindings)
       count    <- // query response should contain one result with one row with the name "count"
         ZIO.fail {
           val msg = s"Fulltext count query is expected to return exactly one row, but ${bindings.size} given"
@@ -613,7 +613,7 @@ final class SearchResponderV2Live(
                         countQuery = false,
                       )
 
-      prequeryResponseNotMerged <- triplestore.query(Select(searchSparql))
+      prequeryResponseNotMerged <- triplestore.query(Select.search(searchSparql))
 
       mainResourceVar = QueryVariable("resource")
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -62,6 +62,7 @@ import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.resources.repo.GetResourcePropertiesAndValuesQuery
 import org.knora.webapi.slice.resources.repo.GetResourcesByClassInProjectPrequery
+import org.knora.webapi.slice.search.FulltextBreadthGuard
 import org.knora.webapi.slice.search.FulltextSearchTerms
 import org.knora.webapi.slice.search.SearchTimeoutException
 import org.knora.webapi.slice.search.repo.SearchFulltextQuery
@@ -328,6 +329,7 @@ trait SearchResponderV2 {
 final class SearchResponderV2Live(
   appConfig: AppConfig,
   triplestore: TriplestoreService,
+  fulltextBreadthGuard: FulltextBreadthGuard,
   constructResponseUtilV2: ConstructResponseUtilV2,
   ontologyCacheHelpers: OntologyCacheHelpers,
   queryTraverser: QueryTraverser,
@@ -546,8 +548,12 @@ final class SearchResponderV2Live(
   // 500 via BaseEndpoints' catch-all. Translate it into a search-specific 503 with a hedged message so the residue
   // that LITERAL-LENGTH and PROBE do not catch fails legibly. Applied at the Select.search call sites — the
   // search-tier queries — not the 120s Gravsearch main query, whose input is already bounded by the prequery.
-  private val translateSearchTimeout: PartialFunction[Throwable, Task[Nothing]] = {
-    case _: TriplestoreTimeoutException => ZIO.fail(SearchTimeoutException())
+  private def translateSearchTimeout(searchValue: String): PartialFunction[Throwable, Task[Nothing]] = {
+    // Only TriplestoreTimeoutException matches, so a query the breadth guard interrupts (a fast refusal winning
+    // the race) never triggers this — the interruption propagates as such and is not logged as a failure.
+    case _: TriplestoreTimeoutException =>
+      ZIO.logWarning(s"Fulltext search for '$searchValue' exceeded the search timeout tier") *>
+        ZIO.fail(SearchTimeoutException())
   }
 
   override def fulltextSearchCountV2(
@@ -573,7 +579,11 @@ final class SearchResponderV2Live(
                        countQuery = true, // do not get the resources themselves, but the sum of results
                      )
       bindings <-
-        triplestore.query(Select.search(countSparql)).catchSome(translateSearchTimeout).map(_.results.bindings)
+        fulltextBreadthGuard
+          .guarded(LuceneQueryString(searchValue), limitToStandoffClass, limitToProject, limitToResourceClass)(
+            triplestore.query(Select.search(countSparql)).catchSome(translateSearchTimeout(searchValue)),
+          )
+          .map(_.results.bindings)
       count <- // query response should contain one result with one row with the name "count"
         ZIO.fail {
           val msg = s"Fulltext count query is expected to return exactly one row, but ${bindings.size} given"
@@ -624,7 +634,11 @@ final class SearchResponderV2Live(
                         countQuery = false,
                       )
 
-      prequeryResponseNotMerged <- triplestore.query(Select.search(searchSparql)).catchSome(translateSearchTimeout)
+      prequeryResponseNotMerged <-
+        fulltextBreadthGuard
+          .guarded(LuceneQueryString(searchValue), limitToStandoffClass, limitToProject, limitToResourceClass)(
+            triplestore.query(Select.search(searchSparql)).catchSome(translateSearchTimeout(searchValue)),
+          )
 
       mainResourceVar = QueryVariable("resource")
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -63,10 +63,12 @@ import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.resources.repo.GetResourcePropertiesAndValuesQuery
 import org.knora.webapi.slice.resources.repo.GetResourcesByClassInProjectPrequery
 import org.knora.webapi.slice.search.FulltextSearchTerms
+import org.knora.webapi.slice.search.SearchTimeoutException
 import org.knora.webapi.slice.search.repo.SearchFulltextQuery
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
+import org.knora.webapi.store.triplestore.errors.TriplestoreTimeoutException
 import org.knora.webapi.util.ApacheLuceneSupport
 import org.knora.webapi.util.ApacheLuceneSupport.*
 
@@ -540,6 +542,14 @@ final class SearchResponderV2Live(
    *
    * @return a [[ResourceCountV2]] representing the number of resources that have been found.
    */
+  // HONEST-TIMEOUT (DEV-6864): a triplestore timeout on the fulltext prequery/count reaches the client as a bare
+  // 500 via BaseEndpoints' catch-all. Translate it into a search-specific 503 with a hedged message so the residue
+  // that LITERAL-LENGTH and PROBE do not catch fails legibly. Applied at the Select.search call sites — the
+  // search-tier queries — not the 120s Gravsearch main query, whose input is already bounded by the prequery.
+  private val translateSearchTimeout: PartialFunction[Throwable, Task[Nothing]] = {
+    case _: TriplestoreTimeoutException => ZIO.fail(SearchTimeoutException())
+  }
+
   override def fulltextSearchCountV2(
     searchValue: IRI,
     limitToProject: Option[ProjectIri],
@@ -562,8 +572,9 @@ final class SearchResponderV2Live(
                        offset = 0,
                        countQuery = true, // do not get the resources themselves, but the sum of results
                      )
-      bindings <- triplestore.query(Select.search(countSparql)).map(_.results.bindings)
-      count    <- // query response should contain one result with one row with the name "count"
+      bindings <-
+        triplestore.query(Select.search(countSparql)).catchSome(translateSearchTimeout).map(_.results.bindings)
+      count <- // query response should contain one result with one row with the name "count"
         ZIO.fail {
           val msg = s"Fulltext count query is expected to return exactly one row, but ${bindings.size} given"
           GravsearchException(msg)
@@ -613,7 +624,7 @@ final class SearchResponderV2Live(
                         countQuery = false,
                       )
 
-      prequeryResponseNotMerged <- triplestore.query(Select.search(searchSparql))
+      prequeryResponseNotMerged <- triplestore.query(Select.search(searchSparql)).catchSome(translateSearchTimeout)
 
       mainResourceVar = QueryVariable("resource")
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2Module.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2Module.scala
@@ -23,6 +23,7 @@ import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
 import org.knora.webapi.slice.ontology.repo.service.OntologyCache
+import org.knora.webapi.slice.search.FulltextBreadthGuard
 import org.knora.webapi.store.triplestore.api.TriplestoreService
 
 object SearchResponderV2Module {
@@ -36,5 +37,6 @@ object SearchResponderV2Module {
     (OntologyInferencer.layer ++ QueryTraverser.layer ++ InferenceOptimizationService.layer) >+>
       (ConstructTransformer.layer ++ InferringGravsearchTypeInspector.layer) >+>
       GravsearchTypeInspectionRunner.layer >+>
+      FulltextBreadthGuard.layer >+>
       ZLayer.derive[SearchResponderV2Live]
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v2/search/SearchEndpoints.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v2/search/SearchEndpoints.scala
@@ -8,8 +8,11 @@ package org.knora.webapi.slice.api.v2.search
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.RefinedTypeOps
 import eu.timepit.refined.numeric.Greater
+import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.codec.refined.*
+import sttp.tapir.generic.auto.*
+import sttp.tapir.json.zio.jsonBody
 import zio.ZIO
 import zio.ZLayer
 
@@ -20,6 +23,7 @@ import org.knora.webapi.slice.api.v2.search.SearchEndpointsInputs.InputIri
 import org.knora.webapi.slice.common.StringValueCompanion
 import org.knora.webapi.slice.common.Value.StringValue
 import org.knora.webapi.slice.common.api.*
+import org.knora.webapi.slice.search.SearchTimeoutException
 
 object SearchEndpointsInputs {
 
@@ -61,6 +65,15 @@ final class SearchEndpoints(baseEndpoints: BaseEndpoints) {
 
   private val gravsearchDescription =
     "The Gravsearch query. See https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/query-language/"
+
+  // A fulltext search that exceeds its triplestore timeout returns 503 with a legible, hedged body rather than
+  // the shared catch-all's bare 500 (DEV-6864, HONEST-TIMEOUT). Prepended so it is matched before the catch-all,
+  // and attached only to the two fulltext endpoints below — never to the shared BaseEndpoints.errorOutputs, which
+  // would advertise 503 on every path in the bot-synced OpenAPI (D11, Spike B).
+  private val searchTimeoutVariant =
+    oneOfVariant[SearchTimeoutException](
+      statusCode(StatusCode.ServiceUnavailable).and(jsonBody[SearchTimeoutException]),
+    )
 
   val postGravsearch = baseEndpoints.withUserEndpoint.post
     .in("v2" / "searchextended")
@@ -191,6 +204,7 @@ final class SearchEndpoints(baseEndpoints: BaseEndpoints) {
     .in(SearchEndpointsInputs.returnFiles)
     .out(ApiV2.Outputs.stringBodyFormatted)
     .out(ApiV2.Outputs.contentTypeHeader)
+    .errorOutVariantsPrepend(searchTimeoutVariant)
     .description(
       "Full-text search for resources. Publicly accessible. Requires appropriate object access permissions on the resources.",
     )
@@ -203,6 +217,7 @@ final class SearchEndpoints(baseEndpoints: BaseEndpoints) {
     .in(SearchEndpointsInputs.limitToStandoffClass)
     .out(ApiV2.Outputs.stringBodyFormatted)
     .out(ApiV2.Outputs.contentTypeHeader)
+    .errorOutVariantsPrepend(searchTimeoutVariant)
     .description(
       "Count full-text search results. Publicly accessible. Requires appropriate object access permissions on the resources.",
     )

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextBreadthGuard.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextBreadthGuard.scala
@@ -64,6 +64,9 @@ final case class FulltextBreadthGuard(
       // (refuse) only when the probe reports over the cap — every other outcome, including a probe error, becomes
       // `ZIO.never`, so the query wins the race untouched (fail open). `raceFirst` lets the decision's *failure*
       // win and interrupt the loser; the sttp canceller then frees the abandoned query in ~6 ms (Spike A).
+      // Being a daemon, the probe outlives interruption of the calling request (a deliberate trade-off: it still
+      // finishes and warms the cache when the client cancels), so its Fuseki round-trip is bounded by the probe's
+      // own semaphore and timeout tier rather than by the request's lifetime.
       for {
         probe  <- cache.get(key).either.forkDaemon
         result <- probe.join.flatMap {

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextBreadthGuard.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextBreadthGuard.scala
@@ -21,15 +21,15 @@ import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 
 /**
  * Refuses a fulltext search whose Lucene candidate set is too broad to run efficiently (DEV-6864, PROBE). It
- * measures breadth with a fast `COUNT` — [[SearchFulltextQuery.buildProbe]] — raced against the real query, and
- * refuses with a 400 when the count exceeds the cap. The probe fails open — any probe error leaves the real query
- * untouched — and measured breadth is cached (single-flight) so a repeated term does not re-probe.
+ * measures breadth with a fast `COUNT` — [[SearchFulltextQuery.buildProbe]] — concurrently with the real query,
+ * and refuses with a 400 when the count exceeds the cap. The probe fails open — any probe error leaves the real
+ * query untouched — and measured breadth is cached (single-flight) so a repeated term does not re-probe.
  *
  * Only queries that can be broad are probed ([[FulltextSearchTerms.shouldProbe]] — a wildcard or more than one
- * term); a single plain term runs unguarded. Racing (not serialising) is what Spike A measured and mandated: an
- * admitted term pays no measurable tax because the probe and the real query run concurrently, and a refused term
- * is rejected at probe speed while its in-flight query is interrupted in ~6 ms (the sttp backend's canceller is
- * non-blocking). See the Spike A outcomes in the DEV-6864 plan.
+ * term); a single plain term runs unguarded. Running the probe concurrently with (not before) the query is what
+ * keeps an admitted term tax-free: the probe's COUNT is far cheaper than the real query, so awaiting its verdict
+ * adds nothing to the latency of the queries this guard exists for. A refused term interrupts its still-running
+ * query (the sttp canceller is non-blocking, ~6 ms — Spike A). See the Spike A outcomes in the DEV-6864 plan.
  */
 final case class FulltextBreadthGuard(
   private val cap: Int,
@@ -38,10 +38,10 @@ final case class FulltextBreadthGuard(
   import FulltextBreadthGuard.BreadthKey
 
   /**
-   * Races the term's Lucene candidate-count probe against `query`: refuses with a 400 as soon as the probe reports
-   * a count over the cap (interrupting the in-flight query), and otherwise returns the query's result — within the
-   * cap, or the probe errored (fail open). Because the two run concurrently, an admitted term pays no serial probe
-   * tax (Spike A).
+   * Runs `query` concurrently with the term's Lucene candidate-count probe, then decides on the probe's verdict:
+   * refuses with a 400 (interrupting the still-running query) when the count is over the cap, and otherwise returns
+   * the query's result — within the cap, or the probe errored (fail open). Because the two run concurrently, an
+   * admitted term pays no serial probe tax (Spike A).
    */
   def guarded[A](
     searchTerms: LuceneQueryString,
@@ -58,22 +58,20 @@ final case class FulltextBreadthGuard(
         limitToProject.map(_.value),
         limitToResourceClass.map(_.toString),
       )
-      // Fork the probe as a daemon and race only its result against the query. Forking (rather than racing the
-      // lookup directly) guarantees the single-flight cache is populated even when the query wins and this effect
-      // returns first; `.either` means the daemon never ends as an unobserved failure. The decision effect fails
-      // (refuse) only when the probe reports over the cap — every other outcome, including a probe error, becomes
-      // `ZIO.never`, so the query wins the race untouched (fail open). `raceFirst` lets the decision's *failure*
-      // win and interrupt the loser; the sttp canceller then frees the abandoned query in ~6 ms (Spike A).
-      // Being a daemon, the probe outlives interruption of the calling request (a deliberate trade-off: it still
-      // finishes and warms the cache when the client cancels), so its Fuseki round-trip is bounded by the probe's
-      // own semaphore and timeout tier rather than by the request's lifetime.
+      // Start the real query immediately (as a structured child fiber), then await the breadth probe and decide on
+      // its verdict. The query and probe run concurrently, so an admitted term pays no serial probe tax on the
+      // queries this guard exists for: the probe's COUNT is far cheaper than the real query, so awaiting its verdict
+      // adds nothing to a slow query's latency. Over the cap → interrupt the still-running query and refuse; within
+      // the cap → return the query's result; a probe error is swallowed (`.either`), so the guard fails open.
+      // Awaiting the probe rather than racing it keeps the outcome decided by effects this fiber owns — the query is
+      // a structured child, cleaned up on any exit — and means an over-cap term is always refused (a fast query can
+      // never resolve the request before the probe's verdict is known).
       for {
-        probe  <- cache.get(key).either.forkDaemon
-        result <- probe.join.flatMap {
-                    case Right(breadth) if breadth > cap => ZIO.fail(tooBroad(searchTerms))
-                    case _                               => ZIO.never
+        queryFib <- query.fork
+        result   <- cache.get(key).either.flatMap {
+                    case Right(breadth) if breadth > cap => queryFib.interrupt *> ZIO.fail(tooBroad(searchTerms))
+                    case _                               => queryFib.join
                   }
-                    .raceFirst(query)
       } yield result
     }
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextBreadthGuard.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextBreadthGuard.scala
@@ -21,15 +21,15 @@ import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 
 /**
  * Refuses a fulltext search whose Lucene candidate set is too broad to run efficiently (DEV-6864, PROBE). It
- * measures breadth with a fast `COUNT` — [[SearchFulltextQuery.buildProbe]] — before running the real query, and
+ * measures breadth with a fast `COUNT` — [[SearchFulltextQuery.buildProbe]] — raced against the real query, and
  * refuses with a 400 when the count exceeds the cap. The probe fails open — any probe error leaves the real query
  * untouched — and measured breadth is cached (single-flight) so a repeated term does not re-probe.
  *
  * Only queries that can be broad are probed ([[FulltextSearchTerms.shouldProbe]] — a wildcard or more than one
- * term); a single plain term runs unguarded, so the probe's latency is paid only on the queries that can actually
- * be over-broad. This is Spike A's sanctioned serial fallback: the raced form it prototyped abandoned the losing
- * query without promptly freeing the request, so the request hung until the probe tier timed out. The serial tax
- * over the probed population (a ~2s probe on a 13-60s query) is small and bounded (Spike A).
+ * term); a single plain term runs unguarded. Racing (not serialising) is what Spike A measured and mandated: an
+ * admitted term pays no measurable tax because the probe and the real query run concurrently, and a refused term
+ * is rejected at probe speed while its in-flight query is interrupted in ~6 ms (the sttp backend's canceller is
+ * non-blocking). See the Spike A outcomes in the DEV-6864 plan.
  */
 final case class FulltextBreadthGuard(
   private val cap: Int,
@@ -38,8 +38,10 @@ final case class FulltextBreadthGuard(
   import FulltextBreadthGuard.BreadthKey
 
   /**
-   * Probes the term's Lucene candidate count, then either refuses with a 400 (count over the cap) or runs `query`
-   * (count within the cap, or the probe errored — fail open).
+   * Races the term's Lucene candidate-count probe against `query`: refuses with a 400 as soon as the probe reports
+   * a count over the cap (interrupting the in-flight query), and otherwise returns the query's result — within the
+   * cap, or the probe errored (fail open). Because the two run concurrently, an admitted term pays no serial probe
+   * tax (Spike A).
    */
   def guarded[A](
     searchTerms: LuceneQueryString,
@@ -56,12 +58,20 @@ final case class FulltextBreadthGuard(
         limitToProject.map(_.value),
         limitToResourceClass.map(_.toString),
       )
-      cache
-        .get(key)
-        .foldZIO(
-          _ => query, // fail open: a probe error runs the query
-          breadth => ZIO.fail(tooBroad(searchTerms)).when(breadth > cap) *> query,
-        )
+      // Fork the probe as a daemon and race only its result against the query. Forking (rather than racing the
+      // lookup directly) guarantees the single-flight cache is populated even when the query wins and this effect
+      // returns first; `.either` means the daemon never ends as an unobserved failure. The decision effect fails
+      // (refuse) only when the probe reports over the cap — every other outcome, including a probe error, becomes
+      // `ZIO.never`, so the query wins the race untouched (fail open). `raceFirst` lets the decision's *failure*
+      // win and interrupt the loser; the sttp canceller then frees the abandoned query in ~6 ms (Spike A).
+      for {
+        probe  <- cache.get(key).either.forkDaemon
+        result <- probe.join.flatMap {
+                    case Right(breadth) if breadth > cap => ZIO.fail(tooBroad(searchTerms))
+                    case _                               => ZIO.never
+                  }
+                    .raceFirst(query)
+      } yield result
     }
 
   private def tooBroad(searchTerms: LuceneQueryString): BadRequestException =

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextBreadthGuard.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextBreadthGuard.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.search
+
+import zio.*
+import zio.cache.Cache
+import zio.cache.Lookup
+
+import dsp.errors.BadRequestException
+import org.knora.webapi.config.AppConfig
+import org.knora.webapi.messages.SmartIri
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
+import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
+import org.knora.webapi.slice.search.repo.SearchFulltextQuery
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
+import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
+
+/**
+ * Refuses a fulltext search whose Lucene candidate set is too broad to run efficiently (DEV-6864, PROBE). It
+ * measures breadth with a fast `COUNT` — [[SearchFulltextQuery.buildProbe]] — before running the real query, and
+ * refuses with a 400 when the count exceeds the cap. The probe fails open — any probe error leaves the real query
+ * untouched — and measured breadth is cached (single-flight) so a repeated term does not re-probe.
+ *
+ * Only queries that can be broad are probed ([[FulltextSearchTerms.shouldProbe]] — a wildcard or more than one
+ * term); a single plain term runs unguarded, so the probe's latency is paid only on the queries that can actually
+ * be over-broad. This is Spike A's sanctioned serial fallback: the raced form it prototyped abandoned the losing
+ * query without promptly freeing the request, so the request hung until the probe tier timed out. The serial tax
+ * over the probed population (a ~2s probe on a 13-60s query) is small and bounded (Spike A).
+ */
+final case class FulltextBreadthGuard(
+  private val cap: Int,
+  private val cache: Cache[FulltextBreadthGuard.BreadthKey, Throwable, Long],
+) {
+  import FulltextBreadthGuard.BreadthKey
+
+  /**
+   * Probes the term's Lucene candidate count, then either refuses with a 400 (count over the cap) or runs `query`
+   * (count within the cap, or the probe errored — fail open).
+   */
+  def guarded[A](
+    searchTerms: LuceneQueryString,
+    limitToStandoffClass: Option[SmartIri],
+    limitToProject: Option[ProjectIri],
+    limitToResourceClass: Option[ResourceClassIri],
+  )(query: Task[A]): Task[A] =
+    if (!FulltextSearchTerms.shouldProbe(searchTerms)) query
+    else {
+      // The probe SPARQL encodes term + standoff (all the probe measures); project and resource class are carried
+      // in the key too so a future project-scoped probe (DEV-6809 (c)) can vary the value without a stale-cache bug.
+      val key = BreadthKey(
+        SearchFulltextQuery.buildProbe(searchTerms, limitToStandoffClass),
+        limitToProject.map(_.value),
+        limitToResourceClass.map(_.toString),
+      )
+      cache
+        .get(key)
+        .foldZIO(
+          _ => query, // fail open: a probe error runs the query
+          breadth => ZIO.fail(tooBroad(searchTerms)).when(breadth > cap) *> query,
+        )
+    }
+
+  private def tooBroad(searchTerms: LuceneQueryString): BadRequestException =
+    BadRequestException(
+      s"The search term '${searchTerms.getQueryString}' matches too many candidates to run efficiently. " +
+        "Try a more specific term or add another word.",
+    )
+}
+
+object FulltextBreadthGuard {
+
+  /**
+   * The cache key. `probeSparql` uniquely encodes the term and the standoff restriction — the only inputs the
+   * current probe measures — so it doubles as the SPARQL the lookup runs. `project` / `resourceClass` are part of
+   * the key but not the current probe: they are future-proofing (Spike A), keeping the cache correct if the probe
+   * ever becomes restriction-aware.
+   */
+  final case class BreadthKey(probeSparql: String, project: Option[String], resourceClass: Option[String])
+
+  /**
+   * Testable core. `probe` is injected so a unit test can supply a counting or failing double — the in-memory
+   * triplestore has no Lucene index, so the real probe fails there by construction, which is exactly the fail-open
+   * path. Built with `Cache.makeWith` so only successes are retained (a probe error is given `Duration.Zero` and
+   * re-probed next time), capacity is bounded, and concurrent probes are capped by the semaphore.
+   */
+  def make(cap: Int, cacheCapacity: Int, cacheTtl: Duration, maxConcurrent: Int)(
+    probe: BreadthKey => Task[Long],
+  ): UIO[FulltextBreadthGuard] =
+    for {
+      semaphore <- Semaphore.make(maxConcurrent.toLong)
+      cache     <- Cache.makeWith(cacheCapacity, Lookup((key: BreadthKey) => semaphore.withPermit(probe(key)))) {
+                 case Exit.Success(_) => cacheTtl
+                 case Exit.Failure(_) => Duration.Zero
+               }
+    } yield FulltextBreadthGuard(cap, cache)
+
+  /** The production probe: run the pre-built COUNT SPARQL on the dedicated probe tier and read the count. */
+  private def runProbe(triplestore: TriplestoreService)(key: BreadthKey): Task[Long] =
+    triplestore
+      .query(Select.searchProbe(key.probeSparql))
+      .flatMap(result => ZIO.attempt(result.results.bindings.head.rowMap("count").toLong))
+
+  val layer: URLayer[AppConfig & TriplestoreService, FulltextBreadthGuard] =
+    ZLayer.scoped {
+      for {
+        config      <- ZIO.service[AppConfig]
+        triplestore <- ZIO.service[TriplestoreService]
+        cfg          = config.v2.fulltextSearch.probe
+        guard       <- make(cfg.cap, cfg.cacheCapacity, cfg.cacheTtl, cfg.maxConcurrent)(runProbe(triplestore))
+      } yield guard
+    }
+}

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextSearchTerms.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextSearchTerms.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.search
+
+import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
+
+/**
+ * Term-shape rules for the fulltext search routes (`/v2/search`, `/v2/search/count`). Both rules operate on the
+ * same phrase-aware split ([[LuceneQueryString.termsAndPhrases]]) so the input validation (LITERAL-LENGTH) and the
+ * breadth probe cannot disagree about what a term is (DEV-6864).
+ */
+object FulltextSearchTerms {
+
+  // Lucene boolean operators advertised in dsp-app's Search tips panel. `OR` is two characters, so a per-term
+  // length rule would reject it; they carry no wildcard and so are never checked, but exempt them explicitly.
+  private val booleanOperators = Set("AND", "OR", "NOT")
+
+  private val wildcardChars = Set('*', '?')
+
+  private def hasWildcard(term: String): Boolean = term.exists(wildcardChars)
+
+  /**
+   * The wildcard terms that carry fewer than `minLength` literal (non-wildcard) characters. `de*` strips to `de`
+   * (2) and is too short; `Alice*` strips to `Alice` (5) and `Unif?rm` to `Unifrm` (6) are fine. Only terms that
+   * actually carry a wildcard are checked — a plain term is governed by the existing whole-string minimum, so this
+   * does not newly reject e.g. `is Alice`. Boolean operators and quoted phrases carry no wildcard and pass.
+   */
+  def tooShortWildcardTerms(query: LuceneQueryString, minLength: Int): Seq[String] =
+    query.termsAndPhrases.filter { term =>
+      hasWildcard(term) &&
+      !booleanOperators.contains(term) &&
+      term.count(!wildcardChars.contains(_)) < minLength
+    }
+}

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextSearchTerms.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/FulltextSearchTerms.scala
@@ -34,4 +34,15 @@ object FulltextSearchTerms {
       !booleanOperators.contains(term) &&
       term.count(!wildcardChars.contains(_)) < minLength
     }
+
+  /**
+   * Whether the breadth probe should race this query. Only queries that can be broad are worth the extra Fuseki
+   * round-trip: a wildcard term (matches many distinct index terms) or more than one term (Lucene ORs them). A
+   * single plain term is the cheap common case and is left unprobed — its residual exposure (a high-frequency
+   * single term above the cap gets a slow timeout rather than a fast refusal) is accepted (DEV-6864, Spike A).
+   */
+  def shouldProbe(query: LuceneQueryString): Boolean = {
+    val terms = query.termsAndPhrases
+    terms.sizeIs > 1 || terms.exists(hasWildcard)
+  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/SearchTimeoutException.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/SearchTimeoutException.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.search
+
+import zio.json.DeriveJsonCodec
+import zio.json.JsonCodec
+
+import dsp.errors.InternalServerException
+
+/**
+ * Raised when a fulltext search (`/v2/search`, `/v2/search/count`) exceeds its triplestore timeout. A store-layer
+ * [[dsp.errors.TriplestoreTimeoutException]] reaches the client as a bare HTTP 500 via the shared catch-all; the
+ * fulltext path translates it into this search-specific type so the two search endpoints — and only those — can map
+ * it to a 503 with a legible, hedged message (DEV-6864). A timeout is not proof the term is too broad (a slow
+ * triplestore, GC pause or contention produces the same symptom), so the message must hedge rather than blame.
+ *
+ * It carries exactly one `message: String` field and no `cause`: `DeriveJsonCodec` derives neither the zio-json
+ * codec nor the tapir `Schema` for an `Option[Throwable]`, so the message-only shape is what makes `jsonBody`
+ * derivation work (Spike B).
+ */
+final case class SearchTimeoutException(message: String) extends InternalServerException(message)
+
+object SearchTimeoutException {
+
+  /** The hedged, user-facing message. Does not assert the term is too broad — see the class doc. */
+  val defaultMessage: String =
+    "This search could not be completed in time; it may be too broad. Try adding another word."
+
+  def apply(): SearchTimeoutException = SearchTimeoutException(defaultMessage)
+
+  implicit val codec: JsonCodec[SearchTimeoutException] = DeriveJsonCodec.gen[SearchTimeoutException]
+}

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuery.scala
@@ -22,6 +22,55 @@ object SearchFulltextQuery extends QueryBuilderHelper {
 
   private val luceneHitLimit = OntologyConstants.Fuseki.luceneHitLimit
 
+  // Escape user-supplied search terms via rdf4j to prevent SPARQL injection.
+  private def searchLiteralOf(searchTerms: LuceneQueryString): String =
+    Rdf.literalOf(searchTerms.getQueryString).getQueryString
+
+  // The standoff restriction, mirrored inside the inner Lucene subquery. Shared by build and buildProbe so the
+  // breadth probe measures exactly the candidate set the real query starts from and cannot drift from it.
+  private def standoffFilterClause(searchTerms: LuceneQueryString, limitToStandoffClass: Option[SmartIri]): String =
+    limitToStandoffClass.fold("") { standoffClassIri =>
+      val standoffIri = toRdfIri(standoffClassIri).getQueryString
+      // Escape each individual term via rdf4j before embedding in REGEX
+      val regexFilters = searchTerms.getSingleTerms.map { term =>
+        val termLiteral = Rdf.literalOf(term).getQueryString
+        s"""    FILTER REGEX(?markedup, $termLiteral, "i")"""
+      }.mkString("\n")
+
+      s"""
+         |    ?matchingSubject a knora-base:TextValue ;
+         |        knora-base:valueHasString ?literal ;
+         |        knora-base:valueHasStandoff ?standoffNode .
+         |    ?standoffNode a $standoffIri ;
+         |        knora-base:standoffTagHasStart ?start ;
+         |        knora-base:standoffTagHasEnd ?end .
+         |    BIND(SUBSTR(?literal, ?start+1, ?end - ?start) AS ?markedup)
+         |$regexFilters""".stripMargin
+    }
+
+  /**
+   * The breadth probe (DEV-6864, PROBE): a `COUNT(*)` over the exact inner Lucene subquery of [[build]] — the
+   * post-Lucene candidate count, before the value/list/resource joins the real query pays. It mirrors only the
+   * standoff filter, which lives inside that subquery; `limitToProject` / `limitToResourceClass` live in the outer
+   * query and are not mirrored (they filter after the joins and do not reduce the candidate count — see the plan).
+   * Run raced against the real query, this measures how broad a term is without paying the joins.
+   */
+  def buildProbe(searchTerms: LuceneQueryString, limitToStandoffClass: Option[SmartIri]): String = {
+    val searchLiteral  = searchLiteralOf(searchTerms)
+    val standoffFilter = standoffFilterClause(searchTerms, limitToStandoffClass)
+    s"""PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+       |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+       |SELECT (COUNT(*) AS ?count)
+       |WHERE {
+       |    {
+       |        SELECT DISTINCT ?matchingSubject WHERE {
+       |            ?matchingSubject <http://jena.apache.org/text#query> ($searchLiteral $luceneHitLimit) .$standoffFilter
+       |        }
+       |    }
+       |}
+       |""".stripMargin
+  }
+
   // The overall query structure (SELECT with GROUP_CONCAT, subqueries, BIND/COALESCE, SUBSTR)
   // is assembled via string interpolation because these features are not supported by the
   // rdf4j SparqlBuilder. Individual values — especially user-supplied search terms and dynamic
@@ -72,27 +121,8 @@ object SearchFulltextQuery extends QueryBuilderHelper {
           s"""SELECT ?resource
              |       (GROUP_CONCAT(IF(BOUND(?valueObject), STR(?valueObject), ""); SEPARATOR="${separator.get}") AS ?valueObjectConcat)""".stripMargin
 
-      // Escape user-supplied search terms via rdf4j to prevent SPARQL injection
-      val searchLiteral = Rdf.literalOf(searchTerms.getQueryString).getQueryString
-
-      val standoffFilter = limitToStandoffClass.fold("") { standoffClassIri =>
-        val standoffIri = toRdfIri(standoffClassIri).getQueryString
-        // Escape each individual term via rdf4j before embedding in REGEX
-        val regexFilters = searchTerms.getSingleTerms.map { term =>
-          val termLiteral = Rdf.literalOf(term).getQueryString
-          s"""    FILTER REGEX(?markedup, $termLiteral, "i")"""
-        }.mkString("\n")
-
-        s"""
-           |    ?matchingSubject a knora-base:TextValue ;
-           |        knora-base:valueHasString ?literal ;
-           |        knora-base:valueHasStandoff ?standoffNode .
-           |    ?standoffNode a $standoffIri ;
-           |        knora-base:standoffTagHasStart ?start ;
-           |        knora-base:standoffTagHasEnd ?end .
-           |    BIND(SUBSTR(?literal, ?start+1, ?end - ?start) AS ?markedup)
-           |$regexFilters""".stripMargin
-      }
+      val searchLiteral  = searchLiteralOf(searchTerms)
+      val standoffFilter = standoffFilterClause(searchTerms, limitToStandoffClass)
 
       val fileValuesBlock =
         if (returnFiles)

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuery.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.search.repo
 
+import org.eclipse.rdf4j.model.vocabulary.RDFS
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import zio.IO
 
@@ -14,6 +15,7 @@ import org.knora.webapi.messages.SmartIri
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
 import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 
 object SearchFulltextQuery extends QueryBuilderHelper {
@@ -25,6 +27,30 @@ object SearchFulltextQuery extends QueryBuilderHelper {
   // rdf4j SparqlBuilder. Individual values — especially user-supplied search terms and dynamic
   // IRIs — are built through rdf4j's Rdf.literalOf / Rdf.iri to ensure proper escaping and
   // guard against SPARQL injection.
+  //
+  // Resource-ness and value-ness are asserted by the presence of a datatype property rather than by walking
+  // rdfs:subClassOf* to knora-base:Resource / knora-base:Value once per Lucene hit. On a prod-mirrored store the
+  // per-hit walks dominated the cost: `count/der` was 82.50s and dropped to 13.09s once they were removed (measured
+  // on stage, 2026-07-29). The substitutions are exact, not heuristic:
+  //
+  //  - Resource-ness (1a): knora-base:creationDate declares `subjectClassConstraint :Resource` with cardinality 1 on
+  //    :Resource, so it is present on every resource and on nothing else (verified on stage: zero types carry it
+  //    outside the :Resource closure, zero resources lack it). `?resource a ?resourceClass` is emitted only when a
+  //    class restriction is requested — see filterByProjectAndResourceClass — so the type join is paid only then.
+  //  - Value-ness (1c): knora-base:valueCreationDate declares `subjectClassConstraint :Value`, the value-side analogue
+  //    (verified: zero indexed values lack it). The direct-type FILTER NOT EXISTS on LinkValue/ListValue is equivalent
+  //    to the old `!=` on a walked type — the two can only diverge for a value carrying more than one asserted
+  //    rdf:type, and no LinkValue/ListValue on stage does — and it closes the multi-type leak the walked form had.
+  //  - The value branch no longer walks `?property rdfs:subPropertyOf* knora-base:hasValue` (1b): its only job was to
+  //    reject non-resource subjects, which the resource-ness probe (1a) already does — the subjects it excluded
+  //    (previousValue links, standoff references) have no creationDate.
+  //  - There is no outer SELECT DISTINCT (1d): `GROUP BY ?resource` already deduplicates the page query, and the count
+  //    branch keeps COUNT(DISTINCT ?resource). The inner SELECT DISTINCT ?matchingSubject stays.
+  //
+  // TODO(DEV-6850): the creationDate / valueCreationDate probes are a stopgap. They mean "when was this made", not
+  // "this is a resource / value"; DEV-6850 materialises the entailed `a knora-base:Resource` / `a knora-base:Value`
+  // and introduces one shared guard for all the sites that ask this question. Replace these probes with that guard
+  // when it lands. See also SearchQueries.selectCountByLabel, which carries the same stopgap.
   def build(
     searchTerms: LuceneQueryString,
     limitToProject: Option[ProjectIri],
@@ -43,7 +69,7 @@ object SearchFulltextQuery extends QueryBuilderHelper {
         if (countQuery)
           "SELECT (COUNT(DISTINCT ?resource) AS ?count)"
         else
-          s"""SELECT DISTINCT ?resource
+          s"""SELECT ?resource
              |       (GROUP_CONCAT(IF(BOUND(?valueObject), STR(?valueObject), ""); SEPARATOR="${separator.get}") AS ?valueObjectConcat)""".stripMargin
 
       // Escape user-supplied search terms via rdf4j to prevent SPARQL injection
@@ -66,16 +92,6 @@ object SearchFulltextQuery extends QueryBuilderHelper {
            |        knora-base:standoffTagHasEnd ?end .
            |    BIND(SUBSTR(?literal, ?start+1, ?end - ?start) AS ?markedup)
            |$regexFilters""".stripMargin
-      }
-
-      val resourceClassFilter = limitToResourceClass.fold("") { rc =>
-        val iri = toRdfIri(rc).getQueryString
-        s"\n    ?resourceClass rdfs:subClassOf* $iri ."
-      }
-
-      val projectFilter = limitToProject.fold("") { p =>
-        val iri = toRdfIri(p).getQueryString
-        s"\n    ?resource knora-base:attachedToProject $iri ."
       }
 
       val fileValuesBlock =
@@ -105,11 +121,10 @@ object SearchFulltextQuery extends QueryBuilderHelper {
          |        }
          |    }
          |    OPTIONAL {
-         |        ?matchingSubject a ?valueObjectType .
-         |        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-         |        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+         |        ?matchingSubject knora-base:valueCreationDate ?valueCreationDate .
+         |        FILTER NOT EXISTS { ?matchingSubject a knora-base:LinkValue . }
+         |        FILTER NOT EXISTS { ?matchingSubject a knora-base:ListValue . }
          |        ?containingResource ?property ?matchingSubject .
-         |        ?property rdfs:subPropertyOf* knora-base:hasValue .
          |        FILTER NOT EXISTS {
          |            ?matchingSubject knora-base:isDeleted true .
          |        }
@@ -126,8 +141,8 @@ object SearchFulltextQuery extends QueryBuilderHelper {
          |        BIND(?listValue AS ?valueObject)
          |    }
          |    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-         |    ?resource a ?resourceClass .
-         |    ?resourceClass rdfs:subClassOf* knora-base:Resource .$resourceClassFilter$projectFilter$fileValuesBlock
+         |    ?resource knora-base:creationDate ?resourceCreationDate .
+         |    ${filterByProjectAndResourceClass(limitToProject, limitToResourceClass)}$fileValuesBlock
          |    FILTER NOT EXISTS {
          |        ?resource knora-base:isDeleted true .
          |    }
@@ -136,4 +151,34 @@ object SearchFulltextQuery extends QueryBuilderHelper {
          |LIMIT $limit
          |""".stripMargin
     }
+
+  /**
+   * Emits the optional project and resource-class restrictions. Duplicated from
+   * SearchQueries.filterByProjectAndResourceClass (D6): the two queries are separate and the shared helper would
+   * couple them, but they must agree on the load-bearing detail — the class restriction walks the whole
+   * `rdfs:subClassOf*` closure, never `subClassOf?`. The subclass closure is not materialised and there is no
+   * query-time inference, so zero-or-one silently excludes every class two or more hops below the target (DEV-6833).
+   *
+   * `?resource a ?resourceClass` is emitted here rather than in the query body so the type join is only paid when a
+   * class restriction is actually requested — the resource-ness probe in build() is unconditional and stands alone.
+   * Project restriction is emitted before the class join: `attachedToProject` on the already-bound `?resource` is a
+   * cheap, selective probe (engine Fact 1 — order relative to the joins is the plan).
+   */
+  private def filterByProjectAndResourceClass(
+    limitToProject: Option[ProjectIri],
+    limitToResourceClass: Option[ResourceClassIri],
+  ): String = {
+    val projectPattern = limitToProject
+      .map(toRdfIri)
+      .map(prj => variable("resource").has(KnoraBase.attachedToProject, prj).getQueryString)
+
+    val resourceClassPatterns = limitToResourceClass.map(toRdfIri).map { cls =>
+      List(
+        variable("resource").isA(variable("resourceClass")).getQueryString,
+        variable("resourceClass").has(zeroOrMore(RDFS.SUBCLASSOF), cls).getQueryString,
+      ).mkString("\n")
+    }
+
+    List(projectPattern, resourceClassPatterns).flatten.mkString("\n")
+  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -189,6 +189,11 @@ object TriplestoreService {
       case Standard
       case Maintenance
       case Gravsearch
+      // The fulltext prequery and count run on this tier. It is longer than Standard (the inverted budget
+      // DEV-6864 fixes: the prequery preceded a 120s Gravsearch main query on the 20s Standard tier) but
+      // shorter than Gravsearch, so a broad query still sheds load well before two minutes. Kept distinct
+      // from Gravsearch so fulltext queries are not filed into Gravsearch dashboards (D3, D7).
+      case Search
     }
 
     sealed trait SparqlQuery {
@@ -204,6 +209,7 @@ object TriplestoreService {
       def apply(sparql: SelectQuery, timeout: SparqlTimeout): Select = Select(sparql.getQueryString, timeout)
 
       def gravsearch(sparql: String): Select = Select(sparql, SparqlTimeout.Gravsearch)
+      def search(sparql: String): Select     = Select(sparql, SparqlTimeout.Search)
     }
 
     case class Construct(sparql: String, override val timeout: SparqlTimeout = SparqlTimeout.Standard)

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/api/TriplestoreService.scala
@@ -194,6 +194,10 @@ object TriplestoreService {
       // shorter than Gravsearch, so a broad query still sheds load well before two minutes. Kept distinct
       // from Gravsearch so fulltext queries are not filed into Gravsearch dashboards (D3, D7).
       case Search
+      // The fulltext breadth probe (a fast COUNT of Lucene candidates) runs raced against the real query. It
+      // reuses the search-timeout value but is a distinct tier so its cheap ~0.2-2.8s samples are not filed into
+      // the search-tier metric alongside the 13-29s real queries (DEV-6864, PROBE).
+      case SearchProbe
     }
 
     sealed trait SparqlQuery {
@@ -208,8 +212,9 @@ object TriplestoreService {
       def apply(sparql: SelectQuery): Select                         = Select(sparql.getQueryString)
       def apply(sparql: SelectQuery, timeout: SparqlTimeout): Select = Select(sparql.getQueryString, timeout)
 
-      def gravsearch(sparql: String): Select = Select(sparql, SparqlTimeout.Gravsearch)
-      def search(sparql: String): Select     = Select(sparql, SparqlTimeout.Search)
+      def gravsearch(sparql: String): Select  = Select(sparql, SparqlTimeout.Gravsearch)
+      def search(sparql: String): Select      = Select(sparql, SparqlTimeout.Search)
+      def searchProbe(sparql: String): Select = Select(sparql, SparqlTimeout.SearchProbe)
     }
 
     case class Construct(sparql: String, override val timeout: SparqlTimeout = SparqlTimeout.Standard)

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -377,6 +377,7 @@ case class TriplestoreServiceLive(
     case SparqlTimeout.Standard    => triplestoreConfig.queryTimeout
     case SparqlTimeout.Maintenance => triplestoreConfig.maintenanceTimeout
     case SparqlTimeout.Gravsearch  => triplestoreConfig.gravsearchTimeout
+    case SparqlTimeout.Search      => triplestoreConfig.searchTimeout
   }
 
   private def executeSparqlQuery(
@@ -441,7 +442,7 @@ case class TriplestoreServiceLive(
     request
       .send(backend)
       .catchSome {
-        case e: java.net.SocketTimeoutException =>
+        case e: SttpClientException.TimeoutException =>
           val msg = s"$context: triplestore timeout"
           ZIO.logError(msg) *> ZIO.fail(TriplestoreTimeoutException(msg, e))
         case e: Exception =>
@@ -492,7 +493,7 @@ case class TriplestoreServiceLive(
     request
       .send(backend)
       .catchSome {
-        case e: java.net.SocketTimeoutException =>
+        case e: SttpClientException.TimeoutException =>
           val msg = "The triplestore took too long to process the NQuads upload."
           ZIO.logError(msg) *> ZIO.fail(TriplestoreTimeoutException(msg, e))
         case e: Exception =>
@@ -513,10 +514,13 @@ case class TriplestoreServiceLive(
   ): Task[Response[Either[String, String]]] = {
     def executeQuery(request: Request[Either[String, String]]): Task[Response[Either[String, String]]] = {
       request.send(backend).catchSome {
-        case socketTimeoutException: java.net.SocketTimeoutException =>
+        // sttp maps a read timeout to SttpClientException.TimeoutException (a ReadException), never a bare
+        // java.net.SocketTimeoutException, so matching the latter was dead code and a client read timeout fell
+        // through to the connection-failure branch below and reached the client as a bare 500 (DEV-6864, Spike B).
+        case timeout: SttpClientException.TimeoutException =>
           val message =
             "The triplestore took too long to process a request. This can happen because the triplestore needed too much time to search through the data that is currently in the triplestore. Query optimisation may help."
-          val error = TriplestoreTimeoutException(message, socketTimeoutException)
+          val error = TriplestoreTimeoutException(message, timeout)
           ZIO.logError(error.toString) *> ZIO.fail(error)
         case e: Exception =>
           val message = s"Failed to connect to triplestore: ${request.uri.toString}"

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -378,6 +378,8 @@ case class TriplestoreServiceLive(
     case SparqlTimeout.Maintenance => triplestoreConfig.maintenanceTimeout
     case SparqlTimeout.Gravsearch  => triplestoreConfig.gravsearchTimeout
     case SparqlTimeout.Search      => triplestoreConfig.searchTimeout
+    // The probe reuses the search-timeout value; the distinct tier exists only for metric separation (PROBE).
+    case SparqlTimeout.SearchProbe => triplestoreConfig.searchTimeout
   }
 
   private def executeSparqlQuery(
@@ -401,6 +403,11 @@ case class TriplestoreServiceLive(
                   .tagged("type", query.getClass.getSimpleName)
                   .tagged("isGravsearch", s"${query.timeout == SparqlTimeout.Gravsearch}")
                   .tagged("isMaintenance", s"${query.timeout == SparqlTimeout.Maintenance}")
+                  // A third boolean rather than a replacement (D7): existing dashboards keep isGravsearch/
+                  // isMaintenance. isSearch isolates the fulltext prequery/count on the 60s tier; the breadth
+                  // probe (SparqlTimeout.SearchProbe) is deliberately isSearch=false so its cheap samples do not
+                  // pollute the search-tier duration the regression watch depends on (DEV-6864).
+                  .tagged("isSearch", s"${query.timeout == SparqlTimeout.Search}")
                   .trackDuration
       _ <- {
              val endTime  = java.lang.System.nanoTime()

--- a/modules/webapi/src/main/scala/org/knora/webapi/util/ApacheLuceneSupport.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/util/ApacheLuceneSupport.scala
@@ -74,5 +74,15 @@ object ApacheLuceneSupport {
      */
     def getSingleTerms: Seq[String] =
       queryString.split(' ').toSeq
+
+    /**
+     * Splits the query into terms and quoted phrases, keeping a quoted phrase (e.g. `"down the rabbit hole"`)
+     * as a single element instead of chopping it on spaces the way [[getSingleTerms]] does. This is the one
+     * place the fulltext input validation and the breadth probe agree on what a "term" is (DEV-6864).
+     *
+     * @return the terms and quoted phrases contained in a Lucene query.
+     */
+    def termsAndPhrases: Seq[String] =
+      ApacheLuceneSupport.separateTermsAndPhrasesRegex.findAllIn(queryString).toList
   }
 }

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__countNoFilters.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__countNoFilters.txt
@@ -8,11 +8,10 @@ WHERE {
         }
     }
     OPTIONAL {
-        ?matchingSubject a ?valueObjectType .
-        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+        ?matchingSubject knora-base:valueCreationDate ?valueCreationDate .
+        FILTER NOT EXISTS { ?matchingSubject a knora-base:LinkValue . }
+        FILTER NOT EXISTS { ?matchingSubject a knora-base:ListValue . }
         ?containingResource ?property ?matchingSubject .
-        ?property rdfs:subPropertyOf* knora-base:hasValue .
         FILTER NOT EXISTS {
             ?matchingSubject knora-base:isDeleted true .
         }
@@ -29,8 +28,8 @@ WHERE {
         BIND(?listValue AS ?valueObject)
     }
     BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-    ?resource a ?resourceClass .
-    ?resourceClass rdfs:subClassOf* knora-base:Resource .
+    ?resource knora-base:creationDate ?resourceCreationDate .
+    
     FILTER NOT EXISTS {
         ?resource knora-base:isDeleted true .
     }

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__countNoFilters.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__countNoFilters.txt
@@ -1,0 +1,39 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT (COUNT(DISTINCT ?resource) AS ?count)
+WHERE {
+    {
+        SELECT DISTINCT ?matchingSubject WHERE {
+            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
+        }
+    }
+    OPTIONAL {
+        ?matchingSubject a ?valueObjectType .
+        ?valueObjectType rdfs:subClassOf* knora-base:Value .
+        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+        ?containingResource ?property ?matchingSubject .
+        ?property rdfs:subPropertyOf* knora-base:hasValue .
+        FILTER NOT EXISTS {
+            ?matchingSubject knora-base:isDeleted true .
+        }
+        BIND(?matchingSubject AS ?valueObject)
+    }
+    OPTIONAL {
+        ?matchingSubject a knora-base:ListNode .
+        ?matchingSubject knora-base:hasSubListNode* ?subListNode .
+        ?listValue knora-base:valueHasListNode ?subListNode .
+        ?subjectWithListValue ?predicate ?listValue .
+        FILTER NOT EXISTS {
+            ?matchingSubject knora-base:isDeleted true .
+        }
+        BIND(?listValue AS ?valueObject)
+    }
+    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
+    ?resource a ?resourceClass .
+    ?resourceClass rdfs:subClassOf* knora-base:Resource .
+    FILTER NOT EXISTS {
+        ?resource knora-base:isDeleted true .
+    }
+}
+
+LIMIT 1

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__countWithProjectAndClass.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__countWithProjectAndClass.txt
@@ -8,11 +8,10 @@ WHERE {
         }
     }
     OPTIONAL {
-        ?matchingSubject a ?valueObjectType .
-        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+        ?matchingSubject knora-base:valueCreationDate ?valueCreationDate .
+        FILTER NOT EXISTS { ?matchingSubject a knora-base:LinkValue . }
+        FILTER NOT EXISTS { ?matchingSubject a knora-base:ListValue . }
         ?containingResource ?property ?matchingSubject .
-        ?property rdfs:subPropertyOf* knora-base:hasValue .
         FILTER NOT EXISTS {
             ?matchingSubject knora-base:isDeleted true .
         }
@@ -29,10 +28,10 @@ WHERE {
         BIND(?listValue AS ?valueObject)
     }
     BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-    ?resource a ?resourceClass .
-    ?resourceClass rdfs:subClassOf* knora-base:Resource .
-    ?resourceClass rdfs:subClassOf* <http://www.knora.org/ontology/0001/anything#Thing> .
-    ?resource knora-base:attachedToProject <http://rdfh.ch/projects/0001> .
+    ?resource knora-base:creationDate ?resourceCreationDate .
+    ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> <http://rdfh.ch/projects/0001> .
+?resource a ?resourceClass .
+?resourceClass <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/0001/anything#Thing> .
     FILTER NOT EXISTS {
         ?resource knora-base:isDeleted true .
     }

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__countWithProjectAndClass.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__countWithProjectAndClass.txt
@@ -1,0 +1,41 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT (COUNT(DISTINCT ?resource) AS ?count)
+WHERE {
+    {
+        SELECT DISTINCT ?matchingSubject WHERE {
+            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
+        }
+    }
+    OPTIONAL {
+        ?matchingSubject a ?valueObjectType .
+        ?valueObjectType rdfs:subClassOf* knora-base:Value .
+        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+        ?containingResource ?property ?matchingSubject .
+        ?property rdfs:subPropertyOf* knora-base:hasValue .
+        FILTER NOT EXISTS {
+            ?matchingSubject knora-base:isDeleted true .
+        }
+        BIND(?matchingSubject AS ?valueObject)
+    }
+    OPTIONAL {
+        ?matchingSubject a knora-base:ListNode .
+        ?matchingSubject knora-base:hasSubListNode* ?subListNode .
+        ?listValue knora-base:valueHasListNode ?subListNode .
+        ?subjectWithListValue ?predicate ?listValue .
+        FILTER NOT EXISTS {
+            ?matchingSubject knora-base:isDeleted true .
+        }
+        BIND(?listValue AS ?valueObject)
+    }
+    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
+    ?resource a ?resourceClass .
+    ?resourceClass rdfs:subClassOf* knora-base:Resource .
+    ?resourceClass rdfs:subClassOf* <http://www.knora.org/ontology/0001/anything#Thing> .
+    ?resource knora-base:attachedToProject <http://rdfh.ch/projects/0001> .
+    FILTER NOT EXISTS {
+        ?resource knora-base:isDeleted true .
+    }
+}
+
+LIMIT 1

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__probeNoStandoff.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__probeNoStandoff.txt
@@ -1,0 +1,10 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT (COUNT(*) AS ?count)
+WHERE {
+    {
+        SELECT DISTINCT ?matchingSubject WHERE {
+            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
+        }
+    }
+}

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__probeWithStandoff.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__probeWithStandoff.txt
@@ -1,0 +1,19 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT (COUNT(*) AS ?count)
+WHERE {
+    {
+        SELECT DISTINCT ?matchingSubject WHERE {
+            ?matchingSubject <http://jena.apache.org/text#query> ("test search" 1000000) .
+    ?matchingSubject a knora-base:TextValue ;
+        knora-base:valueHasString ?literal ;
+        knora-base:valueHasStandoff ?standoffNode .
+    ?standoffNode a <http://www.knora.org/ontology/standoff#StandoffBoldTag> ;
+        knora-base:standoffTagHasStart ?start ;
+        knora-base:standoffTagHasEnd ?end .
+    BIND(SUBSTR(?literal, ?start+1, ?end - ?start) AS ?markedup)
+    FILTER REGEX(?markedup, "test", "i")
+    FILTER REGEX(?markedup, "search", "i")
+        }
+    }
+}

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__searchNoFilters.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__searchNoFilters.txt
@@ -1,0 +1,43 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?resource
+       (GROUP_CONCAT(IF(BOUND(?valueObject), STR(?valueObject), ""); SEPARATOR="") AS ?valueObjectConcat)
+WHERE {
+    {
+        SELECT DISTINCT ?matchingSubject WHERE {
+            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
+        }
+    }
+    OPTIONAL {
+        ?matchingSubject a ?valueObjectType .
+        ?valueObjectType rdfs:subClassOf* knora-base:Value .
+        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+        ?containingResource ?property ?matchingSubject .
+        ?property rdfs:subPropertyOf* knora-base:hasValue .
+        FILTER NOT EXISTS {
+            ?matchingSubject knora-base:isDeleted true .
+        }
+        BIND(?matchingSubject AS ?valueObject)
+    }
+    OPTIONAL {
+        ?matchingSubject a knora-base:ListNode .
+        ?matchingSubject knora-base:hasSubListNode* ?subListNode .
+        ?listValue knora-base:valueHasListNode ?subListNode .
+        ?subjectWithListValue ?predicate ?listValue .
+        FILTER NOT EXISTS {
+            ?matchingSubject knora-base:isDeleted true .
+        }
+        BIND(?listValue AS ?valueObject)
+    }
+    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
+    ?resource a ?resourceClass .
+    ?resourceClass rdfs:subClassOf* knora-base:Resource .
+    FILTER NOT EXISTS {
+        ?resource knora-base:isDeleted true .
+    }
+}
+
+GROUP BY ?resource
+ORDER BY ?resource
+OFFSET 0
+LIMIT 25

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__searchNoFilters.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__searchNoFilters.txt
@@ -1,6 +1,6 @@
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT DISTINCT ?resource
+SELECT ?resource
        (GROUP_CONCAT(IF(BOUND(?valueObject), STR(?valueObject), ""); SEPARATOR="") AS ?valueObjectConcat)
 WHERE {
     {
@@ -9,11 +9,10 @@ WHERE {
         }
     }
     OPTIONAL {
-        ?matchingSubject a ?valueObjectType .
-        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+        ?matchingSubject knora-base:valueCreationDate ?valueCreationDate .
+        FILTER NOT EXISTS { ?matchingSubject a knora-base:LinkValue . }
+        FILTER NOT EXISTS { ?matchingSubject a knora-base:ListValue . }
         ?containingResource ?property ?matchingSubject .
-        ?property rdfs:subPropertyOf* knora-base:hasValue .
         FILTER NOT EXISTS {
             ?matchingSubject knora-base:isDeleted true .
         }
@@ -30,8 +29,8 @@ WHERE {
         BIND(?listValue AS ?valueObject)
     }
     BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-    ?resource a ?resourceClass .
-    ?resourceClass rdfs:subClassOf* knora-base:Resource .
+    ?resource knora-base:creationDate ?resourceCreationDate .
+    
     FILTER NOT EXISTS {
         ?resource knora-base:isDeleted true .
     }

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__searchWithAllFilters.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__searchWithAllFilters.txt
@@ -1,6 +1,6 @@
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT DISTINCT ?resource
+SELECT ?resource
        (GROUP_CONCAT(IF(BOUND(?valueObject), STR(?valueObject), ""); SEPARATOR="") AS ?valueObjectConcat)
 WHERE {
     {
@@ -18,11 +18,10 @@ WHERE {
         }
     }
     OPTIONAL {
-        ?matchingSubject a ?valueObjectType .
-        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+        ?matchingSubject knora-base:valueCreationDate ?valueCreationDate .
+        FILTER NOT EXISTS { ?matchingSubject a knora-base:LinkValue . }
+        FILTER NOT EXISTS { ?matchingSubject a knora-base:ListValue . }
         ?containingResource ?property ?matchingSubject .
-        ?property rdfs:subPropertyOf* knora-base:hasValue .
         FILTER NOT EXISTS {
             ?matchingSubject knora-base:isDeleted true .
         }
@@ -39,10 +38,10 @@ WHERE {
         BIND(?listValue AS ?valueObject)
     }
     BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-    ?resource a ?resourceClass .
-    ?resourceClass rdfs:subClassOf* knora-base:Resource .
-    ?resourceClass rdfs:subClassOf* <http://www.knora.org/ontology/0001/anything#Thing> .
-    ?resource knora-base:attachedToProject <http://rdfh.ch/projects/0001> .
+    ?resource knora-base:creationDate ?resourceCreationDate .
+    ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> <http://rdfh.ch/projects/0001> .
+?resource a ?resourceClass .
+?resourceClass <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/0001/anything#Thing> .
     OPTIONAL {
         ?fileValueProp rdfs:subPropertyOf* knora-base:hasFileValue .
         ?resource ?fileValueProp ?valueObject .

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__searchWithAllFilters.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec__searchWithAllFilters.txt
@@ -1,0 +1,58 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?resource
+       (GROUP_CONCAT(IF(BOUND(?valueObject), STR(?valueObject), ""); SEPARATOR="") AS ?valueObjectConcat)
+WHERE {
+    {
+        SELECT DISTINCT ?matchingSubject WHERE {
+            ?matchingSubject <http://jena.apache.org/text#query> ("test search" 1000000) .
+    ?matchingSubject a knora-base:TextValue ;
+        knora-base:valueHasString ?literal ;
+        knora-base:valueHasStandoff ?standoffNode .
+    ?standoffNode a <http://www.knora.org/ontology/standoff#StandoffBoldTag> ;
+        knora-base:standoffTagHasStart ?start ;
+        knora-base:standoffTagHasEnd ?end .
+    BIND(SUBSTR(?literal, ?start+1, ?end - ?start) AS ?markedup)
+    FILTER REGEX(?markedup, "test", "i")
+    FILTER REGEX(?markedup, "search", "i")
+        }
+    }
+    OPTIONAL {
+        ?matchingSubject a ?valueObjectType .
+        ?valueObjectType rdfs:subClassOf* knora-base:Value .
+        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
+        ?containingResource ?property ?matchingSubject .
+        ?property rdfs:subPropertyOf* knora-base:hasValue .
+        FILTER NOT EXISTS {
+            ?matchingSubject knora-base:isDeleted true .
+        }
+        BIND(?matchingSubject AS ?valueObject)
+    }
+    OPTIONAL {
+        ?matchingSubject a knora-base:ListNode .
+        ?matchingSubject knora-base:hasSubListNode* ?subListNode .
+        ?listValue knora-base:valueHasListNode ?subListNode .
+        ?subjectWithListValue ?predicate ?listValue .
+        FILTER NOT EXISTS {
+            ?matchingSubject knora-base:isDeleted true .
+        }
+        BIND(?listValue AS ?valueObject)
+    }
+    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
+    ?resource a ?resourceClass .
+    ?resourceClass rdfs:subClassOf* knora-base:Resource .
+    ?resourceClass rdfs:subClassOf* <http://www.knora.org/ontology/0001/anything#Thing> .
+    ?resource knora-base:attachedToProject <http://rdfh.ch/projects/0001> .
+    OPTIONAL {
+        ?fileValueProp rdfs:subPropertyOf* knora-base:hasFileValue .
+        ?resource ?fileValueProp ?valueObject .
+    }
+    FILTER NOT EXISTS {
+        ?resource knora-base:isDeleted true .
+    }
+}
+
+GROUP BY ?resource
+ORDER BY ?resource
+OFFSET 50
+LIMIT 25

--- a/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
@@ -34,6 +34,8 @@ class AppConfigSpec extends ZIOSpecDefault {
           appConfig.triplestore.queryTimeout == Duration.ofSeconds(20),
           appConfig.triplestore.gravsearchTimeout == Duration.ofSeconds(120),
           appConfig.triplestore.searchTimeout == Duration.ofSeconds(60),
+          appConfig.v2.fulltextSearch.probe.cap == 250000,
+          appConfig.v2.fulltextSearch.probe.maxConcurrent == 8,
           appConfig.bcryptPasswordStrength == PasswordStrength.unsafeFrom(12).value,
           appConfig.instrumentationServerConfig.interval == Duration.ofSeconds(5),
           appConfig.filePermissionCache.ttl == Duration.ofMinutes(2),

--- a/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
@@ -33,6 +33,7 @@ class AppConfigSpec extends ZIOSpecDefault {
           appConfig.sipi.timeout == Duration.ofSeconds(120),
           appConfig.triplestore.queryTimeout == Duration.ofSeconds(20),
           appConfig.triplestore.gravsearchTimeout == Duration.ofSeconds(120),
+          appConfig.triplestore.searchTimeout == Duration.ofSeconds(60),
           appConfig.bcryptPasswordStrength == PasswordStrength.unsafeFrom(12).value,
           appConfig.instrumentationServerConfig.interval == Duration.ofSeconds(5),
           appConfig.filePermissionCache.ttl == Duration.ofMinutes(2),
@@ -56,6 +57,14 @@ class AppConfigSpec extends ZIOSpecDefault {
     },
     test("reject a file-permission-cache capacity below 1") {
       loadAppConfigWith("app.file-permission-cache.capacity = 0").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
+    test("reject a search-timeout that is not positive") {
+      loadAppConfigWith("app.triplestore.search-timeout = 0 seconds").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
+    test("reject a search-timeout above the gravsearch-timeout") {
+      loadAppConfigWith("app.triplestore.search-timeout = 121 seconds").exit
         .map(exit => assertTrue(exit.isFailure))
     },
   )

--- a/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
@@ -35,6 +35,8 @@ class AppConfigSpec extends ZIOSpecDefault {
           appConfig.triplestore.gravsearchTimeout == Duration.ofSeconds(120),
           appConfig.triplestore.searchTimeout == Duration.ofSeconds(60),
           appConfig.v2.fulltextSearch.probe.cap == 250000,
+          appConfig.v2.fulltextSearch.probe.cacheCapacity == 1024,
+          appConfig.v2.fulltextSearch.probe.cacheTtl == Duration.ofMinutes(10),
           appConfig.v2.fulltextSearch.probe.maxConcurrent == 8,
           appConfig.bcryptPasswordStrength == PasswordStrength.unsafeFrom(12).value,
           appConfig.instrumentationServerConfig.interval == Duration.ofSeconds(5),

--- a/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
@@ -77,6 +77,10 @@ class AppConfigSpec extends ZIOSpecDefault {
       loadAppConfigWith("app.v2.fulltext-search.probe.cache-capacity = 0").exit
         .map(exit => assertTrue(exit.isFailure))
     },
+    test("reject a probe cache-ttl that is not positive") {
+      loadAppConfigWith("app.v2.fulltext-search.probe.cache-ttl = 0 seconds").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
     test("reject a probe max-concurrent below 1") {
       loadAppConfigWith("app.v2.fulltext-search.probe.max-concurrent = 0").exit
         .map(exit => assertTrue(exit.isFailure))

--- a/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/config/AppConfigSpec.scala
@@ -69,6 +69,18 @@ class AppConfigSpec extends ZIOSpecDefault {
       loadAppConfigWith("app.triplestore.search-timeout = 121 seconds").exit
         .map(exit => assertTrue(exit.isFailure))
     },
+    test("reject a probe cap below 1") {
+      loadAppConfigWith("app.v2.fulltext-search.probe.cap = 0").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
+    test("reject a probe cache-capacity below 1") {
+      loadAppConfigWith("app.v2.fulltext-search.probe.cache-capacity = 0").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
+    test("reject a probe max-concurrent below 1") {
+      loadAppConfigWith("app.v2.fulltext-search.probe.max-concurrent = 0").exit
+        .map(exit => assertTrue(exit.isFailure))
+    },
   )
 
   // Loads the full application.conf, overriding the given HOCON keys, so a validation failure isolates to the override.

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/api/v2/search/SearchEndpointsSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/api/v2/search/SearchEndpointsSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.api.v2.search
+
+import org.junit.runner.RunWith
+import zio.*
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.slice.admin.domain.model.Email
+import org.knora.webapi.slice.admin.domain.model.User
+import org.knora.webapi.slice.admin.domain.model.UserIri
+import org.knora.webapi.slice.admin.domain.model.Username
+import org.knora.webapi.slice.common.api.BaseEndpoints
+import org.knora.webapi.slice.infrastructure.Jwt
+import org.knora.webapi.slice.security.Authenticator
+import org.knora.webapi.slice.security.AuthenticatorError
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class SearchEndpointsSpec extends ZIOSpecDefault {
+
+  // Stub authenticator -- these are contract tests over endpoint metadata, not security logic.
+  private val stubAuthenticator: Authenticator = new Authenticator {
+    def calculateCookieName(): String                                                         = "stub"
+    def invalidateToken(jwt: String): IO[AuthenticatorError, Unit]                            = ZIO.fail(AuthenticatorError.BadCredentials)
+    def parseToken(jwt: String): IO[AuthenticatorError, Jwt]                                  = ZIO.fail(AuthenticatorError.BadCredentials)
+    def authenticate(userIri: UserIri, password: String): IO[AuthenticatorError, (User, Jwt)] =
+      ZIO.fail(AuthenticatorError.BadCredentials)
+    def authenticate(username: Username, password: String): IO[AuthenticatorError, (User, Jwt)] =
+      ZIO.fail(AuthenticatorError.BadCredentials)
+    def authenticate(email: Email, password: String): IO[AuthenticatorError, (User, Jwt)] =
+      ZIO.fail(AuthenticatorError.BadCredentials)
+    def authenticate(jwtToken: String): IO[AuthenticatorError, User] = ZIO.fail(AuthenticatorError.BadCredentials)
+  }
+
+  private val endpoints = new SearchEndpoints(BaseEndpoints(stubAuthenticator))
+
+  // Tapir's `.show` renders each endpoint's error outputs, including the fixed status codes of its oneOf variants.
+  private val fullTextSearch      = endpoints.getFullTextSearch.endpoint.show
+  private val fullTextSearchCount = endpoints.getFullTextSearchCount.endpoint.show
+  private val searchByLabel       = endpoints.getSearchByLabel.endpoint.show
+  private val gravsearch          = endpoints.getGravsearch.endpoint.show
+
+  // HONEST-TIMEOUT (DEV-6864): the two fulltext routes translate a triplestore timeout into a 503, attached via
+  // errorOutVariantsPrepend on those endpoints only. These tests are the regression net for that being scoped to
+  // the fulltext routes and for the prepend not dropping the shared client-error variants.
+  override def spec: Spec[TestEnvironment, Any] = suite("SearchEndpoints HONEST-TIMEOUT contract (DEV-6864)")(
+    test("the fulltext search and count endpoints advertise a 503") {
+      assertTrue(
+        fullTextSearch.contains("503"),
+        fullTextSearchCount.contains("503"),
+      )
+    },
+    test("the 503 is attached only to the fulltext endpoints, not search-by-label or gravsearch") {
+      assertTrue(
+        !searchByLabel.contains("503"),
+        !gravsearch.contains("503"),
+      )
+    },
+    test("the fulltext endpoints keep their documented client-error variants (nothing dropped by prepending)") {
+      assertTrue(
+        fullTextSearch.contains("400"),
+        fullTextSearch.contains("404"),
+        fullTextSearchCount.contains("400"),
+      )
+    },
+  )
+}

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.search
+
+import org.junit.runner.RunWith
+import zio.*
+import zio.test.*
+import zio.test.Assertion.failsWithA
+
+import dsp.errors.BadRequestException
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.slice.search.FulltextBreadthGuard.BreadthKey
+import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class FulltextBreadthGuardSpec extends ZIOSpecDefault {
+
+  private val cap = 250000
+
+  private def guardWith(probe: BreadthKey => Task[Long]): UIO[FulltextBreadthGuard] =
+    FulltextBreadthGuard.make(cap, cacheCapacity = 16, cacheTtl = 1.minute, maxConcurrent = 4)(probe)
+
+  private val wildcard = LuceneQueryString("der*") // shouldProbe = true
+  private val single   = LuceneQueryString("der")  // shouldProbe = false
+
+  override def spec: Spec[TestEnvironment, Any] = suite("FulltextBreadthGuard")(
+    // The probe runs before the query and refuses over-cap, so the query is never reached — ZIO.never proves it.
+    test("refuses a query whose probed breadth exceeds the cap") {
+      for {
+        guard <- guardWith(_ => ZIO.succeed(cap.toLong + 1))
+        exit  <- guard.guarded(wildcard, None, None, None)(ZIO.never).exit
+      } yield assert(exit)(failsWithA[BadRequestException])
+    },
+    test("admits a query whose probed breadth is exactly at the cap") {
+      for {
+        guard  <- guardWith(_ => ZIO.succeed(cap.toLong))
+        result <- guard.guarded(wildcard, None, None, None)(ZIO.succeed("ok"))
+      } yield assertTrue(result == "ok")
+    },
+    test("fails open when the probe errors (the real query is untouched)") {
+      for {
+        guard  <- guardWith(_ => ZIO.fail(new RuntimeException("no lucene index")))
+        result <- guard.guarded(wildcard, None, None, None)(ZIO.succeed("ok"))
+      } yield assertTrue(result == "ok")
+    },
+    test("does not probe a single plain term, even one that would be refused") {
+      for {
+        probes <- Ref.make(0)
+        guard  <- guardWith(_ => probes.update(_ + 1).as(cap.toLong + 1))
+        result <- guard.guarded(single, None, None, None)(ZIO.succeed("ok"))
+        count  <- probes.get
+      } yield assertTrue(result == "ok", count == 0)
+    },
+  )
+}

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
@@ -27,8 +27,9 @@ class FulltextBreadthGuardSpec extends ZIOSpecDefault {
   private val single   = LuceneQueryString("der")  // shouldProbe = false
 
   override def spec: Spec[TestEnvironment, Any] = suite("FulltextBreadthGuard")(
-    // An over-cap probe refuses the search and interrupts the query; ZIO.never as the query proves it is
-    // interrupted rather than awaited (the raced-guard property — a serial guard would hang here).
+    // An over-cap probe refuses with a 400 even though the query never completes: the refusal comes from the
+    // probe decision winning the race, so a never-ending query does not block it. (That the losing query is
+    // actually interrupted is asserted separately below.)
     test("refuses a query whose probed breadth exceeds the cap") {
       for {
         guard <- guardWith(_ => ZIO.succeed(cap.toLong + 1))
@@ -73,6 +74,28 @@ class FulltextBreadthGuardSpec extends ZIOSpecDefault {
         exit        <- guard.guarded(wildcard, None, None, None)(query).exit
         _           <- interrupted.await
       } yield assert(exit)(failsWithA[BadRequestException])
+    },
+    // Forking the probe (rather than racing `cache.get` directly) must populate the single-flight cache even when
+    // the query wins the race first — the load-bearing reason `guarded` uses `forkDaemon`. Were it reverted to
+    // racing the lookup directly, the losing lookup would be interrupted and zio-cache evicts the entry on
+    // interruption, so the same key would re-probe. This asserts it does not: the probe runs exactly once across
+    // a query-wins call and a following same-key call that refuses from the cached breadth.
+    test("forking populates the single-flight cache even when the query wins the race") {
+      for {
+        probes  <- Ref.make(0)
+        started <- Promise.make[Nothing, Unit]
+        finish  <- Promise.make[Nothing, Unit]
+        // Over-cap probe, gated: count the call, signal it started, block until released, then report over-cap.
+        guard <- guardWith(_ => probes.update(_ + 1) *> started.succeed(()) *> finish.await.as(cap.toLong + 1))
+        // The query wins while the probe is still blocked, so this first call is admitted by timing.
+        first <- guard.guarded(wildcard, None, None, None)(ZIO.succeed("first"))
+        _     <- started.await // the forked probe is running (lookup in flight)
+        _     <- finish.succeed(())
+        // A second call for the same key must refuse from the cached over-cap breadth, not re-probe; ZIO.never as
+        // the query makes the cached decision win deterministically.
+        exit  <- guard.guarded(wildcard, None, None, None)(ZIO.never).exit
+        count <- probes.get
+      } yield assert(exit)(failsWithA[BadRequestException]) && assertTrue(first == "first", count == 1)
     },
   )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
@@ -26,6 +26,9 @@ class FulltextBreadthGuardSpec extends ZIOSpecDefault {
   private val wildcard = LuceneQueryString("der*") // shouldProbe = true
   private val single   = LuceneQueryString("der")  // shouldProbe = false
 
+  // A query failure unrelated to the breadth cap (stands in for e.g. a TriplestoreTimeoutException).
+  private final class QueryBoom extends Exception("boom")
+
   override def spec: Spec[TestEnvironment, Any] = suite("FulltextBreadthGuard")(
     // An over-cap probe refuses with a 400 even though the query never completes: the refusal comes from the
     // probe decision winning the race, so a never-ending query does not block it. (That the losing query is
@@ -96,6 +99,16 @@ class FulltextBreadthGuardSpec extends ZIOSpecDefault {
         exit  <- guard.guarded(wildcard, None, None, None)(ZIO.never).exit
         count <- probes.get
       } yield assert(exit)(failsWithA[BadRequestException]) && assertTrue(first == "first", count == 1)
+    },
+    // `raceFirst` (not `race`) is load-bearing: a query that fails while the decision is still parked on
+    // `ZIO.never` (under the cap, or the probe still pending) must propagate promptly. Under `race`, a
+    // first-completing failure waits for the other side — here the never-resolving decision — so the request
+    // would hang instead of surfacing the error. This pins that the query failure wins the race and surfaces.
+    test("propagates a query failure while the probe decision is still pending (raceFirst, not race)") {
+      for {
+        guard <- guardWith(_ => ZIO.never) // decision never resolves -> the query must decide the race
+        exit  <- guard.guarded(wildcard, None, None, None)(ZIO.fail(new QueryBoom)).exit
+      } yield assert(exit)(failsWithA[QueryBoom])
     },
   )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
@@ -30,13 +30,15 @@ class FulltextBreadthGuardSpec extends ZIOSpecDefault {
   private final class QueryBoom extends Exception("boom")
 
   override def spec: Spec[TestEnvironment, Any] = suite("FulltextBreadthGuard")(
-    // An over-cap probe refuses with a 400 even though the query never completes: the refusal comes from the
-    // probe decision winning the race, so a never-ending query does not block it. (That the losing query is
-    // actually interrupted is asserted separately below.)
-    test("refuses a query whose probed breadth exceeds the cap") {
+    // An over-cap probe refuses with a 400 and interrupts the still-running query — a query that never completes
+    // on its own does not hold the refusal up, and its onInterrupt firing proves it was actually freed.
+    test("refuses an over-cap term and interrupts the in-flight query") {
       for {
-        guard <- guardWith(_ => ZIO.succeed(cap.toLong + 1))
-        exit  <- guard.guarded(wildcard, None, None, None)(ZIO.never).exit
+        interrupted <- Promise.make[Nothing, Unit]
+        guard       <- guardWith(_ => ZIO.succeed(cap.toLong + 1))
+        query        = ZIO.never.onInterrupt(interrupted.succeed(()))
+        exit        <- guard.guarded(wildcard, None, None, None)(query).exit
+        _           <- interrupted.await
       } yield assert(exit)(failsWithA[BadRequestException])
     },
     test("admits a query whose probed breadth is exactly at the cap") {
@@ -59,56 +61,38 @@ class FulltextBreadthGuardSpec extends ZIOSpecDefault {
         count  <- probes.get
       } yield assertTrue(result == "ok", count == 0)
     },
-    // The raced guard must not serialise: an admitted query returns as soon as it succeeds, without waiting for
-    // the probe. The probe here never returns a breadth, so a serial guard would block on it forever.
-    test("an admitted query does not wait for the probe to finish (raced, not serial)") {
+    // The guard must not serialise: the query starts immediately, concurrently with the probe, rather than only
+    // after it. The probe here is gated open, yet the query still runs (signals `queryStarted`) — a serial guard
+    // that ran the probe first would block on the gate forever and `queryStarted.await` would deadlock.
+    test("starts the query concurrently with the probe (the query is not delayed by the probe)") {
       for {
-        guard  <- guardWith(_ => ZIO.never) // probe never completes
-        result <- guard.guarded(wildcard, None, None, None)(ZIO.succeed("ok"))
+        queryStarted <- Promise.make[Nothing, Unit]
+        probeGate    <- Promise.make[Nothing, Unit]
+        guard        <- guardWith(_ => probeGate.await.as(cap.toLong)) // probe blocks until released
+        query         = queryStarted.succeed(()) *> ZIO.succeed("ok")
+        fib          <- guard.guarded(wildcard, None, None, None)(query).fork
+        _            <- queryStarted.await                             // the query ran while the probe was still gated
+        _            <- probeGate.succeed(())
+        result       <- fib.join
       } yield assertTrue(result == "ok")
     },
-    // A refused search must free its in-flight query, not leave it running until it times out. The query's
-    // onInterrupt fulfils the promise; awaiting it proves the loser was actually interrupted.
-    test("a refused query interrupts the in-flight real query (frees the request)") {
+    // A query failure unrelated to the cap (a timeout, say) is surfaced once the probe admits the term.
+    test("propagates a query failure for an admitted term") {
       for {
-        interrupted <- Promise.make[Nothing, Unit]
-        guard       <- guardWith(_ => ZIO.succeed(cap.toLong + 1))
-        query        = ZIO.never.onInterrupt(interrupted.succeed(()))
-        exit        <- guard.guarded(wildcard, None, None, None)(query).exit
-        _           <- interrupted.await
-      } yield assert(exit)(failsWithA[BadRequestException])
-    },
-    // Forking the probe (rather than racing `cache.get` directly) must populate the single-flight cache even when
-    // the query wins the race first — the load-bearing reason `guarded` uses `forkDaemon`. Were it reverted to
-    // racing the lookup directly, the losing lookup would be interrupted and zio-cache evicts the entry on
-    // interruption, so the same key would re-probe. This asserts it does not: the probe runs exactly once across
-    // a query-wins call and a following same-key call that refuses from the cached breadth.
-    test("forking populates the single-flight cache even when the query wins the race") {
-      for {
-        probes  <- Ref.make(0)
-        started <- Promise.make[Nothing, Unit]
-        finish  <- Promise.make[Nothing, Unit]
-        // Over-cap probe, gated: count the call, signal it started, block until released, then report over-cap.
-        guard <- guardWith(_ => probes.update(_ + 1) *> started.succeed(()) *> finish.await.as(cap.toLong + 1))
-        // The query wins while the probe is still blocked, so this first call is admitted by timing.
-        first <- guard.guarded(wildcard, None, None, None)(ZIO.succeed("first"))
-        _     <- started.await // the forked probe is running (lookup in flight)
-        _     <- finish.succeed(())
-        // A second call for the same key must refuse from the cached over-cap breadth, not re-probe; ZIO.never as
-        // the query makes the cached decision win deterministically.
-        exit  <- guard.guarded(wildcard, None, None, None)(ZIO.never).exit
-        count <- probes.get
-      } yield assert(exit)(failsWithA[BadRequestException]) && assertTrue(first == "first", count == 1)
-    },
-    // `raceFirst` (not `race`) is load-bearing: a query that fails while the decision is still parked on
-    // `ZIO.never` (under the cap, or the probe still pending) must propagate promptly. Under `race`, a
-    // first-completing failure waits for the other side — here the never-resolving decision — so the request
-    // would hang instead of surfacing the error. This pins that the query failure wins the race and surfaces.
-    test("propagates a query failure while the probe decision is still pending (raceFirst, not race)") {
-      for {
-        guard <- guardWith(_ => ZIO.never) // decision never resolves -> the query must decide the race
+        guard <- guardWith(_ => ZIO.succeed(cap.toLong))
         exit  <- guard.guarded(wildcard, None, None, None)(ZIO.fail(new QueryBoom)).exit
       } yield assert(exit)(failsWithA[QueryBoom])
+    },
+    // Measured breadth is cached single-flight: a repeated term for the same key reuses the cached verdict and
+    // does not re-probe. The probe function is invoked exactly once across two calls.
+    test("caches the probed breadth so a repeated term does not re-probe") {
+      for {
+        probes <- Ref.make(0)
+        guard  <- guardWith(_ => probes.update(_ + 1).as(cap.toLong))
+        first  <- guard.guarded(wildcard, None, None, None)(ZIO.succeed("a"))
+        second <- guard.guarded(wildcard, None, None, None)(ZIO.succeed("b"))
+        count  <- probes.get
+      } yield assertTrue(first == "a", second == "b", count == 1)
     },
   )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextBreadthGuardSpec.scala
@@ -27,7 +27,8 @@ class FulltextBreadthGuardSpec extends ZIOSpecDefault {
   private val single   = LuceneQueryString("der")  // shouldProbe = false
 
   override def spec: Spec[TestEnvironment, Any] = suite("FulltextBreadthGuard")(
-    // The probe runs before the query and refuses over-cap, so the query is never reached — ZIO.never proves it.
+    // An over-cap probe refuses the search and interrupts the query; ZIO.never as the query proves it is
+    // interrupted rather than awaited (the raced-guard property — a serial guard would hang here).
     test("refuses a query whose probed breadth exceeds the cap") {
       for {
         guard <- guardWith(_ => ZIO.succeed(cap.toLong + 1))
@@ -53,6 +54,25 @@ class FulltextBreadthGuardSpec extends ZIOSpecDefault {
         result <- guard.guarded(single, None, None, None)(ZIO.succeed("ok"))
         count  <- probes.get
       } yield assertTrue(result == "ok", count == 0)
+    },
+    // The raced guard must not serialise: an admitted query returns as soon as it succeeds, without waiting for
+    // the probe. The probe here never returns a breadth, so a serial guard would block on it forever.
+    test("an admitted query does not wait for the probe to finish (raced, not serial)") {
+      for {
+        guard  <- guardWith(_ => ZIO.never) // probe never completes
+        result <- guard.guarded(wildcard, None, None, None)(ZIO.succeed("ok"))
+      } yield assertTrue(result == "ok")
+    },
+    // A refused search must free its in-flight query, not leave it running until it times out. The query's
+    // onInterrupt fulfils the promise; awaiting it proves the loser was actually interrupted.
+    test("a refused query interrupts the in-flight real query (frees the request)") {
+      for {
+        interrupted <- Promise.make[Nothing, Unit]
+        guard       <- guardWith(_ => ZIO.succeed(cap.toLong + 1))
+        query        = ZIO.never.onInterrupt(interrupted.succeed(()))
+        exit        <- guard.guarded(wildcard, None, None, None)(query).exit
+        _           <- interrupted.await
+      } yield assert(exit)(failsWithA[BadRequestException])
     },
   )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextSearchTermsSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextSearchTermsSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.search
+
+import org.junit.runner.RunWith
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class FulltextSearchTermsSpec extends ZIOSpecDefault {
+
+  private val minLength               = 3
+  private def tooShort(query: String) = FulltextSearchTerms.tooShortWildcardTerms(LuceneQueryString(query), minLength)
+
+  override def spec: Spec[TestEnvironment, Any] = suite("FulltextSearchTerms.tooShortWildcardTerms")(
+    test("rejects a wildcard term with fewer than 3 literal characters") {
+      assertTrue(tooShort("de*") == Seq("de*"))
+    },
+    test("admits a wildcard term with 3 or more literal characters") {
+      assertTrue(tooShort("Alice*").isEmpty)
+    },
+    test("rejects a short wildcard term even when a long plain term follows it (Lucene ORs terms)") {
+      assertTrue(tooShort("de* Alice") == Seq("de*"))
+    },
+    test("admits an advertised boolean OR chain (OR is two characters but carries no wildcard)") {
+      assertTrue(tooShort("Alice OR Wonderland").isEmpty)
+    },
+    test("admits a quoted phrase without splitting it on spaces") {
+      assertTrue(tooShort(""""down the rabbit hole"""").isEmpty)
+    },
+    test("counts a single-character wildcard's literal characters, admitting Unif?rm") {
+      assertTrue(tooShort("Unif?rm").isEmpty)
+    },
+    test("admits a short plain term, which the whole-string minimum governs, not this rule") {
+      assertTrue(tooShort("is Alice").isEmpty)
+    },
+  )
+}

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextSearchTermsSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/FulltextSearchTermsSpec.scala
@@ -39,5 +39,17 @@ class FulltextSearchTermsSpec extends ZIOSpecDefault {
     test("admits a short plain term, which the whole-string minimum governs, not this rule") {
       assertTrue(tooShort("is Alice").isEmpty)
     },
+    test("does not probe a single plain term") {
+      assertTrue(!FulltextSearchTerms.shouldProbe(LuceneQueryString("der")))
+    },
+    test("does not probe a single quoted phrase") {
+      assertTrue(!FulltextSearchTerms.shouldProbe(LuceneQueryString(""""down the rabbit hole"""")))
+    },
+    test("probes a wildcard term") {
+      assertTrue(FulltextSearchTerms.shouldProbe(LuceneQueryString("der*")))
+    },
+    test("probes a multi-term query") {
+      assertTrue(FulltextSearchTerms.shouldProbe(LuceneQueryString("der und")))
+    },
   )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec.scala
@@ -120,6 +120,16 @@ class SearchFulltextQuerySpec extends ZIOSpecDefault with GoldenTest {
         assertGolden(sparql, "searchWithAllFilters")
       },
     ),
+    suite("probe query")(
+      test("probe query without standoff") {
+        val sparql = SearchFulltextQuery.buildProbe(searchTerms, None)
+        assertGolden(sparql, "probeNoStandoff")
+      },
+      test("probe query with standoff") {
+        val sparql = SearchFulltextQuery.buildProbe(LuceneQueryString("test search"), Some(testStandoffIri))
+        assertGolden(sparql, "probeWithStandoff")
+      },
+    ),
     suite("escaping of user input")(
       test("apostrophe in search term is correctly escaped") {
         // The caller passes the raw user input — Rdf.literalOf handles SPARQL escaping.

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/search/repo/SearchFulltextQuerySpec.scala
@@ -6,10 +6,14 @@
 package org.knora.webapi.slice.search.repo
 
 import org.junit.runner.RunWith
+import zio.IO
+import zio.Runtime
+import zio.Unsafe
 import zio.test.*
 
 import dsp.errors.SparqlGenerationException
 import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.GoldenTest
 import org.knora.webapi.messages.IriConversions.ConvertibleIri
 import org.knora.webapi.messages.StringFormatter
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
@@ -17,7 +21,7 @@ import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 import org.knora.webapi.util.ApacheLuceneSupport.LuceneQueryString
 
 @RunWith(classOf[DspZTestJUnitRunner])
-class SearchFulltextQuerySpec extends ZIOSpecDefault {
+class SearchFulltextQuerySpec extends ZIOSpecDefault with GoldenTest {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
@@ -26,263 +30,94 @@ class SearchFulltextQuerySpec extends ZIOSpecDefault {
   private val testResourceIri =
     ResourceClassIri.unsafeFrom("http://www.knora.org/ontology/0001/anything#Thing".toSmartIri)
   private val testStandoffIri = "http://www.knora.org/ontology/standoff#StandoffBoldTag".toSmartIri
+  private val separator       = '\u001F'
 
+  // `build` is effectful but pure for valid arguments; render it to a String and pass that expression straight to
+  // `assertGolden`. A bare local val bound to the result collides with `assertGolden`'s own `actual` parameter during
+  // inlining and makes its `assertTrue` macro lose the source position (a None.get in zio-test's showExpr).
+  private def render(query: IO[SparqlGenerationException, String]): String =
+    Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(query).getOrThrow())
+
+  // Invariants these goldens exist to protect. A golden pins the query text and cannot tell a correct query from a
+  // plausible one — check them by eye when regenerating:
+  //
+  //  - The text:query list must carry an explicit hit limit (1000000). Without one Jena caps the Lucene lookup at
+  //    10'000 hits and silently drops matches before the project/class filters apply (DEV-6716, DEV-6822).
+  //  - The class restriction must use rdfs:subClassOf* — never subClassOf?. The subclass closure is not materialised
+  //    and there is no query-time inference, so zero-or-one silently excludes every class more than one hop below the
+  //    target (DEV-6833). `?resource a ?resourceClass` is emitted only when a class restriction is requested.
+  //  - Resource-ness is asserted via knora-base:creationDate, not a subClassOf* walk to knora-base:Resource; the
+  //    value branch asserts value-ness via knora-base:valueCreationDate. Both replace per-hit property-path walks
+  //    that DEV-6864 measured at 2.2-6.3x their cost for identical results. See SearchFulltextQuery and DEV-6850.
+  //  - There is no outer SELECT DISTINCT: GROUP BY ?resource already deduplicates. The inner SELECT DISTINCT
+  //    ?matchingSubject and the count branch's COUNT(DISTINCT ?resource) stay (DEV-6809 (d)).
   override def spec: Spec[TestEnvironment, Any] = suite("SearchFulltextQuery")(
     suite("count query")(
       test("minimal count query") {
-        val actual = SearchFulltextQuery.build(
-          searchTerms = searchTerms,
-          limitToProject = None,
-          limitToResourceClass = None,
-          limitToStandoffClass = None,
-          returnFiles = false,
-          separator = None,
-          limit = 1,
-          offset = 0,
-          countQuery = true,
-        )
-        assertZIO(actual)(
-          Assertion.equalTo(
-            """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-              |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-              |SELECT (COUNT(DISTINCT ?resource) AS ?count)
-              |WHERE {
-              |    {
-              |        SELECT DISTINCT ?matchingSubject WHERE {
-              |            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
-              |        }
-              |    }
-              |    OPTIONAL {
-              |        ?matchingSubject a ?valueObjectType .
-              |        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-              |        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
-              |        ?containingResource ?property ?matchingSubject .
-              |        ?property rdfs:subPropertyOf* knora-base:hasValue .
-              |        FILTER NOT EXISTS {
-              |            ?matchingSubject knora-base:isDeleted true .
-              |        }
-              |        BIND(?matchingSubject AS ?valueObject)
-              |    }
-              |    OPTIONAL {
-              |        ?matchingSubject a knora-base:ListNode .
-              |        ?matchingSubject knora-base:hasSubListNode* ?subListNode .
-              |        ?listValue knora-base:valueHasListNode ?subListNode .
-              |        ?subjectWithListValue ?predicate ?listValue .
-              |        FILTER NOT EXISTS {
-              |            ?matchingSubject knora-base:isDeleted true .
-              |        }
-              |        BIND(?listValue AS ?valueObject)
-              |    }
-              |    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-              |    ?resource a ?resourceClass .
-              |    ?resourceClass rdfs:subClassOf* knora-base:Resource .
-              |    FILTER NOT EXISTS {
-              |        ?resource knora-base:isDeleted true .
-              |    }
-              |}
-              |
-              |LIMIT 1
-              |""".stripMargin,
+        val sparql = render(
+          SearchFulltextQuery.build(
+            searchTerms = searchTerms,
+            limitToProject = None,
+            limitToResourceClass = None,
+            limitToStandoffClass = None,
+            returnFiles = false,
+            separator = None,
+            limit = 1,
+            offset = 0,
+            countQuery = true,
           ),
         )
+        assertGolden(sparql, "countNoFilters")
       },
       test("count query with project and resource class limit") {
-        val actual = SearchFulltextQuery.build(
-          searchTerms = searchTerms,
-          limitToProject = Some(testProjectIri),
-          limitToResourceClass = Some(testResourceIri),
-          limitToStandoffClass = None,
-          returnFiles = false,
-          separator = None,
-          limit = 1,
-          offset = 0,
-          countQuery = true,
-        )
-        assertZIO(actual)(
-          Assertion.equalTo(
-            """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-              |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-              |SELECT (COUNT(DISTINCT ?resource) AS ?count)
-              |WHERE {
-              |    {
-              |        SELECT DISTINCT ?matchingSubject WHERE {
-              |            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
-              |        }
-              |    }
-              |    OPTIONAL {
-              |        ?matchingSubject a ?valueObjectType .
-              |        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-              |        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
-              |        ?containingResource ?property ?matchingSubject .
-              |        ?property rdfs:subPropertyOf* knora-base:hasValue .
-              |        FILTER NOT EXISTS {
-              |            ?matchingSubject knora-base:isDeleted true .
-              |        }
-              |        BIND(?matchingSubject AS ?valueObject)
-              |    }
-              |    OPTIONAL {
-              |        ?matchingSubject a knora-base:ListNode .
-              |        ?matchingSubject knora-base:hasSubListNode* ?subListNode .
-              |        ?listValue knora-base:valueHasListNode ?subListNode .
-              |        ?subjectWithListValue ?predicate ?listValue .
-              |        FILTER NOT EXISTS {
-              |            ?matchingSubject knora-base:isDeleted true .
-              |        }
-              |        BIND(?listValue AS ?valueObject)
-              |    }
-              |    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-              |    ?resource a ?resourceClass .
-              |    ?resourceClass rdfs:subClassOf* knora-base:Resource .
-              |    ?resourceClass rdfs:subClassOf* <http://www.knora.org/ontology/0001/anything#Thing> .
-              |    ?resource knora-base:attachedToProject <http://rdfh.ch/projects/0001> .
-              |    FILTER NOT EXISTS {
-              |        ?resource knora-base:isDeleted true .
-              |    }
-              |}
-              |
-              |LIMIT 1
-              |""".stripMargin,
+        val sparql = render(
+          SearchFulltextQuery.build(
+            searchTerms = searchTerms,
+            limitToProject = Some(testProjectIri),
+            limitToResourceClass = Some(testResourceIri),
+            limitToStandoffClass = None,
+            returnFiles = false,
+            separator = None,
+            limit = 1,
+            offset = 0,
+            countQuery = true,
           ),
         )
+        assertGolden(sparql, "countWithProjectAndClass")
       },
     ),
     suite("regular query")(
       test("minimal regular query") {
-        val actual = SearchFulltextQuery.build(
-          searchTerms = searchTerms,
-          limitToProject = None,
-          limitToResourceClass = None,
-          limitToStandoffClass = None,
-          returnFiles = false,
-          separator = Some('\u001F'),
-          limit = 25,
-          offset = 0,
-          countQuery = false,
-        )
-        assertZIO(actual)(
-          Assertion.equalTo(
-            s"""PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-               |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-               |SELECT DISTINCT ?resource
-               |       (GROUP_CONCAT(IF(BOUND(?valueObject), STR(?valueObject), ""); SEPARATOR="\u001F") AS ?valueObjectConcat)
-               |WHERE {
-               |    {
-               |        SELECT DISTINCT ?matchingSubject WHERE {
-               |            ?matchingSubject <http://jena.apache.org/text#query> ("test" 1000000) .
-               |        }
-               |    }
-               |    OPTIONAL {
-               |        ?matchingSubject a ?valueObjectType .
-               |        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-               |        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
-               |        ?containingResource ?property ?matchingSubject .
-               |        ?property rdfs:subPropertyOf* knora-base:hasValue .
-               |        FILTER NOT EXISTS {
-               |            ?matchingSubject knora-base:isDeleted true .
-               |        }
-               |        BIND(?matchingSubject AS ?valueObject)
-               |    }
-               |    OPTIONAL {
-               |        ?matchingSubject a knora-base:ListNode .
-               |        ?matchingSubject knora-base:hasSubListNode* ?subListNode .
-               |        ?listValue knora-base:valueHasListNode ?subListNode .
-               |        ?subjectWithListValue ?predicate ?listValue .
-               |        FILTER NOT EXISTS {
-               |            ?matchingSubject knora-base:isDeleted true .
-               |        }
-               |        BIND(?listValue AS ?valueObject)
-               |    }
-               |    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-               |    ?resource a ?resourceClass .
-               |    ?resourceClass rdfs:subClassOf* knora-base:Resource .
-               |    FILTER NOT EXISTS {
-               |        ?resource knora-base:isDeleted true .
-               |    }
-               |}
-               |
-               |GROUP BY ?resource
-               |ORDER BY ?resource
-               |OFFSET 0
-               |LIMIT 25
-               |""".stripMargin,
+        val sparql = render(
+          SearchFulltextQuery.build(
+            searchTerms = searchTerms,
+            limitToProject = None,
+            limitToResourceClass = None,
+            limitToStandoffClass = None,
+            returnFiles = false,
+            separator = Some(separator),
+            limit = 25,
+            offset = 0,
+            countQuery = false,
           ),
         )
+        assertGolden(sparql, "searchNoFilters")
       },
       test("regular query with all filters") {
-        val actual = SearchFulltextQuery.build(
-          searchTerms = LuceneQueryString("test search"),
-          limitToProject = Some(testProjectIri),
-          limitToResourceClass = Some(testResourceIri),
-          limitToStandoffClass = Some(testStandoffIri),
-          returnFiles = true,
-          separator = Some('\u001F'),
-          limit = 25,
-          offset = 50,
-          countQuery = false,
-        )
-        assertZIO(actual)(
-          Assertion.equalTo(
-            s"""PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-               |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-               |SELECT DISTINCT ?resource
-               |       (GROUP_CONCAT(IF(BOUND(?valueObject), STR(?valueObject), ""); SEPARATOR="\u001F") AS ?valueObjectConcat)
-               |WHERE {
-               |    {
-               |        SELECT DISTINCT ?matchingSubject WHERE {
-               |            ?matchingSubject <http://jena.apache.org/text#query> ("test search" 1000000) .
-               |    ?matchingSubject a knora-base:TextValue ;
-               |        knora-base:valueHasString ?literal ;
-               |        knora-base:valueHasStandoff ?standoffNode .
-               |    ?standoffNode a <http://www.knora.org/ontology/standoff#StandoffBoldTag> ;
-               |        knora-base:standoffTagHasStart ?start ;
-               |        knora-base:standoffTagHasEnd ?end .
-               |    BIND(SUBSTR(?literal, ?start+1, ?end - ?start) AS ?markedup)
-               |    FILTER REGEX(?markedup, "test", "i")
-               |    FILTER REGEX(?markedup, "search", "i")
-               |        }
-               |    }
-               |    OPTIONAL {
-               |        ?matchingSubject a ?valueObjectType .
-               |        ?valueObjectType rdfs:subClassOf* knora-base:Value .
-               |        FILTER(?valueObjectType != knora-base:LinkValue && ?valueObjectType != knora-base:ListValue)
-               |        ?containingResource ?property ?matchingSubject .
-               |        ?property rdfs:subPropertyOf* knora-base:hasValue .
-               |        FILTER NOT EXISTS {
-               |            ?matchingSubject knora-base:isDeleted true .
-               |        }
-               |        BIND(?matchingSubject AS ?valueObject)
-               |    }
-               |    OPTIONAL {
-               |        ?matchingSubject a knora-base:ListNode .
-               |        ?matchingSubject knora-base:hasSubListNode* ?subListNode .
-               |        ?listValue knora-base:valueHasListNode ?subListNode .
-               |        ?subjectWithListValue ?predicate ?listValue .
-               |        FILTER NOT EXISTS {
-               |            ?matchingSubject knora-base:isDeleted true .
-               |        }
-               |        BIND(?listValue AS ?valueObject)
-               |    }
-               |    BIND(COALESCE(?containingResource, ?subjectWithListValue, ?matchingSubject) AS ?resource)
-               |    ?resource a ?resourceClass .
-               |    ?resourceClass rdfs:subClassOf* knora-base:Resource .
-               |    ?resourceClass rdfs:subClassOf* <http://www.knora.org/ontology/0001/anything#Thing> .
-               |    ?resource knora-base:attachedToProject <http://rdfh.ch/projects/0001> .
-               |    OPTIONAL {
-               |        ?fileValueProp rdfs:subPropertyOf* knora-base:hasFileValue .
-               |        ?resource ?fileValueProp ?valueObject .
-               |    }
-               |    FILTER NOT EXISTS {
-               |        ?resource knora-base:isDeleted true .
-               |    }
-               |}
-               |
-               |GROUP BY ?resource
-               |ORDER BY ?resource
-               |OFFSET 50
-               |LIMIT 25
-               |""".stripMargin,
+        val sparql = render(
+          SearchFulltextQuery.build(
+            searchTerms = LuceneQueryString("test search"),
+            limitToProject = Some(testProjectIri),
+            limitToResourceClass = Some(testResourceIri),
+            limitToStandoffClass = Some(testStandoffIri),
+            returnFiles = true,
+            separator = Some(separator),
+            limit = 25,
+            offset = 50,
+            countQuery = false,
           ),
         )
+        assertGolden(sparql, "searchWithAllFilters")
       },
     ),
     suite("escaping of user input")(


### PR DESCRIPTION
[DEV-6864](https://linear.app/dasch/issue/DEV-6864)

## Summary

Fixes the HTTP 500 regression on `/v2/search/{term}` and `/v2/search/count/{term}` for common
terms (`der`, `und`, …). PR #4207 removed Jena's accidental 10k-hit Lucene cap on the fulltext
route but did not port #4216's query optimisations, so the fulltext query absorbed a 10–100×
increase in post-Lucene rows on the 20s tier and timed out. On the stage prod-mirror, `count/der`
now returns **200 in ~11s** (was 500 after 20s), with correct counts.

This is the dsp-api half only. The dsp-app half (client-side validation, Search-tips rewording,
error state — plan Phase 5, closes DEV-6866) is a separate follow-up; the API rule is the enforcement.

## Changes

**Query (the fix):**
- **REWRITE** — replace the per-hit `rdfs:subClassOf*` / `subPropertyOf*` walks in
  `SearchFulltextQuery` with `creationDate` / `valueCreationDate` bound-subject probes; the class
  type-join is now conditional on a class restriction (still walking the full `subClassOf*` closure,
  DEV-6833); drop the no-op outer `DISTINCT`. `count/der` 82.50s → 13.09s, byte-identical counts.
- **60s search tier** (`SparqlTimeout.Search`) for the prequery and count, correcting the inverted
  budget (they ran on 20s while the following main query got 120s).

**Over-broad input, defence in depth:**
- **LITERAL-LENGTH** — reject a wildcard term with < 3 literal characters (`de*`) with a 400 before
  any query runs; fulltext-route only, phrase-aware.
- **PROBE** — for wildcard / multi-term queries, a fast `COUNT` of the Lucene candidate set refuses
  a search over a 250,000 cap with a 400 (serial, cached, fails open). Refuses the 434k wildcard
  chain in ~3.5s instead of a 60s timeout.
- **HONEST-TIMEOUT** — a fulltext timeout now returns 503 with a hedged message instead of a bare
  500 (per-endpoint variant, not the shared contract); the sttp read-timeout classification bug that
  made it a 500 is fixed.

**Observability & docs:** `isSearch` metric tag; term-naming timeout log; timeout-tier and
`matchFulltext`-cap doc corrections; engine Fact 11 data point.

## Test Plan

- Full suites green: `//modules/webapi:test` **1653**, `//modules/test-it:test` **814**,
  `//modules/test-e2e:test` **886**; `just check` (scalafmt + license + no-relative-imports) clean.
  New specs: golden conversion, restricted-search integration, LITERAL-LENGTH, PROBE guard, 503 contract.
- A multi-agent adversarial review (scala-zio / consistency / performance / security) ran over the diff:
  7 findings, 6 refuted on verification, 1 confirmed and fixed (bounds-guards on the env-overridable probe
  config knobs).
- Output equivalence proven: golden diff reviewed; full-RDF-model-equality + count-parity e2e green.
- **Stage prod-mirror re-measurement** (db.stage.dasch.swiss, 115M triples): `der` count 91,535 in
  ~11.4s warm; `Bild` 35,004 (correct, not the truncated 10,151); `Brief` 3,990 / `Universal` 893
  unchanged; PROBE breadth `der` 131k / `the*` 158k / `der und` 183k admitted, `der und die das ein
  sch* the*` 434k refused. All 200.