### PR TITLE
build(sipi): downgrade SIPI base image to v6.2.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -306,23 +306,23 @@ use_repo(image_versions, "dsp_image_versions")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v6.3.0), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v6.2.3), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v6.3.0 index carries a `v8`
+# index/variant matching — the arm64 entry of the v6.2.3 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. These two
 # digests are the SOLE source of the sipi version: the /version endpoint reads
 # the tag from the image's own `org.opencontainers.image.version` OCI label
 # (//tools/buildinfo:oci_config_label), so there is no duplicated tag string to
 # keep in sync. To bump, see "Bumping the SIPI version" in CLAUDE.md.
-# Index digest: sha256:0096b8d62023fac37291d1f4a298cdef79e3979a034deee21d10721fab8caa6f
+# Index digest: sha256:6d1d176a231eb4bcd368afe326d82e0b5008c692166a5ea57ecf284f3b6e05c8
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:ca8b1c78bb5aba0e4b16835dfbc5367f46d921f9ab7b936f1de6034db730bca0",
+    digest = "sha256:6342a952a1e956a5b973201f520c05b28b38ee674359367a18045ee103d98783",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:f803a8b2c76096b08a057714036396597f45d09eba84f0138b56f8d40d3f4ca1",
+    digest = "sha256:ec5eee0d6dbec845ee1e40bfcb38d9d770a672337cbe8a828a39d0172aee7278",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(


### PR DESCRIPTION
Reverts the v6.3.0 bump (#4238). v6.3.0 is crashing on stage, so this pins the upstream SIPI base image back to the previous working release **v6.2.3**.

## Changes

- `sipi_base_amd64` and `sipi_base_arm64` `oci.pull` digests restored to their v6.2.3 values
- Comment tag `v6.3.0` → `v6.2.3` and the index-digest comment (Renovate anchor + docs)

Exact reverse of the #4238 diff. `bazel fetch @sipi_base_amd64 @sipi_base_arm64` resolves both digests cleanly.

> [!NOTE]
> CI is currently blocked by a separate transitive issue (tests don't run yet); fix is on the way. This PR is ready to merge once CI is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)