### PR TITLE
build(sipi): bump SIPI base image to v6.3.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -306,23 +306,23 @@ use_repo(image_versions, "dsp_image_versions")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v6.2.3), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v6.3.1), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v6.2.3 index carries a `v8`
+# index/variant matching — the arm64 entry of the v6.3.1 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. These two
 # digests are the SOLE source of the sipi version: the /version endpoint reads
 # the tag from the image's own `org.opencontainers.image.version` OCI label
 # (//tools/buildinfo:oci_config_label), so there is no duplicated tag string to
 # keep in sync. To bump, see "Bumping the SIPI version" in CLAUDE.md.
-# Index digest: sha256:6d1d176a231eb4bcd368afe326d82e0b5008c692166a5ea57ecf284f3b6e05c8
+# Index digest: sha256:91f72b1d3a58b9b3bdd4ee8473ab24a047c6e43af105956c7bcb6c82bc29b5a3
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:6342a952a1e956a5b973201f520c05b28b38ee674359367a18045ee103d98783",
+    digest = "sha256:fbd5adc7889c0e604d4161c773cfcfcb2ef605de9ef889d02f1f91b0f045f602",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:ec5eee0d6dbec845ee1e40bfcb38d9d770a672337cbe8a828a39d0172aee7278",
+    digest = "sha256:9eef75ef70e0481ce2f3e40a58ff294f65d0e48261ef3bcf5c65aca1d96b785c",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(


### PR DESCRIPTION
Bumps the upstream SIPI base image from `v6.2.3` to `v6.3.1`.

`v6.3.1` fixes the crash that `v6.3.0` introduced (SIPI [#772](https://github.com/dasch-swiss/sipi/pull/772), the mimalloc-stats C-shim fix), so this moves **forward** off the `v6.2.3` downgrade ([#4241](https://github.com/dasch-swiss/dsp-api/pull/4241)) rather than back to the broken `v6.3.0`.

## Changes

- `sipi_base_amd64` and `sipi_base_arm64` `oci.pull` digests → v6.3.1 values
- Comment tag `v6.2.3` → `v6.3.1` and the index-digest comment (Renovate anchor + docs)

Digests obtained via `docker buildx imagetools inspect daschswiss/sipi:v6.3.1`, pulling each platform's single manifest directly (the arm64 index entry carries a `v8` variant a bare `linux/arm64` request won't match). `bazel fetch @sipi_base_amd64 @sipi_base_arm64` resolves both cleanly.

## Follow-up

- Sync the same SIPI version in the **ops-deploy** repo when this DSP release is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)