### PR TITLE
perf(admin): trim the view-restrictions permission probes and bound the grouped counts (DEV-6778)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
@@ -140,7 +140,7 @@ final case class ViewRestrictionsRepo(
         resourceCounts <-
           if (wantResources)
             runCountByGroup(
-              ViewRestrictionsRepo.resourceCountQuery(projectIri, permissions, classes),
+              ViewRestrictionsRepo.resourceCountQuery(projectIri, permissions, _),
               CountUnit.Resources,
               classes,
             )
@@ -154,7 +154,7 @@ final case class ViewRestrictionsRepo(
                   groupBy,
                   ViewRestrictionsRepo.effectiveItemType(groupBy, itemType),
                   permissions,
-                  classes,
+                  _,
                 ),
               CountUnit.Items,
               classes,
@@ -171,14 +171,51 @@ final case class ViewRestrictionsRepo(
    * so the service asks for this in class mode only.
    */
   def totalResourcesByClass(projectIri: ProjectIri, classes: ProjectClasses): Task[Seq[GroupCountRow]] =
-    runCountByGroup(ViewRestrictionsRepo.resourceTotalByClassQuery(projectIri, classes), CountUnit.Resources, classes)
+    runCountByGroup(ViewRestrictionsRepo.resourceTotalByClassQuery(projectIri, _), CountUnit.Resources, classes)
 
-  private def runCountByGroup(query: SelectQuery, unit: CountUnit, classes: ProjectClasses): Task[Seq[GroupCountRow]] =
-    triplestore
-      .query(select(query, classes))
-      .map(_.flatMap { row =>
-        row.get("groupId").flatMap(g => row.get("cnt").flatMap(c => c.toIntOption.map(GroupCountRow(g, _, unit))))
-      })
+  /**
+   * Runs one grouped count as a fan-out over chunks of the project's classes, then merges.
+   *
+   * The whole-project query is a single scan whose cost grows with the project; Fuseki applies
+   * `query-timeout` per request, so past some size that one query is cancelled mid-stream and the request
+   * fails, however fast the rest of the pipeline is. Splitting the class list bounds each individual query
+   * instead: on a 46k-resource / 265k-value project the single query took 8.1s while the slowest chunk took
+   * 1.4s, so the same work survives a budget the whole-project form eventually will not.
+   *
+   * Merging depends on the grouping key, so both cases are handled by summing per `(groupId, unit)`:
+   *
+   *   - grouping by resource class, the chunks partition the groups themselves, so every `groupId` occurs in
+   *     exactly one chunk and the sum is a concatenation;
+   *   - grouping by property, every chunk can report every property — the classes partition the *rows*, not
+   *     the groups — so a property's total is the sum of its per-chunk counts.
+   *
+   * Summing is only sound because each counted object belongs to exactly one chunk: a value belongs to one
+   * resource, and `dedupeRows = true` (the default these count queries use) pins a resource to a single
+   * `?resClass` binding. Were a resource to bind several classes in the hierarchy, its objects would be
+   * counted once per chunk. `ViewRestrictionsQuerySpec` pins that the count queries keep the dedup filter.
+   */
+  private def runCountByGroup(
+    query: ProjectClasses => SelectQuery,
+    unit: CountUnit,
+    classes: ProjectClasses,
+  ): Task[Seq[GroupCountRow]] =
+    ZIO
+      .foreachPar(classes.chunked(ViewRestrictionsRepo.ClassChunkSize))(chunk =>
+        triplestore
+          .query(select(query(chunk), chunk))
+          .map(_.flatMap { row =>
+            row.get("groupId").flatMap(g => row.get("cnt").flatMap(c => c.toIntOption.map(GroupCountRow(g, _, unit))))
+          }),
+      )
+      .withParallelism(ViewRestrictionsRepo.MaxConcurrentChunkQueries)
+      .map(mergeCounts)
+
+  /** Sums chunk results per `(groupId, unit)`; see [[runCountByGroup]] for why summing is sound. */
+  private def mergeCounts(perChunk: Seq[Seq[GroupCountRow]]): Seq[GroupCountRow] =
+    perChunk.flatten
+      .groupMapReduce(r => (r.groupId, r.unit))(_.count)(_ + _)
+      .map { case ((groupId, unit), count) => GroupCountRow(groupId, count, unit) }
+      .toSeq
 
   /**
    * The distinct resource IRIs of one page of the drill-down, ordered by label then IRI so paging is
@@ -404,6 +441,17 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
      *                   — it is a row *reducer*, and reducing rows cannot add or remove a literal that
      *                   some other row still carries.
      */
+    /**
+     * Splits into groups of at most `size` classes, each carrying the same `multiTyped` flag, so a grouped
+     * count can be issued per chunk instead of once for the whole project — see `runCountByGroup`.
+     *
+     * An empty class list yields a single empty chunk rather than none: with no discovered class the queries
+     * fall back to the `subClassOf*` guard ([[resClassPatterns]]) and must still be run once.
+     */
+    def chunked(size: Int): Seq[ProjectClasses] =
+      if (iris.isEmpty) Seq(this)
+      else iris.grouped(math.max(1, size)).map(ProjectClasses(_, multiTyped)).toSeq
+
     def resClassPatterns(resource: Variable, resClass: Variable, dedupeRows: Boolean): Seq[GraphPattern] = {
       val classGuard =
         Option.when(iris.isEmpty)(resClass.has(zeroOrMore(RDFS.SUBCLASSOF), KnoraBase.Resource))
@@ -411,6 +459,23 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       (classGuard ++ specific).toSeq
     }
   }
+
+  /**
+   * How many of the project's classes one grouped-count query covers.
+   *
+   * Small enough that each query stays well inside the triplestore's `query-timeout`, large enough not to
+   * pay the fixed per-request overhead once per class: measured on a 46k-resource project, per-class queries
+   * bottomed out at ~25ms of overhead each, so grouping a few classes together costs nothing and cuts the
+   * number of round-trips.
+   */
+  private[repo] val ClassChunkSize = 3
+
+  /**
+   * Concurrent chunk queries per grouped count. Deliberately small: the service already fans out over
+   * (audience, state) with its own cap, and these multiply, so a large value here would put the product of
+   * the two on the triplestore for a single request.
+   */
+  private[repo] val MaxConcurrentChunkQueries = 2
 
   /** `VALUES ?v { <a> <b> … }` for a set of IRIs. */
   private[repo] def valuesOf(v: Variable, iris: Seq[String]): String =

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
@@ -393,12 +393,21 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
      *     leave `?resClass` matching every asserted type — including value and non-resource classes —
      *     and inflate every count.
      *   - The most-specific-class filter is added only when the project's data can actually produce an
-     *     ambiguous binding (see [[multiTypedQuery]]).
+     *     ambiguous binding (see [[multiTypedQuery]]) *and* the caller's result depends on how many rows
+     *     a resource contributes — see `dedupeRows`.
+     *
+     * @param dedupeRows whether the caller needs one `?resClass` binding per resource. True for the
+     *                   counting and paging queries, whose answer changes if a multi-typed resource is
+     *                   counted or listed once per class in its hierarchy. False for
+     *                   `SELECT DISTINCT ?permissions`, which projects only the permission literal, so
+     *                   duplicate rows collapse in `DISTINCT` and the filter cannot change the result set
+     *                   — it is a row *reducer*, and reducing rows cannot add or remove a literal that
+     *                   some other row still carries.
      */
-    def resClassPatterns(resource: Variable, resClass: Variable): Seq[GraphPattern] = {
+    def resClassPatterns(resource: Variable, resClass: Variable, dedupeRows: Boolean): Seq[GraphPattern] = {
       val classGuard =
         Option.when(iris.isEmpty)(resClass.has(zeroOrMore(RDFS.SUBCLASSOF), KnoraBase.Resource))
-      val specific = Option.when(multiTyped)(mostSpecificClass(resource, resClass))
+      val specific = Option.when(multiTyped && dedupeRows)(mostSpecificClass(resource, resClass))
       (classGuard ++ specific).toSeq
     }
   }
@@ -515,6 +524,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     creator: Variable,
     permissions: Variable,
     classes: ProjectClasses,
+    dedupeRows: Boolean = true,
   ) =
     resource
       .isA(resClass)
@@ -522,7 +532,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .andHas(KnoraBase.attachedToUser, creator)
       .andHas(KnoraBase.hasPermissions, permissions)
       .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
-      .and(classes.resClassPatterns(resource, resClass)*)
+      .and(classes.resClassPatterns(resource, resClass, dedupeRows)*)
 
   /**
    * `FILTER NOT EXISTS { ?resource a ?subClass . ?subClass rdfs:subClassOf+ ?resClass }` — keeps only the
@@ -562,12 +572,13 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     creator: Variable,
     permissions: Variable,
     classes: ProjectClasses,
+    dedupeRows: Boolean = true,
   ) =
     resource
       .isA(resClass)
       .andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
       .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
-      .and(classes.resClassPatterns(resource, resClass)*)
+      .and(classes.resClassPatterns(resource, resClass, dedupeRows)*)
       .and(
         resource
           .has(prop, value)
@@ -673,7 +684,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
       .where(
         GraphPatterns
-          .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes))
+          .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes, dedupeRows = false))
           .filter(onlyRestricted(permissions)),
       )
   }
@@ -693,7 +704,9 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
       .where(
         GraphPatterns
-          .and(valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes))
+          .and(
+            valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes, dedupeRows = false),
+          )
           .filter(onlyRestricted(permissions)),
       )
   }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
@@ -516,6 +516,8 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * Without that, a resource asserted as (or inferred to be) several classes in one hierarchy would bind
    * `?resClass` once per class, which double-counts it in the aggregated summary and duplicates it in the
    * drill-down.
+   *
+   * `bindCreator = false` drops the `attachedToUser ?creator` pattern — see [[valueCore]].
    */
   private def resourceCore(
     projectIri: ProjectIri,
@@ -525,14 +527,17 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     permissions: Variable,
     classes: ProjectClasses,
     dedupeRows: Boolean = true,
-  ) =
-    resource
-      .isA(resClass)
-      .andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
-      .andHas(KnoraBase.attachedToUser, creator)
+    bindCreator: Boolean = true,
+  ) = {
+    val withProject = resource.isA(resClass).andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
+    // The creator keeps its position in the chain rather than being appended, so enabling/disabling it
+    // cannot reorder the other patterns.
+    val withCreator = if (bindCreator) withProject.andHas(KnoraBase.attachedToUser, creator) else withProject
+    withCreator
       .andHas(KnoraBase.hasPermissions, permissions)
       .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
       .and(classes.resClassPatterns(resource, resClass, dedupeRows)*)
+  }
 
   /**
    * `FILTER NOT EXISTS { ?resource a ?subClass . ?subClass rdfs:subClassOf+ ?resClass }` — keeps only the
@@ -562,6 +567,10 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * `?resClass` is pinned to the most specific asserted class for the same reason as in [[resourceCore]]:
    * in class mode it is the grouping key, so a multi-typed resource would otherwise count its values once
    * per class in the hierarchy.
+   *
+   * `bindCreator = false` drops the `attachedToUser ?creator` pattern for callers that neither project nor
+   * constrain the creator — the permission probes. It is an unconstrained join whose only effect there is to
+   * multiply intermediate rows.
    */
   private def valueCore(
     projectIri: ProjectIri,
@@ -573,7 +582,17 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     permissions: Variable,
     classes: ProjectClasses,
     dedupeRows: Boolean = true,
-  ) =
+    bindCreator: Boolean = true,
+  ) = {
+    // As in resourceCore, the creator keeps its leading position in the value block so toggling it cannot
+    // reorder the remaining patterns.
+    val valuePatterns =
+      if (bindCreator)
+        value
+          .has(KnoraBase.attachedToUser, creator)
+          .andHas(KnoraBase.hasPermissions, permissions)
+          .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
+      else value.has(KnoraBase.hasPermissions, permissions).andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
     resource
       .isA(resClass)
       .andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
@@ -584,13 +603,9 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
           .has(prop, value)
           .and(prop.has(zeroOrMore(RDFS.SUBPROPERTYOF), KnoraBase.hasValue)),
       )
-      .and(
-        value
-          .has(KnoraBase.attachedToUser, creator)
-          .andHas(KnoraBase.hasPermissions, permissions)
-          .andHas(KnoraBase.isDeleted, Rdf.literalOf(false)),
-      )
+      .and(valuePatterns)
       .and(GraphPatterns.filterNotExists(value.isA(KnoraBase.linkValue)))
+  }
 
   /** OPTIONAL `?fileClass`, bound iff the value is (a subclass of) `knora-base:FileValue`. */
   private def optionalFileClass(value: Variable, fileClass: Variable): GraphPattern =
@@ -684,7 +699,18 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
       .where(
         GraphPatterns
-          .and(resourceCore(projectIri, resource, resClass, creator, permissions, classes, dedupeRows = false))
+          .and(
+            resourceCore(
+              projectIri,
+              resource,
+              resClass,
+              creator,
+              permissions,
+              classes,
+              dedupeRows = false,
+              bindCreator = false,
+            ),
+          )
           .filter(onlyRestricted(permissions)),
       )
   }
@@ -705,7 +731,18 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .where(
         GraphPatterns
           .and(
-            valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes, dedupeRows = false),
+            valueCore(
+              projectIri,
+              resource,
+              resClass,
+              prop,
+              value,
+              creator,
+              permissions,
+              classes,
+              dedupeRows = false,
+              bindCreator = false,
+            ),
           )
           .filter(onlyRestricted(permissions)),
       )

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__distinctResourcePermissions__multiTyped.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__distinctResourcePermissions__multiTyped.txt
@@ -3,7 +3,6 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?permissions
 WHERE { ?resource a ?resClass ;
     knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
-    knora-base:attachedToUser ?creator ;
     knora-base:hasPermissions ?permissions ;
     knora-base:isDeleted false .
 FILTER ( !( REGEX( ?permissions, "(^|[|])(V|M|D|CR) [^|]*knora-admin:UnknownUser" ) ) ) }

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__distinctResourcePermissions__multiTyped.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__distinctResourcePermissions__multiTyped.txt
@@ -1,0 +1,9 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?permissions
+WHERE { ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:attachedToUser ?creator ;
+    knora-base:hasPermissions ?permissions ;
+    knora-base:isDeleted false .
+FILTER ( !( REGEX( ?permissions, "(^|[|])(V|M|D|CR) [^|]*knora-admin:UnknownUser" ) ) ) }

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__distinctValuePermissions__multiTyped.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__distinctValuePermissions__multiTyped.txt
@@ -6,8 +6,7 @@ WHERE { ?resource a ?resClass ;
     knora-base:isDeleted false .
 { ?resource ?prop ?value .
 ?prop rdfs:subPropertyOf* knora-base:hasValue . }
-?value knora-base:attachedToUser ?creator ;
-    knora-base:hasPermissions ?permissions ;
+?value knora-base:hasPermissions ?permissions ;
     knora-base:isDeleted false .
 FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
 FILTER ( !( REGEX( ?permissions, "(^|[|])(V|M|D|CR) [^|]*knora-admin:UnknownUser" ) ) ) }

--- a/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__distinctValuePermissions__multiTyped.txt
+++ b/modules/webapi/src/test/resources/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec__distinctValuePermissions__multiTyped.txt
@@ -1,0 +1,13 @@
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?permissions
+WHERE { ?resource a ?resClass ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    knora-base:isDeleted false .
+{ ?resource ?prop ?value .
+?prop rdfs:subPropertyOf* knora-base:hasValue . }
+?value knora-base:attachedToUser ?creator ;
+    knora-base:hasPermissions ?permissions ;
+    knora-base:isDeleted false .
+FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+FILTER ( !( REGEX( ?permissions, "(^|[|])(V|M|D|CR) [^|]*knora-admin:UnknownUser" ) ) ) }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsServiceSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsServiceSpec.scala
@@ -163,6 +163,48 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
        |  kb:isDeleted false .
        |""".stripMargin
 
+  /**
+   * Five resource classes, each with one restricted value carried by the SAME property.
+   *
+   * Five classes exceeds `ViewRestrictionsRepo.ClassChunkSize` (3), so the grouped counts really are issued
+   * as more than one per-chunk query and merged. In property mode all five classes contribute to the one
+   * `hasText` group, so that group's count spans every chunk — the case where the merge must add the
+   * per-chunk counts rather than pick one of them. With a single chunk the merge is a no-op and a broken
+   * merge would go unnoticed.
+   */
+  private val manyClassesTurtle: String = {
+    val classes = (1 to 5).map(i => s"http://www.knora.org/ontology/0001/anything#Klass$i")
+    val decls   = classes.map(c => s"<$c> rdfs:subClassOf kb:Resource .").mkString("\n")
+    val bodies  = classes.zipWithIndex.map { case (cls, i) =>
+      s"""
+         |<http://rdfh.ch/0001/many$i>
+         |  a <$cls> ;
+         |  rdfs:label "Many $i" ;
+         |  kb:attachedToProject <${projectIri.value}> ;
+         |  kb:attachedToUser <http://rdfh.ch/users/creator> ;
+         |  kb:hasPermissions "V knora-admin:UnknownUser" ;
+         |  kb:isDeleted false ;
+         |  <$hasText> <http://rdfh.ch/0001/many$i/values/text> .
+         |
+         |<http://rdfh.ch/0001/many$i/values/text>
+         |  a kb:TextValue ;
+         |  kb:attachedToUser <http://rdfh.ch/users/creator> ;
+         |  kb:hasPermissions "M knora-admin:ProjectMember" ;
+         |  kb:isDeleted false .
+         |""".stripMargin
+    }.mkString
+
+    s"""
+       |@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+       |@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+       |@prefix kb:    <$kb> .
+       |
+       |$decls
+       |<$hasText> rdfs:subPropertyOf kb:hasValue .
+       |$bodies
+       |""".stripMargin
+  }
+
   private val subThingClass = "http://www.knora.org/ontology/0001/anything#SubThing"
 
   /**
@@ -741,6 +783,63 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
     // Property mode has no resource population to report: a property groups values across classes, so any
     // number here would be arbitrary. Absent, not zero. Unrestricted properties are omitted entirely, since
     // such a row would be empty in every column.
+    // The dsp-app summary footer shows `totals` above a column of per-row `counts` and cross-checks
+    // neither against the other, so a `totals` that did not reconcile with the rows would render as a
+    // column that visibly fails to add up. Pinned in both grouping modes because they build `groups`
+    // differently — class mode from the class population (unrestricted classes included), property mode
+    // from the restriction rows only — and because the counts behind them are now assembled from several
+    // per-chunk queries and merged (see ViewRestrictionsRepo.runCountByGroup), so an error in that merge
+    // would surface here.
+    test("totals reconcile with the sum of the per-group counts, grouping by class") {
+      for {
+        result <- service(_.summary(projectIri, GroupBy.ResourceClass, ItemType.All))
+      } yield {
+        val summed = result.groups.map(_.counts).foldLeft(AudienceCounts.zero)(addCounts)
+        assertTrue(
+          result.groups.size > 1, // more than one group, or the sum is trivially the single row
+          result.totals == summed,
+        )
+      }
+    }.provide(commonLayers, datasetLayerFromTurtle(unrestrictedClassTurtle)),
+    test("totals reconcile with the sum of the per-group counts, grouping by property") {
+      for {
+        result <- service(_.summary(projectIri, GroupBy.Property, ItemType.All))
+      } yield {
+        val summed = result.groups.map(_.counts).foldLeft(AudienceCounts.zero)(addCounts)
+        assertTrue(
+          result.groups.nonEmpty,
+          result.totals == summed,
+        )
+      }
+    }.provide(commonLayers, datasetLayerFromTurtle(valuesTurtle)),
+    // Five classes -> more than one chunk, so these two exercise the per-chunk merge rather than a no-op.
+    // In property mode the single `hasText` group is populated from every chunk, so its count is only right
+    // if the merge sums the per-chunk contributions.
+    test("a group whose rows span several class chunks gets the summed count") {
+      for {
+        result <- service(_.summary(projectIri, GroupBy.Property, ItemType.All))
+      } yield {
+        val text = result.groups.find(_.id == hasText)
+        assertTrue(
+          result.groups.size == 1,
+          // one hidden value per class, all five under the same property
+          text.map(_.counts.anonymous.items) == Some(rc(5, 0)),
+        )
+      }
+    }.provide(commonLayers, datasetLayerFromTurtle(manyClassesTurtle)),
+    test("every class chunk is counted, so no class is dropped from the class-mode row set") {
+      for {
+        result <- service(_.summary(projectIri, GroupBy.ResourceClass, ItemType.All))
+      } yield {
+        val summed = result.groups.map(_.counts).foldLeft(AudienceCounts.zero)(addCounts)
+        assertTrue(
+          result.groups.size == 5,
+          result.groups.flatMap(_.totalResources).sum == 5,
+          result.totals == summed,
+          result.totals.anonymous.items == rc(5, 0),
+        )
+      }
+    }.provide(commonLayers, datasetLayerFromTurtle(manyClassesTurtle)),
     test("omits totalResources entirely when grouping by property") {
       for {
         result <- service(_.summary(projectIri, GroupBy.Property, ItemType.All))
@@ -750,6 +849,27 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
       )
     }.provide(commonLayers, datasetLayerFromTurtle(valuesTurtle)),
   )
+
+  /**
+   * Adds two [[AudienceCounts]] per audience and unit. Deliberately spelled out here rather than reusing the
+   * service's private `plus`, so the reconciliation tests below check the service's arithmetic against an
+   * independent one instead of against itself.
+   */
+  private def addCounts(a: AudienceCounts, b: AudienceCounts): AudienceCounts =
+    AudienceCounts(
+      anonymous = addUnits(a.anonymous, b.anonymous),
+      authenticated = addUnits(a.authenticated, b.authenticated),
+      projectMember = addUnits(a.projectMember, b.projectMember),
+    )
+
+  private def addUnits(a: UnitCounts, b: UnitCounts): UnitCounts =
+    UnitCounts(
+      resources = RestrictionCounts(
+        a.resources.hidden + b.resources.hidden,
+        a.resources.restrictedView + b.resources.restrictedView,
+      ),
+      items = RestrictionCounts(a.items.hidden + b.items.hidden, a.items.restrictedView + b.items.restrictedView),
+    )
 
   // ----- drill-down over seeded data -----
 

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
@@ -61,19 +61,21 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
           !q.contains("LIMIT"),
         )
       },
-      // Both variants omit the most-specific-class filter even for a multi-typed project: they project
-      // only ?permissions under DISTINCT, so the filter can only remove rows, never change which literals
-      // survive. Pinned as golden snapshots because dropping it is a large win on big projects
-      // (measured on 46k resources / 265k values: 121s -> 16s, byte-identical results).
+      // Both variants project only ?permissions under DISTINCT, so two patterns the shared cores emit are
+      // dead weight here and are left out:
+      //   - the most-specific-class filter, which can only remove rows and so cannot change which literals
+      //     survive (measured on 46k resources / 265k values: 121s -> 16s, byte-identical results);
+      //   - the `attachedToUser ?creator` join, which is neither projected nor constrained (-18%).
+      // Pinned as golden snapshots so neither silently comes back.
       test("resource variant omits the most-specific-class filter for a multi-typed project") {
         val q = ViewRestrictionsRepo.distinctResourcePermissionsQuery(projectIri, multiTyped).getQueryString
         assertGolden(q, "distinctResourcePermissions__multiTyped") &&
-        assertTrue(!q.contains("rdfs:subClassOf+"))
+        assertTrue(!q.contains("rdfs:subClassOf+"), !q.contains("?creator"))
       },
       test("value variant omits the most-specific-class filter for a multi-typed project") {
         val q = ViewRestrictionsRepo.distinctValuePermissionsQuery(projectIri, multiTyped).getQueryString
         assertGolden(q, "distinctValuePermissions__multiTyped") &&
-        assertTrue(!q.contains("rdfs:subClassOf+"))
+        assertTrue(!q.contains("rdfs:subClassOf+"), !q.contains("?creator"))
       },
     ),
     suite("aggregated counts")(

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
@@ -78,6 +78,38 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
         assertTrue(!q.contains("rdfs:subClassOf+"), !q.contains("?creator"))
       },
     ),
+    suite("class chunking")(
+      test("chunks cover every class exactly once and carry the multiTyped flag") {
+        val many    = ViewRestrictionsRepo.ProjectClasses((1 to 7).map(i => s"http://example.org/C$i"), true)
+        val chunks  = many.chunked(3)
+        val covered = chunks.flatMap(_.iris)
+        assertTrue(
+          chunks.size == 3,
+          chunks.forall(_.iris.size <= 3),
+          // a partition: no class lost, none duplicated into two chunks (which would double-count it)
+          covered == many.iris,
+          covered.distinct == covered,
+          chunks.forall(_.multiTyped),
+        )
+      },
+      test("an empty class list still yields one chunk, so the subClassOf* fallback runs") {
+        val none = ViewRestrictionsRepo.ProjectClasses(Seq.empty, multiTyped = false)
+        assertTrue(none.chunked(3) == Seq(none))
+      },
+      test("each chunk's query binds only that chunk's classes") {
+        val three              = ViewRestrictionsRepo.ProjectClasses(Seq("http://example.org/A", "http://example.org/B"), false)
+        val Seq(first, second) = three.chunked(1)
+        val qA                 = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, first),
+          first.valuesClause(resClassVar),
+        )
+        assertTrue(
+          qA.contains("http://example.org/A"),
+          !qA.contains("http://example.org/B"),
+          second.iris == Seq("http://example.org/B"),
+        )
+      },
+    ),
     suite("aggregated counts")(
       test("resource counts group by class and COUNT DISTINCT, filtered to the hidden literals") {
         val q = ViewRestrictionsRepo.resourceCountQuery(projectIri, hidden, singleTyped).getQueryString

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
@@ -61,6 +61,20 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
           !q.contains("LIMIT"),
         )
       },
+      // Both variants omit the most-specific-class filter even for a multi-typed project: they project
+      // only ?permissions under DISTINCT, so the filter can only remove rows, never change which literals
+      // survive. Pinned as golden snapshots because dropping it is a large win on big projects
+      // (measured on 46k resources / 265k values: 121s -> 16s, byte-identical results).
+      test("resource variant omits the most-specific-class filter for a multi-typed project") {
+        val q = ViewRestrictionsRepo.distinctResourcePermissionsQuery(projectIri, multiTyped).getQueryString
+        assertGolden(q, "distinctResourcePermissions__multiTyped") &&
+        assertTrue(!q.contains("rdfs:subClassOf+"))
+      },
+      test("value variant omits the most-specific-class filter for a multi-typed project") {
+        val q = ViewRestrictionsRepo.distinctValuePermissionsQuery(projectIri, multiTyped).getQueryString
+        assertGolden(q, "distinctValuePermissions__multiTyped") &&
+        assertTrue(!q.contains("rdfs:subClassOf+"))
+      },
     ),
     suite("aggregated counts")(
       test("resource counts group by class and COUNT DISTINCT, filtered to the hidden literals") {


### PR DESCRIPTION
Follow-up to #4251, which made the view-restrictions endpoints usable on real projects. That PR removed two `rdfs:subClassOf` traversals the triplestore was re-evaluating per result row; this one removes two more patterns that were doing no work, bounds the per-query cost, and pins the invariants the dsp-app page depends on.

No API surface change: endpoints, DTOs, the service layer and `docs/openapi/openapi.yaml` are untouched, so the generated dsp-das client regenerates identically and needs no update.

## Changes

**`perf`: drop the most-specific-class filter from the permission probes.** `distinctResourcePermissionsQuery`/`distinctValuePermissionsQuery` inherited `FILTER NOT EXISTS { … subClassOf+ … }` from the shared cores, but they `SELECT DISTINCT ?permissions` — the filter can only remove rows, and removing rows cannot change which literals survive. `resClassPatterns` takes a `dedupeRows` flag, defaulting to true so the counting and paging queries are unchanged. Measured on a synthetic 46k-resource / 265k-value project with 40% of resources multi-typed (so the filter was actually emitted): **121.2s → 15.8s** on the value probe, result set byte-identical (16 literals, verified by diff).

**`perf`: drop the unused creator join from the permission probes.** The same two queries bound `attachedToUser ?creator` without ever projecting or constraining it — an unconstrained join whose only effect was to multiply intermediate rows before `DISTINCT` collapsed them. `distinctPermissions`' own scaladoc already said the creator is irrelevant here; the query didn't match. **875ms → 720ms (−18%)** on the 5k project. `bindCreator` joins `dedupeRows` as a flag; in both cores the creator keeps its position in the pattern chain, so toggling it cannot reorder the rendered SPARQL of unrelated queries.

**`perf`: chunk the grouped counts by resource class.** Each grouped count was one query over the project's whole class list, and Fuseki applies `query-timeout` (20s) per request — so past some size that single query is cancelled mid-stream regardless of how efficient the per-row work is. `runCountByGroup` now fans out over chunks of 3 classes and `mergeCounts` sums per `(groupId, unit)`.

Please read that commit message before reviewing this one: it is a correctness-preserving restructuring that bounds per-query cost, **not** a throughput win, and it does **not** rescue the large case. At 46k resources / 265k values the summary still takes 40-49s through the API and returns 500 for `itemType=File`/`Value` — one 3-class chunk is ~4.4s idle and 13-17s under the request's own concurrency. Fuseki's log confirms the fan-out is active (133 grouped-count queries where the unchunked form issues ~12); the volume is simply past what a 20s budget absorbs, and the unchunkable `distinctPermissions` probes run first. An earlier draft of that message claimed "8.1s → 1.4s slowest chunk" from hand-run queries against an idle store; that figure does not survive real concurrency and has been retracted in the message.

**`test`: pin the summary invariants dsp-app relies on.** The dsp-app page shows `totals` above a column of per-group `counts` and cross-checks neither, and sums `group.totalResources` client-side for the footer. Two tests assert `totals` equals the fold of the group counts in both grouping modes, with the fold spelled out independently rather than reusing the service's `plus`.

More importantly, a `manyClassesTurtle` fixture with five classes sharing one property. Every pre-existing fixture has at most three classes and `ClassChunkSize` is 3, so **the merge was a no-op in every test**: mutating `mergeCounts` from `_ + _` to `math.max` passed the entire suite. With the new fixture that mutation fails on the property-mode case where one group is populated from every chunk.

## Verification

- `just check` and `bazel test //modules/webapi:test` green.
- Correctness of the chunked merge verified against the triplestore at the chunk size the code uses: three chunks of three classes, summed, reproduce the single-query result exactly for `groupBy=Property`, all 10 property counts identical.
- All 10 summary variants (2 `groupBy` × 5 `itemType`) on `incunabula` return **0.9-2.7s**; drill-down pages in 1.4s.
- Exercised through the dsp-app View restrictions page against a local API built from this branch.

## Known ceiling, not a regression

A 46k-resource / 265k-value project still exceeds `query-timeout`. Closing that needs a longer timeout tier for admin reporting, more Fuseki heap than the local `-Xmx3G`, or a different shape for the `distinctPermissions` probes, which have no group key to chunk on. Worth a separate ticket rather than stretching this PR.

Also worth recording: no project in the local test data asserts a class together with one of its ancestors — all four probe 0 — so the most-specific-class filter never fires on that data and the first commit's 121s → 16s is insurance for a shape that does not currently occur, not a win visible today.

The synthetic-data generator used for these measurements is deliberately **not** included here.
