### PR TITLE
chore: trace every SPARQL request and view-restrictions stage

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/ViewRestrictionsService.scala
@@ -180,11 +180,35 @@ final case class ViewRestrictionsService(
   private val countedStates: Seq[Visibility] = Seq(Visibility.Hidden, Visibility.RestrictedView)
 
   def summary(projectIri: ProjectIri, groupBy: GroupBy, itemType: ItemType): Task[ViewRestrictionsSummary] =
+    // DEBUG BRANCH — a failing summary must name the phase it died in. Without this the request just
+    // disappears from the log after its last successful stage marker.
+    summaryTraced(projectIri, groupBy, itemType).tapErrorCause(c =>
+      ZIO.logError(s"[vr-trace] summary FAILED interrupted=${c.isInterrupted}\n${c.squash.getMessage}").ignore,
+    )
+
+  private def summaryTraced(
+    projectIri: ProjectIri,
+    groupBy: GroupBy,
+    itemType: ItemType,
+  ): Task[ViewRestrictionsSummary] =
     for {
+      // DEBUG BRANCH — stage markers so the log says which *phase* of the summary was in flight when a
+      // request died, not just which SPARQL. Pair these with the `[sparql-trace …]` lines from
+      // TriplestoreServiceLive: the last stage that logged START without its DONE is the one that hung.
+      _ <- ZIO.logInfo(s"[vr-trace] summary START project=$projectIri groupBy=$groupBy itemType=$itemType")
       // Resolved once and reused by every query below: the project's asserted resource classes, which
       // replace two per-row `rdfs:subClassOf` traversals in the queries themselves.
-      classes  <- repo.projectClasses(projectIri)
-      literals <- repo.distinctPermissions(projectIri, itemType, groupBy, classes)
+      classes <-
+        repo
+          .projectClasses(projectIri)
+          .tap(c =>
+            ZIO.logInfo(s"[vr-trace] stage=projectClasses DONE classes=${c.iris.size} multiTyped=${c.multiTyped}"),
+          )
+      // The one query in the request that is never chunked, and scans the project's whole value
+      // population to return a handful of literals — the prime suspect for a timeout.
+      literals <- repo
+                    .distinctPermissions(projectIri, itemType, groupBy, classes)
+                    .tap(l => ZIO.logInfo(s"[vr-trace] stage=distinctPermissions DONE literals=${l.size}"))
       // One count per (audience, state). Both are tiny fixed sets — 3 x 2 — and each classification pass
       // runs over the small distinct-literal set, so this stays cheap regardless of project size.
       //
@@ -202,12 +226,16 @@ final case class ViewRestrictionsService(
             repo.countByGroup(projectIri, groupBy, itemType, hits, classes).map(rows => (audience, state, rows))
           }
           .withParallelism(ViewRestrictionsService.MaxConcurrentCountQueries)
+          .tap(rows => ZIO.logInfo(s"[vr-trace] stage=countByGroup DONE fanOut=${rows.size}"))
           // Every resource class the project has, with its population — independent of any restriction and
           // of the itemType filter. In class mode this is the row set itself (see below), so a class is
           // reported with its true size whether or not anything in it is restricted. A property has no
           // resource population of its own, so property mode has no equivalent and reports none.
           .zipPar(
-            if (groupBy == GroupBy.ResourceClass) repo.totalResourcesByClass(projectIri, classes)
+            if (groupBy == GroupBy.ResourceClass)
+              repo
+                .totalResourcesByClass(projectIri, classes)
+                .tap(r => ZIO.logInfo(s"[vr-trace] stage=totalResourcesByClass DONE rows=${r.size}"))
             else ZIO.succeed(Seq.empty),
           )
       (counted, classTotals) = countedAndTotals
@@ -244,6 +272,7 @@ final case class ViewRestrictionsService(
             )
             .sortBy(orderKey)
       totals = groups.map(_.counts).foldLeft(AudienceCounts.zero)(plus)
+      _     <- ZIO.logInfo(s"[vr-trace] summary DONE groups=${groups.size}")
       // Counts come from SPARQL aggregation over the whole project, so they are always exact.
     } yield ViewRestrictionsSummary(projectIri.value, groupBy, itemType, groups, totals)
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/impl/TriplestoreServiceLive.scala
@@ -496,8 +496,32 @@ case class TriplestoreServiceLive(
   private def trackQueryDuration[T](query: SparqlQuery, reqTask: Task[T]): Task[T] = {
     val trackingThreshold = fusekiConfig.queryLoggingThreshold
     val startTime         = java.lang.System.nanoTime()
+    // DEBUG BRANCH — temporary tracing to locate a request that dies on the Fuseki query-timeout.
+    //
+    // The existing logging below cannot answer "which query failed": it fires only on the success path
+    // (a query the store cancels logs nothing at all), only above `queryLoggingThreshold`, and it prints
+    // the SPARQL without any identifier tying it back to a call site. So a timing-out request leaves a
+    // gap in the log exactly where the culprit is.
+    //
+    // These three log lines close that gap. Each request gets a correlation id so the before/after pair
+    // can be matched in an interleaved log — the summary fans out over several queries concurrently, so
+    // without an id the lines cannot be paired.
+    // A monotonic counter, not `nanoTime`: two fibers starting in the same nanosecond tick collided in
+    // practice (observed on the summary's fan-out), and a duplicated id makes the START/DONE pair
+    // ambiguous — which is the one thing this tracing exists to provide.
+    val queryId   = f"q${TriplestoreServiceLive.traceCounter.incrementAndGet()}%05d"
+    val queryKind = query.getClass.getSimpleName
+    // The first line of the query's WHERE-bearing body is usually enough to recognise the call site
+    // without dumping several KB of SPARQL per request into the log.
+    val shape = query.sparql.linesIterator
+      .map(_.trim)
+      .filter(l => l.nonEmpty && !l.startsWith("PREFIX") && !l.startsWith("#"))
+      .take(2)
+      .mkString(" ")
+      .take(160)
     for {
-      result <- reqTask @@ requestTimer
+      _      <- ZIO.logInfo(s"[sparql-trace $queryId] START kind=$queryKind timeout=${query.timeout} shape=$shape")
+      result <- (reqTask @@ requestTimer
                   .tagged("type", query.getClass.getSimpleName)
                   .tagged("isGravsearch", s"${query.timeout == SparqlTimeout.Gravsearch}")
                   .tagged("isMaintenance", s"${query.timeout == SparqlTimeout.Maintenance}")
@@ -506,15 +530,29 @@ case class TriplestoreServiceLive(
                   // probe (SparqlTimeout.SearchProbe) is deliberately isSearch=false so its cheap samples do not
                   // pollute the search-tier duration the regression watch depends on (DEV-6864).
                   .tagged("isSearch", s"${query.timeout == SparqlTimeout.Search}")
-                  .trackDuration
+                  .trackDuration)
+                  // The failure path is the whole point: a query cancelled by the store's query-timeout, or
+                  // one whose HTTP read times out, must say so *and* say which query it was. `tapErrorCause`
+                  // rather than `tapError` so a defect or an interrupt (the fan-out cancelling its siblings
+                  // once one fails) is reported too, and the cause is re-raised untouched.
+                  .tapErrorCause { cause =>
+                    val failed = Duration.fromNanos(java.lang.System.nanoTime() - startTime)
+                    ZIO
+                      .logError(
+                        s"[sparql-trace $queryId] FAILED after $failed kind=$queryKind timeout=${query.timeout}" +
+                          s" interrupted=${cause.isInterrupted}\n${cause.squash.getMessage}\n${query.sparql}",
+                      )
+                      .ignore
+                  }
       _ <- {
              val endTime  = java.lang.System.nanoTime()
              val duration = Duration.fromNanos(endTime - startTime)
-             ZIO.when(!triplestoreConfig.isTestEnv && duration >= trackingThreshold) {
-               ZIO.logDebug(
-                 s"Fuseki request took $duration, which is longer than $trackingThreshold, timeout=${query.timeout}\n ${query.sparql}",
-               )
-             }
+             ZIO.logInfo(s"[sparql-trace $queryId] DONE  after $duration kind=$queryKind") *>
+               ZIO.when(!triplestoreConfig.isTestEnv && duration >= trackingThreshold) {
+                 ZIO.logDebug(
+                   s"Fuseki request took $duration, which is longer than $trackingThreshold, timeout=${query.timeout}\n ${query.sparql}",
+                 )
+               }
            }.ignore
     } yield result
   }
@@ -664,6 +702,9 @@ case class TriplestoreServiceLive(
 }
 
 object TriplestoreServiceLive {
+
+  /** DEBUG BRANCH — source of the `[sparql-trace …]` correlation ids. */
+  private val traceCounter = new java.util.concurrent.atomic.AtomicLong(0L)
 
   val layer: URLayer[Triplestore & Tracing, TriplestoreService] =
     TracingHttpClient.layer(FiniteDuration(1, TimeUnit.MINUTES)) >>> ZLayer.derive[TriplestoreServiceLive]


### PR DESCRIPTION

## Why

A view-restrictions summary request times out on an environment I cannot reproduce locally. The existing logging cannot say which query is responsible, in three specific ways:

- it fires only on the **success** path, so a query cancelled by Fuseki's `query-timeout` — precisely the case under investigation — logs nothing at all and simply vanishes from the log;
- it fires only above `queryLoggingThreshold` (1s), so the queries leading up to the failure are invisible;
- it prints the SPARQL with nothing tying it back to a call site.

So a timing-out request leaves a gap in the log exactly where the culprit is.

## What it does

`trackQueryDuration` in `TriplestoreServiceLive` is the single chokepoint every SPARQL query already flows through, so the tracing goes there rather than being scattered across call sites. Every request now logs:

```
[sparql-trace q00047] START kind=Select timeout=Standard shape=SELECT ?groupId ( COUNT( DISTINCT ?value )…
[sparql-trace q00047] DONE  after PT0.389507708S kind=Select
[sparql-trace q00047] FAILED after PT20.01S kind=Select timeout=Standard interrupted=false   ← plus the full SPARQL
```

`ViewRestrictionsService` additionally logs stage markers, so the log names the *phase* in flight rather than only the SPARQL:

```
[vr-trace] summary START project=… groupBy=ResourceClass itemType=All
[vr-trace] stage=projectClasses DONE classes=5 multiTyped=false
[vr-trace] stage=distinctPermissions DONE literals=16
[vr-trace] stage=totalResourcesByClass DONE rows=5
[vr-trace] stage=countByGroup DONE fanOut=6
[vr-trace] summary DONE groups=5
```

**Reading it: the last `START` with no matching `DONE` is the query that hung.**

## Decisions worth flagging

**`tapErrorCause`, not `tapError`** — the failure path is the entire point. A cause also covers defects and interrupts, so the fan-out cancelling its siblings after one failure is visible rather than silent. The cause is re-raised untouched, so behaviour is unchanged.

**Correlation ids come from an atomic counter, not `nanoTime`.** I used `nanoTime` first, ran it, and observed **duplicate ids across concurrent fibers** on the summary's fan-out — which made `START`/`DONE` pairs ambiguous, i.e. destroyed the one thing this tracing exists to provide. Switched to a counter and re-verified that ids are unique.

**INFO, not DEBUG.** The root log level defaults to INFO (`DSP_API_LOG_LEVEL`), so at DEBUG these lines would not appear without extra setup on the target environment.

**A 160-char query shape on `START`**, so a call site is recognisable without dumping several KB of SPARQL per request into the log. The full SPARQL is still printed on `FAILED`, where it is needed.

## Logging only

Verified by auditing the diff line by line: every removed line reappears with only a `.tap(...)` attached. No SPARQL was altered, no control flow, no config, no timeout tiers. The one structural change is `summary` being split into a thin wrapper plus `summaryTraced`, purely so the error tap can attach to the effect.

## Verification

Ran against the local perftest project (5 classes, 5k resources, 337k triples): the summary returns `200` in ~4s and emits **52 SPARQL requests**, all ids unique, every `START` paired with a `DONE`, and the stage markers in order. `//modules/webapi:test` passes.

Incidental data point from that run: the slowest single query was 2.63s at 5k resources. Extrapolated to a 15k-resource project that is ~8s — close to the 20s budget but not obviously over it, which is part of why the failing environment needs to be measured directly rather than inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
