### PR TITLE
perf(admin): chunk the grouped value counts by property as well as class

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsService.scala
@@ -183,8 +183,11 @@ final case class ViewRestrictionsService(
     for {
       // Resolved once and reused by every query below: the project's asserted resource classes, which
       // replace two per-row `rdfs:subClassOf` traversals in the queries themselves.
-      classes  <- repo.projectClasses(projectIri)
-      literals <- repo.distinctPermissions(projectIri, itemType, groupBy, classes)
+      classes <- repo.projectClasses(projectIri)
+      // The second axis the grouped value counts are chunked along, so a single large class cannot produce
+      // an unbounded query — see ViewRestrictionsRepo.runCountByGroup.
+      properties <- repo.projectProperties(projectIri)
+      literals   <- repo.distinctPermissions(projectIri, itemType, groupBy, classes)
       // One count per (audience, state). Both are tiny fixed sets — 3 x 2 — and each classification pass
       // runs over the small distinct-literal set, so this stays cheap regardless of project size.
       //
@@ -199,7 +202,9 @@ final case class ViewRestrictionsService(
         ZIO
           .foreachPar(for (a <- Audience.ordered; s <- countedStates) yield (a, s)) { case (audience, state) =>
             val hits = literalsResolvingTo(literals, state, audience, projectIri)
-            repo.countByGroup(projectIri, groupBy, itemType, hits, classes).map(rows => (audience, state, rows))
+            repo
+              .countByGroup(projectIri, groupBy, itemType, hits, classes, properties)
+              .map(rows => (audience, state, rows))
           }
           .withParallelism(ViewRestrictionsService.MaxConcurrentCountQueries)
           // Every resource class the project has, with its population — independent of any restriction and

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsRepo.scala
@@ -21,6 +21,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.CountUnit
 import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.GroupCountRow
 import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.ProjectClasses
+import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.ProjectProperties
 import org.knora.webapi.slice.admin.repo.ViewRestrictionsRepo.RestrictedObjectRow
 import org.knora.webapi.slice.api.admin.ViewRestrictionsEndpoints.GroupBy
 import org.knora.webapi.slice.api.admin.ViewRestrictionsEndpoints.ItemType
@@ -76,6 +77,17 @@ final case class ViewRestrictionsRepo(
     } yield ProjectClasses(iris, multi)
 
   /**
+   * The project's value properties, the second axis [[countByGroup]] chunks its value counts along.
+   *
+   * One small anchored query per request, in exchange for both a finer chunk granularity than the class
+   * list can offer and the removal of a `subPropertyOf*` traversal from every value count in that request.
+   */
+  def projectProperties(projectIri: ProjectIri): Task[ProjectProperties] =
+    triplestore
+      .query(Select(ViewRestrictionsRepo.projectPropertiesQuery(projectIri)))
+      .map(rows => ProjectProperties(rows.flatMap(_.get("prop"))))
+
+  /**
    * The project's distinct `knora-base:hasPermissions` literals among restriction-bearing objects, across
    * both resources and values. The service classifies these (and only these) with
    * [[org.knora.webapi.messages.util.PermissionUtilADM]] to decide which literals mean hidden and which
@@ -113,6 +125,15 @@ final case class ViewRestrictionsRepo(
   private def select(query: SelectQuery, classes: ProjectClasses): Select =
     Select(ViewRestrictionsRepo.withValues(query, classes.valuesClause(variable("resClass"))))
 
+  /** As above, additionally pinning `?prop` for the value counts' second chunking axis. */
+  private def select(query: SelectQuery, classes: ProjectClasses, properties: ProjectProperties): Select =
+    Select(
+      ViewRestrictionsRepo.withValues(
+        query,
+        (classes.valuesClause(variable("resClass")) ++ properties.valuesClause(variable("prop"))).toSeq,
+      ),
+    )
+
   /**
    * Per-group counts of the objects whose permission literal is in `permissions`, computed by the
    * triplestore with `GROUP BY` + `COUNT`. Exact regardless of project size.
@@ -128,6 +149,7 @@ final case class ViewRestrictionsRepo(
     itemType: ItemType,
     permissions: Set[String],
     classes: ProjectClasses,
+    properties: ProjectProperties,
   ): Task[Seq[GroupCountRow]] =
     if (permissions.isEmpty) ZIO.succeed(Seq.empty)
     else {
@@ -139,25 +161,30 @@ final case class ViewRestrictionsRepo(
       for {
         resourceCounts <-
           if (wantResources)
+            // No property axis: a resource-level count has no `?prop` to chunk on.
             runCountByGroup(
-              ViewRestrictionsRepo.resourceCountQuery(projectIri, permissions, _),
+              (cs, _) => ViewRestrictionsRepo.resourceCountQuery(projectIri, permissions, cs),
               CountUnit.Resources,
               classes,
+              ProjectProperties(Seq.empty),
             )
           else ZIO.succeed(Seq.empty[GroupCountRow])
         valueCounts <-
           if (wantValues)
             runCountByGroup(
-              ViewRestrictionsRepo
-                .valueCountQuery(
-                  projectIri,
-                  groupBy,
-                  ViewRestrictionsRepo.effectiveItemType(groupBy, itemType),
-                  permissions,
-                  _,
-                ),
+              (cs, ps) =>
+                ViewRestrictionsRepo
+                  .valueCountQuery(
+                    projectIri,
+                    groupBy,
+                    ViewRestrictionsRepo.effectiveItemType(groupBy, itemType),
+                    permissions,
+                    cs,
+                    ps,
+                  ),
               CountUnit.Items,
               classes,
+              properties,
             )
           else ZIO.succeed(Seq.empty[GroupCountRow])
       } yield resourceCounts ++ valueCounts
@@ -171,7 +198,12 @@ final case class ViewRestrictionsRepo(
    * so the service asks for this in class mode only.
    */
   def totalResourcesByClass(projectIri: ProjectIri, classes: ProjectClasses): Task[Seq[GroupCountRow]] =
-    runCountByGroup(ViewRestrictionsRepo.resourceTotalByClassQuery(projectIri, _), CountUnit.Resources, classes)
+    runCountByGroup(
+      (cs, _) => ViewRestrictionsRepo.resourceTotalByClassQuery(projectIri, cs),
+      CountUnit.Resources,
+      classes,
+      ProjectProperties(Seq.empty),
+    )
 
   /**
    * Runs one grouped count as a fan-out over chunks of the project's classes, then merges.
@@ -182,33 +214,48 @@ final case class ViewRestrictionsRepo(
    * instead: on a 46k-resource / 265k-value project the single query took 8.1s while the slowest chunk took
    * 1.4s, so the same work survives a budget the whole-project form eventually will not.
    *
-   * Merging depends on the grouping key, so both cases are handled by summing per `(groupId, unit)`:
+   * Chunking runs on **two** axes, the cartesian product of class chunks and property chunks. Classes alone
+   * have a floor — a chunk of one class cannot be subdivided — so a project with a single very large class
+   * still issued one unbounded query. Binding `?prop` splits below that floor, and it also removes the
+   * `subPropertyOf*` traversal from the query (see [[ProjectProperties]]): measured on the perftest project,
+   * one class went from 232ms to ~110ms with identical counts. Resource-level counts pass an empty
+   * [[ProjectProperties]], which yields a single chunk — they have no `?prop` to split on.
    *
-   *   - grouping by resource class, the chunks partition the groups themselves, so every `groupId` occurs in
-   *     exactly one chunk and the sum is a concatenation;
-   *   - grouping by property, every chunk can report every property — the classes partition the *rows*, not
-   *     the groups — so a property's total is the sum of its per-chunk counts.
+   * Merging depends on the grouping key, so every case is handled by summing per `(groupId, unit)`:
    *
-   * Summing is only sound because each counted object belongs to exactly one chunk: a value belongs to one
-   * resource, and `dedupeRows = true` (the default these count queries use) pins a resource to a single
-   * `?resClass` binding. Were a resource to bind several classes in the hierarchy, its objects would be
-   * counted once per chunk. `ViewRestrictionsQuerySpec` pins that the count queries keep the dedup filter.
+   *   - grouping by resource class, the class chunks partition the groups themselves, so a `groupId` occurs
+   *     in one class chunk — but in as many property chunks as it has properties, and those are summed;
+   *   - grouping by property, the property chunks partition the groups and the class chunks partition the
+   *     *rows*, so a property's total is the sum of its per-class-chunk counts.
+   *
+   * Summing is only sound because each counted object belongs to exactly one chunk on each axis: a value
+   * belongs to one resource, `dedupeRows = true` (the default these count queries use) pins a resource to a
+   * single `?resClass` binding, and a value is reached through exactly one property, so the property chunks
+   * partition the values rather than overlapping them. Were a resource to bind several classes in the
+   * hierarchy, its objects would be counted once per chunk. `ViewRestrictionsQuerySpec` pins that the count
+   * queries keep the dedup filter.
    */
   private def runCountByGroup(
-    query: ProjectClasses => SelectQuery,
+    query: (ProjectClasses, ProjectProperties) => SelectQuery,
     unit: CountUnit,
     classes: ProjectClasses,
-  ): Task[Seq[GroupCountRow]] =
+    properties: ProjectProperties,
+  ): Task[Seq[GroupCountRow]] = {
+    val chunks = for {
+      classChunk <- classes.chunked(ViewRestrictionsRepo.ClassChunkSize)
+      propChunk  <- properties.chunked(ViewRestrictionsRepo.PropertyChunkSize)
+    } yield (classChunk, propChunk)
     ZIO
-      .foreachPar(classes.chunked(ViewRestrictionsRepo.ClassChunkSize))(chunk =>
+      .foreachPar(chunks) { case (classChunk, propChunk) =>
         triplestore
-          .query(select(query(chunk), chunk))
+          .query(select(query(classChunk, propChunk), classChunk, propChunk))
           .map(_.flatMap { row =>
             row.get("groupId").flatMap(g => row.get("cnt").flatMap(c => c.toIntOption.map(GroupCountRow(g, _, unit))))
-          }),
-      )
+          })
+      }
       .withParallelism(ViewRestrictionsRepo.MaxConcurrentChunkQueries)
       .map(mergeCounts)
+  }
 
   /** Sums chunk results per `(groupId, unit)`; see [[runCountByGroup]] for why summing is sound. */
   private def mergeCounts(perChunk: Seq[Seq[GroupCountRow]]): Seq[GroupCountRow] =
@@ -461,6 +508,51 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
   }
 
   /**
+   * The value properties a project's data actually uses — the second axis the grouped value counts are
+   * chunked along.
+   *
+   * Class chunking alone has a floor: once a chunk is a single class it cannot be subdivided, so a project
+   * with one very large class still issues one query whose cost grows without bound. Binding `?prop` from a
+   * discovered list splits *below* that floor, and it simultaneously replaces the
+   * `?prop rdfs:subPropertyOf* knora-base:hasValue` traversal — which the store would otherwise re-evaluate
+   * per candidate row — with a table the engine can anchor on. Measured on the perftest project, one class
+   * went from 232ms (traversal) to ~110ms (bound), returning identical counts.
+   *
+   * As with [[ProjectClasses]], these are the properties **present in the data**, not the sub-property
+   * closure from the ontology: inlining a large ontology closure as `VALUES` is the shape DEV-6803 measured
+   * as catastrophic.
+   *
+   * @param iris the value-property IRIs asserted in the project, empty when none was discovered.
+   */
+  final case class ProjectProperties(iris: Seq[String]) {
+
+    /**
+     * `VALUES ?prop { <…> }`, or `None` when no property was discovered.
+     *
+     * `None` does **not** mean "no constraint": [[propPatterns]] falls back to the original
+     * `subPropertyOf*` traversal in that case, so `?prop` is never left unconstrained.
+     */
+    def valuesClause(prop: Variable): Option[String] =
+      Option.when(iris.nonEmpty)(ViewRestrictionsRepo.valuesOf(prop, iris))
+
+    /**
+     * The pattern that pins `?prop` beyond the `VALUES` clause: the original `subPropertyOf*` traversal,
+     * emitted only when nothing was discovered. Dropping both would let `?prop` match every predicate on
+     * the resource — including `rdf:type` and the admin properties — and inflate every count.
+     */
+    def propPatterns(prop: Variable): Seq[GraphPattern] =
+      Option.when(iris.isEmpty)(prop.has(zeroOrMore(RDFS.SUBPROPERTYOF), KnoraBase.hasValue)).toSeq
+
+    /**
+     * Splits into groups of at most `size` properties. An empty list yields a single empty chunk rather
+     * than none: the queries must still run once, falling back to the traversal.
+     */
+    def chunked(size: Int): Seq[ProjectProperties] =
+      if (iris.isEmpty) Seq(this)
+      else iris.grouped(math.max(1, size)).map(ProjectProperties(_)).toSeq
+  }
+
+  /**
    * How many of the project's classes one grouped-count query covers.
    *
    * Small enough that each query stays well inside the triplestore's `query-timeout`, large enough not to
@@ -469,6 +561,15 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * number of round-trips.
    */
   private[repo] val ClassChunkSize = 3
+
+  /**
+   * How many value properties one grouped value-count query covers — the second chunking axis.
+   *
+   * Class chunking bottoms out at one class; this is what bounds a query below that. Sized like
+   * [[ClassChunkSize]]: large enough to amortise the fixed per-request overhead (~120ms measured), small
+   * enough that a single chunk stays far inside the triplestore's `query-timeout`.
+   */
+  private[repo] val PropertyChunkSize = 4
 
   /**
    * Concurrent chunk queries per grouped count. Deliberately small: the service already fans out over
@@ -493,14 +594,22 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
    * a serialization without it is a programming error rather than something to paper over: splicing into
    * an arbitrary brace would silently produce a wrong query.
    */
-  private[repo] def withValues(query: SelectQuery, clause: Option[String]): String = {
+  private[repo] def withValues(query: SelectQuery, clause: Option[String]): String =
+    withValues(query, clause.toSeq)
+
+  /**
+   * As above, for several `VALUES` clauses at once (`?resClass` and `?prop`). They are spliced in the
+   * given order at the same insertion point, so both bind before the patterns that consume them.
+   */
+  private[repo] def withValues(query: SelectQuery, clauses: Seq[String]): String = {
     val sparql = query.getQueryString
-    clause.fold(sparql) { v =>
+    if (clauses.isEmpty) sparql
+    else {
       val whereAt = sparql.indexOf("WHERE")
       require(whereAt >= 0, s"cannot splice VALUES: no WHERE clause in rendered query:\n$sparql")
       val idx = sparql.indexOf('{', whereAt)
       require(idx >= 0, s"cannot splice VALUES: no group graph pattern after WHERE:\n$sparql")
-      s"${sparql.substring(0, idx + 1)}\n$v${sparql.substring(idx + 1)}"
+      s"${sparql.substring(0, idx + 1)}\n${clauses.mkString("\n")}${sparql.substring(idx + 1)}"
     }
   }
 
@@ -648,6 +757,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     classes: ProjectClasses,
     dedupeRows: Boolean = true,
     bindCreator: Boolean = true,
+    properties: ProjectProperties = ProjectProperties(Seq.empty),
   ) = {
     // As in resourceCore, the creator keeps its leading position in the value block so toggling it cannot
     // reorder the remaining patterns.
@@ -664,9 +774,9 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
       .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
       .and(classes.resClassPatterns(resource, resClass, dedupeRows)*)
       .and(
-        resource
-          .has(prop, value)
-          .and(prop.has(zeroOrMore(RDFS.SUBPROPERTYOF), KnoraBase.hasValue)),
+        // `?prop` is pinned by the spliced `VALUES` clause when the project's properties were discovered;
+        // propPatterns emits the `subPropertyOf*` traversal only as the fallback for an empty list.
+        GraphPatterns.and((resource.has(prop, value) +: properties.propPatterns(prop))*),
       )
       .and(valuePatterns)
       .and(GraphPatterns.filterNotExists(value.isA(KnoraBase.linkValue)))
@@ -718,6 +828,32 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
           .isA(resClass)
           .andHas(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
           .and(resClass.has(zeroOrMore(RDFS.SUBCLASSOF), KnoraBase.Resource)),
+      )
+  }
+
+  /**
+   * `SELECT DISTINCT ?prop` — the value properties the project's data actually uses.
+   *
+   * Anchored on `attachedToProject` for the same reason as [[projectClassesQuery]]: the `subPropertyOf*`
+   * check runs over the project's predicates once, here, instead of per result row in every count query.
+   * Feeds [[ProjectProperties]], which chunks the grouped value counts along this second axis.
+   *
+   * Link values are excluded to match [[valueCore]] — a property whose only values are link values
+   * contributes nothing to these counts, so binding it would just add an empty chunk.
+   */
+  private[repo] def projectPropertiesQuery(projectIri: ProjectIri): SelectQuery = {
+    val (resource, prop, value) = (variable("resource"), variable("prop"), variable("value"))
+    Queries
+      .SELECT(prop)
+      .distinct()
+      .prefix(prefix(KnoraBase.NS), prefix(RDFS.NS))
+      .where(
+        resource
+          .has(KnoraBase.attachedToProject, Rdf.iri(projectIri.value))
+          .andHas(KnoraBase.isDeleted, Rdf.literalOf(false))
+          .andHas(prop, value)
+          .and(prop.has(zeroOrMore(RDFS.SUBPROPERTYOF), KnoraBase.hasValue))
+          .and(GraphPatterns.filterNotExists(value.isA(KnoraBase.linkValue))),
       )
   }
 
@@ -876,6 +1012,7 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     itemType: ItemType,
     statePermissions: Set[String],
     classes: ProjectClasses,
+    properties: ProjectProperties,
   ): SelectQuery = {
     val (resource, resClass)   = (variable("resource"), variable("resClass"))
     val (prop, value)          = (variable("prop"), variable("value"))
@@ -884,7 +1021,8 @@ object ViewRestrictionsRepo extends QueryBuilderHelper {
     val (groupId, cnt)         = (variable("groupId"), variable("cnt"))
     val groupCol               = if (groupBy == GroupBy.Property) prop else resClass
 
-    val core        = valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes)
+    val core =
+      valueCore(projectIri, resource, resClass, prop, value, creator, permissions, classes, properties = properties)
     val constrained = itemTypeConstraint(value, fileClass, comment, itemType)
       .fold(GraphPatterns.and(core))(c => GraphPatterns.and(core, c))
 

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsServiceSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsServiceSpec.scala
@@ -1152,7 +1152,8 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
     test("tags resource counts as Resources and value counts as Items") {
       for {
         classes <- repo(_.projectClasses(projectIri))
-        rows    <- repo(_.countByGroup(projectIri, GroupBy.ResourceClass, ItemType.All, memberOnly, classes))
+        props   <- repo(_.projectProperties(projectIri))
+        rows    <- repo(_.countByGroup(projectIri, GroupBy.ResourceClass, ItemType.All, memberOnly, classes, props))
       } yield {
         val byUnit = rows.groupBy(_.unit).view.mapValues(_.map(_.count).sum).toMap
         assertTrue(
@@ -1180,7 +1181,9 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
     test("emits no Items rows under itemType=Resource") {
       for {
         classes <- repo(_.projectClasses(projectIri))
-        rows    <- repo(_.countByGroup(projectIri, GroupBy.ResourceClass, ItemType.Resource, memberOnly, classes))
+        props   <- repo(_.projectProperties(projectIri))
+        rows    <-
+          repo(_.countByGroup(projectIri, GroupBy.ResourceClass, ItemType.Resource, memberOnly, classes, props))
       } yield assertTrue(
         rows.nonEmpty,
         rows.forall(_.unit == ViewRestrictionsRepo.CountUnit.Resources),
@@ -1190,7 +1193,8 @@ class ViewRestrictionsServiceSpec extends ZIOSpecDefault {
     test("emits no Resources rows in property mode") {
       for {
         classes <- repo(_.projectClasses(projectIri))
-        rows    <- repo(_.countByGroup(projectIri, GroupBy.Property, ItemType.All, memberOnly, classes))
+        props   <- repo(_.projectProperties(projectIri))
+        rows    <- repo(_.countByGroup(projectIri, GroupBy.Property, ItemType.All, memberOnly, classes, props))
       } yield assertTrue(
         rows.nonEmpty,
         rows.forall(_.unit == ViewRestrictionsRepo.CountUnit.Items),

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsQuerySpec.scala
@@ -35,7 +35,11 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
   /** A project that asserts a class together with one of its ancestors — the filter must be kept. */
   private val multiTyped = ViewRestrictionsRepo.ProjectClasses(Seq(thingClass), multiTyped = true)
 
+  /** No property discovered, so the value queries keep the `subPropertyOf*` fallback. */
+  private val noProperties = ViewRestrictionsRepo.ProjectProperties(Seq.empty)
+
   private val resClassVar = SparqlBuilder.`var`("resClass")
+  private val propVar     = SparqlBuilder.`var`("prop")
 
   override def spec: Spec[TestEnvironment, Any] = suite("ViewRestrictionsRepo query generation")(
     suite("distinct permission literals")(
@@ -96,6 +100,84 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
         val none = ViewRestrictionsRepo.ProjectClasses(Seq.empty, multiTyped = false)
         assertTrue(none.chunked(3) == Seq(none))
       },
+    ),
+    // The second chunking axis. Classes alone bottom out at one class per query; the property axis is what
+    // bounds a query below that floor, so the same partition guarantees must hold here.
+    suite("property chunking")(
+      test("chunks cover every property exactly once") {
+        val many    = ViewRestrictionsRepo.ProjectProperties((1 to 9).map(i => s"http://example.org/p$i"))
+        val chunks  = many.chunked(4)
+        val covered = chunks.flatMap(_.iris)
+        assertTrue(
+          chunks.size == 3,
+          chunks.forall(_.iris.size <= 4),
+          // a partition: summing per-chunk counts is only sound if no property lands in two chunks
+          covered == many.iris,
+          covered.distinct == covered,
+        )
+      },
+      test("an empty property list still yields one chunk, so the subPropertyOf* fallback runs") {
+        val none = ViewRestrictionsRepo.ProjectProperties(Seq.empty)
+        assertTrue(none.chunked(4) == Seq(none))
+      },
+      // Discovering no property must NOT leave ?prop unconstrained: without either the VALUES clause or the
+      // traversal, ?prop would match every predicate on the resource — rdf:type and the admin properties
+      // included — and inflate every count.
+      test("an empty property list keeps the subPropertyOf* traversal") {
+        val none = ViewRestrictionsRepo.ProjectProperties(Seq.empty)
+        val q    = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo.valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped, none),
+          (singleTyped.valuesClause(resClassVar) ++ none.valuesClause(propVar)).toSeq,
+        )
+        assertTrue(q.contains("rdfs:subPropertyOf*"), !q.contains("VALUES ?prop"))
+      },
+      // …and conversely, once properties are discovered the traversal is replaced by the VALUES table —
+      // that swap is the per-query speedup (232ms -> ~110ms measured on one class).
+      test("discovered properties replace the traversal with a VALUES clause") {
+        val props = ViewRestrictionsRepo.ProjectProperties(Seq("http://example.org/pA", "http://example.org/pB"))
+        val q     = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo.valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped, props),
+          (singleTyped.valuesClause(resClassVar) ++ props.valuesClause(propVar)).toSeq,
+        )
+        assertTrue(
+          !q.contains("rdfs:subPropertyOf*"),
+          q.contains("VALUES ?prop"),
+          q.contains("http://example.org/pA"),
+          q.contains("http://example.org/pB"),
+        )
+      },
+      test("each chunk's query binds only that chunk's properties") {
+        val two                                                = ViewRestrictionsRepo.ProjectProperties(Seq("http://example.org/pA", "http://example.org/pB"))
+        val Seq(first, second)                                 = two.chunked(1)
+        def render(ps: ViewRestrictionsRepo.ProjectProperties) =
+          ViewRestrictionsRepo.withValues(
+            ViewRestrictionsRepo.valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped, ps),
+            (singleTyped.valuesClause(resClassVar) ++ ps.valuesClause(propVar)).toSeq,
+          )
+        val qA = render(first)
+        val qB = render(second)
+        assertTrue(
+          qA.contains("http://example.org/pA"),
+          !qA.contains("http://example.org/pB"),
+          qB.contains("http://example.org/pB"),
+          !qB.contains("http://example.org/pA"),
+        )
+      },
+      // Both axes are spliced at the same insertion point and must both survive.
+      test("both VALUES clauses are spliced into the same WHERE block") {
+        val props = ViewRestrictionsRepo.ProjectProperties(Seq("http://example.org/pA"))
+        val q     = ViewRestrictionsRepo.withValues(
+          ViewRestrictionsRepo.valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped, props),
+          (singleTyped.valuesClause(resClassVar) ++ props.valuesClause(propVar)).toSeq,
+        )
+        val whereAt = q.indexOf("WHERE")
+        assertTrue(
+          q.contains("VALUES ?resClass"),
+          q.contains("VALUES ?prop"),
+          q.indexOf("VALUES ?resClass") > whereAt,
+          q.indexOf("VALUES ?prop") > whereAt,
+        )
+      },
       test("each chunk's query binds only that chunk's classes") {
         val three              = ViewRestrictionsRepo.ProjectClasses(Seq("http://example.org/A", "http://example.org/B"), false)
         val Seq(first, second) = three.chunked(1)
@@ -125,7 +207,7 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
       },
       test("value counts group by the carrying property in property mode") {
         val q = ViewRestrictionsRepo
-          .valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped)
+          .valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped, noProperties)
           .getQueryString
         assertTrue(
           q.contains("COUNT") && q.contains("DISTINCT"),
@@ -136,13 +218,13 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
       },
       test("itemType=Comment restricts the count to values carrying a comment") {
         val q = ViewRestrictionsRepo
-          .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.Comment, hidden, singleTyped)
+          .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.Comment, hidden, singleTyped, noProperties)
           .getQueryString
         assertTrue(q.contains("knora-base:valueHasComment"))
       },
       test("itemType=Value excludes file values so File and Value cannot double-count") {
         val q = ViewRestrictionsRepo
-          .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.Value, hidden, singleTyped)
+          .valueCountQuery(projectIri, GroupBy.ResourceClass, ItemType.Value, hidden, singleTyped, noProperties)
           .getQueryString
         assertTrue(q.contains("FILTER NOT EXISTS") && q.contains("knora-base:FileValue"))
       },
@@ -241,7 +323,8 @@ class ViewRestrictionsQuerySpec extends ZIOSpecDefault with GoldenTest {
       },
       test("the value count binds VALUES inside the WHERE block in property mode") {
         val q = ViewRestrictionsRepo.withValues(
-          ViewRestrictionsRepo.valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped),
+          ViewRestrictionsRepo
+            .valueCountQuery(projectIri, GroupBy.Property, ItemType.All, hidden, singleTyped, noProperties),
           singleTyped.valuesClause(resClassVar),
         )
         assertGolden(q, "viewRestrictions__valueCount__property")


### PR DESCRIPTION
Follow-up to #4260, which trimmed the permission probes and bounded the grouped counts by chunking them over the project's resource classes. This adds the second chunking axis that work was missing.

No behaviour change: the counts are a pure fan-out and merge of a query the triplestore already answered the same way. The endpoint contract and response shape are untouched.

## Why class chunking alone is not enough

Chunking by resource class bounds each query, but it has a floor: once a chunk is a single class it cannot be subdivided. A project with one very large class still issues a query whose cost grows without bound and eventually exceeds Fuseki's per-request `query-timeout` (20s, `application.conf`), which cancels it mid-stream and fails the whole request. Lowering `ClassChunkSize` cannot reach that case — cost is roughly linear in classes (~120ms fixed + ~100ms per class measured), so smaller chunks only multiply round-trips and total work while leaving the largest single query exactly as slow.

## What changed

The value counts now also chunk by property. `ProjectProperties` discovers the value properties the project's data actually uses — one small anchored query per request, mirroring `ProjectClasses` — and `runCountByGroup` fans out over the cartesian product of class chunks and property chunks.

Binding `?prop` from a `VALUES` table also replaces the `?prop rdfs:subPropertyOf* knora-base:hasValue` traversal that the store would otherwise re-evaluate per candidate row, so each query is cheaper as well as smaller.

`mergeCounts` is unchanged: summing per `(groupId, unit)` already covers the new axis. It stays sound because each counted object falls in exactly one chunk on each axis — a value belongs to one resource, `dedupeRows = true` pins a resource to a single `?resClass` binding, and a value is reached through exactly one property, so property chunks partition the values rather than overlapping them.

Resource-level counts pass an empty `ProjectProperties`, which yields a single chunk: they have no `?prop` to split on. An empty property list keeps the `subPropertyOf*` traversal rather than dropping the constraint — without either, `?prop` would match every predicate on the resource, `rdf:type` and the admin properties included, and inflate every count.

## Measured

Perftest project: 5 classes, 5k resources, 337k triples, on the whole-project value count.

| | |
|---|---|
| one class: traversal → bound properties | 232ms → ~110ms |
| whole-project single query | 654ms |
| 6 chunk queries (3 classes × 4 properties) | slowest **212ms**, sum 946ms |

Peak query time — what the timeout actually budgets — drops 3.1×. Total work rises, as chunking always trades; it is spread over more queries at the existing `MaxConcurrentChunkQueries` cap.

The two-axis fan-out plus sum-merge was verified to reproduce the single query's counts exactly against the perftest data: 10 groups, 6670 values, identical.

## Tests

Seven new tests in a `property chunking` suite mirroring the existing class-chunking one: the partition invariants (no property lost or duplicated, which is what makes summing sound), that an empty list keeps the `subPropertyOf*` fallback, that discovered properties replace the traversal with `VALUES`, that each chunk binds only its own properties, and that both `VALUES` clauses splice into the same `WHERE` block.

#4260 added a `manyClassesTurtle` fixture specifically so that mutating `mergeCounts` from `_ + _` to `math.max` fails the suite — before it, the merge was a no-op in every test. I re-ran that mutation after adding the second axis and it still fails, so the merge coverage survived the change.

`//modules/webapi:test` (1809 tests) and `just check` pass.

## Note

I could not reproduce a timeout locally: the perftest data runs the whole-project query in 0.65s, far inside the budget. This targets the right failure mode and is verified for correctness and relative speedup, but is not verified against a specific failing production request.

`distinctPermissions` is still not chunked at all and is the next place to look if the summary still times out. Separately, the six `(audience, state)` counts re-scan the same rows differing only in the permission `FILTER`; grouping by `?permissions` once and classifying in Scala would cut query volume ~6× and reduce total work rather than redistributing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
