### PR TITLE
build: fix the release-publish scalac worker crash (8 MB stack + run publish over RBE)

### DIFF
--- a/.github/actions/bazel-rbe/action.yml
+++ b/.github/actions/bazel-rbe/action.yml
@@ -4,16 +4,13 @@ description: >
   string (the `flags` output) that each CI step passes to a `just` recipe. Bazel does
   NOT expand env vars in .bazelrc, so the connection + mTLS flags live here (per CI step), not in the
   rc file; the backend-agnostic tuning flags (--remote_download_toplevel, --remote_local_fallback,
-  --repository_cache, …) are in .bazelrc. stage=cache emits remote-cache-only flags; stage=full also
-  adds the remote executor. Flags are empty when mTLS material is absent (fork PR → cold local build).
+  --repository_cache, …) are in .bazelrc. The flags enable the remote cache (AC+CAS) and the remote
+  executor. Flags are empty when mTLS material is absent (fork PR → cold local build).
   dsp-api is single-arch (all runners are x86_64 = the worker arch), so there is no cross-compile /
   target-platform machinery. External archives are cached via --repository_cache + the actions/cache
   step, not a remote downloader.
 
 inputs:
-  stage:
-    description: "cache = remote cache only (local execution); full = also remote executor."
-    default: "cache"
   runner-endpoint:
     description: RE-API endpoint, e.g. grpcs://<host>:50051 — serves the remote cache (AC+CAS) and the remote executor.
     required: true
@@ -38,7 +35,6 @@ runs:
     - id: build
       shell: bash
       env:
-        RBE_STAGE: ${{ inputs.stage }}
         RBE_RUNNER_ENDPOINT: ${{ inputs.runner-endpoint }}
         RBE_CA_CERT: ${{ inputs.ca-cert }}
         RBE_CLIENT_CERT: ${{ inputs.client-cert }}
@@ -64,12 +60,10 @@ runs:
         FLAGS="--remote_cache=$RBE_RUNNER_ENDPOINT --remote_instance_name=main"
         FLAGS="$FLAGS --tls_certificate=$CERT_DIR/ca.crt --tls_client_certificate=$CERT_DIR/client.crt --tls_client_key=$CERT_DIR/client.key"
         FLAGS="$FLAGS --noremote_cache_compression --remote_upload_local_results=true --experimental_remote_cache_eviction_retries=5"
-        if [ "$RBE_STAGE" = "full" ]; then
-          # Remote executor: build/compile actions run on the x86_64 worker; the scheduler matches it
-          # on cpu_arch. Docker-dependent test targets opt out locally via a `no-remote` BUILD tag
-          # (they need the local Docker daemon); unit tests run remotely + result-cache. --jobs raises
-          # the client fan-out far above the runner core count (actions run on the worker, not locally)
-          # — start at 128, retune with ops as more repos onboard.
-          FLAGS="$FLAGS --remote_executor=$RBE_RUNNER_ENDPOINT --remote_default_exec_properties=cpu_arch=x86_64 --jobs=128"
-        fi
+        # Remote executor: build/compile actions run on the x86_64 worker; the scheduler matches it on
+        # cpu_arch. Docker-dependent test targets opt out locally via a `no-remote` BUILD tag (they need
+        # the local Docker daemon); unit tests run remotely + result-cache. --jobs raises the client
+        # fan-out far above the runner core count (actions run on the worker, not locally) — start at
+        # 128, retune with ops as more repos onboard.
+        FLAGS="$FLAGS --remote_executor=$RBE_RUNNER_ENDPOINT --remote_default_exec_properties=cpu_arch=x86_64 --jobs=128"
         echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,11 +67,9 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          # Stage 2: remote EXECUTOR — compiles + tests run on the NativeLink worker (the unit-tests
-          # spike proved this green: 1483/2464 actions remote, all tests pass). All Bazel jobs use it;
-          # Docker/testcontainer test targets still run local via their `no-remote` tag.
-          # `--remote_local_fallback` degrades to a local build if the worker is unreachable.
-          stage: full
+          # The RBE action enables the remote cache + executor: compiles and tests run on the
+          # NativeLink worker. Docker/testcontainer test targets still run local via their `no-remote`
+          # tag; `--remote_local_fallback` degrades to a local build if the worker is unreachable.
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
@@ -137,7 +135,6 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
@@ -199,7 +196,6 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
@@ -259,7 +255,6 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
@@ -338,7 +333,6 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
@@ -371,7 +365,6 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,11 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          stage: cache
+          # full = remote executor: compile + OCI image assembly run on NativeLink (where
+          # :webapi has never crashed), reusing PR CI's cached compile. Only `bazel run
+          # //modules/*:push` stays local; --remote_download_toplevel (.bazelrc) materializes
+          # the image bytes for it. cache-mode local compiles are the release-flake exposure.
+          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,11 +29,6 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          # full = remote executor: compile + OCI image assembly run on NativeLink (where
-          # :webapi has never crashed), reusing PR CI's cached compile. Only `bazel run
-          # //modules/*:push` stays local; --remote_download_toplevel (.bazelrc) materializes
-          # the image bytes for it. cache-mode local compiles are the release-flake exposure.
-          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}

--- a/.github/workflows/publish-from-branch.yml
+++ b/.github/workflows/publish-from-branch.yml
@@ -24,11 +24,6 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          # full = remote executor: compile + OCI image assembly run on NativeLink (where
-          # :webapi has never crashed), reusing PR CI's cached compile. Only `bazel run
-          # //modules/*:push` stays local; --remote_download_toplevel (.bazelrc) materializes
-          # the image bytes for it. cache-mode local compiles are the release-flake exposure.
-          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}

--- a/.github/workflows/publish-from-branch.yml
+++ b/.github/workflows/publish-from-branch.yml
@@ -24,7 +24,11 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          stage: cache
+          # full = remote executor: compile + OCI image assembly run on NativeLink (where
+          # :webapi has never crashed), reusing PR CI's cached compile. Only `bazel run
+          # //modules/*:push` stays local; --remote_download_toplevel (.bazelrc) materializes
+          # the image bytes for it. cache-mode local compiles are the release-flake exposure.
+          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,7 +26,11 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          stage: cache
+          # full = remote executor: compile + OCI image assembly run on NativeLink (where
+          # :webapi has never crashed), reusing PR CI's cached compile. Only `bazel run
+          # //modules/*:push` stays local; --remote_download_toplevel (.bazelrc) materializes
+          # the image bytes for it. cache-mode local compiles are the release-flake exposure.
+          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,11 +26,6 @@ jobs:
         id: rbe
         uses: ./.github/actions/bazel-rbe
         with:
-          # full = remote executor: compile + OCI image assembly run on NativeLink (where
-          # :webapi has never crashed), reusing PR CI's cached compile. Only `bazel run
-          # //modules/*:push` stays local; --remote_download_toplevel (.bazelrc) materializes
-          # the image bytes for it. cache-mode local compiles are the release-flake exposure.
-          stage: full
           runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
           ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
           client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}

--- a/bazel/toolchains/BUILD.bazel
+++ b/bazel/toolchains/BUILD.bazel
@@ -41,5 +41,18 @@ setup_scala_toolchain(
     # `-Dotel.java.global-autoconfigure.enabled=true` is a JVM system property (it sits in
     # build.sbt's scalacOptions only because sbt forks the compiler) — it belongs on the
     # compiler worker JVM, not in scalacopts.
-    scalac_jvm_flags = ["-Dotel.java.global-autoconfigure.enabled=true"],
+    #
+    # -Xss8m: dotty's `staging` phase (CrossStageSafety) recurses once per statement while
+    # walking blocks, so the stack depth it needs scales with module size. On the JVM default
+    # (~1 MB thread stack) //modules/webapi:webapi overflows it and the worker dies with
+    # "Worker process did not return a WorkResponse" plus ~1000 repeated CrossStageSafety
+    # frames — nondeterministically, since JIT inlining moves frame sizes around. sbt never hit
+    # this: sbtx launched the compiler JVM with -Xss2m. PR CI is immune because it compiles on
+    # the RBE executor (bazel-rbe stage=full); the image-publish workflows run stage=cache and
+    # compile locally in a worker, which is why the flake only ever broke image publishing
+    # (v37.6.0 and v37.7.0 releases, ~half of all publish runs).
+    scalac_jvm_flags = [
+        "-Dotel.java.global-autoconfigure.enabled=true",
+        "-Xss8m",
+    ],
 )

--- a/docs/development/dsp-api-rbe.md
+++ b/docs/development/dsp-api-rbe.md
@@ -39,8 +39,8 @@ Bazel does **not** expand env vars in `.bazelrc`, and the connection/cert values
 runtime. So they are **not** committed to `.bazelrc` and **no** `ci.bazelrc` is generated. Instead:
 
 1. The `bazel-rbe` composite action (`.github/actions/bazel-rbe`) writes the mTLS material to
-   `$RUNNER_TEMP/.nl/` (outside the checkout) and emits a `flags` step-output string. Its `stage`
-   input selects `cache` (remote cache only) or `full` (also the executor).
+   `$RUNNER_TEMP/.nl/` (outside the checkout) and emits a `flags` step-output string enabling the
+   remote cache and executor.
 2. Each CI step runs a `just` recipe with the flags appended:
    `nix develop --command just <recipe> ${{ steps.rbe.outputs.flags }}`.
 3. Each bazel-invoking `just` recipe takes `*FLAGS=''` and appends `{{FLAGS}}` to its `bazel` command.
@@ -59,9 +59,9 @@ RBE is **CI-only**. Developers never contact the backend; Bazel's own local incr
 inner-loop. Machine-local flags (e.g. `--disk_cache=…`) go in a gitignored `user.bazelrc`
 (`try-import`ed by `.bazelrc`).
 
-## Every CI job runs `stage: full`
+## What runs remotely
 
-Every RBE-using CI job runs the `bazel-rbe` action with `stage: full` — remote cache **and** executor:
+Every RBE-using CI job runs the `bazel-rbe` action, which enables the remote cache **and** executor:
 `build-and-test.yml` (PR + push-to-main build/test jobs) and the three publish workflows
 (`docker-publish.yml`, `publish-release.yml`, `publish-from-branch.yml`). Build, compile, and
 unit-test actions run on the NativeLink worker; only `bazel run //modules/*:push` (registry auth) and

--- a/docs/development/dsp-api-rbe.md
+++ b/docs/development/dsp-api-rbe.md
@@ -63,15 +63,25 @@ inner-loop. Machine-local flags (e.g. `--disk_cache=…`) go in a gitignored `us
 
 ## Staged rollout
 
-- **Stage 1 (current): remote cache only** — the `bazel-rbe` steps use `stage: cache`. All actions
-  execute locally; results are cached remotely.
-- **Stage 2: add the remote executor** — flip `stage: cache` → `stage: full`, starting with the
-  `unit-tests` job. This is gated on an empirical check: rules_scala compiles and JVM unit-test
-  execution on the NativeLink worker are unproven (sipi proved remote execution for C++/Rust, not
-  Scala/JVM). Verify via `--execution_log_json_file` (or the build event stream) that the Scalac and
-  `webapi:test`/`ingest:test` actions report `runner: remote` and stay green; if a target fights the
-  persistent-worker default, try `--strategy=Scalac=remote`/`Javac=remote`, or pin that one target
-  local. `--remote_local_fallback` means a backend outage degrades to a local build, never a CI break.
+- **Stage 1: remote cache only** — `stage: cache`. All actions execute locally; results are cached
+  remotely. This was the initial rollout; no CI job runs here any more (see below).
+- **Stage 2: add the remote executor** — `stage: full` adds `--remote_executor` so build/compile/test
+  actions run on the NativeLink worker. rules_scala compiles and JVM unit-test execution were verified
+  green (`--execution_log_json_file` / build event stream showing `runner: remote`); if a target
+  fights the persistent-worker default, try `--strategy=Scalac=remote`/`Javac=remote`, or pin that one
+  target local. `--remote_local_fallback` means a backend outage degrades to a local build, never a CI
+  break.
+
+**Current state: every RBE-using CI job runs `stage: full`.**
+
+- `build-and-test.yml` (the PR + push-to-main build/test jobs) runs `full`.
+- The three publish workflows (`docker-publish.yml`, `publish-release.yml`,
+  `publish-from-branch.yml`) also run `full`. Previously `cache`, they compiled `:webapi` locally on
+  every publish — the release-flake exposure: 4 of 8 `Docker publish images` runs and the last two
+  releases died on a local scalac worker `StackOverflowError`. Under `full` the compile + image
+  assembly run on the executor (reusing PR CI's cached compile for the same commit); only
+  `bazel run //modules/*:push` stays local to reach Docker Hub. The `-Xss8m` on the scalac toolchain
+  (`bazel/toolchains/BUILD.bazel`) remains the safety net for the `--remote_local_fallback` path.
 
 ## OCI images (both arches)
 
@@ -79,7 +89,9 @@ All four images build for `image_amd64` and `image_arm64` on the x86_64 worker u
 arch-neutral (the per-arch base is pulled by digest at the repository-fetch phase, JVM jars / the
 fuseki dist are packed, and the sipi binary is extracted from a local OCI tarball). `:load`/`:push`
 run locally (Docker daemon / registry auth), which `--remote_download_toplevel` supports by
-materializing the image tarball on the runner.
+materializing the image tarball on the runner. This is the same path the publish workflows now take
+under `stage: full`, and the `docker-healthcheck` job's `bazel run //modules/*:load` exercises it on
+every PR.
 
 ## Tuning
 

--- a/docs/development/dsp-api-rbe.md
+++ b/docs/development/dsp-api-rbe.md
@@ -1,9 +1,8 @@
 # Remote Build Execution (RBE) for dsp-api
 
 dsp-api's Bazel CI runs against a shared, DaSCH-hosted **NativeLink** backend for a remote **cache**
-(and, in Stage 2, a remote **executor**). This eliminates the cold-compile penalty every CI job used
-to pay (Nix's build cache persists only the Nix store, not the Bazel output base or the Maven repo
-cache).
+and **executor**. This eliminates the cold-compile penalty every CI job used to pay (Nix's build cache
+persists only the Nix store, not the Bazel output base or the Maven repo cache).
 
 ## Backend
 
@@ -15,14 +14,13 @@ cache).
   `vars.REMOTEBUILD_RUNNER_ENDPOINT`, `secrets.REMOTEBUILD_CA_CERT`, `secrets.REMOTEBUILD_CLIENT_CERT`,
   `secrets.REMOTEBUILD_CLIENT_KEY`.
 
-## Why cache is the win here (and executor is secondary)
+## Why the cache is the primary win
 
 sipi runs RBE primarily for **cross-compilation** (building linux-amd64/arm64 + darwin-arm64 from one
 x86_64 worker); its own docs note RBE "buys no per-PR speed on a single worker" on a warm cache.
-dsp-api compiles to **JVM bytecode** — arch-independent, no cross-compile need — so the executor's
-only real upside is fanning Scala compiles and the JVM unit-test suites across the 250-core backend.
-The **remote cache** is what directly kills the cold-compile pain, so it lands first (Stage 1) and the
-executor is layered on afterward (Stage 2).
+dsp-api compiles to **JVM bytecode** — arch-independent, no cross-compile need — so the **remote
+cache** is what directly kills the cold-compile pain. The executor adds parallel fan-out of Scala
+compiles and JVM unit-test suites across the 250-core backend on top.
 
 ## Compile remote, test local
 
@@ -61,27 +59,20 @@ RBE is **CI-only**. Developers never contact the backend; Bazel's own local incr
 inner-loop. Machine-local flags (e.g. `--disk_cache=…`) go in a gitignored `user.bazelrc`
 (`try-import`ed by `.bazelrc`).
 
-## Staged rollout
+## Every CI job runs `stage: full`
 
-- **Stage 1: remote cache only** — `stage: cache`. All actions execute locally; results are cached
-  remotely. This was the initial rollout; no CI job runs here any more (see below).
-- **Stage 2: add the remote executor** — `stage: full` adds `--remote_executor` so build/compile/test
-  actions run on the NativeLink worker. rules_scala compiles and JVM unit-test execution were verified
-  green (`--execution_log_json_file` / build event stream showing `runner: remote`); if a target
-  fights the persistent-worker default, try `--strategy=Scalac=remote`/`Javac=remote`, or pin that one
-  target local. `--remote_local_fallback` means a backend outage degrades to a local build, never a CI
-  break.
+Every RBE-using CI job runs the `bazel-rbe` action with `stage: full` — remote cache **and** executor:
+`build-and-test.yml` (PR + push-to-main build/test jobs) and the three publish workflows
+(`docker-publish.yml`, `publish-release.yml`, `publish-from-branch.yml`). Build, compile, and
+unit-test actions run on the NativeLink worker; only `bazel run //modules/*:push` (registry auth) and
+the `no-remote` Docker/testcontainer suites run locally.
 
-**Current state: every RBE-using CI job runs `stage: full`.**
-
-- `build-and-test.yml` (the PR + push-to-main build/test jobs) runs `full`.
-- The three publish workflows (`docker-publish.yml`, `publish-release.yml`,
-  `publish-from-branch.yml`) also run `full`. Previously `cache`, they compiled `:webapi` locally on
-  every publish — the release-flake exposure: 4 of 8 `Docker publish images` runs and the last two
-  releases died on a local scalac worker `StackOverflowError`. Under `full` the compile + image
-  assembly run on the executor (reusing PR CI's cached compile for the same commit); only
-  `bazel run //modules/*:push` stays local to reach Docker Hub. The `-Xss8m` on the scalac toolchain
-  (`bazel/toolchains/BUILD.bazel`) remains the safety net for the `--remote_local_fallback` path.
+- `--remote_local_fallback` degrades to a local build on a backend outage, so an outage is never a CI
+  break — just a slower run.
+- The `-Xss8m` on the scalac toolchain (`bazel/toolchains/BUILD.bazel`) keeps the local-fallback
+  `:webapi` compile from overflowing the worker's stack. Keep it whenever compiler JVM flags move.
+- If a target fights the persistent-worker default under remote execution, try
+  `--strategy=Scalac=remote`/`Javac=remote`, or pin that one target local.
 
 ## OCI images (both arches)
 
@@ -89,11 +80,11 @@ All four images build for `image_amd64` and `image_arm64` on the x86_64 worker u
 arch-neutral (the per-arch base is pulled by digest at the repository-fetch phase, JVM jars / the
 fuseki dist are packed, and the sipi binary is extracted from a local OCI tarball). `:load`/`:push`
 run locally (Docker daemon / registry auth), which `--remote_download_toplevel` supports by
-materializing the image tarball on the runner. This is the same path the publish workflows now take
-under `stage: full`, and the `docker-healthcheck` job's `bazel run //modules/*:load` exercises it on
-every PR.
+materializing the image tarball on the runner. This is the same path the publish workflows take for
+`bazel run //modules/*:push`, and the `docker-healthcheck` job's `bazel run //modules/*:load`
+exercises it on every PR.
 
 ## Tuning
 
-`--jobs=128` is the Stage 2 starting point (sipi runs 192 across a 3-leg matrix). Retune with the ops
-team as more repositories onboard, watching the backend's operator queue metric.
+`--jobs=128` is the executor fan-out starting point (sipi runs 192 across a 3-leg matrix). Retune with
+the ops team as more repositories onboard, watching the backend's operator queue metric.


### PR DESCRIPTION
## Motivation

The last two release publishes failed: **v37.7.0** (run 32034161094) and **v37.6.0** (run 31381168141). Both died in the same step with the same signature — the Bazel scalac worker crashing while compiling `//modules/webapi:webapi`:

```
ERROR: modules/webapi/BUILD.bazel:56:14: scala @@//modules/webapi:webapi failed:
       Worker process did not return a WorkResponse
error: recipe `docker-publish-dsp-api-image` failed with exit code 1
```

Neither release got its images from the release workflow: v37.6.0 was covered by the concurrent `Docker publish images` run on the same commit, and v37.7.0 needed a manual `Docker Publish from branch` dispatch ~18 h later. It is not release-specific either — the same crash hit 4 of the last 8 `Docker publish images` runs on main (first occurrence 2026-07-28).

## Summary

This PR fixes both the symptom and the exposure:

- **The fix (symptom):** adds `-Xss8m` to `scalac_jvm_flags` in `bazel/toolchains/BUILD.bazel`, restoring (with headroom) the compiler stack size sbt used to set.
- **The fix (exposure):** runs the three Docker publish workflows over the NativeLink remote executor, so the compile and OCI image assembly run remotely — where `:webapi` has never crashed and where publish runs reuse PR CI's cached compile — instead of on a local scalac worker on every publish.

## Key Changes

### bazel/toolchains/BUILD.bazel
- `scalac_jvm_flags` becomes a two-element list: the existing OTel system property plus `-Xss8m`, with a comment recording the failure mode so the flag is not pruned as unexplained.

### .github/actions/bazel-rbe + the publish workflows
- The three publish workflows previously ran the `bazel-rbe` action with `stage: cache` (remote cache only, local execution); `build-and-test.yml` already ran `stage: full` (remote executor). With every call site now on the executor, the `stage` input is removed entirely — the action always emits the remote cache **and** executor flags. No `justfile`, `BUILD.bazel`, or `.bazelrc` change is needed: `--remote_download_toplevel` is already set so `bazel run //modules/*:push` gets its image bytes locally.

### docs/development/dsp-api-rbe.md
- Rewritten to current state (no staged-rollout history): every RBE-using CI job runs the remote cache + executor, including the publish workflows, with `-Xss8m` as the `--remote_local_fallback` safety net.

## Challenges and Decisions

### The worker crash is a compiler StackOverflowError, not a compile error

**Problem:** the printed worker log is ~1000 frames of one repeating cycle in dotty's `staging` phase (`CrossStageSafety.transform` → `TreeMapWithStages.transform` → `TreeMapWithPreciseStatContexts.transformStats/loop`). Bazel truncates the exception header, so the throwable class is not in the log — but ~1024 repeated frames is exactly the JVM's default `MaxJavaStackTraceDepth`, which makes `StackOverflowError` the only fit. `staging` recurses once per statement while walking blocks, so the stack depth it needs scales with module size, and `webapi` has grown past what a default (~1 MB) thread stack supports.

**Tried:** ruling out a code defect and a resource limit. The same commit compiles both ways: for v37.7.0, `Docker publish images` (started 13:15:36) compiled `:webapi` in a local worker for 220 s and passed, while `Publish-release` (started 13:16:02, identical tree) crashed at 130 s. Identical inputs, opposite outcomes — JIT inlining shifts frame sizes run to run, which is how a stack that sits right at the limit behaves. No `OutOfMemoryError` or GC-overhead output anywhere in the logs.

**Solution:** `git log` shows where the setting went. `sbtx` (removed in #4228) launched with `default_jvm_opts_common="-Xms512m -Xss2m -XX:MaxInlineLevel=18"`; the Bazel toolchain only ever carried the OTel system property, so the migration silently halved the compiler's stack. `-Xss8m` restores it with 4× the margin sbt had. rules_scala 7.2.6 passes `scalac_jvm_flags` to the scalac launcher as `--jvm_flag=…` (`scala/private/rule_impls.bzl`), which lands on the worker JVM's command line in both worker and non-worker mode.

### Why PR CI never saw it — and why `stage: full` removes the exposure

**Problem:** `CI-build-and-test` compiles the same target on every PR and has never hit this.

**Cause:** it uses the `bazel-rbe` action with `stage: full`, so `:webapi` is executed on the NativeLink executor (`remote, remote-cache` in its logs). `docker-publish.yml`, `publish-release.yml` and `publish-from-branch.yml` used `stage: cache` — remote cache only, local execution (`remote-cache, worker`). Only the local worker path was exposed. Because exec platform properties are part of the action key, the publish runs also could not reuse CI's remotely-executed result, so they recompiled `:webapi` locally on *every* publish and rolled the dice each time.

**Solution:** run the publish workflows over the remote executor. The compile and image assembly then run remotely (arch-neutral JVM bytecode — no cross-compile need), and a publish on a main commit reuses the action-cache entries PR CI already produced for that commit. Only `bazel run //modules/*:push` runs locally to reach the registry; `--remote_download_toplevel` (already in `.bazelrc`, `build --remote_download_toplevel`) materializes the image tarball on the runner. The `docker-healthcheck` job already runs the analogous `bazel run //modules/*:load` on the executor on every PR, so the "build remote → materialize bytes locally → run locally" path is already proven for OCI targets. `-Xss8m` stays load-bearing: `--remote_local_fallback` degrades to a local compile on a backend outage, which is exactly the crashing path.

## Gotchas

- **Keep an `-Xss` on the scalac toolchain.** The default JVM thread stack is not enough for `webapi` and the requirement grows with the module. If a future change moves compiler JVM flags around, carry `-Xss` with them. It also guards the `--remote_local_fallback` path where the publish compile still runs locally.
- **Keep the publish workflows on the remote executor.** Making them build locally again re-exposes the local-worker compile on every publish. If the `bazel run //modules/*:push` bytes-materialization ever regresses, prefer fixing that over pushing the compile back onto the runner.
- **A green PR proves nothing about the local-worker path.** PR CI compiles remotely; the exposed path was the publish workflows compiling locally.
- **Bazel does not retry a dead worker.** One crash fails the build, so a flake here is a hard release failure, not a slow build.

## Test Plan

- [ ] CI green on this PR (validates the flag is accepted by the launcher, the toolchain still builds, and the workflow YAML is valid; note that PR CI compiles remotely and only healthchecks `:load`, so it does not exercise the publish push path).
- [ ] Merge → `Docker publish images` green on the merge commit. Merging to `main` triggers `docker-publish.yml`, which now compiles on the executor — the `:webapi` compile runs remotely (or is a cache hit), all four `bazel run //modules/*:push` steps push `latest` + the git tag, and `trigger-dev-deployment` fires. This is the first run that actually validates the switch.
- [ ] Next release publish (`Publish-release`) completes without a worker crash.

No automated regression test: the failure is a compiler stack-depth threshold in a Bazel worker, which cannot be asserted from a unit test. The publish path staying green across subsequent runs is the confirming evidence.

## Rollback

If a publish fails because `bazel run //modules/*:push` cannot find the image bytes, make the affected publish workflow(s) build locally again (drop the executor flags for that step) — `-Xss8m` keeps that local compile path safe — then investigate the multi-arch `:index` runfiles-materialization case separately.
