### PR TITLE
chore(ci): add a dedicated Claude review job with a false-flag-resistant prompt

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,14 +10,159 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Prevent multiple Claude runs on the same PR or issue from interfering with each other
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.event.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
-  claude:
+  # Job 1: Dedicated code review with a predefined prompt, triggered by '@claude review' on a PR
+  claude-code-review:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'assigned') && contains(github.event.issue.body, '@claude'))
+      (github.event.issue.pull_request || github.event.pull_request) &&
+      (contains(github.event.comment.body, '@claude review') || contains(github.event.review.body, '@claude review'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number)) || (github.event.pull_request && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+
+            Review this pull request for correctness, security, performance, and test coverage.
+
+            Read `REVIEW.md` at the repository root before you start. It is the review-phase
+            checklist for this repository and its rules override the defaults below; it also points
+            to `CONVENTIONS.md` and `docs/development/` for the authoritative detail. Honour its
+            "Skip" section — do not spend the run on Scalafmt-only diffs, `CHANGELOG.md` /
+            version-bump commits, generated sources, or legacy `responders/` code paths that the PR
+            is not migrating.
+
+            ## Scope
+
+            Report issues **only in lines this PR changed**. But READ WHATEVER YOU NEED to decide
+            whether an issue is real: open the changed files in full (the diff hunks alone give too
+            little surrounding context), plus their callers, their tests, neighbouring
+            implementations of the same pattern, and read-only git history. Reading widely is
+            required; reporting widely is not.
+
+            ## Every finding must survive this test
+
+            Name the concrete input or state that triggers it, and the wrong output, crash, or
+            regression that results.
+
+            DELETE — do not downgrade — any finding where:
+            - you cannot name a specific input and a specific wrong outcome;
+            - the justification is "more robust", "best practice", or "could break if X" where X
+              does not occur in this codebase;
+            - the code is already correct under Scala 3 or ZIO semantics — an effect that looks
+              unexecuted is being composed rather than dropped, a narrowed error channel already
+              excludes the case, an `Option` / `Either` is destructured by an exhaustive match, or a
+              value object's `from` has already validated the input;
+            - it is a deliberate decision explained in a comment (read the comment before flagging).
+
+            Three defensible findings beat twelve speculative ones. Reporting no findings is a
+            valid and useful outcome.
+
+            ## Verify every Critical or Major finding before reporting it
+
+            Spawn a separate agent per finding to attack it. Give that agent the finding, the file
+            and the surrounding code — but NOT the reasoning that led you to suspect it, so its
+            judgement is not shaped by yours. Instruct it to argue the finding is WRONG, to check
+            the claim against the source, and to default to "refuted" where the evidence is
+            ambiguous. Drop every finding its verifier refutes.
+
+            If you cannot spawn agents at all, do NOT check the findings yourself and do NOT post a
+            review. Post only a short error stating that subagents were unavailable and what
+            happened when you tried. A review that reads as verified but was not is worse than no
+            review, and quietly falling back to self-checking restores the exact anchoring this
+            section exists to remove.
+
+            If an individual spawn fails, retry it once; if it fails again keep that finding but
+            label it `unverified` and carry on. One flaky spawn should not sink a whole review.
+
+            Apply the deletion test to Minor findings without a verifier.
+
+            Work inside the job's time budget: verify in descending order of severity, and if you
+            run short, report the remaining findings explicitly marked as unverified rather than
+            letting the run time out. A partial review is useful; a timed-out one is not.
+
+            ## Checking claims about libraries
+
+            Do not assert an API contract from memory. When a finding depends on how a dependency
+            behaves — a method signature, a ZIO or Tapir combinator's semantics, a documented limit
+            — confirm it against the version this repo actually builds against
+            (`project/Dependencies.scala`, `build.sbt`) or against the library's own documentation
+            via web search. An unverified claim about a dependency is a finding to delete, not to
+            report.
+
+            ## Test coverage
+
+            For a bug fix, check that a test exists which would FAIL without the change — name it,
+            or state that none exists. Tests live in `webapi/src/test/scala/` (unit),
+            `modules/test-it/src/test/scala/` (integration) and `modules/test-e2e/src/test/scala/`
+            (end-to-end), so look in all three before concluding a fix is untested. Do not ask for
+            tests that only restate an implementation line or assert a config value.
+
+            ## Output
+
+            1. One-paragraph summary of what the PR does.
+            2. Findings, most severe first. For each: `file:line`, the failure scenario, and the
+               fix. Grade Critical / Major / Minor, where Critical means a bug, security hole, or
+               regression that reaches users.
+            3. Ready to merge: yes or no, based **only** on Critical findings.
+
+            Be precise and concise. Do **not** change code, push, or run build, test or `sbt`
+            commands — you cannot compile this project and must not claim to have.
+            Use `gh pr comment` to leave your review as a comment on the PR.
+
+          # Reading files is already in the action's base tool set; search, web lookup and Task are
+          # not, and the prompt above depends on all three — Grep/Glob to confirm a suspicion across
+          # the repo, WebSearch/WebFetch to check a dependency's real API instead of recalling it,
+          # and Task to verify findings in an agent that has not seen the reasoning behind them.
+          # Bash stays confined to read-only gh commands, so no path to secrets is opened.
+          claude_args: '--allowed-tools "Grep,Glob,WebSearch,WebFetch,Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            gh issue comment "$PR_NUMBER" --body "⚠️ Claude Code Review failed. Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  # Job 2: General Claude assistant (flexible), triggered by '@claude <PROMPT>' on PRs, issues etc.
+  # The negated clause is exactly job 1's condition, so the two jobs are mutually exclusive by
+  # construction, while '@claude review' on a plain issue — where job 1 cannot run — still lands here.
+  claude-general:
+    if: |
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'assigned') && contains(github.event.issue.body, '@claude'))
+      ) &&
+      !(
+        (github.event.issue.pull_request || github.event.pull_request) &&
+        (contains(github.event.comment.body, '@claude review') || contains(github.event.review.body, '@claude review'))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -31,3 +176,13 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            gh issue comment "$PR_NUMBER" --body "⚠️ Claude Code failed. Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Ports the review-prompt hardening from [dsp-app#3300](https://github.com/dasch-swiss/dsp-app/pull/3300) to this repository.

## Why this is bigger than the source PR

dsp-app#3300 edited the prompt and `--allowed-tools` of a `claude-code-review` job that repo already had. **This repository has no such job** — `claude.yml` was a single bare `@claude` passthrough with no prompt, no timeout, no concurrency group and no failure notification. There was nothing here to apply the prompt change *to*, so this PR ports the whole job.

## What the prompt does differently

| | Before (no review job existed) | After |
|---|---|---|
| Reading vs. reporting | — | report only on changed lines; read callers, tests, neighbouring implementations and read-only history freely |
| Diff context | — | read changed files in full (`gh pr diff` shows 3 lines of context) |
| Finding bar | — | name a triggering input and a wrong outcome |
| Weak findings | — | **deleted**, not downgraded to Minor; "no findings" stated to be valid |
| Verification | — | a **separate agent per Critical/Major finding**, given the code but *not* the reasoning behind the suspicion, told to argue the finding is wrong and default to "refuted" when ambiguous |
| Subagents unavailable | — | hard stop: short error, no review |
| Dependency claims | — | verified against `project/Dependencies.scala` / `build.sbt` or the library's docs, or deleted |
| Guidance file | — | `REVIEW.md`, read up front |

The two load-bearing ideas: a Critical/Major/Minor taxonomy with no floor invites padding, because anything noticed can be filed as Minor rather than dropped; and an agent that has just built the case for a finding is a poor judge of it, so verification goes to an agent that never saw the reasoning.

## Adapted for this repository

- **Deletion test names Scala 3 / ZIO semantics** that commonly read as bugs but are not — a composed effect that looks unexecuted, an error channel already narrowed past the case, an exhaustively matched `Option`/`Either`, a value object whose `from` already validated the input.
- **Dependency claims** check `project/Dependencies.scala` and `build.sbt` instead of dsp-app's `node_modules` / lock file.
- **All three test roots named** (`webapi/src/test`, `modules/test-it`, `modules/test-e2e`) so a fix is not declared untested after looking in one.
- **`REVIEW.md` is read unconditionally**, not "if present" — it exists here (dsp-app still lacks one, tracked as DEV-6879). Its "Skip" section is what keeps the run off Scalafmt-only diffs, `release-please` commits, generated sources and legacy `responders/` paths.
- **"Do not run commands"** is narrowed to build/test/`sbt` — the reviewer must run `gh` commands, and the old blanket wording contradicted that.

## Infrastructure this repository lacked

Concurrency group, `timeout-minutes: 15`, checkout of the PR head ref, and failure notification on both jobs. `actions/checkout@v5` matches the other ten uses in this repository (dsp-app is on `@v7`; repo consistency wins here).

The existing job becomes `claude-general`. Its `if:` gains a negated clause that is *exactly* job 1's condition, so the two are mutually exclusive by construction while `@claude review` on a plain issue — where the review job cannot run — still reaches the general job. This is a small improvement over dsp-app, whose blanket exclusion drops that case.

Its `contents: write` is **kept as-is**, so no existing capability is removed. Worth a separate decision: the review job runs at `contents: read`, and a comment-triggered job that can push is a wider surface than a reviewer needs.

## Known risk: `Task` is undocumented for `claude-code-action`

The prompt's verification pass depends on `Task`, which does not appear in the action's `--allowedTools` documentation, and the design deliberately **hard-fails rather than silently self-checking** if subagents are unavailable. So the first `@claude review` here either produces a verified review or an explicit error — not a plausible-looking unverified one.

Two data points, neither conclusive:

- dsp-app has had **no successful review run since #3300 merged** (both successes in its recent history predate the merge), so the sibling repo has not answered this either.
- The action's own docs use `--disallowedTools "TaskOutput,KillTask"` ([configuration.md:240](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md)) — the companions to `Task`. You do not disallow tools the runtime lacks, which is reasonable evidence the agent machinery is present.

## Timeout

`timeout-minutes: 15`, matching dsp-app, which measured 2 min median / 6 min p90 / 14 min max across 128 runs of the same action and a near-identical prompt. **This repository has no usable baseline** — `claude.yml`'s last 60 runs are 59 skipped and 1 success at 2.5 min. Picking a different number without data would be arbitrary, and the prompt already instructs partial-report-over-timeout. If 15 proves tight on large Scala PRs it is a one-line bump.

## What this does not fix

The reviewer cannot run `sbt`, tests, or the build — `Bash` stays confined to read-only `gh` patterns — so any claim about runtime behaviour is unverified by construction. Granting `Bash(sbt *)` would let a comment-triggered job execute repository code, which is not a trade worth making.

`WebSearch`/`WebFetch` widen the prompt-injection surface, since a diff or comment could induce a fetch to an attacker-chosen URL. The job cannot push and `Bash` reaches no secrets, so the realistic worst case is a wasted run.

Neither job has author gating: any account that can comment can trigger a run and spend the org's API key. Out of scope here — dsp-app tracks the same gap as DEV-6884.

## Test plan

- `actionlint` 1.7.12 passes clean on the workflow (exit 0) — this validates the GitHub expression syntax, not just YAML shape.
- Negative control run: introducing an unbalanced paren in the new `claude-general` condition makes `actionlint` fail at that exact line, confirming the linter is actually exercising the expression rather than being silently permissive.
- Resolved config verified: 2 jobs, 13 allowed tools including `Task`, an 89-line prompt, both jobs at `timeout-minutes: 15`, no leftover `node_modules` / TypeScript / RxJS / Angular references from the source prompt.
- Title matches `check-pr-title.yml`'s regex.
- End-to-end verification is the first `@claude review` on a real PR: fewer findings, each naming a concrete failure, and either evidence that subagents ran or the explicit error that they were unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
