### PR TITLE
build: bump sipi to v6.4.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -306,23 +306,23 @@ use_repo(image_versions, "dsp_image_versions")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v6.3.1), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v6.4.1), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v6.3.1 index carries a `v8`
+# index/variant matching — the arm64 entry of the v6.4.1 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. These two
 # digests are the SOLE source of the sipi version: the /version endpoint reads
 # the tag from the image's own `org.opencontainers.image.version` OCI label
 # (//tools/buildinfo:oci_config_label), so there is no duplicated tag string to
 # keep in sync. To bump, see "Bumping the SIPI version" in CLAUDE.md.
-# Index digest: sha256:91f72b1d3a58b9b3bdd4ee8473ab24a047c6e43af105956c7bcb6c82bc29b5a3
+# Index digest: sha256:e1d751b5a1df1b6274769da28c8cc5f050bf506cd23617523d80b5e3d64ab980
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:fbd5adc7889c0e604d4161c773cfcfcb2ef605de9ef889d02f1f91b0f045f602",
+    digest = "sha256:84918319f5b76a9263e10b5ad031763913b7319bafc68742900dcd021a7b7baa",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:9eef75ef70e0481ce2f3e40a58ff294f65d0e48261ef3bcf5c65aca1d96b785c",
+    digest = "sha256:da59ebcdb71a7779e60b037438a45f7851d3dd96c83e3e20569774df684ed520",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(


### PR DESCRIPTION
## What

Bumps the pinned upstream Sipi image from `v6.3.1` to `v6.4.1` (released 2026-08-20).

Repins both `oci.pull` base images in `MODULE.bazel` to the `v6.4.1` per-arch manifest digests and updates the comment anchors (tag references + index digest). `MODULE.bazel` is the sole source of the Sipi version.

| arch | digest |
|---|---|
| linux/amd64 | `sha256:84918319f5b76a9263e10b5ad031763913b7319bafc68742900dcd021a7b7baa` |
| linux/arm64v8 | `sha256:da59ebcdb71a7779e60b037438a45f7851d3dd96c83e3e20569774df684ed520` |

Index digest (comment only): `sha256:e1d751b5a1df1b6274769da28c8cc5f050bf506cd23617523d80b5e3d64ab980`

## Verification

- `just docker-build-sipi-image` pulls both new digests and builds `knora-sipi` successfully.
- `docker inspect` of the built image reports `org.opencontainers.image.version = v6.4.1`.

## Follow-up

Sync the same Sipi version in the **ops-deploy** repo when this DSP release is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)