### PR TITLE
chore(ci): skip CI on release-please merge commits and drop graphite trigger

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,13 +2,20 @@ name: CI-build-and-test
 
 on:
   # Run on every push to main to keep main green visible per-commit.
+  # `paths-ignore` skips the whole workflow when a main push touches only these
+  # two files — which is exactly (and only) what a release-please merge commit
+  # changes. That source-identical commit was already fully tested on the feature
+  # PRs behind it, so re-running unit/IT/E2E on it tests nothing new. Applied to
+  # `push` only: on `pull_request` the jobs must still REPORT (as skipped) for
+  # branch protection, so those keep their job-level `if:` guards. See DEV-6678.
   push:
     branches:
       - main
+    paths-ignore:
+      - CHANGELOG.md
+      - version.txt
   pull_request:
     types: [opened, reopened, synchronize]
-    branches-ignore:
-      - "**/graphite-base/**"
 
 # Least-privilege token. `checks: write` is required by dorny/test-reporter.
 permissions:
@@ -21,10 +28,13 @@ env:
 # Release PRs (head branch `release-please--*`, opened by release-please) only
 # bump CHANGELOG.md and version.txt — no source changes — so every job below is
 # skipped for them via `!startsWith(github.head_ref, 'release-please')`. This
-# saves CI resources and lets the release PR go green immediately. On `push`
-# events `github.head_ref` is empty, so main pushes still run the full suite.
-# A required check skipped by a job-level `if:` counts as passing in branch
-# protection, so the release PR stays mergeable. See DEV-6678.
+# saves CI resources and lets the release PR go green immediately. A required
+# check skipped by a job-level `if:` counts as passing in branch protection, so
+# the release PR stays mergeable. On `push` events `github.head_ref` is empty,
+# so ordinary main pushes run the test jobs (unit/IT/E2E) as usual; the
+# `paths-ignore` on the `push` trigger above then skips the whole workflow for
+# the release-please *merge* commit, which touches only those two files. See
+# DEV-6678.
 
 jobs:
   # All pure-JVM unit tests run in a single job: one `bazel test` over every


### PR DESCRIPTION
## What

Two small CI-workflow cleanups in `.github/workflows/build-and-test.yml`:

1. **Skip `CI-build-and-test` on the release-please merge commit.** Added `paths-ignore: [CHANGELOG.md, version.txt]` to the `push` trigger. A release-please merge commit changes *only* those two files, so it is source-identical to the previous green `main` commit — re-running unit/IT/E2E on it tests nothing new (those jobs already ran on the feature PRs behind the release). The `paths-ignore` is on the `push` trigger only: on `pull_request` the jobs must still **report** (as skipped) for branch protection, so those keep their existing job-level `if:` guards (DEV-6678).
2. **Remove the `graphite-base` `branches-ignore` filter** from the `pull_request` trigger — we no longer use Graphite. It was the only remaining `graphite` reference in the repo.

## Why

On the release merge that produced `37.5.2`, the three test jobs ran post-merge even though the commit only bumped the changelog and version. That's anticipated by the old comment but pointless given "no source changes", and — worth noting — those merge-commit tests are **not** a gate on the release: `docker-publish` / `publish-release` are independent workflows on the same event and publish in parallel regardless. So this is a tidiness/CI-spend change, not a correctness fix.

## Notes / caveats

- `paths-ignore` is content-based: if a release commit ever also changed source (it won't — release-please only bumps those two files), CI would correctly still run.
- Not applied to the `pull_request` trigger on purpose — doing so would stop required checks from reporting and hang the release PR "pending" forever, the exact DEV-6678 bug.
- The header comment block was updated to match the new behavior (it previously claimed main pushes "run the full suite").

🤖 Generated with [Claude Code](https://claude.com/claude-code)