### PR TITLE
fix(admin): don't key the asset-permission cache on the decorative shortcode

### DIFF
--- a/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/admin/AdminFilesE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/e2e/admin/AdminFilesE2ESpec.scala
@@ -14,6 +14,7 @@ import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.E2EZSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.api.admin.model.PermissionCodeAndProjectRestrictedViewSettings
 import org.knora.webapi.slice.api.admin.model.ProjectRestrictedViewSettingsADM
 import org.knora.webapi.testservices.ResponseOps.*
@@ -36,6 +37,22 @@ class AdminFilesE2ESpec extends E2EZSpec {
       for {
         response <- TestAdminApiClient
                       .getAdminFilesPermissions(anythingShortcode, "B1D0OkEgfFp-Cew2Seur7Wi.jp2", normalUser)
+                      .flatMap(_.assert200)
+      } yield assertTrue(
+        response == PermissionCodeAndProjectRestrictedViewSettings(
+          1,
+          Some(ProjectRestrictedViewSettingsADM(Some("!128,128"), watermark = false)),
+        ),
+      )
+    },
+    test("return the same RV (1) decision when the shortcode does not match the file's project (DEV-6867)") {
+      // The {shortcode} path segment is non-authoritative: the file is identified by its filename alone. A
+      // permission-code-1 request that previously returned 404 for a mismatched (or nonexistent) project shortcode
+      // must now return 200 with the identical restricted-view decision. This pins the behaviour at the HTTP/routing
+      // layer so a future reintroduction of shortcode validation there would fail CI.
+      for {
+        response <- TestAdminApiClient
+                      .getAdminFilesPermissions(Shortcode.unsafeFrom("9999"), "B1D0OkEgfFp-Cew2Seur7Wi.jp2", normalUser)
                       .flatMap(_.assert200)
       } yield assertTrue(
         response == PermissionCodeAndProjectRestrictedViewSettings(

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsCacheE2ESpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsCacheE2ESpec.scala
@@ -9,7 +9,6 @@ import org.junit.runner.RunWith
 import zio.ZIO
 import zio.test.*
 
-import dsp.errors.NotFoundException
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.*
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
@@ -56,10 +55,20 @@ class AssetPermissionsCacheE2ESpec extends E2EZSpec {
         ),
       )
     },
-    test("still fail with NotFound when the file belongs to a different project than the given shortcode") {
-      cache(
-        _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(Shortcode.unsafeFrom("0001"), asset),
-      ).exit.map(exit => assert(exit)(Assertion.fails(Assertion.isSubtype[NotFoundException](Assertion.anything))))
+    test("treats the shortcode as non-authoritative and not part of the cache key (DEV-6806 regression)") {
+      // The `{shortcode}` path segment must never affect the decision, and must not be part of the cache key —
+      // otherwise an anonymous caller varying only the shortcode over one filename produces unlimited distinct
+      // keys that all resolve to the same value, evicting genuinely-hot entries.
+      for {
+        decisionA <-
+          cache(
+            _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(incunabulaProject.shortcode, asset),
+          )
+        decisionB <-
+          cache(
+            _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(Shortcode.unsafeFrom("0001"), asset),
+          )
+      } yield assertTrue(decisionA == decisionB)
     },
     test(
       "cached anonymous decision equals the direct responder decision with the constant AnonymousUser (REQ-1.5/1.3)",
@@ -70,9 +79,7 @@ class AssetPermissionsCacheE2ESpec extends E2EZSpec {
             _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(incunabulaProject.shortcode, asset),
           )
         direct <-
-          responder(
-            _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(incunabulaProject.shortcode, asset),
-          )
+          responder(_.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(asset))
       } yield assertTrue(cached == direct)
     },
     test("cached authenticated decision equals the direct responder decision (REQ-1.3)") {
@@ -83,12 +90,7 @@ class AssetPermissionsCacheE2ESpec extends E2EZSpec {
                       asset,
                     ),
                   )
-        direct <- responder(
-                    _.getPermissionCodeAndProjectRestrictedViewSettings(incunabulaMemberUser)(
-                      incunabulaProject.shortcode,
-                      asset,
-                    ),
-                  )
+        direct <- responder(_.getPermissionCodeAndProjectRestrictedViewSettings(incunabulaMemberUser)(asset))
       } yield assertTrue(cached == direct)
     },
   )

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsResponderSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsResponderSpec.scala
@@ -9,13 +9,11 @@ import org.junit.runner.RunWith
 import zio.ZIO
 import zio.test.*
 
-import dsp.errors.NotFoundException
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.*
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
 import org.knora.webapi.slice.admin.domain.model.InternalFilename
-import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.api.admin.model.PermissionCodeAndProjectRestrictedViewSettings
 import org.knora.webapi.slice.api.admin.model.ProjectRestrictedViewSettingsADM
 
@@ -30,7 +28,7 @@ class AssetPermissionsResponderSpec extends E2EZSpec {
   override val e2eSpec = suite("The AssetPermissionsResponder")(
     test("return details of a full quality file value") {
       assetPermissionResponder(
-        _.getPermissionCodeAndProjectRestrictedViewSettings(incunabulaMemberUser)(incunabulaProject.shortcode, asset),
+        _.getPermissionCodeAndProjectRestrictedViewSettings(incunabulaMemberUser)(asset),
       ).map { actual =>
         assertTrue(actual == PermissionCodeAndProjectRestrictedViewSettings(permissionCode = 6, None))
       }
@@ -38,7 +36,7 @@ class AssetPermissionsResponderSpec extends E2EZSpec {
     test("return details of a restricted view file value") {
       // http://localhost:3333/v1/files/http%3A%2F%2Frdfh.ch%2F8a0b1e75%2Freps%2F7e4ba672
       assetPermissionResponder(
-        _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(incunabulaProject.shortcode, asset),
+        _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(asset),
       ).map(actual =>
         assertTrue(
           actual == PermissionCodeAndProjectRestrictedViewSettings(
@@ -47,20 +45,6 @@ class AssetPermissionsResponderSpec extends E2EZSpec {
           ),
         ),
       )
-    },
-    test(
-      "return NotFound for a restricted view if the file belongs to a different project than the given shortcode",
-    ) {
-      assetPermissionResponder(
-        _.getPermissionCodeAndProjectRestrictedViewSettings(anonymousUser)(Shortcode.unsafeFrom("0001"), asset),
-      ).exit.map(exit => assert(exit)(Assertion.fails(Assertion.isSubtype[NotFoundException](Assertion.anything))))
-    },
-    test("not validate the shortcode when no restricted-view settings are needed") {
-      // Only permission code 1 needs the project (for its restricted-view settings); every other code
-      // answers from the permission query alone, without a project lookup.
-      assetPermissionResponder(
-        _.getPermissionCodeAndProjectRestrictedViewSettings(incunabulaMemberUser)(Shortcode.unsafeFrom("0001"), asset),
-      ).map(actual => assertTrue(actual == PermissionCodeAndProjectRestrictedViewSettings(permissionCode = 6, None)))
     },
   )
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/admin/AssetPermissionsCache.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/admin/AssetPermissionsCache.scala
@@ -11,6 +11,8 @@ import zio.cache.Lookup
 import zio.metrics.Metric
 import zio.metrics.PollingMetric
 
+import scala.annotation.unused
+
 import dsp.errors.BadRequestException
 import dsp.errors.NotFoundException
 import org.knora.webapi.config.AppConfig
@@ -25,9 +27,9 @@ import org.knora.webapi.slice.api.admin.model.PermissionCodeAndProjectRestricted
  * A short-lived, in-memory cache in front of [[AssetPermissionsResponder]] for the IIIF tile-serving path (DEV-6806).
  *
  * A single tiled image fires many identical `GET /admin/files/{shortcode}/{filename}` checks in a short burst; caching
- * the decision keyed by `(UserIri, Shortcode, InternalFilename)` sheds the repeated `FileValuePermissionsQuery`
- * round-trip and permission computation within that burst, and zio-cache's single-flight behaviour collapses the
- * simultaneous first-tile salvo into one resolution.
+ * the decision keyed by `(UserIri, InternalFilename)` sheds the repeated `FileValuePermissionsQuery` round-trip and
+ * permission computation within that burst, and zio-cache's single-flight behaviour collapses the simultaneous
+ * first-tile salvo into one resolution.
  *
  * The responder stays a pure resolver: this is a wrapping service, so the cache is self-contained and independently
  * testable. Only successful decisions are retained (failures re-resolve on the next request), expiry is lazy after a
@@ -43,10 +45,12 @@ final case class AssetPermissionsCache(
 
   /**
    * Same shape as [[AssetPermissionsResponder.getPermissionCodeAndProjectRestrictedViewSettings]], so the
-   * `serverLogic(...)` binding in `FilesServerEndpoints` is unchanged.
+   * `serverLogic(...)` binding in `FilesServerEndpoints` is unchanged. The `shortcode` parameter is accepted only to
+   * match the endpoint's path shape — it is non-authoritative for the permission decision and is deliberately kept
+   * out of the cache key (see [[CacheKey]]).
    */
   def getPermissionCodeAndProjectRestrictedViewSettings(user: User)(
-    shortcode: Shortcode,
+    @unused shortcode: Shortcode,
     filename: InternalFilename,
   ): Task[PermissionCodeAndProjectRestrictedViewSettings] =
     // `User.id` is a `String` (only `KnoraUser.id` is a typed `UserIri`); convert per the IRI-handling convention —
@@ -56,12 +60,12 @@ final case class AssetPermissionsCache(
     ZIO
       .fromEither(UserIri.from(user.id))
       .mapError(BadRequestException.apply)
-      .flatMap(iri => cache.get(AssetPermissionsCache.CacheKey(iri, shortcode, filename)))
+      .flatMap(iri => cache.get(AssetPermissionsCache.CacheKey(iri, filename)))
 }
 
 object AssetPermissionsCache {
 
-  final case class CacheKey(userIri: UserIri, shortcode: Shortcode, filename: InternalFilename)
+  final case class CacheKey(userIri: UserIri, filename: InternalFilename)
 
   /**
    * Testable core of the cache. Unit tests pass a counting/failing `resolve`; production passes the real one (see
@@ -91,7 +95,7 @@ object AssetPermissionsCache {
     users
       .findUserByIri(key.userIri)
       .someOrFail(NotFoundException(s"No user found for ${key.userIri.value}"))
-      .flatMap(responder.getPermissionCodeAndProjectRestrictedViewSettings(_)(key.shortcode, key.filename))
+      .flatMap(responder.getPermissionCodeAndProjectRestrictedViewSettings(_)(key.filename))
 
   val layer: URLayer[AppConfig & UserService & AssetPermissionsResponder, AssetPermissionsCache] =
     ZLayer.scoped {

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/admin/AssetPermissionsResponder.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/admin/AssetPermissionsResponder.scala
@@ -11,7 +11,6 @@ import dsp.errors.NotFoundException
 import org.knora.webapi.messages.util.PermissionUtilADM
 import org.knora.webapi.slice.admin.domain.model.InternalFilename
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
-import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.User
 import org.knora.webapi.slice.admin.domain.service.KnoraProjectService
 import org.knora.webapi.slice.admin.repo.FileValuePermissionsQuery
@@ -30,7 +29,6 @@ final class AssetPermissionsResponder(
 ) {
 
   def getPermissionCodeAndProjectRestrictedViewSettings(user: User)(
-    shortcode: Shortcode,
     filename: InternalFilename,
   ): Task[PermissionCodeAndProjectRestrictedViewSettings] =
     for {
@@ -48,17 +46,14 @@ final class AssetPermissionsResponder(
                          )
                          .map(_.code)
                          .getOrElse(0)
-      response <- buildResponse(projectIri, shortcode, filename, permissionCode)
+      response <- buildResponse(projectIri, permissionCode)
     } yield response
 
-  // The project is only needed for its restricted-view settings, i.e. for permission code 1; every other
-  // code answers without any project lookup. When it is needed, the project is resolved by the IRI already
-  // returned from the permission query so the lookup is served by the EntityCache (findById);
-  // findByShortcode would query the triplestore on every tile request.
+  // Permission code 1 needs the project only for its restricted-view settings; it is resolved by the IRI
+  // returned from the permission query, so the lookup is EntityCache-served (findById). Every other code
+  // answers without any project lookup.
   private def buildResponse(
     projectIri: ProjectIri,
-    shortcode: Shortcode,
-    filename: InternalFilename,
     permissionCode: Int,
   ): Task[PermissionCodeAndProjectRestrictedViewSettings] =
     permissionCode match {
@@ -66,9 +61,6 @@ final class AssetPermissionsResponder(
         knoraProjectService
           .findById(projectIri)
           .someOrFail(NotFoundException(s"No project found for IRI ${projectIri.value}"))
-          .filterOrFail(_.shortcode == shortcode)(
-            NotFoundException(s"No file value was found for filename $filename in project ${shortcode.value}"),
-          )
           .map(project =>
             PermissionCodeAndProjectRestrictedViewSettings(
               permissionCode,

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/admin/FilesEndpoints.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/admin/FilesEndpoints.scala
@@ -26,7 +26,7 @@ final class FilesEndpoints(base: BaseEndpoints) {
     .in("admin" / "files" / projectShortcode / filename)
     .out(jsonBody[PermissionCodeAndProjectRestrictedViewSettings])
     .description(
-      "Returns the permission code and the project's restricted view settings for a given shortcode and filename. " +
+      "Returns the permission code and the project's restricted view settings for a given filename. " +
         "Publicly accessible. The `{shortcode}` path segment is not authoritative and does not affect the result " +
         "— the file is identified by its filename alone (internal filenames are globally-unique asset IDs); the " +
         "segment is retained only for URL compatibility.",

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/admin/FilesEndpoints.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/admin/FilesEndpoints.scala
@@ -27,7 +27,9 @@ final class FilesEndpoints(base: BaseEndpoints) {
     .out(jsonBody[PermissionCodeAndProjectRestrictedViewSettings])
     .description(
       "Returns the permission code and the project's restricted view settings for a given shortcode and filename. " +
-        "Publicly accessible.",
+        "Publicly accessible. The `{shortcode}` path segment is not authoritative and does not affect the result " +
+        "— the file is identified by its filename alone (internal filenames are globally-unique asset IDs); the " +
+        "segment is retained only for URL compatibility.",
     )
 }
 

--- a/modules/webapi/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsCacheSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/responders/admin/AssetPermissionsCacheSpec.scala
@@ -12,7 +12,6 @@ import zio.test.*
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.responders.admin.AssetPermissionsCache.CacheKey
 import org.knora.webapi.slice.admin.domain.model.InternalFilename
-import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.api.admin.model.PermissionCodeAndProjectRestrictedViewSettings
 
@@ -28,10 +27,9 @@ class AssetPermissionsCacheSpec extends ZIOSpecDefault {
 
   private def keyFor(
     user: String = "http://rdfh.ch/users/aaaa",
-    shortcode: String = "0001",
     filename: String = "test.jp2",
   ): CacheKey =
-    CacheKey(UserIri.unsafeFrom(user), Shortcode.unsafeFrom(shortcode), InternalFilename.unsafeFrom(filename))
+    CacheKey(UserIri.unsafeFrom(user), InternalFilename.unsafeFrom(filename))
 
   private def decision(code: Int): PermissionCodeAndProjectRestrictedViewSettings =
     PermissionCodeAndProjectRestrictedViewSettings(code, restrictedViewSettings = None)


### PR DESCRIPTION
## What

`GET /admin/files/{shortcode}/{filename}` identifies the file by its internal `filename` alone (a globally-unique asset ID). The `{shortcode}` path segment only ever affected the permission-code-1 (restricted view) branch, yet the permission cache introduced in DEV-6806 keyed on `(userIri, shortcode, filename)`. An anonymous caller varying only the shortcode over one known filename could therefore fill the bounded 10k-entry cache with duplicate entries that all resolve to the same value, evicting the genuinely-hot tile entries the cache exists to serve — with no authentication and no invalid response to signal it.

## Change (Option B — shortcode non-authoritative)

- The shortcode no longer affects the answer for **any** permission code, and is **dropped from the cache key** (now `(userIri, filename)`).
- Code 1 still resolves the project by IRI (EntityCache-served `findById`) for its restricted-view settings, but no longer compares the shortcode — so the divergent `"... in project {shortcode}"` 404 message is gone; only `"No file value was found for filename ..."` remains.
- The endpoint keeps the `{shortcode}` segment for URL compatibility and its description now documents it as non-authoritative.

This closes the amplification vector by construction, adds no per-request triplestore query on the tile hot path, and reconciles the error messages.

### Behaviour change
A permission-code-1 request with a *wrong* project shortcode previously returned `404`; it now returns `200 {"permissionCode":1, ...}` like every other code. The shortcode is documented as decorative.

## Acceptance criteria (DEV-6867)
- [x] Filling the cache by varying only the shortcode no longer evicts other `(user, filename)` entries — shortcode is out of the key.
- [x] Shortcode treatment is consistent across permission codes (never authoritative) and documented as such.
- [x] "file not found" / "not in this project" error messages reconciled (the latter is removed).
- [x] No per-request triplestore query added on the tile hot path.

## Verification
- `bazel build //modules/webapi` + `//modules/test-it:test` — compile clean under `-Wunused:all -Werror`.
- `//modules/webapi:test --test_filter=.*AssetPermissionsCacheSpec.*` — passes.
- `just check` (scalafmt, SPDX headers, no-relative-imports) — passes.
- Integration specs (`AssetPermissionsResponderSpec`, `AssetPermissionsCacheE2ESpec`) compile; not run locally (need Docker + triplestore) — relying on CI. `AssetPermissionsCacheE2ESpec` gains a regression test asserting two different shortcodes for the same `(user, filename)` yield the same decision.

## Follow-up
DEV-6892 — deprecate this route in favour of a shortcode-independent one, since the segment is now decorative.

Fixes DEV-6867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)