### PR TITLE
fix(admin): make the view-restrictions endpoints usable on real projects (DEV-6778)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsService.scala
@@ -181,19 +181,31 @@ final case class ViewRestrictionsService(
 
   def summary(projectIri: ProjectIri, groupBy: GroupBy, itemType: ItemType): Task[ViewRestrictionsSummary] =
     for {
-      literals <- repo.distinctPermissions(projectIri, itemType, groupBy)
+      // Resolved once and reused by every query below: the project's asserted resource classes, which
+      // replace two per-row `rdfs:subClassOf` traversals in the queries themselves.
+      classes  <- repo.projectClasses(projectIri)
+      literals <- repo.distinctPermissions(projectIri, itemType, groupBy, classes)
       // One count per (audience, state). Both are tiny fixed sets — 3 x 2 — and each classification pass
       // runs over the small distinct-literal set, so this stays cheap regardless of project size.
-      counted <- ZIO.foreach(for (a <- Audience.ordered; s <- countedStates) yield (a, s)) { case (audience, state) =>
-                   val hits = literalsResolvingTo(literals, state, audience, projectIri)
-                   repo.countByGroup(projectIri, groupBy, itemType, hits).map(rows => (audience, state, rows))
-                 }
-      // Every resource class the project has, with its population — independent of any restriction and of
-      // the itemType filter. In class mode this is the row set itself (see below), so a class is reported
-      // with its true size whether or not anything in it is restricted. A property has no resource
-      // population of its own, so property mode has no equivalent and reports none.
-      classTotals <- if (groupBy == GroupBy.ResourceClass) repo.totalResourcesByClass(projectIri)
-                     else ZIO.succeed(Seq.empty)
+      //
+      // Issued in parallel, together with the class population below: the six counts are independent
+      // read-only aggregations over disjoint permission literals, so serialising them just added up their
+      // latencies (the summary was ~17 sequential round-trips).
+      countedAndTotals <-
+        ZIO
+          .foreachPar(for (a <- Audience.ordered; s <- countedStates) yield (a, s)) { case (audience, state) =>
+            val hits = literalsResolvingTo(literals, state, audience, projectIri)
+            repo.countByGroup(projectIri, groupBy, itemType, hits, classes).map(rows => (audience, state, rows))
+          }
+          // Every resource class the project has, with its population — independent of any restriction and
+          // of the itemType filter. In class mode this is the row set itself (see below), so a class is
+          // reported with its true size whether or not anything in it is restricted. A property has no
+          // resource population of its own, so property mode has no equivalent and reports none.
+          .zipPar(
+            if (groupBy == GroupBy.ResourceClass) repo.totalResourcesByClass(projectIri, classes)
+            else ZIO.succeed(Seq.empty),
+          )
+      (counted, classTotals) = countedAndTotals
       // groupId -> per-audience counts. Contributions accumulate per unit, so a group's resource count and
       // its value count stay separate all the way to the response.
       byGroup = counted.foldLeft(Map.empty[String, AudienceCounts]) { case (acc, (audience, state, rows)) =>
@@ -301,15 +313,23 @@ final case class ViewRestrictionsService(
     for {
       // Paging happens in SPARQL: `rows` are already exactly the resources of the requested page, and
       // `total` is an exact COUNT over the whole result set — no scan cap, no Scala-side slicing.
-      total <- repo.countRestrictedResources(projectIri, groupBy, itemType, group)
-      rows  <- repo.findRestrictedObjects(
-                projectIri,
-                groupBy,
-                itemType,
-                group,
-                offset = pageAndSize.size * (pageAndSize.page - 1),
-                limit = pageAndSize.size,
-              )
+      classes <- repo.projectClasses(projectIri)
+      // The page total and the page itself are independent reads over the same snapshot, so they go out
+      // together rather than one after the other.
+      totalAndRows <- repo
+                        .countRestrictedResources(projectIri, groupBy, itemType, group, classes)
+                        .zipPar(
+                          repo.findRestrictedObjects(
+                            projectIri,
+                            groupBy,
+                            itemType,
+                            group,
+                            offset = pageAndSize.size * (pageAndSize.page - 1),
+                            limit = pageAndSize.size,
+                            classes,
+                          ),
+                        )
+      (total, rows) = totalAndRows
       // Assemble one RestrictedResource per affected resource, with its restricted parts nested under it.
       byResource = rows.groupBy(_.resourceIri).toSeq.map { case (resourceIri, resourceRows) =>
                      val head            = resourceRows.head

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsService.scala
@@ -191,12 +191,17 @@ final case class ViewRestrictionsService(
       // Issued in parallel, together with the class population below: the six counts are independent
       // read-only aggregations over disjoint permission literals, so serialising them just added up their
       // latencies (the summary was ~17 sequential round-trips).
+      //
+      // Bounded on purpose: each count can itself issue two queries (resources + values), so an unbounded
+      // fan-out would put ~13 concurrent queries per request on the triplestore, multiplied across
+      // concurrent dashboard users. The cap keeps most of the win while leaving the store backpressure.
       countedAndTotals <-
         ZIO
           .foreachPar(for (a <- Audience.ordered; s <- countedStates) yield (a, s)) { case (audience, state) =>
             val hits = literalsResolvingTo(literals, state, audience, projectIri)
             repo.countByGroup(projectIri, groupBy, itemType, hits, classes).map(rows => (audience, state, rows))
           }
+          .withParallelism(ViewRestrictionsService.MaxConcurrentCountQueries)
           // Every resource class the project has, with its population — independent of any restriction and
           // of the itemType filter. In class mode this is the row set itself (see below), so a class is
           // reported with its true size whether or not anything in it is restricted. A property has no
@@ -314,8 +319,9 @@ final case class ViewRestrictionsService(
       // Paging happens in SPARQL: `rows` are already exactly the resources of the requested page, and
       // `total` is an exact COUNT over the whole result set — no scan cap, no Scala-side slicing.
       classes <- repo.projectClasses(projectIri)
-      // The page total and the page itself are independent reads over the same snapshot, so they go out
-      // together rather than one after the other.
+      // The page total and the page itself are independent reads, so they go out together rather than one
+      // after the other. They are separate transactions, not a snapshot: a concurrent write between them
+      // can leave `totalItems` inconsistent with the rows — as it could before, when they ran in sequence.
       totalAndRows <- repo
                         .countRestrictedResources(projectIri, groupBy, itemType, group, classes)
                         .zipPar(
@@ -362,5 +368,14 @@ final case class ViewRestrictionsService(
 }
 
 object ViewRestrictionsService {
+
+  /**
+   * Cap on the summary's concurrent per-(audience, state) count queries.
+   *
+   * Each of the six can issue two triplestore queries (resources + values); four in flight keeps the
+   * latency win without letting one dashboard request saturate the store's connections.
+   */
+  private[service] val MaxConcurrentCountQueries = 4
+
   val layer = ZLayer.derive[ViewRestrictionsService]
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
@@ -70,12 +70,9 @@ final case class ViewRestrictionsRepo(
       iris <- triplestore
                 .query(Select(ViewRestrictionsRepo.projectClassesQuery(projectIri)))
                 .map(_.flatMap(_.get("resClass")))
-      // With fewer than two classes in play no resource can carry two of them, so the probe is skipped.
-      multi <- if (iris.sizeIs < 2) ZIO.succeed(false)
-               else
-                 triplestore
-                   .query(Select(ViewRestrictionsRepo.multiTypedSparql(projectIri, iris)))
-                   .map(_.nonEmpty)
+      multi <- triplestore
+                 .query(Select(ViewRestrictionsRepo.multiTypedQuery(projectIri)))
+                 .map(_.nonEmpty)
     } yield ProjectClasses(iris, multi)
 
   /**
@@ -374,25 +371,41 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * scan instead — the shape that doc endorses.
    *
    * @param iris       the project's asserted resource-class IRIs.
-   * @param multiTyped whether any resource asserts a class together with one of that class's ancestors, in
-   *                   which case the most-specific-class filter is still required for correctness.
+   * @param multiTyped whether any resource asserts a class together with a strict subclass of it, in which
+   *                   case the most-specific-class filter is still required for correctness.
    */
   final case class ProjectClasses(iris: Seq[String], multiTyped: Boolean) {
 
-    /** `VALUES ?resClass { <…> }`, or `None` when the project has no resources to scan. */
+    /**
+     * `VALUES ?resClass { <…> }`, or `None` when no class was discovered.
+     *
+     * `None` does **not** mean "no constraint": [[resClassPatterns]] falls back to the original
+     * `subClassOf*` guard in that case, so `?resClass` is never left unconstrained.
+     */
     def valuesClause(resClass: Variable): Option[String] =
-      Option.when(iris.nonEmpty)(
-        s"VALUES ${resClass.getQueryString} { ${iris.map(i => s"<$i>").mkString(" ")} }",
-      )
+      Option.when(iris.nonEmpty)(ViewRestrictionsRepo.valuesOf(resClass, iris))
 
     /**
-     * The patterns that pin `?resClass`, beyond the `VALUES` clause spliced in by [[withValues]]: the
-     * most-specific-class filter, and only when the project's data can actually produce an ambiguous
-     * binding.
+     * The patterns that pin `?resClass`, beyond the `VALUES` clause spliced in by [[withValues]].
+     *
+     *   - When no class was discovered, the `VALUES` clause is omitted, so the original
+     *     `?resClass rdfs:subClassOf* knora-base:Resource` guard is emitted instead. Dropping both would
+     *     leave `?resClass` matching every asserted type — including value and non-resource classes —
+     *     and inflate every count.
+     *   - The most-specific-class filter is added only when the project's data can actually produce an
+     *     ambiguous binding (see [[multiTypedQuery]]).
      */
-    def resClassPatterns(resource: Variable, resClass: Variable): Seq[GraphPattern] =
-      if (multiTyped) Seq(mostSpecificClass(resource, resClass)) else Seq.empty
+    def resClassPatterns(resource: Variable, resClass: Variable): Seq[GraphPattern] = {
+      val classGuard =
+        Option.when(iris.isEmpty)(resClass.has(zeroOrMore(RDFS.SUBCLASSOF), KnoraBase.Resource))
+      val specific = Option.when(multiTyped)(mostSpecificClass(resource, resClass))
+      (classGuard ++ specific).toSeq
+    }
   }
+
+  /** `VALUES ?v { <a> <b> … }` for a set of IRIs. */
+  private[repo] def valuesOf(v: Variable, iris: Seq[String]): String =
+    s"VALUES ${v.getQueryString} { ${iris.map(i => s"<$i>").mkString(" ")} }"
 
   /**
    * Splices a `VALUES` clause into a built query's WHERE block.
@@ -401,12 +414,19 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * `docs/development/dsp-api-sparql-queries.md`), so the documented string fallback is used. The clause
    * is inserted immediately after the opening brace of the WHERE block, where it binds `?resClass` before
    * the patterns that consume it.
+   *
+   * The insertion point is located from the `WHERE` keyword rather than the first brace in the query, and
+   * a serialization without it is a programming error rather than something to paper over: splicing into
+   * an arbitrary brace would silently produce a wrong query.
    */
   private[repo] def withValues(query: SelectQuery, clause: Option[String]): String = {
     val sparql = query.getQueryString
     clause.fold(sparql) { v =>
-      val idx = sparql.indexOf('{', sparql.indexOf("WHERE"))
-      if (idx < 0) sparql else s"${sparql.substring(0, idx + 1)}\n$v${sparql.substring(idx + 1)}"
+      val whereAt = sparql.indexOf("WHERE")
+      require(whereAt >= 0, s"cannot splice VALUES: no WHERE clause in rendered query:\n$sparql")
+      val idx = sparql.indexOf('{', whereAt)
+      require(idx >= 0, s"cannot splice VALUES: no group graph pattern after WHERE:\n$sparql")
+      s"${sparql.substring(0, idx + 1)}\n$v${sparql.substring(idx + 1)}"
     }
   }
 
@@ -590,7 +610,6 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
   // Summary: distinct permission literals, then aggregated counts.
   // ---------------------------------------------------------------------------------------------------
 
-  /** `SELECT DISTINCT ?permissions` over a project's restriction-bearing resources. */
   /**
    * `SELECT DISTINCT ?resClass` — the resource classes the project actually asserts.
    *
@@ -612,36 +631,38 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
   }
 
   /**
-   * Whether any of the project's resources asserts **more than one** resource class — the only situation in
-   * which [[mostSpecificClass]] can change the answer, since `?resource a ?class` matches asserted types
-   * only (no inference is materialised, so an ancestor never matches unless it too is asserted).
+   * Whether [[mostSpecificClass]] can actually change the answer for this project: does any non-deleted
+   * resource assert a class together with a **strict subclass** of that class?
    *
-   * Deliberately free of any `subClassOf` traversal: asking "does any resource carry two of these classes?"
-   * is a bounded join over the already-discovered class list, whereas `?sub subClassOf+ ?resClass` is an
-   * unbounded walk whose cost grows with the class hierarchy. Returns at most one row — the answer is
-   * existential.
+   * This mirrors the gated filter exactly, which is what makes omitting the filter sound. In particular
+   * `?subClass` is **not** restricted to the project's discovered classes: the filter's own `?subClass` is
+   * unconstrained, so a resource typed with a subclass that is not itself a resource class (and so never
+   * appears in [[projectClassesQuery]]) still makes the filter load-bearing. Narrowing the probe to the
+   * discovered list would answer "no" for exactly that case and silently inflate the counts.
+   *
+   * The `isDeleted false` guard matches [[resourceCore]]/[[valueCore]]: a deleted resource can never
+   * produce a `?resClass` binding there, so it must not drag the expensive filter back on for the request.
+   *
+   * The traversal is unavoidable here, but it runs **once per request** and stops at the first hit
+   * (`LIMIT 1`) — as opposed to the gated filter, which the store re-evaluates on every result row.
    */
   private[repo] def multiTypedQuery(projectIri: ProjectIri): SelectQuery = {
-    val (resource, classA, classB) = (variable("resource"), variable("classA"), variable("classB"))
+    val (resource, resClass, subClass) = (variable("resource"), variable("resClass"), variable("subClass"))
     Queries
       .SELECT(resource)
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
       .where(
         resource
-          .isA(classA)
+          .isA(resClass)
           .andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
-          .andIsA(classB)
-          .filter(Expressions.notEquals(classA, classB)),
+          .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
+          .andIsA(subClass)
+          .and(subClass.has(PropertyPathBuilder.of(RDFS.SUBCLASSOF).oneOrMore().build(), resClass)),
       )
       .limit(1)
   }
 
-  /** [[multiTypedQuery]] with both class variables bound to the project's classes. */
-  private[repo] def multiTypedSparql(projectIri: ProjectIri, classes: Seq[String]): String = {
-    val vals = classes.map(c => s"<$c>").mkString(" ")
-    withValues(multiTypedQuery(projectIri), Some(s"VALUES ?classA { $vals }\nVALUES ?classB { $vals }"))
-  }
-
+  /** `SELECT DISTINCT ?permissions` over a project's restriction-bearing resources. */
   private[repo] def distinctResourcePermissionsQuery(projectIri: ProjectIri, classes: ProjectClasses): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (creator, permissions) = (variable("creator"), variable("permissions"))

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
@@ -20,6 +20,7 @@ import zio.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.CountUnit
 import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.GroupCountRow
+import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.ProjectClasses
 import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.RestrictedObjectRow
 import org.knora.webapi.slice.api.admin.ViewRestrictionsEndpoints.GroupBy
 import org.knora.webapi.slice.api.admin.ViewRestrictionsEndpoints.ItemType
@@ -58,6 +59,26 @@ final case class ViewRestrictionsRepo(
 ) extends QueryBuilderHelper {
 
   /**
+   * Resolves the project's asserted resource classes, and whether the most-specific-class filter is
+   * needed at all — see [[ViewRestrictionsRepo.ProjectClasses]].
+   *
+   * Two small anchored queries per request, in exchange for dropping two `rdfs:subClassOf` traversals
+   * that the store would otherwise re-evaluate on every result row of every query in that request.
+   */
+  def projectClasses(projectIri: ProjectIri): Task[ProjectClasses] =
+    for {
+      iris <- triplestore
+                .query(Select(ViewRestrictionsRepo.projectClassesQuery(projectIri)))
+                .map(_.flatMap(_.get("resClass")))
+      // With fewer than two classes in play no resource can carry two of them, so the probe is skipped.
+      multi <- if (iris.sizeIs < 2) ZIO.succeed(false)
+               else
+                 triplestore
+                   .query(Select(ViewRestrictionsRepo.multiTypedSparql(projectIri, iris)))
+                   .map(_.nonEmpty)
+    } yield ProjectClasses(iris, multi)
+
+  /**
    * The project's distinct `knora-base:hasPermissions` literals among restriction-bearing objects, across
    * both resources and values. The service classifies these (and only these) with
    * [[org.knora.webapi.messages.util.PermissionUtilADM]] to decide which literals mean hidden and which
@@ -68,22 +89,32 @@ final case class ViewRestrictionsRepo(
    * group when the requesting user *is* the creator, which these users never are). `ViewRestrictionsServiceSpec`
    * pins that equivalence.
    */
-  def distinctPermissions(projectIri: ProjectIri, itemType: ItemType, groupBy: GroupBy): Task[Set[String]] = {
+  def distinctPermissions(
+    projectIri: ProjectIri,
+    itemType: ItemType,
+    groupBy: GroupBy,
+    classes: ProjectClasses,
+  ): Task[Set[String]] = {
     val wantResources = ViewRestrictionsRepo.wantResources(groupBy, itemType)
     val wantValues    = ViewRestrictionsRepo.wantValues(groupBy, itemType)
     for {
       fromResources <-
-        if (wantResources) runDistinctPermissions(ViewRestrictionsRepo.distinctResourcePermissionsQuery(projectIri))
+        if (wantResources)
+          runDistinctPermissions(ViewRestrictionsRepo.distinctResourcePermissionsQuery(projectIri, classes), classes)
         else ZIO.succeed(Set.empty[String])
       fromValues <-
         if (wantValues)
-          runDistinctPermissions(ViewRestrictionsRepo.distinctValuePermissionsQuery(projectIri))
+          runDistinctPermissions(ViewRestrictionsRepo.distinctValuePermissionsQuery(projectIri, classes), classes)
         else ZIO.succeed(Set.empty[String])
     } yield fromResources ++ fromValues
   }
 
-  private def runDistinctPermissions(query: SelectQuery): Task[Set[String]] =
-    triplestore.query(Select(query)).map(_.map(_.getRequired("permissions")).toSet)
+  private def runDistinctPermissions(query: SelectQuery, classes: ProjectClasses): Task[Set[String]] =
+    triplestore.query(select(query, classes)).map(_.map(_.getRequired("permissions")).toSet)
+
+  /** Renders `query` with the project's `VALUES ?resClass { … }` spliced into its WHERE block. */
+  private def select(query: SelectQuery, classes: ProjectClasses): Select =
+    Select(ViewRestrictionsRepo.withValues(query, classes.valuesClause(variable("resClass"))))
 
   /**
    * Per-group counts of the objects whose permission literal is in `permissions`, computed by the
@@ -99,6 +130,7 @@ final case class ViewRestrictionsRepo(
     groupBy: GroupBy,
     itemType: ItemType,
     permissions: Set[String],
+    classes: ProjectClasses,
   ): Task[Seq[GroupCountRow]] =
     if (permissions.isEmpty) ZIO.succeed(Seq.empty)
     else {
@@ -110,7 +142,11 @@ final case class ViewRestrictionsRepo(
       for {
         resourceCounts <-
           if (wantResources)
-            runCountByGroup(ViewRestrictionsRepo.resourceCountQuery(projectIri, permissions), CountUnit.Resources)
+            runCountByGroup(
+              ViewRestrictionsRepo.resourceCountQuery(projectIri, permissions, classes),
+              CountUnit.Resources,
+              classes,
+            )
           else ZIO.succeed(Seq.empty[GroupCountRow])
         valueCounts <-
           if (wantValues)
@@ -121,8 +157,10 @@ final case class ViewRestrictionsRepo(
                   groupBy,
                   ViewRestrictionsRepo.effectiveItemType(groupBy, itemType),
                   permissions,
+                  classes,
                 ),
               CountUnit.Items,
+              classes,
             )
           else ZIO.succeed(Seq.empty[GroupCountRow])
       } yield resourceCounts ++ valueCounts
@@ -135,12 +173,12 @@ final case class ViewRestrictionsRepo(
    * Only meaningful when grouping by resource class: a property group has no resource population of its own,
    * so the service asks for this in class mode only.
    */
-  def totalResourcesByClass(projectIri: ProjectIri): Task[Seq[GroupCountRow]] =
-    runCountByGroup(ViewRestrictionsRepo.resourceTotalByClassQuery(projectIri), CountUnit.Resources)
+  def totalResourcesByClass(projectIri: ProjectIri, classes: ProjectClasses): Task[Seq[GroupCountRow]] =
+    runCountByGroup(ViewRestrictionsRepo.resourceTotalByClassQuery(projectIri, classes), CountUnit.Resources, classes)
 
-  private def runCountByGroup(query: SelectQuery, unit: CountUnit): Task[Seq[GroupCountRow]] =
+  private def runCountByGroup(query: SelectQuery, unit: CountUnit, classes: ProjectClasses): Task[Seq[GroupCountRow]] =
     triplestore
-      .query(Select(query))
+      .query(select(query, classes))
       .map(_.flatMap { row =>
         row.get("groupId").flatMap(g => row.get("cnt").flatMap(c => c.toIntOption.map(GroupCountRow(g, _, unit))))
       })
@@ -159,15 +197,21 @@ final case class ViewRestrictionsRepo(
     group: String,
     offset: Int,
     limit: Int,
+    classes: ProjectClasses,
   ): Task[Seq[RestrictedObjectRow]] = {
     val effective = ViewRestrictionsRepo.effectiveItemType(groupBy, itemType)
     for {
       pageIris <-
         triplestore
-          .query(Select(ViewRestrictionsRepo.resourcePageQuery(projectIri, groupBy, effective, group, offset, limit)))
+          .query(
+            select(
+              ViewRestrictionsRepo.resourcePageQuery(projectIri, groupBy, effective, group, offset, limit, classes),
+              classes,
+            ),
+          )
           .map(_.flatMap(_.get("resource")))
       rows <- if (pageIris.isEmpty) ZIO.succeed(Seq.empty[RestrictedObjectRow])
-              else fetchRowsFor(projectIri, groupBy, effective, group, pageIris)
+              else fetchRowsFor(projectIri, groupBy, effective, group, pageIris, classes)
     } yield rows
   }
 
@@ -177,12 +221,14 @@ final case class ViewRestrictionsRepo(
     itemType: ItemType,
     group: String,
     resourceIris: Seq[String],
+    classes: ProjectClasses,
   ): Task[Seq[RestrictedObjectRow]] = {
     val wantResources = ViewRestrictionsRepo.wantResources(groupBy, itemType)
     val wantValues    = ViewRestrictionsRepo.wantValues(groupBy, itemType)
     for {
-      resources <- if (wantResources) runResourceQuery(projectIri, group, resourceIris) else ZIO.succeed(Seq.empty)
-      values    <- if (wantValues) runValueQuery(projectIri, group, groupBy, itemType, resourceIris)
+      resources <- if (wantResources) runResourceQuery(projectIri, group, resourceIris, classes)
+                   else ZIO.succeed(Seq.empty)
+      values <- if (wantValues) runValueQuery(projectIri, group, groupBy, itemType, resourceIris, classes)
                 else ZIO.succeed(Seq.empty)
     } yield resources ++ values
   }
@@ -193,10 +239,16 @@ final case class ViewRestrictionsRepo(
     groupBy: GroupBy,
     itemType: ItemType,
     group: String,
+    classes: ProjectClasses,
   ): Task[Int] = {
     val effective = ViewRestrictionsRepo.effectiveItemType(groupBy, itemType)
     triplestore
-      .query(Select(ViewRestrictionsRepo.resourceCountForDrillDownQuery(projectIri, groupBy, effective, group)))
+      .query(
+        select(
+          ViewRestrictionsRepo.resourceCountForDrillDownQuery(projectIri, groupBy, effective, group, classes),
+          classes,
+        ),
+      )
       .map(_.getFirst("cnt").flatMap(_.toIntOption).getOrElse(0))
   }
 
@@ -204,9 +256,10 @@ final case class ViewRestrictionsRepo(
     projectIri: ProjectIri,
     group: String,
     resourceIris: Seq[String],
+    classes: ProjectClasses,
   ): Task[Seq[RestrictedObjectRow]] =
     triplestore
-      .query(Select(ViewRestrictionsRepo.resourceQuery(projectIri, Some(group), resourceIris)))
+      .query(select(ViewRestrictionsRepo.resourceQuery(projectIri, Some(group), resourceIris, classes), classes))
       .map(_.map { row =>
         val resource = row.getRequired("resource")
         val resClass = row.getRequired("resClass")
@@ -234,9 +287,12 @@ final case class ViewRestrictionsRepo(
     groupBy: GroupBy,
     itemType: ItemType,
     resourceIris: Seq[String],
+    classes: ProjectClasses,
   ): Task[Seq[RestrictedObjectRow]] =
     triplestore
-      .query(Select(ViewRestrictionsRepo.valueQuery(projectIri, Some(group), groupBy, resourceIris)))
+      .query(
+        select(ViewRestrictionsRepo.valueQuery(projectIri, Some(group), groupBy, resourceIris, classes), classes),
+      )
       .map(_.flatMap { row =>
         val resource   = row.getRequired("resource")
         val resClass   = row.getRequired("resClass")
@@ -297,6 +353,62 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
 
   /** One row of the aggregated summary: a grouping key, a count, and the unit that count is in. */
   final case class GroupCountRow(groupId: String, count: Int, unit: CountUnit)
+
+  /**
+   * The resource classes a project actually asserts, resolved once per request and reused by every query
+   * of that request.
+   *
+   * This replaces two `rdfs:subClassOf` traversals that the triplestore would otherwise re-evaluate for
+   * every result row (rows scale as resources × properties × values):
+   *
+   *   - `?resClass rdfs:subClassOf* knora-base:Resource` — restricting `?resClass` to resource classes.
+   *     Superseded by binding `?resClass` to this list, which is *already* the set of resource classes the
+   *     project uses.
+   *   - `FILTER NOT EXISTS { … subClassOf+ … }` ([[mostSpecificClass]]) — needed only when a project
+   *     asserts both a class and one of its ancestors on the same resource, which `multiTyped` records.
+   *
+   * The list is deliberately the classes **present in the project's data**, not the `Resource` subclass
+   * closure from the ontology: `docs/development/dsp-api-sparql-queries.md` (DEV-6803) measured that
+   * inlining a large closure as `VALUES` is catastrophic (2.1s → >60s), because the engine joins the whole
+   * table against a large intermediate. A project's asserted classes are a small set that *anchors* the
+   * scan instead — the shape that doc endorses.
+   *
+   * @param iris       the project's asserted resource-class IRIs.
+   * @param multiTyped whether any resource asserts a class together with one of that class's ancestors, in
+   *                   which case the most-specific-class filter is still required for correctness.
+   */
+  final case class ProjectClasses(iris: Seq[String], multiTyped: Boolean) {
+
+    /** `VALUES ?resClass { <…> }`, or `None` when the project has no resources to scan. */
+    def valuesClause(resClass: Variable): Option[String] =
+      Option.when(iris.nonEmpty)(
+        s"VALUES ${resClass.getQueryString} { ${iris.map(i => s"<$i>").mkString(" ")} }",
+      )
+
+    /**
+     * The patterns that pin `?resClass`, beyond the `VALUES` clause spliced in by [[withValues]]: the
+     * most-specific-class filter, and only when the project's data can actually produce an ambiguous
+     * binding.
+     */
+    def resClassPatterns(resource: Variable, resClass: Variable): Seq[GraphPattern] =
+      if (multiTyped) Seq(mostSpecificClass(resource, resClass)) else Seq.empty
+  }
+
+  /**
+   * Splices a `VALUES` clause into a built query's WHERE block.
+   *
+   * The rdf4j SparqlBuilder cannot express `VALUES` (see the SparqlBuilder limitations in
+   * `docs/development/dsp-api-sparql-queries.md`), so the documented string fallback is used. The clause
+   * is inserted immediately after the opening brace of the WHERE block, where it binds `?resClass` before
+   * the patterns that consume it.
+   */
+  private[repo] def withValues(query: SelectQuery, clause: Option[String]): String = {
+    val sparql = query.getQueryString
+    clause.fold(sparql) { v =>
+      val idx = sparql.indexOf('{', sparql.indexOf("WHERE"))
+      if (idx < 0) sparql else s"${sparql.substring(0, idx + 1)}\n$v${sparql.substring(idx + 1)}"
+    }
+  }
 
   /**
    * One restriction-bearing object as read from the triplestore, before visibility resolution.
@@ -382,6 +494,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     resClass: Variable,
     creator: Variable,
     permissions: Variable,
+    classes: ProjectClasses,
   ) =
     resource
       .isA(resClass)
@@ -389,13 +502,18 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .andHas(KnoraBase.attachedToUser, creator)
       .andHas(KnoraBase.hasPermissions, permissions)
       .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
-      .and(resClass.has(zeroOrMore(RDFS.SUBCLASSOF), KnoraBase.Resource))
-      .and(mostSpecificClass(resource, resClass))
+      .and(classes.resClassPatterns(resource, resClass)*)
 
   /**
    * `FILTER NOT EXISTS { ?resource a ?subClass . ?subClass rdfs:subClassOf+ ?resClass }` — keeps only the
    * most specific asserted class of a resource, so one resource yields exactly one `?resClass` binding even
    * when the triplestore asserts or infers its superclasses too.
+   *
+   * Only emitted when the project actually asserts a class together with one of its ancestors
+   * ([[ViewRestrictionsRepo.needsMostSpecificClassFilter]]). The filter is a `subClassOf+` traversal
+   * re-evaluated per result row — rows scale as resources × properties × values — so on the common case
+   * where every resource carries exactly one class it is pure overhead and is left out entirely
+   * (measured on `incunabula`: 2.46s → 0.78s for that pattern alone).
    */
   private def mostSpecificClass(resource: Variable, resClass: Variable): GraphPattern = {
     val subClass = variable("subClass")
@@ -423,13 +541,13 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     value: Variable,
     creator: Variable,
     permissions: Variable,
+    classes: ProjectClasses,
   ) =
     resource
       .isA(resClass)
       .andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
       .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
-      .and(resClass.has(zeroOrMore(RDFS.SUBCLASSOF), KnoraBase.Resource))
-      .and(mostSpecificClass(resource, resClass))
+      .and(classes.resClassPatterns(resource, resClass)*)
       .and(
         resource
           .has(prop, value)
@@ -473,7 +591,58 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
   // ---------------------------------------------------------------------------------------------------
 
   /** `SELECT DISTINCT ?permissions` over a project's restriction-bearing resources. */
-  private[repo] def distinctResourcePermissionsQuery(projectIri: ProjectIri): SelectQuery = {
+  /**
+   * `SELECT DISTINCT ?resClass` — the resource classes the project actually asserts.
+   *
+   * Anchored on `attachedToProject`, so the `subClassOf*` check runs over the handful of classes the
+   * project uses rather than per result row. Feeds [[ProjectClasses]].
+   */
+  private[repo] def projectClassesQuery(projectIri: ProjectIri): SelectQuery = {
+    val (resource, resClass) = (variable("resource"), variable("resClass"))
+    Queries
+      .SELECT(resClass)
+      .distinct()
+      .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
+      .where(
+        resource
+          .isA(resClass)
+          .andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
+          .and(resClass.has(zeroOrMore(RDFS.SUBCLASSOF), KnoraBase.Resource)),
+      )
+  }
+
+  /**
+   * Whether any of the project's resources asserts **more than one** resource class — the only situation in
+   * which [[mostSpecificClass]] can change the answer, since `?resource a ?class` matches asserted types
+   * only (no inference is materialised, so an ancestor never matches unless it too is asserted).
+   *
+   * Deliberately free of any `subClassOf` traversal: asking "does any resource carry two of these classes?"
+   * is a bounded join over the already-discovered class list, whereas `?sub subClassOf+ ?resClass` is an
+   * unbounded walk whose cost grows with the class hierarchy. Returns at most one row — the answer is
+   * existential.
+   */
+  private[repo] def multiTypedQuery(projectIri: ProjectIri): SelectQuery = {
+    val (resource, classA, classB) = (variable("resource"), variable("classA"), variable("classB"))
+    Queries
+      .SELECT(resource)
+      .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
+      .where(
+        resource
+          .isA(classA)
+          .andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
+          .andIsA(classB)
+          .filter(Expressions.notEquals(classA, classB)),
+      )
+      .limit(1)
+  }
+
+  /** [[multiTypedQuery]] with both class variables bound to the project's classes. */
+  private[repo] def multiTypedSparql(projectIri: ProjectIri, classes: Seq[String]): String = {
+    val vals = classes.map(c => s"<$c>").mkString(" ")
+    withValues(multiTypedQuery(projectIri), Some(s"VALUES ?classA { $vals }\nVALUES ?classB { $vals }"))
+  }
+
+  private[repo] def distinctResourcePermissionsQuery(projectIri: ProjectIri, classes: ProjectClasses): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (creator, permissions) = (variable("creator"), variable("permissions"))
 
@@ -483,7 +652,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
       .where(
         GraphPatterns
-          .and(resourceCore(projectIri, resource, resClass, creator, permissions))
+          .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes))
           .filter(onlyRestricted(permissions)),
       )
   }
@@ -492,7 +661,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * `SELECT DISTINCT ?permissions` over a project's restriction-bearing values. Independent of `GroupBy`:
    * grouping changes how counts are bucketed, not which literals exist.
    */
-  private[repo] def distinctValuePermissionsQuery(projectIri: ProjectIri): SelectQuery = {
+  private[repo] def distinctValuePermissionsQuery(projectIri: ProjectIri, classes: ProjectClasses): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (prop, value)          = (variable("prop"), variable("value"))
     val (creator, permissions) = (variable("creator"), variable("permissions"))
@@ -503,7 +672,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
       .where(
         GraphPatterns
-          .and(valueCore(projectIri, resource, resClass, prop, value, creator, permissions))
+          .and(valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes))
           .filter(onlyRestricted(permissions)),
       )
   }
@@ -512,7 +681,11 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * `SELECT ?groupId (COUNT(DISTINCT ?resource) AS ?cnt) … GROUP BY ?groupId` over the resources whose
    * permission literal the service classified into the requested state. Exact at any project size.
    */
-  private[repo] def resourceCountQuery(projectIri: ProjectIri, statePermissions: Set[String]): SelectQuery = {
+  private[repo] def resourceCountQuery(
+    projectIri: ProjectIri,
+    statePermissions: Set[String],
+    classes: ProjectClasses,
+  ): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (creator, permissions) = (variable("creator"), variable("permissions"))
     val (groupId, cnt)         = (variable("groupId"), variable("cnt"))
@@ -522,7 +695,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
       .where(
         GraphPatterns
-          .and(resourceCore(projectIri, resource, resClass, creator, permissions))
+          .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes))
           .filter(permissionsIn(permissions, statePermissions))
           .and(Expressions.bind(resClass, groupId)),
       )
@@ -537,7 +710,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * count and this total are counted over the same universe (non-deleted, project-owned, keyed by the
    * resource's most specific asserted class) and the ratio between them is meaningful.
    */
-  private[repo] def resourceTotalByClassQuery(projectIri: ProjectIri): SelectQuery = {
+  private[repo] def resourceTotalByClassQuery(projectIri: ProjectIri, classes: ProjectClasses): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (creator, permissions) = (variable("creator"), variable("permissions"))
     val (groupId, cnt)         = (variable("groupId"), variable("cnt"))
@@ -547,7 +720,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
       .where(
         GraphPatterns
-          .and(resourceCore(projectIri, resource, resClass, creator, permissions))
+          .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes))
           .and(Expressions.bind(resClass, groupId)),
       )
       .groupBy(groupId)
@@ -566,6 +739,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     groupBy: GroupBy,
     itemType: ItemType,
     statePermissions: Set[String],
+    classes: ProjectClasses,
   ): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (prop, value)          = (variable("prop"), variable("value"))
@@ -574,7 +748,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     val (groupId, cnt)         = (variable("groupId"), variable("cnt"))
     val groupCol               = if (groupBy == GroupBy.Property) prop else resClass
 
-    val core        = valueCore(projectIri, resource, resClass, prop, value, creator, permissions)
+    val core        = valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes)
     val constrained = itemTypeConstraint(value, fileClass, comment, itemType)
       .fold(GraphPatterns.and(core))(c => GraphPatterns.and(core, c))
 
@@ -607,6 +781,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     group: String,
     offset: Int,
     limit: Int,
+    classes: ProjectClasses,
   ): SelectQuery = {
     val resource   = variable("resource")
     val labelOrIri = variable("labelOrIri")
@@ -615,7 +790,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .SELECT(resource, labelOrIri)
       .distinct()
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
-      .where(drillDownPattern(projectIri, groupBy, itemType, group, resource, Some(labelOrIri)))
+      .where(drillDownPattern(projectIri, groupBy, itemType, group, resource, Some(labelOrIri), classes))
       .orderBy(labelOrIri.asc(), resource.asc())
       .offset(offset)
       .limit(limit)
@@ -627,6 +802,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     groupBy: GroupBy,
     itemType: ItemType,
     group: String,
+    classes: ProjectClasses,
   ): SelectQuery = {
     val resource = variable("resource")
     val cnt      = variable("cnt")
@@ -634,7 +810,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     Queries
       .SELECT(Expressions.count(resource).distinct().as(cnt))
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
-      .where(drillDownPattern(projectIri, groupBy, itemType, group, resource, None))
+      .where(drillDownPattern(projectIri, groupBy, itemType, group, resource, None, classes))
   }
 
   /**
@@ -648,6 +824,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     group: String,
     resource: Variable,
     orderKey: Option[Variable],
+    classes: ProjectClasses,
   ): GraphPattern = {
     val resClass               = variable("resClass")
     val (prop, value)          = (variable("prop"), variable("value"))
@@ -656,7 +833,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     val label                  = variable("label")
 
     val valueBranch = {
-      val core        = valueCore(projectIri, resource, resClass, prop, value, creator, permissions)
+      val core        = valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes)
       val constrained = itemTypeConstraint(value, fileClass, comment, itemType)
         .fold(GraphPatterns.and(core))(c => GraphPatterns.and(core, c))
       withGroupFilter(
@@ -671,7 +848,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
         // Resource-only filter: the resource itself must be restricted.
         withGroupFilter(
           GraphPatterns
-            .and(resourceCore(projectIri, resource, resClass, creator, permissions))
+            .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes))
             .filter(onlyRestricted(permissions)),
           resClass,
           Some(group),
@@ -681,7 +858,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
         // Both are in scope: a resource qualifies via its own restriction OR via a restricted value.
         val resourceBranch = withGroupFilter(
           GraphPatterns
-            .and(resourceCore(projectIri, resource, resClass, creator, permissions))
+            .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes))
             .filter(onlyRestricted(permissions)),
           resClass,
           Some(group),
@@ -705,13 +882,14 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     projectIri: ProjectIri,
     group: Option[String],
     resourceIris: Seq[String],
+    classes: ProjectClasses,
   ): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (creator, permissions) = (variable("creator"), variable("permissions"))
     val label                  = variable("label")
 
     val pattern = GraphPatterns
-      .and(resourceCore(projectIri, resource, resClass, creator, permissions))
+      .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes))
       .and(resource.has(RDFS.LABEL, label).optional())
       .filter(onlyRestricted(permissions))
       .filter(resourceIn(resource, resourceIris))
@@ -733,6 +911,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     group: Option[String],
     groupBy: GroupBy,
     resourceIris: Seq[String],
+    classes: ProjectClasses,
   ): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (prop, value)          = (variable("prop"), variable("value"))
@@ -741,7 +920,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     val label                  = variable("label")
 
     val pattern = GraphPatterns
-      .and(valueCore(projectIri, resource, resClass, prop, value, creator, permissions))
+      .and(valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes))
       .and(resource.has(RDFS.LABEL, label).optional())
       .and(optionalFileClass(value, fileClass))
       .and(value.has(KnoraBase.valueHasComment, comment).optional())

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__discovery.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__discovery.txt
@@ -1,0 +1,6 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?resClass
+WHERE { ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> .
+?resClass rdfs:subClassOf* knora-base:Resource . }

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__drillDownPage.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__drillDownPage.txt
@@ -1,0 +1,26 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?resource ?labelOrIri
+WHERE {
+VALUES ?resClass { <http://www.knora.org/ontology/0001/anything#Thing> } { ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:attachedToUser ?creator ;
+    knora-base:hasPermissions ?permissions ;
+    knora-base:isDeleted false .
+FILTER ( !( REGEX( ?permissions, "(^|[|])(V|M|D|CR) [^|]*knora-admin:UnknownUser" ) ) )
+FILTER ( ?resClass = <http://www.knora.org/ontology/0001/anything#Thing> ) } UNION { ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:isDeleted false .
+{ ?resource ?prop ?value .
+?prop rdfs:subPropertyOf* knora-base:hasValue . }
+?value knora-base:attachedToUser ?creator ;
+    knora-base:hasPermissions ?permissions ;
+    knora-base:isDeleted false .
+FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+FILTER ( !( REGEX( ?permissions, "(^|[|])(V|M|D|CR) [^|]*knora-admin:UnknownUser" ) ) )
+FILTER ( ?resClass = <http://www.knora.org/ontology/0001/anything#Thing> ) }
+OPTIONAL { ?resource rdfs:label ?label . }
+BIND( COALESCE( ?label, STR( ?resource ) ) AS ?labelOrIri ) }
+ORDER BY ASC( ?labelOrIri ) ASC( ?resource )
+LIMIT 25
+OFFSET 50

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__multiTyped.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__multiTyped.txt
@@ -1,0 +1,9 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?resource
+WHERE { ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:isDeleted false ;
+    a ?subClass .
+?subClass rdfs:subClassOf+ ?resClass . }
+LIMIT 1

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__resourceCount__multiTyped.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__resourceCount__multiTyped.txt
@@ -1,0 +1,14 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?groupId ( COUNT( DISTINCT ?resource ) AS ?cnt )
+WHERE {
+VALUES ?resClass { <http://www.knora.org/ontology/0001/anything#Thing> } ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:attachedToUser ?creator ;
+    knora-base:hasPermissions ?permissions ;
+    knora-base:isDeleted false .
+FILTER NOT EXISTS { ?resource a ?subClass .
+?subClass rdfs:subClassOf+ ?resClass . }
+BIND( ?resClass AS ?groupId )
+FILTER ( ?permissions IN ( "M knora-admin:ProjectMember", "V knora-admin:KnownUser" ) ) }
+GROUP BY ?groupId

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__resourceCount__noClassesDiscovered.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__resourceCount__noClassesDiscovered.txt
@@ -1,0 +1,12 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?groupId ( COUNT( DISTINCT ?resource ) AS ?cnt )
+WHERE { ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:attachedToUser ?creator ;
+    knora-base:hasPermissions ?permissions ;
+    knora-base:isDeleted false .
+?resClass rdfs:subClassOf* knora-base:Resource .
+BIND( ?resClass AS ?groupId )
+FILTER ( ?permissions IN ( "M knora-admin:ProjectMember", "V knora-admin:KnownUser" ) ) }
+GROUP BY ?groupId

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__resourceCount__singleTyped.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__resourceCount__singleTyped.txt
@@ -1,0 +1,12 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?groupId ( COUNT( DISTINCT ?resource ) AS ?cnt )
+WHERE {
+VALUES ?resClass { <http://www.knora.org/ontology/0001/anything#Thing> } ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:attachedToUser ?creator ;
+    knora-base:hasPermissions ?permissions ;
+    knora-base:isDeleted false .
+BIND( ?resClass AS ?groupId )
+FILTER ( ?permissions IN ( "M knora-admin:ProjectMember", "V knora-admin:KnownUser" ) ) }
+GROUP BY ?groupId

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__valueCount__property.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__viewRestrictions__valueCount__property.txt
@@ -1,0 +1,16 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?groupId ( COUNT( DISTINCT ?value ) AS ?cnt )
+WHERE {
+VALUES ?resClass { <http://www.knora.org/ontology/0001/anything#Thing> } ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:isDeleted false .
+{ ?resource ?prop ?value .
+?prop rdfs:subPropertyOf* knora-base:hasValue . }
+?value knora-base:attachedToUser ?creator ;
+    knora-base:hasPermissions ?permissions ;
+    knora-base:isDeleted false .
+FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+BIND( ?prop AS ?groupId )
+FILTER ( ?permissions IN ( "M knora-admin:ProjectMember", "V knora-admin:KnownUser" ) ) }
+GROUP BY ?groupId

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsServiceSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsServiceSpec.scala
@@ -1031,7 +1031,8 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
     // value queries could be conflated, so it is pinned directly rather than only through the service.
     test("tags resource counts as Resources and value counts as Items") {
       for {
-        rows <- repo(_.countByGroup(projectIri, GroupBy.ResourceClass, ItemType.All, memberOnly))
+        classes <- repo(_.projectClasses(projectIri))
+        rows    <- repo(_.countByGroup(projectIri, GroupBy.ResourceClass, ItemType.All, memberOnly, classes))
       } yield {
         val byUnit = rows.groupBy(_.unit).view.mapValues(_.map(_.count).sum).toMap
         assertTrue(
@@ -1048,7 +1049,8 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
     // resources unit downstream.
     test("tags the class population as Resources") {
       for {
-        rows <- repo(_.totalResourcesByClass(projectIri))
+        classes <- repo(_.projectClasses(projectIri))
+        rows    <- repo(_.totalResourcesByClass(projectIri, classes))
       } yield assertTrue(
         rows.nonEmpty,
         rows.forall(_.unit == ViewRestrictionsRepo.CountUnit.Resources),
@@ -1057,7 +1059,8 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
     // itemType=Resource must not even run the value query, so no Items rows can appear.
     test("emits no Items rows under itemType=Resource") {
       for {
-        rows <- repo(_.countByGroup(projectIri, GroupBy.ResourceClass, ItemType.Resource, memberOnly))
+        classes <- repo(_.projectClasses(projectIri))
+        rows    <- repo(_.countByGroup(projectIri, GroupBy.ResourceClass, ItemType.Resource, memberOnly, classes))
       } yield assertTrue(
         rows.nonEmpty,
         rows.forall(_.unit == ViewRestrictionsRepo.CountUnit.Resources),
@@ -1066,7 +1069,8 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
     // …and property mode never counts whole resources, so no Resources rows can appear.
     test("emits no Resources rows in property mode") {
       for {
-        rows <- repo(_.countByGroup(projectIri, GroupBy.Property, ItemType.All, memberOnly))
+        classes <- repo(_.projectClasses(projectIri))
+        rows    <- repo(_.countByGroup(projectIri, GroupBy.Property, ItemType.All, memberOnly, classes))
       } yield assertTrue(
         rows.nonEmpty,
         rows.forall(_.unit == ViewRestrictionsRepo.CountUnit.Items),

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith
 import zio.test.*
 
 import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.GoldenTest
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.api.admin.ViewRestrictionsEndpoints.GroupBy
 import org.knora.webapi.slice.api.admin.ViewRestrictionsEndpoints.ItemType
@@ -21,7 +22,7 @@ import org.knora.webapi.slice.api.admin.ViewRestrictionsEndpoints.ItemType
  * counts, and deterministic ordering + windowing for the drill-down.
  */
 @RunWith(classOf[DspZTestJUnitRunner])
-class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
+class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
 
   private val projectIri = ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001")
   private val thingClass = "http://www.knora.org/ontology/0001/anything#Thing"
@@ -33,6 +34,8 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
 
   /** A project that asserts a class together with one of its ancestors — the filter must be kept. */
   private val multiTyped = ViewRestrictionsRepo.ProjectClasses(Seq(thingClass), multiTyped = true)
+
+  private val resClassVar = SparqlBuilder.`var`("resClass")
 
   override def spec: Spec[TestEnvironment, Any] = suite("ViewRestrictionsRepo query generation")(
     suite("distinct permission literals")(
@@ -168,66 +171,58 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
     // traversals re-evaluated per result row. Rows scale as resources × properties × values, so these
     // paths dominated the endpoint's runtime — measured on `incunabula`, 3.60s → 0.72s for the value
     // count, with byte-identical results.
+    //
+    // Golden snapshots rather than substring assertions: what matters is *where* the VALUES clause and
+    // the filters land, which `contains` cannot express, and an absence assertion like
+    // `!q.contains("rdfs:subClassOf*")` would pass for the wrong reason if the path were ever rendered
+    // unprefixed. See "Golden tests (preferred)" in docs/development/dsp-api-sparql-queries.md.
     suite("class-hierarchy resolution")(
-      test("no subClassOf traversal is emitted when the project is not multi-typed") {
-        val counts = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, singleTyped).getQueryString
-        val values =
-          ViewRestrictionsRepo
-            .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.All, hidden, singleTyped)
-            .getQueryString
-        assertTrue(
-          // neither the `?resClass subClassOf* Resource` guard…
-          !counts.contains("rdfs:subClassOf*"),
-          !values.contains("rdfs:subClassOf*"),
-          // …nor the most-specific-class filter, which cannot change the answer here
-          !counts.contains("rdfs:subClassOf+"),
-          !values.contains("rdfs:subClassOf+"),
-          !counts.contains("?subClass"),
-        )
-      },
-      test("the most-specific-class filter is kept when a project asserts a class and its ancestor") {
-        val q = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, multiTyped).getQueryString
-        assertTrue(
-          q.contains("FILTER NOT EXISTS"),
-          q.contains("rdfs:subClassOf+"),
-          q.contains("?subClass"),
-        )
-      },
-      test("the project's classes are bound with VALUES, which anchors the scan") {
+      test("the single-typed project binds VALUES and emits no traversal") {
         val q = ViewRestrictionsRepo.withValues(
           ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, singleTyped),
-          singleTyped.valuesClause(SparqlBuilder.`var`("resClass")),
+          singleTyped.valuesClause(resClassVar),
         )
-        assertTrue(
-          q.contains(s"VALUES ?resClass { <$thingClass> }"),
-          // spliced inside the WHERE block, before the patterns that consume ?resClass
-          q.indexOf("VALUES ?resClass") > q.indexOf("WHERE"),
-          q.contains("GROUP BY ?groupId"),
-        )
+        assertGolden(q, "viewRestrictions__resourceCount__singleTyped")
       },
-      test("a project with no resources yields no VALUES clause and an unchanged query") {
+      test("the multi-typed project keeps the most-specific-class filter alongside VALUES") {
+        val q = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, multiTyped),
+          multiTyped.valuesClause(resClassVar),
+        )
+        assertGolden(q, "viewRestrictions__resourceCount__multiTyped")
+      },
+      test("the value count binds VALUES inside the WHERE block in property mode") {
+        val q = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo.valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped),
+          singleTyped.valuesClause(resClassVar),
+        )
+        assertGolden(q, "viewRestrictions__valueCount__property")
+      },
+      // Discovering no class must NOT leave ?resClass unconstrained: the original subClassOf* guard is
+      // emitted instead, so the query still binds only resource classes.
+      test("an empty class list falls back to the subClassOf* guard instead of dropping it") {
         val empty = ViewRestrictionsRepo.ProjectClasses(Seq.empty, multiTyped = false)
-        val built = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, empty)
-        assertTrue(
-          empty.valuesClause(SparqlBuilder.`var`("resClass")).isEmpty,
-          ViewRestrictionsRepo.withValues(built, None) == built.getQueryString,
+        val q     = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, empty),
+          empty.valuesClause(resClassVar),
         )
+        assertGolden(q, "viewRestrictions__resourceCount__noClassesDiscovered")
       },
-      test("the discovery queries are anchored on the project and are not themselves per-row") {
-        val classes = ViewRestrictionsRepo.projectClassesQuery(projectIri).getQueryString
-        val multi   = ViewRestrictionsRepo.multiTypedSparql(projectIri, Seq(thingClass, hasPicture))
-        assertTrue(
-          classes.contains("SELECT DISTINCT ?resClass"),
-          classes.contains(s"knora-base:attachedToProject <${projectIri.value}>"),
-          // the traversal runs here, once, over the project's classes — not per result row
-          classes.contains("rdfs:subClassOf*"),
-          // the multi-typed probe is existential and carries no traversal at all: it asks whether any
-          // resource holds two of the known classes, which is bounded by the class list.
-          multi.contains("LIMIT 1"),
-          !multi.contains("rdfs:subClassOf+"),
-          multi.contains("VALUES ?classA"),
-          multi.contains("VALUES ?classB"),
+      test("the class-discovery query is anchored on the project") {
+        assertGolden(ViewRestrictionsRepo.projectClassesQuery(projectIri).getQueryString, "viewRestrictions__discovery")
+      },
+      // The probe must mirror the filter it gates exactly — `?subClass` unrestricted (it need not be a
+      // resource class) and deleted resources excluded — or omitting the filter would change counts.
+      test("the multi-typed probe mirrors the filter it gates") {
+        assertGolden(ViewRestrictionsRepo.multiTypedQuery(projectIri).getQueryString, "viewRestrictions__multiTyped")
+      },
+      test("the drill-down page query binds VALUES once for the whole UNION") {
+        val q = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo
+            .resourcePageQuery(projectIri, GroupBy.ResourceClass, ItemType.All, thingClass, 50, 25, singleTyped),
+          singleTyped.valuesClause(resClassVar),
         )
+        assertGolden(q, "viewRestrictions__drillDownPage")
       },
     ),
   )

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.admin.repo
 
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -27,10 +28,16 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
   private val hasPicture = "http://www.knora.org/ontology/0001/anything#hasPicture"
   private val hidden     = Set("M knora-admin:ProjectMember", "V knora-admin:KnownUser")
 
+  /** The common case: every resource carries exactly one class, so no most-specific-class filter is needed. */
+  private val singleTyped = ViewRestrictionsRepo.ProjectClasses(Seq(thingClass), multiTyped = false)
+
+  /** A project that asserts a class together with one of its ancestors — the filter must be kept. */
+  private val multiTyped = ViewRestrictionsRepo.ProjectClasses(Seq(thingClass), multiTyped = true)
+
   override def spec: Spec[TestEnvironment, Any] = suite("ViewRestrictionsRepo query generation")(
     suite("distinct permission literals")(
       test("resource variant selects only the distinct literal, restricted rows, excluding deleted") {
-        val q = ViewRestrictionsRepo.distinctResourcePermissionsQuery(projectIri).getQueryString
+        val q = ViewRestrictionsRepo.distinctResourcePermissionsQuery(projectIri, singleTyped).getQueryString
         assertTrue(
           q.contains("SELECT DISTINCT ?permissions"),
           q.contains(s"knora-base:attachedToProject <${projectIri.value}>"),
@@ -44,7 +51,7 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
         )
       },
       test("value variant excludes link values and is likewise uncapped") {
-        val q = ViewRestrictionsRepo.distinctValuePermissionsQuery(projectIri).getQueryString
+        val q = ViewRestrictionsRepo.distinctValuePermissionsQuery(projectIri, singleTyped).getQueryString
         assertTrue(
           q.contains("SELECT DISTINCT ?permissions"),
           q.contains("FILTER NOT EXISTS") && q.contains("knora-base:LinkValue"),
@@ -54,7 +61,7 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
     ),
     suite("aggregated counts")(
       test("resource counts group by class and COUNT DISTINCT, filtered to the hidden literals") {
-        val q = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden).getQueryString
+        val q = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, singleTyped).getQueryString
         assertTrue(
           q.contains("COUNT") && q.contains("DISTINCT"),
           q.contains("GROUP BY ?groupId"),
@@ -67,7 +74,7 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
       },
       test("value counts group by the carrying property in property mode") {
         val q = ViewRestrictionsRepo
-          .valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden)
+          .valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped)
           .getQueryString
         assertTrue(
           q.contains("COUNT") && q.contains("DISTINCT"),
@@ -78,13 +85,13 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
       },
       test("itemType=Comment restricts the count to values carrying a comment") {
         val q = ViewRestrictionsRepo
-          .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.Comment, hidden)
+          .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.Comment, hidden, singleTyped)
           .getQueryString
         assertTrue(q.contains("knora-base:valueHasComment"))
       },
       test("itemType=Value excludes file values so File and Value cannot double-count") {
         val q = ViewRestrictionsRepo
-          .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.Value, hidden)
+          .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.Value, hidden, singleTyped)
           .getQueryString
         assertTrue(q.contains("FILTER NOT EXISTS") && q.contains("knora-base:FileValue"))
       },
@@ -92,7 +99,15 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
     suite("drill-down paging")(
       test("the page query orders deterministically and windows in SPARQL") {
         val q = ViewRestrictionsRepo
-          .resourcePageQuery(projectIri, GroupBy.ResourceClass, ItemType.All, thingClass, offset = 50, limit = 25)
+          .resourcePageQuery(
+            projectIri,
+            GroupBy.ResourceClass,
+            ItemType.All,
+            thingClass,
+            offset = 50,
+            limit = 25,
+            singleTyped,
+          )
           .getQueryString
         assertTrue(
           // ordering by the label-or-IRI key then the IRI makes paging reproducible
@@ -105,7 +120,7 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
       },
       test("the page total is a COUNT DISTINCT over resources, unwindowed") {
         val q = ViewRestrictionsRepo
-          .resourceCountForDrillDownQuery(projectIri, GroupBy.ResourceClass, ItemType.All, thingClass)
+          .resourceCountForDrillDownQuery(projectIri, GroupBy.ResourceClass, ItemType.All, thingClass, singleTyped)
           .getQueryString
         assertTrue(
           q.contains("COUNT") && q.contains("DISTINCT"),
@@ -117,8 +132,10 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
       },
       test("row queries are scoped to the page's resource IRIs and carry no cap of their own") {
         val iris = Seq("http://rdfh.ch/0001/a", "http://rdfh.ch/0001/b")
-        val rq   = ViewRestrictionsRepo.resourceQuery(projectIri, Some(thingClass), iris).getQueryString
-        val vq   = ViewRestrictionsRepo.valueQuery(projectIri, Some(hasPicture), GroupBy.Property, iris).getQueryString
+        val rq   = ViewRestrictionsRepo.resourceQuery(projectIri, Some(thingClass), iris, singleTyped).getQueryString
+        val vq   = ViewRestrictionsRepo
+          .valueQuery(projectIri, Some(hasPicture), GroupBy.Property, iris, singleTyped)
+          .getQueryString
         assertTrue(
           iris.forall(rq.contains),
           iris.forall(vq.contains),
@@ -134,9 +151,83 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault {
       },
       test("in property mode the group filter applies to the carrying property") {
         val q = ViewRestrictionsRepo
-          .resourcePageQuery(projectIri, GroupBy.Property, ItemType.All, hasPicture, offset = 0, limit = 25)
+          .resourcePageQuery(
+            projectIri,
+            GroupBy.Property,
+            ItemType.All,
+            hasPicture,
+            offset = 0,
+            limit = 25,
+            singleTyped,
+          )
           .getQueryString
         assertTrue(q.contains(hasPicture))
+      },
+    ),
+    // The class hierarchy is resolved once per request (ProjectClasses) instead of by `rdfs:subClassOf`
+    // traversals re-evaluated per result row. Rows scale as resources × properties × values, so these
+    // paths dominated the endpoint's runtime — measured on `incunabula`, 3.60s → 0.72s for the value
+    // count, with byte-identical results.
+    suite("class-hierarchy resolution")(
+      test("no subClassOf traversal is emitted when the project is not multi-typed") {
+        val counts = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, singleTyped).getQueryString
+        val values =
+          ViewRestrictionsRepo
+            .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.All, hidden, singleTyped)
+            .getQueryString
+        assertTrue(
+          // neither the `?resClass subClassOf* Resource` guard…
+          !counts.contains("rdfs:subClassOf*"),
+          !values.contains("rdfs:subClassOf*"),
+          // …nor the most-specific-class filter, which cannot change the answer here
+          !counts.contains("rdfs:subClassOf+"),
+          !values.contains("rdfs:subClassOf+"),
+          !counts.contains("?subClass"),
+        )
+      },
+      test("the most-specific-class filter is kept when a project asserts a class and its ancestor") {
+        val q = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, multiTyped).getQueryString
+        assertTrue(
+          q.contains("FILTER NOT EXISTS"),
+          q.contains("rdfs:subClassOf+"),
+          q.contains("?subClass"),
+        )
+      },
+      test("the project's classes are bound with VALUES, which anchors the scan") {
+        val q = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, singleTyped),
+          singleTyped.valuesClause(SparqlBuilder.`var`("resClass")),
+        )
+        assertTrue(
+          q.contains(s"VALUES ?resClass { <$thingClass> }"),
+          // spliced inside the WHERE block, before the patterns that consume ?resClass
+          q.indexOf("VALUES ?resClass") > q.indexOf("WHERE"),
+          q.contains("GROUP BY ?groupId"),
+        )
+      },
+      test("a project with no resources yields no VALUES clause and an unchanged query") {
+        val empty = ViewRestrictionsRepo.ProjectClasses(Seq.empty, multiTyped = false)
+        val built = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, empty)
+        assertTrue(
+          empty.valuesClause(SparqlBuilder.`var`("resClass")).isEmpty,
+          ViewRestrictionsRepo.withValues(built, None) == built.getQueryString,
+        )
+      },
+      test("the discovery queries are anchored on the project and are not themselves per-row") {
+        val classes = ViewRestrictionsRepo.projectClassesQuery(projectIri).getQueryString
+        val multi   = ViewRestrictionsRepo.multiTypedSparql(projectIri, Seq(thingClass, hasPicture))
+        assertTrue(
+          classes.contains("SELECT DISTINCT ?resClass"),
+          classes.contains(s"knora-base:attachedToProject <${projectIri.value}>"),
+          // the traversal runs here, once, over the project's classes — not per result row
+          classes.contains("rdfs:subClassOf*"),
+          // the multi-typed probe is existential and carries no traversal at all: it asks whether any
+          // resource holds two of the known classes, which is bounded by the class list.
+          multi.contains("LIMIT 1"),
+          !multi.contains("rdfs:subClassOf+"),
+          multi.contains("VALUES ?classA"),
+          multi.contains("VALUES ?classB"),
+        )
       },
     ),
   )


### PR DESCRIPTION
## What

The view-restrictions endpoints added in #4239 **time out on real projects**. Reported from the dev
stack as:

```
ERROR org.knora.webapi.store.triplestore.impl.TriplestoreServiceLive
Triplestore timed out while sending a response, after sending statuscode 200.
```

This makes them usable. Counts are unchanged — the endpoint returns exactly what it did before, faster.

## Why it was slow

Two `rdfs:subClassOf` patterns lived in the shared query skeletons (`resourceCore` / `valueCore`) and
were therefore evaluated **per result row** — and rows scale as resources × properties × values:

- `?resClass rdfs:subClassOf* knora-base:Resource` — restricting the grouping key to resource classes.
- `FILTER NOT EXISTS { ?resource a ?sub . ?sub rdfs:subClassOf+ ?resClass }` — keeping only the most
  specific asserted class.

Measured in isolation on the value-count query against `incunabula` (a *small* project, 4231 resources):

| Query variant | Time |
| --- | --- |
| Neither pattern | 0.78s |
| `+ subClassOf* Resource` | 2.10s |
| `+ most-specific-class filter` | 2.46s |
| **Both (what shipped)** | **4.09s** |

A summary request issues several such queries, sequentially — roughly 17 round-trips.

## What changed

**Resolve the class hierarchy once per request** (`ProjectClasses`) instead of per result row:

- The project's asserted resource classes are discovered once and bound with a `VALUES ?resClass`
  clause, replacing the `subClassOf*` guard.
- The most-specific-class filter is emitted **only** when the project actually asserts a class
  together with a strict subclass of it — the only case where it can change the answer, since
  `?resource a ?class` matches asserted types only.

The class list is deliberately the classes **present in the project's data** (6 for `incunabula`, 19
for `anything`), *not* the `Resource` closure from the ontology. `docs/development/dsp-api-sparql-queries.md`
records that inlining a large closure as `VALUES` is catastrophic (DEV-6803: 2.1s → >60s); a project's
asserted classes are a small set that anchors the scan, which is the shape that doc endorses.

**Parallelise independent reads** — the six per-(audience, state) counts and the class population, and
the drill-down's total and page. Bounded at 4 concurrent so one request cannot saturate the store.

## Results

Measured over all 6 local projects × 2 `groupBy` × 5 `itemType` = 60 requests:

| | Before | After |
| --- | --- | --- |
| Total | 39.59s | **22.89s** |
| Worst case (`incunabula`, ResourceClass/All) | 5.53s | **2.71s** |
| Responses identical to baseline | — | **60/60 byte-identical** |

## Review

A local review pass at high effort found a correctness bug in the first commit and nine smaller
issues; the second commit fixes them. The one that mattered:

> The multi-typed probe was **not equivalent** to the filter it gates. The filter's `?subClass` is
> unconstrained, but the probe compared only classes from the discovered list (which is filtered to
> resource classes), and a `sizeIs < 2` short-circuit skipped it entirely for single-class projects.
> A resource typed with a subclass outside that list would have been **counted twice** — on an
> endpoint contracted to return exact counts.

The probe now mirrors the filter exactly, including the `isDeleted false` guard the real queries use.
Also fixed: an empty class list no longer drops the resource-class guard; `withValues` requires a
`WHERE` clause rather than splicing into an arbitrary brace; the parallel fan-out is bounded.

## Testing

- `ViewRestrictionsQuerySpec` — the class-resolution suite is **golden snapshots** (per `REVIEW.md`
  and the SPARQL doc) rather than `contains`/`!contains` assertions, covering the single-typed,
  multi-typed, empty-class-list, discovery, probe, value-count and drill-down query shapes. The
  golden files make clause placement reviewable in the diff — and would have caught the bug above.
- `ViewRestrictionsServiceSpec` — the repo-level tests now resolve `ProjectClasses` from the real
  fixture data, so the discovery step is exercised end to end.
- Verified against the local stack: all 60 summary responses byte-identical to the pre-change
  baseline, `AdminViewRestrictionsE2ESpec` (15 tests) green.

## Notes / follow-ups

- **Known gap, deliberately left:** the class list is discovered in a separate read from the counts,
  so a class first asserted mid-request is missed. Closing it needs a single snapshot across a
  request, which is the cost this change removes. The window is milliseconds on an admin reporting
  dashboard, and the pre-existing total/page split already has the same property. Worth a decision,
  not a blocker.
- `subPropertyOf*` in `valueCore` is deliberately untouched — removing it measured **168s** vs 0.71s.
  It is load-bearing, not a missed optimisation.
- Numbers here are from local test data. The original timeout came from a larger project, so the
  real-world win should be bigger but is unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)