### PR TITLE
chore(ci): verify constructed strings against spec preconditions, pin review to --effort high

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,10 +67,22 @@ jobs:
             A few defensible issues beat many speculative ones, and reporting no issues at all
             is a valid and useful outcome.
 
-            Do not assert how a library behaves from memory. When an issue depends on a
-            dependency's API or semantics, confirm it against the version this repo builds
-            with (`MODULE.bazel`) or the library's own documentation via web search — or
-            grade the issue Suspected.
+            Do not assert how a library or external service behaves from memory — in either
+            direction. When the diff constructs a string that some other system parses (a
+            SPARQL or SQL query, a URL or IIIF image request, a path template, a regex, a
+            cron expression, a media-type string), you must check the constructed form
+            against that system's own specification before you either report it **or clear
+            it**. Well-formed is not the same as accepted: a form can be valid syntax, and
+            listed as supported by the receiving system, and still be rejected at runtime
+            because of a precondition attached to that form — a permitted value range, a
+            limit that depends on the input data rather than on the string, a flag that must
+            be present for the operation to be allowed. So do not stop at "the syntax is
+            valid" or "the server supports this feature": find the preconditions the
+            specification attaches to the form you built, and for each one name the input
+            that would violate it or state why none can. Confirm against the version this
+            repo builds with (`MODULE.bazel`) or the spec itself via web search. If you
+            cannot complete that check, say so explicitly and grade the line Suspected — do
+            not declare it correct.
 
             Structure your review as follows:
             1. Summary of PR changes (one paragraph)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -109,7 +109,7 @@ jobs:
           # --model: pinned to Opus. In the 2026-08 prompt benchmark the model choice dominated
           # the prompt choice: Opus caught 6/6 planted bugs with zero blocking false positives;
           # Sonnet caught 1/6 and produced the only merge-blocking false positives.
-          claude_args: '--model claude-opus-5 --allowed-tools "Grep,Glob,WebSearch,WebFetch,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-5 --effort high --allowed-tools "Grep,Glob,WebSearch,WebFetch,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       # cancelled() as well as failure(): a `timeout-minutes` kill marks the job cancelled, not
       # failed, so the previous `if: failure()` skipped this step on the one run that most needed


### PR DESCRIPTION
Adopts the configuration that came out of the 2026-08 review-prompt benchmark: **86 cells across five real commits with known answers** (two carrying a bug confirmed by a later fix commit, two clean but carrying a plausible-looking trap, one mixed). Two commits, revertable independently.

### 1. The verification clause now binds on *preconditions*, not grammar

The old wording asked the reviewer to confirm a dependency's behaviour against its documentation instead of asserting from memory. A grammar check satisfies that — and a grammar check is not a correctness check.

Worked example from the benchmark: a thumbnail URL built as `full/,512`. That is valid IIIF 3.0, and Sipi does advertise Level 2 support, so both facts a reviewer would cite are true. But the un-prefixed `,h` form forbids upscaling, so Sipi answers `400 Upscaling not allowed!` for any page image shorter than 512px — and the repo's own fixture is 512×256.

| | Old wording | New wording |
|---|---|---|
| That defect | **missed 16/16** — three models, five prompts, three effort levels; one run cited the spec and declared the line correct | **caught 2/2**, Critical, merge blocked |

No regression elsewhere. The new wording caught both other planted bugs, kept both clean commits clean, flagged **no** trap as merge-blocking, and surfaced three further genuine defects the old prompt missed — each verified against the code by hand rather than credited on plausibility. It also ran cheaper on four of the five commits.

### 2. `--effort high` is now pinned

The job pinned a model but no effort level, so it ran at an unmeasured default. Effort moves the *gate*, not just the prose — same prompt, same commit:

| Effort | Grade | Merge call |
|---|---|---|
| `high` | Critical | **blocked** |
| `medium` | Suspected | ready to merge |

Across the three benchmark commits carrying a real blocking defect, `medium` blocked **1 of 3**; `high` blocked all three. `medium` finds the same defects and under-grades them, so the gate never fires — the review reads as informative while the PR is waved through. `xhigh` beat `high` on no commit and cost more ($11.18 vs $7.60 on one), so `high` is the pin.

### Caveats, stated plainly

- The five benchmark commits collapse to **two bug patterns** (external-spec grammar defects; documented-deliberate decisions that read as defects). This clause speaks directly to the first, so it may be partly fitted to the benchmark. Widening the commit set is the next piece of work.
- Every benchmark commit was found *because a later commit fixed it*, which biases the set toward bugs humans eventually caught. The miss rates are a floor, not a production estimate.
- On the subtlest commit the new prompt is 2/3 where the old is 2/2 — one cell wide, not resolvable at that sample size. Recorded as open rather than as parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
