### PR TITLE
chore(ci): raise the review timeout, notify on cancellation, and run review on Sonnet

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,10 @@ jobs:
       (github.event.issue.pull_request || github.event.pull_request) &&
       (contains(github.event.comment.body, '@claude review') || contains(github.event.review.body, '@claude review'))
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 30, not 15: the first real run on a 26-file PR was killed at 15 min having produced nothing
+    # (the action writes its result only at the end, so a killed run yields no review and no usage
+    # data at all). A generous ceiling costs nothing on the runs that finish early.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -134,14 +137,20 @@ jobs:
           # the repo, WebSearch/WebFetch to check a dependency's real API instead of recalling it,
           # and Task to verify findings in an agent that has not seen the reasoning behind them.
           # Bash stays confined to read-only gh commands, so no path to secrets is opened.
-          claude_args: '--allowed-tools "Grep,Glob,WebSearch,WebFetch,Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
+          #
+          # --model: the action defaults to Opus, which measured $3.70 for one review of a 7-file PR.
+          # Sonnet 5 is the cost lever for a read-only reviewer that never compiles anything.
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Grep,Glob,WebSearch,WebFetch,Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
 
+      # cancelled() as well as failure(): a `timeout-minutes` kill marks the job cancelled, not
+      # failed, so the previous `if: failure()` skipped this step on the one run that most needed
+      # it — the 15-minute timeout passed silently with no comment on the PR.
       - name: Notify on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
           if [ -n "$PR_NUMBER" ]; then
-            gh issue comment "$PR_NUMBER" --body "⚠️ Claude Code Review failed. Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+            gh issue comment "$PR_NUMBER" --body "⚠️ Claude Code Review did not complete (failed, timed out, or was cancelled). Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
           fi
         env:
           GH_TOKEN: ${{ github.token }}
@@ -177,12 +186,13 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
+      # Same cancelled() fix as job 1 — a timeout here would otherwise also pass silently.
       - name: Notify on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
           if [ -n "$PR_NUMBER" ]; then
-            gh issue comment "$PR_NUMBER" --body "⚠️ Claude Code failed. Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+            gh issue comment "$PR_NUMBER" --body "⚠️ Claude Code did not complete (failed, timed out, or was cancelled). Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
           fi
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Follow-up to #4235, driven by what the first real `@claude review` runs actually did.

## What the runs showed

| PR reviewed | Size | Outcome |
|---|---|---|
| [#4236](https://github.com/dasch-swiss/dsp-api/pull/4236) | 7 files, +56/−57 | Succeeded — 10 min 00 s, 32 turns, **$3.70**, 6 permission denials |
| [#4233](https://github.com/dasch-swiss/dsp-api/pull/4233) | 26 files, +1138/−289 | **Killed at 15 min 18 s**, no output, no notification |

The small PR nearly hit the ceiling. The large one blew through it.

## 1. `timeout-minutes: 15` → `30`

The killed run produced **nothing usable**: the action buffers its telemetry and writes the result JSON only at the end, so a `timeout-minutes` kill leaves no review, no partial findings, and no token/turn counts — its 585 log lines are setup and teardown only. Every token was spent for zero output.

30 minutes costs nothing on runs that finish early (the one measured success took 10 min). The 15 was inherited from dsp-app's measured figure and never had a dsp-api baseline behind it — dsp-api's PRs are visibly larger.

## 2. `if: failure()` → `if: failure() || cancelled()`

A `timeout-minutes` kill marks the job **cancelled**, not failed, so the notification step was skipped on the one run that most needed it. The timeout passed in complete silence.

This is verified rather than assumed: the killed job's step list reads `Run Claude Code Review: cancelled` → `Notify on failure: skipped`. The step was **reached and its condition evaluated to false** — so `cancelled()` is sufficient and `always()` is not needed.

Applied to both jobs, and the message no longer asserts "failed" when the cause may have been a timeout or a manual cancel.

Minor accepted trade-off: manually cancelling a run now posts a comment. The wording covers that case, and silent timeouts are the worse failure.

## 3. `--model claude-sonnet-5` on the review job

The action defaults to Opus (`claude-opus-5[1m]` in the run log) — $3.70 and 32 turns for one review of a 113-line diff. At ~50 review invocations a month that is real money, and the killed run spent 15 minutes of Opus for nothing.

The reviewer is **read-only** — `Bash` is confined to `gh` patterns, so it cannot compile, test, or build. That makes the model a cost lever rather than a capability one here.

The `claude-general` job keeps the default, since that one does work the user directs and may want the stronger model.

### Honest caveat on this one

Sonnet 5 follows conservative-reporting instructions **more literally** than Opus, and this prompt is built around exactly that kind of instruction — "DELETE, do not downgrade", "three defensible findings beat twelve speculative ones". The documented effect is that measured recall can fall while precision rises. So this may under-report relative to the Opus baseline.

That baseline is worth protecting: on #4236 the Opus review found a real test-coverage gap (a security invariant pinned only by a constructor-arity compile error) and **correctly refuted two of its own Major candidates** instead of reporting them. If Sonnet's next few reviews come back visibly thinner, reverting this one line is the first thing to try — the other two changes stand on their own.

## Not included here

Deliberately out of scope, in rough priority order:

- **The prompt still posts its review in the last step**, so a run that exhausts its budget before `gh pr comment` still delivers nothing. Posting findings first and appending verdicts after is the real fix for truncation; a bigger timeout only buys headroom.
- **`--max-turns`** — deferred. It caps spend but does not guarantee output for the same reason, and there is no calibration for a value yet (one data point: 32 turns for 7 files).
- **Unbounded fan-out and reading** in the prompt — one verifier agent per Critical/Major finding, and "open the changed files in full" — are what make cost scale with diff size.
- **The 6 permission denials** are unexplained; the action does not log tool names and the run uploaded no artifacts.

## Test plan

- `actionlint` 1.7.12 passes clean (exit 0).
- Resolved config verified: review job `timeout-minutes: 30`, general job `15`, both notify steps `failure() || cancelled()`, `--model claude-sonnet-5` present, and the allowed-tools list still resolves to the same 13 entries.
- No change to the prompt, the triggers, the concurrency group, or either job's permissions.
- Real verification is the next `@claude review` on a large PR: it should either complete inside 30 min or post a comment saying it did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
