### PR TITLE
chore(ci): rebuild the review gate — blocking predicate, --effort medium, corrected tool set

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -126,10 +126,21 @@ jobs:
             section — do not spend the run on diffs it tells you to skip.
             Use `gh pr comment` to leave your review as a comment on the PR.
 
-          # Reading files is already in the action's base tool set; search and web lookup are
-          # not, and the prompt above depends on both — Grep/Glob to check a suspicion against
-          # the rest of the repo instead of guessing, WebSearch/WebFetch to check a dependency's
-          # real API instead of recalling it. Bash stays confined to read-only gh commands.
+          # --allowed-tools is the complete, resolved tool set: the action adds nothing to it.
+          # Verified by reading a real run's `SDK options:` echo in the job log (dsp-api run
+          # 31606435936). An earlier version of this comment claimed Read came from an action
+          # base tool set; it does not, and the prompt above tells the reviewer to read the
+          # changed files in full — so Read is granted explicitly here. The other entries: Grep
+          # and Glob to check a suspicion against the rest of the repo instead of guessing,
+          # WebSearch/WebFetch to check a dependency's real API instead of recalling it. Bash
+          # stays confined to read-only gh commands.
+          #
+          # --setting-sources user: do NOT load the repo's own .claude/settings.json. That file
+          # is a local-developer convenience list (it arrived in a dependency-bot PR as
+          # claude-flow scaffolding and outlived the tool), and loading it silently widened this
+          # job's permissions with git/npm/node grants that differ per repository — dsp-api had
+          # them, dsp-app did not, so the same review job behaved differently in each. The tool
+          # set for this job is defined on this line and nowhere else.
           #
           # --model: pinned to Opus. In the 2026-08 prompt benchmark the model choice dominated
           # the prompt choice: Opus caught 6/6 planted bugs with zero blocking false positives;
@@ -142,7 +153,7 @@ jobs:
           # a wrong merge call in 10 runs. high retrieves pinned external sources more reliably
           # (3/3 vs 1/3 on one commit) but that never changed a merge outcome. medium is ~16%
           # cheaper per run.
-          claude_args: '--model claude-opus-5 --effort medium --allowed-tools "Grep,Glob,WebSearch,WebFetch,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-5 --effort medium --setting-sources user --allowed-tools "Read,Grep,Glob,WebSearch,WebFetch,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       # cancelled() as well as failure(): a `timeout-minutes` kill marks the job cancelled, not
       # failed, so the previous `if: failure()` skipped this step on the one run that most needed

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -134,7 +134,15 @@ jobs:
           # --model: pinned to Opus. In the 2026-08 prompt benchmark the model choice dominated
           # the prompt choice: Opus caught 6/6 planted bugs with zero blocking false positives;
           # Sonnet caught 1/6 and produced the only merge-blocking false positives.
-          claude_args: '--model claude-opus-5 --effort high --allowed-tools "Grep,Glob,WebSearch,WebFetch,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          #
+          # --effort: medium. Detection is identical to high -- across 9 commits run at both
+          # levels the two agreed on every catch, every miss and every clean pass. The only
+          # behavioural difference is that high additionally held one clean diff on a genuine
+          # but minor pager desync (2/2 runs), which medium did not, and medium never produced
+          # a wrong merge call in 10 runs. high retrieves pinned external sources more reliably
+          # (3/3 vs 1/3 on one commit) but that never changed a merge outcome. medium is ~16%
+          # cheaper per run.
+          claude_args: '--model claude-opus-5 --effort medium --allowed-tools "Grep,Glob,WebSearch,WebFetch,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       # cancelled() as well as failure(): a `timeout-minutes` kill marks the job cancelled, not
       # failed, so the previous `if: failure()` skipped this step on the one run that most needed

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,19 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Merge readiness is gated on a verified wrong outcome, not on a severity label.
+          # Why: severity was the least stable token in the output. In the 2026-08 benchmark the
+          # same defect on the same commit was graded Major at --effort high (2/2 runs, merge
+          # cleared) and Critical at medium (merge blocked), and a documented-deliberate trap was
+          # mislabelled Major by 6 of 7 runs. What was stable across every run was the pair
+          # (named trigger, wrong outcome). Under the old Critical-only rule two of three gate
+          # failures were rule-forced: the review identified a real defect and its own rubric
+          # obliged it to clear, arguing against its own verdict in the same paragraph.
+          #
+          # The trade, measured and accepted: the block rate goes up and the added blocks are on
+          # real findings. Across 20 runs on 9 commits this rule produced one wrong merge call --
+          # a genuine but minor pager/page-index desync on a clean diff, held at --effort high and
+          # not at medium (see the --effort note below).
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
@@ -86,14 +99,26 @@ jobs:
 
             Structure your review as follows:
             1. Summary of PR changes (one paragraph)
-            2. Identified issues, most severe first. For each: `file:line`, the failure
-               scenario, and a suggested fix. Grade each as Critical, Major, Minor, or Suspected:
-              - Critical: a bug, security vulnerability, or regression that reaches users.
-                Only Critical issues prevent the PR from being ready to merge.
-              - Major / Minor: worth fixing / worth noting, but do not affect merge readiness.
-              - Suspected: a concern you could not prove — state what would confirm or refute
-                it. Never blocks merge.
-            3. Clear statement whether the PR is ready to merge (based **only** on Critical issues)
+            2. Identified issues, blocking ones first. For each: `file:line`, the trigger and
+               wrong outcome you named above, how you verified the mechanism, and a suggested
+               fix. Mark each issue Blocking or Non-blocking. This is independent of how bad
+               the outcome is:
+              - Blocking: you established, from the code or an authoritative external source,
+                that a reachable input or state produces a wrong outcome — an error thrown on
+                a normal path, incorrect data written or returned, access incorrectly granted
+                or denied, or a deterministic CI failure. "Reachable" means you can name the
+                input. It does **not** require the feature to stop working, and it does
+                **not** require the outcome to be severe.
+              - Non-blocking: everything else — style, naming, missing tests, performance that
+                is not a regression, and anything you could not verify.
+              - Suspected: a concern you could not prove. Always Non-blocking. State what
+                would confirm or refute it.
+              Separately, grade impact High, Medium or Low, for triage ordering only. Impact
+              never determines Blocking.
+            3. Clear statement whether the PR is ready to merge: "not ready" if any issue is
+               Blocking, otherwise "ready", and state the number of blocking issues. Do not
+               override this in prose — if you find yourself arguing that a Non-blocking issue
+               should hold the PR, it is Blocking; re-mark it.
 
             Be constructive, precise, and concise. Avoid verbose explanations unless necessary for clarity.
             Read `REVIEW.md` at the repository root before you start; it is this repository's


### PR DESCRIPTION
Three scoped changes to the `claude-code-review` job, from a 70-cell prompt/model benchmark run against 15 real commits from this repo and dsp-app (8 with a known defect, 4 clean, 3 mixed — each chosen because a later commit fixed it, so the answer is known).

## 1. Gate merge-readiness on a verified wrong outcome, not a severity label

The reviewer previously blocked only on `Critical`. That coupled two independent judgements — *how bad is this* and *should this ship* — and the benchmark's dominant failure mode was the reviewer identifying a real defect and then being obliged by its own rubric to clear.

The new rule marks each finding **Blocking** or **Non-blocking**, independently of impact: Blocking means *you established, from the code or an authoritative external source, that a reachable input or state produces a wrong outcome* — an error on a normal path, incorrect data written or returned, access incorrectly granted or denied, or a deterministic CI failure. Impact (High/Medium/Low) is graded separately, for triage ordering only, and never decides the gate.

**Evidence.** Across 20 cells on the deployed model, this produced **correct merge outcomes in 10 of 10 runs at the shipped effort**, against gate failures in every prior configuration. On the sharpest commit the old rule could only block by *over-grading* the defect to Critical; the one configuration that graded it accurately was forced to clear. The new rule blocks it while grading impact Medium — correct calibration and correct gate together, which no previous configuration achieved there.

Two fears were pre-registered and both were refuted by measurement: false blocks on clean diffs (**0 across 4 clean commits** at the shipped effort) and more false positives on deliberately-documented-as-intended code (**0 of 4**, against 2 of 3 under the old rule on the same commit).

## 2. Pin `--effort medium`

Detection is **identical** at `medium` and `high` across all nine commits run at both — same catches, same misses, same clean passes. The only behavioural difference is that `high` holds one clean PR shape: a diff carrying a verified real *non-blocking* Major. Measured across all runs of that commit, `high` surfaces that finding in 3 of 4 runs and blocks in 3 of 3 runs where it surfaced it; `medium` has never surfaced it. `medium` produced no wrong merge call in ten runs and is ~16% cheaper.

`high` does verify more deeply — it retrieves pinned external sources more reliably (4/4 vs 2/5 on one commit) and in one case caught a wrong *fix* that `medium` proposed for a defect both had correctly found. That never changed a merge outcome, and the cost is the failure mode that erodes trust in a gate: holding a PR that should ship.

## 3. Correct the tool set — and stop the job inheriting repo settings

Both corrections came from reading a real CI run's `SDK options:` echo in the job log rather than from the workflow's intent.

**`Read` is now granted.** The comment here previously claimed reading files came from the action's base tool set. It does not — `--allowed-tools` is the complete resolved set and the action adds nothing to it. Meanwhile the prompt instructs the reviewer to read the changed files in full, an instruction it could not satisfy. Runs show 3–10 permission denials each, consistent with the reviewer repeatedly reaching for tools it lacks.

**`--setting-sources user` stops the job loading this repo's own `.claude/settings.json`.** The action passes `settingSources: user,project,local` and CI restores that file from `origin/main`, so a local-developer convenience list was silently widening this job's permissions — and differently per repository. dsp-api carried `git`/`npm`/`node`/`jq` grants (plus write-capable `git add`/`commit`/`push`, inert only because the token is `contents: read`) that arrived in a dependency-bot PR as `claude-flow` scaffolding and outlived the tool by a year; dsp-app carried none. **The same review job therefore behaved differently in the two repos.** Its tool set is now defined on the `claude_args` line and nowhere else, identically in both.

Developers' local settings are untouched — this only changes what the CI job loads.

**Validated, not assumed.** All three commissioned defects were re-caught under this exact tool set at both efforts (6 cells, 6/6), and the clean-commit false block was re-measured under it too. The restriction turned out to be cost-neutral to cheaper: at `medium`, −4% cost and −21% tokens against the same commits on the old tool set, with wall-clock flat.

## Scope and what is not covered

- `claude-general` (job 2) is deliberately unchanged — it passes no `claude_args` and is not a review gate.
- The benchmark's 15 commits were all found because a later commit fixed them, so detection rates are floors, not production rates.
- One known detection gap is untouched by this PR: on two commits the reviewer verifies the change does what its author intended and never asks what the construction implies elsewhere. A candidate prompt clause for it was tested and not promoted.
- Confirm after the first run on this change by reading the job log's `SDK options:` block and `permission_denials_count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
