### PR TITLE
feat(ingest): backfill sidecar sizes for existing assets (DEV-6957)

### DIFF
--- a/modules/ingest/BUILD.bazel
+++ b/modules/ingest/BUILD.bazel
@@ -98,6 +98,14 @@ scala_binary(
     runtime_deps = [":ingest"],
 )
 
+# One-off sidecar size backfill; not part of the service startup.
+scala_binary(
+    name = "migrate-sizes",
+    main_class = "swiss.dasch.MigrateSizes",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":ingest"],
+)
+
 scala_junit_test(
     name = "test",
     srcs = glob(["src/test/scala/**/*.scala"]),

--- a/modules/ingest/src/main/scala/swiss/dasch/MigrateSizes.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/MigrateSizes.scala
@@ -18,11 +18,16 @@ import zio.*
  * One-off migration backfilling `sizeOriginal`/`sizeDerivative` into every `.info` sidecar in the store.
  * Reads `STORAGE_ASSET_DIR` like the service does, so point it at the same volume.
  *
+ * Locally, via Bazel:
+ *
  * {{{
  *   bazel run //modules/ingest:migrate-sizes            # whole asset store
  *   bazel run //modules/ingest:migrate-sizes -- 0801    # a single project
  * }}}
+ *
+ * Against a deployed image, swapping only the main class out of the image's own entrypoint:
  */
+// docker compose run --rm --no-deps --entrypoint java ingest -cp '/sipi/lib/*' swiss.dasch.MigrateSizes
 object MigrateSizes extends ZIOAppDefault {
 
   override val bootstrap: Layer[Config.Error, ServiceConfig & JwtConfig & StorageConfig] =

--- a/modules/ingest/src/main/scala/swiss/dasch/MigrateSizes.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/MigrateSizes.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch
+
+import swiss.dasch.config.Configuration
+import swiss.dasch.config.Configuration.JwtConfig
+import swiss.dasch.config.Configuration.ServiceConfig
+import swiss.dasch.config.Configuration.StorageConfig
+import swiss.dasch.db.Db
+import swiss.dasch.domain.*
+import swiss.dasch.infrastructure.*
+import zio.*
+
+/**
+ * One-off migration backfilling `sizeOriginal`/`sizeDerivative` into every `.info` sidecar in the store.
+ * Reads `STORAGE_ASSET_DIR` like the service does, so point it at the same volume.
+ *
+ * {{{
+ *   bazel run //modules/ingest:migrate-sizes            # whole asset store
+ *   bazel run //modules/ingest:migrate-sizes -- 0801    # a single project
+ * }}}
+ */
+object MigrateSizes extends ZIOAppDefault {
+
+  override val bootstrap: Layer[Config.Error, ServiceConfig & JwtConfig & StorageConfig] =
+    Configuration.layer >+> Logger.layer
+
+  private def migrate(shortcodes: Chunk[String]) =
+    for {
+      migration <- ZIO.service[AssetSizeMigrationService]
+      report    <- shortcodes match {
+                  case Chunk() => migration.migrateAll()
+                  case codes   =>
+                    ZIO
+                      .foreach(codes) { code =>
+                        ZIO
+                          .fromEither(ProjectShortcode.from(code))
+                          .mapError(e => IllegalArgumentException(s"Invalid project shortcode '$code': $e"))
+                          .flatMap(migration.migrateProject)
+                      }
+                      .map(_.fold(AssetSizeMigrationReport.zero)(_ + _))
+                }
+    } yield report
+
+  override val run: ZIO[ZIOAppArgs, Any, ExitCode] =
+    (for {
+      args   <- ZIOAppArgs.getArgs
+      report <- migrate(args)
+      // Non-zero exit so partial failures are visible to the caller.
+      exitCode = if (report.failed > 0) ExitCode.failure else ExitCode.success
+    } yield exitCode)
+      .provideSome[ZIOAppArgs](
+        AssetInfoServiceLive.layer,
+        AssetSizeMigrationService.layer,
+        Configuration.layer,
+        Db.dataSourceLive,
+        FileChecksumServiceLive.layer,
+        ProjectRepositoryLive.layer,
+        ProjectService.layer,
+        StorageServiceLive.layer,
+      )
+}

--- a/modules/ingest/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
@@ -49,6 +49,9 @@ final private case class AssetInfoFileContent(
 ) {
   def withDerivative(checksum: Sha256Hash, size: SizeInBytes): AssetInfoFileContent =
     copy(checksumDerivative = checksum, sizeDerivative = Some(size))
+
+  def withSizes(original: Option[SizeInBytes], derivative: Option[SizeInBytes]): AssetInfoFileContent =
+    copy(sizeOriginal = original, sizeDerivative = derivative)
 }
 
 private object AssetInfoFileContent {
@@ -94,6 +97,12 @@ trait AssetInfoService {
   def save(assetInfo: AssetInfo): Task[Unit]
   def findAllInPath(path: Path, shortcode: ProjectShortcode): ZStream[Any, Throwable, AssetInfo]
   def updateAssetInfoForDerivative(derivative: Path): Task[Unit]
+
+  /**
+   * Records the on-disk sizes of `original` and `derivative` in the sidecar, leaving every other field
+   * — checksums included — untouched. A file that is not on disk is logged and its size left absent.
+   */
+  def updateSizes(infoFile: Path, original: Path, derivative: Path): Task[Unit]
   def createAssetInfo(asset: Asset): IO[IOException, AssetInfo]
 }
 
@@ -104,6 +113,8 @@ object AssetInfoService {
     ZIO.serviceWithZIO[AssetInfoService](_.loadFromFilesystem(infoFile, shortcode))
   def updateAssetInfoForDerivative(derivative: Path): ZIO[AssetInfoService, Throwable, Unit] =
     ZIO.serviceWithZIO[AssetInfoService](_.updateAssetInfoForDerivative(derivative))
+  def updateSizes(infoFile: Path, original: Path, derivative: Path): ZIO[AssetInfoService, Throwable, Unit] =
+    ZIO.serviceWithZIO[AssetInfoService](_.updateSizes(infoFile, original, derivative))
   def getInfoFilePath(asset: AssetRef): ZIO[AssetInfoService, Nothing, Path] =
     ZIO.serviceWithZIO[AssetInfoService](_.getInfoFilePath(asset))
   def createAssetInfo(asset: Asset): ZIO[AssetInfoService, IOException, AssetInfo] =
@@ -190,6 +201,19 @@ final case class AssetInfoServiceLive(storage: StorageService) extends AssetInfo
     newSize     <- SizeInBytes.of(derivative)
     _           <- storage.saveJsonFile(infoFile, content.withDerivative(newChecksum, newSize))
   } yield ()
+
+  override def updateSizes(infoFile: Path, original: Path, derivative: Path): Task[Unit] = for {
+    content        <- storage.loadJsonFile[AssetInfoFileContent](infoFile)
+    sizeOriginal   <- sizeIfPresent(original, "original")
+    sizeDerivative <- sizeIfPresent(derivative, "derivative")
+    _              <- storage.saveJsonFile(infoFile, content.withSizes(sizeOriginal, sizeDerivative))
+  } yield ()
+
+  private def sizeIfPresent(file: Path, role: String): UIO[Option[SizeInBytes]] =
+    SizeInBytes
+      .of(file)
+      .asSome
+      .catchAll(e => ZIO.logWarning(s"No size for $role $file: ${e.getMessage}").as(None))
 
   override def createAssetInfo(asset: Asset): IO[IOException, AssetInfo] = for {
     checksumOriginal   <- FileChecksumService.createSha256Hash(asset.original.file)

--- a/modules/ingest/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
@@ -213,7 +213,7 @@ final case class AssetInfoServiceLive(storage: StorageService) extends AssetInfo
     SizeInBytes
       .of(file)
       .asSome
-      .catchAll(e => ZIO.logWarning(s"No size for $role $file: ${e.getMessage}").as(None))
+      .catchAll(e => ZIO.logWarning(s"No size for $role $file: ${e.getClass.getSimpleName}").as(None))
 
   override def createAssetInfo(asset: Asset): IO[IOException, AssetInfo] = for {
     checksumOriginal   <- FileChecksumService.createSha256Hash(asset.original.file)

--- a/modules/ingest/src/main/scala/swiss/dasch/domain/AssetSizeMigrationService.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/domain/AssetSizeMigrationService.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch.domain
+
+import swiss.dasch.domain.AugmentedPath.ProjectFolder
+import zio.*
+import zio.nio.file.Path
+import zio.stream.ZStream
+
+/** The `.info` sidecar plus the original and derivative paths it names — which may not exist on disk. */
+final case class AssetFileGroup(
+  assetRef: AssetRef,
+  infoFile: Path,
+  original: Path,
+  derivative: Path,
+)
+
+final case class AssetSizeMigrationReport(found: Int, updated: Int, failed: Int) {
+  def +(other: AssetSizeMigrationReport): AssetSizeMigrationReport =
+    AssetSizeMigrationReport(found + other.found, updated + other.updated, failed + other.failed)
+}
+
+object AssetSizeMigrationReport {
+  val zero: AssetSizeMigrationReport       = AssetSizeMigrationReport(0, 0, 0)
+  val oneUpdated: AssetSizeMigrationReport = AssetSizeMigrationReport(1, 1, 0)
+  val oneFailed: AssetSizeMigrationReport  = AssetSizeMigrationReport(1, 0, 1)
+}
+
+/**
+ * Backfills `sizeOriginal`/`sizeDerivative` into `.info` sidecars written before those fields existed.
+ * Checksums are left alone, so a corrupted asset stays detectable. Entrypoint: [[swiss.dasch.MigrateSizes]].
+ */
+final case class AssetSizeMigrationService(
+  assetInfoService: AssetInfoService,
+  projectService: ProjectService,
+) {
+
+  /** A failing sidecar (unreadable or unparsable) is logged and counted, so it cannot strand the rest. */
+  def migrateAll(): Task[AssetSizeMigrationReport] =
+    for {
+      _      <- ZIO.logInfo("Collecting asset groups for size migration")
+      groups <- findAllGroups().runCollect
+      _      <- ZIO.logInfo(s"Found ${groups.size} asset groups, refreshing sidecars")
+      report <- refreshAll(groups)
+      _      <- ZIO.logInfo(
+             s"Size migration finished: ${report.updated} updated, ${report.failed} failed of ${report.found}",
+           )
+    } yield report
+
+  /** [[migrateAll]] limited to one project. */
+  def migrateProject(shortcode: ProjectShortcode): Task[AssetSizeMigrationReport] =
+    for {
+      project <- projectService
+                   .findProject(shortcode)
+                   .someOrFail(IllegalArgumentException(s"Project $shortcode not found"))
+      groups <- findGroupsOfProject(project).runCollect
+      _      <- ZIO.logInfo(s"Found ${groups.size} asset groups in $shortcode, refreshing sidecars")
+      report <- refreshAll(groups)
+    } yield report
+
+  def findAllGroups(): ZStream[Any, Throwable, AssetFileGroup] =
+    ZStream
+      .fromIterableZIO(projectService.listAllProjects())
+      .flatMap(findGroupsOfProject)
+
+  /** One group per `.info` file beneath the project folder. */
+  def findGroupsOfProject(project: ProjectFolder): ZStream[Any, Throwable, AssetFileGroup] =
+    StorageService
+      .findInPath(project.path, FileFilters.isInfoFile)
+      .mapZIOPar(StorageService.maxParallelism())(toGroup(_, project.shortcode))
+
+  private def toGroup(infoFile: Path, shortcode: ProjectShortcode): Task[AssetFileGroup] =
+    assetInfoService
+      .loadFromFilesystem(infoFile, shortcode)
+      .map(info => AssetFileGroup(info.assetRef, infoFile, info.original.file, info.derivative.file))
+
+  private def refreshAll(groups: Chunk[AssetFileGroup]): Task[AssetSizeMigrationReport] =
+    ZStream
+      .fromChunk(groups)
+      .mapZIOPar(StorageService.maxParallelism())(group =>
+        refreshGroup(group)
+          .as(AssetSizeMigrationReport.oneUpdated)
+          .catchAll(e =>
+            ZIO
+              .logError(s"Failed to refresh sidecar ${group.infoFile}: $e")
+              .as(AssetSizeMigrationReport.oneFailed),
+          ),
+      )
+      .runFold(AssetSizeMigrationReport.zero)(_ + _)
+
+  def refreshGroup(group: AssetFileGroup): Task[Unit] =
+    assetInfoService.updateSizes(group.infoFile, group.original, group.derivative)
+}
+
+object AssetSizeMigrationService {
+  val layer = ZLayer.derive[AssetSizeMigrationService]
+}

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/AssetSizeMigrationServiceSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/AssetSizeMigrationServiceSpec.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch.domain
+
+import eu.timepit.refined.types.string.NonEmptyString
+import org.junit.runner.RunWith
+import swiss.dasch.domain.AssetInfoFileTestHelper.*
+import swiss.dasch.domain.AugmentedPath.AssetFolder
+import swiss.dasch.test.SpecConfigurations
+import swiss.dasch.util.TestUtils
+import zio.*
+import zio.nio.file.Files
+import zio.nio.file.Path
+import zio.test.*
+
+import java.nio.file.StandardOpenOption.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class AssetSizeMigrationServiceSpec extends ZIOSpecDefault {
+
+  private val migration = ZIO.service[AssetSizeMigrationService]
+
+  // Original and derivative next to a sidecar that carries no sizes yet.
+  private def createAssetWithFiles(origBytes: Int, derivativeBytes: Int) =
+    for {
+      assetDir <- createInfoFile(originalFileExt = "pdf", derivativeFileExt = "pdf")
+      _        <- fillFile(assetDir / s"${assetDir.assetId}.pdf.orig", origBytes)
+      _        <- fillFile(assetDir / s"${assetDir.assetId}.pdf", derivativeBytes)
+    } yield assetDir
+
+  private def fillFile(path: Path, size: Int) =
+    Files.writeBytes(path, Chunk.fill(size)(0.toByte), WRITE, CREATE, TRUNCATE_EXISTING)
+
+  // The group as the migration discovers it: paths read out of the sidecar.
+  private def groupOf(assetDir: AssetFolder) =
+    AssetInfoService
+      .findByAssetRef(assetDir.assetRef)
+      .map(_.head)
+      .map(info =>
+        AssetFileGroup(
+          assetDir.assetRef,
+          assetDir / s"${assetDir.assetId}.info",
+          info.original.file,
+          info.derivative.file,
+        ),
+      )
+
+  /** The asset as [[createAssetWithFiles]] leaves it: both sizes absent until the migration supplies them. */
+  private def assetInfoFixture(
+    assetDir: AssetFolder,
+    sizeOriginal: Option[Long] = None,
+    sizeDerivative: Option[Long] = None,
+  ) =
+    AssetInfo(
+      assetRef = assetDir.assetRef,
+      original = FileAndChecksum(
+        assetDir / s"${assetDir.assetId}.pdf.orig",
+        testChecksumOriginal,
+        sizeOriginal.map(SizeInBytes.apply),
+      ),
+      originalFilename = NonEmptyString.unsafeFrom("test.pdf"),
+      derivative = FileAndChecksum(
+        assetDir / s"${assetDir.assetId}.pdf",
+        testChecksumDerivative,
+        sizeDerivative.map(SizeInBytes.apply),
+      ),
+      metadata = OtherMetadata(None, None),
+    )
+
+  private val migrateProjectSuite = suite("migrateProject")(
+    test("refreshes every asset of a project and reports per-group outcomes") {
+      for {
+        good <- createAssetWithFiles(origBytes = 33, derivativeBytes = 44)
+        // no files on disk — both sizes stay absent, yet the asset counts as updated
+        noFiles      <- createInfoFile(originalFileExt = "pdf", derivativeFileExt = "pdf")
+        report       <- migration.flatMap(_.migrateProject(testProject))
+        after        <- AssetInfoService.findByAssetRef(good.assetRef).map(_.head)
+        afterNoFiles <- AssetInfoService.findByAssetRef(noFiles.assetRef).map(_.head)
+      } yield assertTrue(
+        after == assetInfoFixture(good, sizeOriginal = Some(33L), sizeDerivative = Some(44L)),
+        afterNoFiles == assetInfoFixture(noFiles),
+        // the store is shared across this spec, so assert on the invariant rather than an exact count
+        report.found >= 2,
+        report.updated == report.found,
+        report.failed == 0,
+      )
+    },
+    test("fails for a project that does not exist") {
+      for {
+        result <- migration.flatMap(_.migrateProject(ProjectShortcode.unsafeFrom("9999"))).flip
+      } yield assertTrue(
+        result.isInstanceOf[IllegalArgumentException],
+        result.getMessage == "Project 9999 not found",
+      )
+    },
+  )
+
+  private val findGroupsSuite = suite("findAllGroups")(
+    test("finds one group per info file, with the paths the sidecar points at") {
+      for {
+        assetDir <- createAssetWithFiles(origBytes = 11, derivativeBytes = 22)
+        groups   <- migration.flatMap(_.findAllGroups().runCollect)
+        // the store also holds checked-in fixtures, so look at this asset's dir only
+        found = groups.filter(_.infoFile.parent.contains(assetDir.path)).toList
+      } yield assertTrue(
+        found == List(
+          AssetFileGroup(
+            assetDir.assetRef,
+            assetDir / s"${assetDir.assetId}.info",
+            assetDir / s"${assetDir.assetId}.pdf.orig",
+            assetDir / s"${assetDir.assetId}.pdf",
+          ),
+        ),
+      )
+    },
+  )
+
+  private val refreshGroupSuite = suite("refreshGroup")(
+    test("backfills sizeOriginal and sizeDerivative on a sidecar that lacks them") {
+      for {
+        assetDir <- createAssetWithFiles(origBytes = 11, derivativeBytes = 22)
+        before   <- AssetInfoService.findByAssetRef(assetDir.assetRef).map(_.head)
+        group     = AssetFileGroup(
+                  assetDir.assetRef,
+                  assetDir / s"${assetDir.assetId}.info",
+                  before.original.file,
+                  before.derivative.file,
+                )
+        _     <- migration.flatMap(_.refreshGroup(group))
+        after <- AssetInfoService.findByAssetRef(assetDir.assetRef).map(_.head)
+      } yield assertTrue(
+        before == assetInfoFixture(assetDir),
+        after == assetInfoFixture(assetDir, sizeOriginal = Some(11L), sizeDerivative = Some(22L)),
+      )
+    },
+    test("leaves the derivative size absent when only the original is on disk") {
+      for {
+        assetDir <- createInfoFile(originalFileExt = "pdf", derivativeFileExt = "pdf")
+        _        <- fillFile(assetDir / s"${assetDir.assetId}.pdf.orig", 11)
+        group    <- groupOf(assetDir)
+        _        <- migration.flatMap(_.refreshGroup(group))
+        after    <- AssetInfoService.findByAssetRef(assetDir.assetRef).map(_.head)
+      } yield assertTrue(after == assetInfoFixture(assetDir, sizeOriginal = Some(11L)))
+    },
+    test("leaves both sizes absent when neither file is on disk, and logs each") {
+      for {
+        assetDir <- createInfoFile(originalFileExt = "pdf", derivativeFileExt = "pdf")
+        group    <- groupOf(assetDir)
+        _        <- migration.flatMap(_.refreshGroup(group))
+        after    <- AssetInfoService.findByAssetRef(assetDir.assetRef).map(_.head)
+        warnings <- ZTestLogger.logOutput.map(_.filter(_.logLevel == LogLevel.Warning).map(_.message()))
+      } yield assertTrue(
+        after == assetInfoFixture(assetDir),
+        warnings.exists(_.startsWith(s"No size for original ${assetDir / s"${assetDir.assetId}.pdf.orig"}")),
+        warnings.exists(_.startsWith(s"No size for derivative ${assetDir / s"${assetDir.assetId}.pdf"}")),
+      )
+    },
+  )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("AssetSizeMigrationServiceSpec")(
+      migrateProjectSuite,
+      findGroupsSuite,
+      refreshGroupSuite,
+    ).provide(
+      AssetInfoServiceLive.layer,
+      AssetSizeMigrationService.layer,
+      FileChecksumServiceLive.layer,
+      ProjectRepositoryLive.layer,
+      ProjectService.layer,
+      StorageServiceLive.layer,
+      SpecConfigurations.storageConfigLayer,
+      TestUtils.testDbLayerWithEmptyDb,
+    )
+}


### PR DESCRIPTION
[DEV-6957](https://linear.app/dasch/issue/DEV-6957/sidecar-file-migration-precompute-file-size)

## Summary

Follow-up to #4255, which added optional `sizeOriginal` / `sizeDerivative` to the asset sidecar (`<assetId>.info`) at ingest time. Those fields are only populated for assets ingested *since* that change — every sidecar already on disk still has them absent. This PR adds the one-off migration that backfills them, other fields (incl. checksums) untouched.

## Changes

**`AssetInfoService.updateSizes(infoFile, original, derivative)`** (new) — reads the sidecar, stamps the two on-disk sizes, writes it back. Every other field, checksums included, is preserved. A file the sidecar references but that is not on disk is logged at WARN and its size left absent, rather than failing the asset.

**`AssetSizeMigrationService`** (new) — walks the asset store, one `AssetFileGroup` per `.info` file, and refreshes each. Original/derivative paths come out of the sidecar rather than being guessed from the filename. Traversal and refresh both run at `StorageService.maxParallelism()`. A sidecar that fails to read or parse is logged and counted, not fatal, so one bad asset cannot strand the rest of the store. Returns an `AssetSizeMigrationReport(found, updated, failed)`.

**`MigrateSizes`** (new) — `ZIOAppDefault` entrypoint, wired as the `//modules/ingest:migrate-sizes` `scala_binary`. Not part of service startup; it reads `STORAGE_ASSET_DIR` the same way the service does, so it must be pointed at the same volume. Exits non-zero when `failed > 0` so partial failures are visible to the caller.

## Running it

Locally, via Bazel:

```bash
bazel run //modules/ingest:migrate-sizes            # whole asset store
bazel run //modules/ingest:migrate-sizes -- 0801    # a single project
```

Against a deployed image, swapping only the main class out of the image's own entrypoint (`java -cp '/sipi/lib/*' swiss.dasch.Main`):

```bash
docker compose run --rm --no-deps --entrypoint java ingest -cp '/sipi/lib/*' swiss.dasch.MigrateSizes
```

`--no-deps` is safe because the migration touches the asset volume and its own config only; it needs no other service. The compose `ingest` service already sets `STORAGE_ASSET_DIR=/opt/images` and mounts the asset volume, so no extra wiring is needed. Append a shortcode to scope it to one project.

Idempotent — a second run recomputes the same sizes. An unknown shortcode fails fast.

## Test Plan

- `bazel test //modules/ingest:test` — full module suite passes, not just the new spec.
- `just fmt` / license headers — clean.
- The `docker compose run` command above, executed against the built image on the local asset store: `Found 6 asset groups` / `Size migration finished: 6 updated, 0 failed of 6`, with a WARN for the one asset whose `.orig` is absent and `sizeDerivative` correctly written into its sidecar.
- New `AssetSizeMigrationServiceSpec`: whole-project refresh with per-group outcomes; unknown project fails; one group discovered per info file with the sidecar's own paths; backfill onto a sidecar lacking both sizes; derivative absent when only the original is on disk; both absent (and each warned) when neither is.

Note the spec's storage layer is provided at suite level, so the asset store is shared across its tests. The project-wide assertions are written as invariants (`updated == found`, `failed == 0`) rather than an exact asset count, so they don't depend on suite ordering.
