### PR TITLE
feat: emit the target project(s) on the Gravsearch root span (DEV-7031)

### DIFF
--- a/docs/observability/gravsearch-trace-runbook.md
+++ b/docs/observability/gravsearch-trace-runbook.md
@@ -60,14 +60,37 @@ the root — four prequery-side stages, no main-query or result-transform spans.
 
 The `gravsearch` root span carries a **query shape** — a bounded fingerprint of *what kind* of query
 this was, with no user data in any attribute. Use it to group "queries like this one" without
-aggregating over FILTER literals or instance IRIs. For the query *itself*, see
-[§5](#5-read-the-submitted-query) — it is on the same span, as an event.
+aggregating over FILTER literals or instance IRIs. It also carries the **target project(s)**, so you
+can tell whose data a slow query was reading without opening the query text. For the query *itself*,
+see [§5](#5-read-the-submitted-query) — it is on the same span, as an event.
 
 | Attribute | Example | Use |
 | --- | --- | --- |
 | `gravsearch.query.shape` | `resource-list\|has_filter\|has_order_by\|patterns:4-7\|joins:1` | Bounded label; safe to group/aggregate by. Format: result-type, then each true flag, then `patterns:<bucket>` and `joins:<bucket>` (buckets: `0`, `1`, `2-3`, `4-7`, `8+`) |
 | `gravsearch.shape.has_filter` | `true` | Per-flag booleans for TraceQL filtering — also `has_optional`, `has_union`, `has_order_by`, `has_offset`, `has_link_traversal`, `is_fulltext` |
 | `gravsearch.schema_predicates` | `hasTitle,isPartOf` | Sorted, de-duplicated **ontology** predicate names only (never instance IRIs). Drill-down detail, not a metric label |
+| `gravsearch.project_shortcodes` | `0803` | Sorted, de-duplicated shortcodes of the projects the query **refers to**, inferred from its IRIs. Usually one; a cross-project query lists several. Always present — an empty value means no project was identifiable (a query over built-in ontologies only). Drill-down detail, not a metric label |
+| `gravsearch.project_restriction` | `http://rdfh.ch/projects/0803` | The project the request was explicitly **scoped to** (`limitToProject` and the project-restricted entry points). Present only when the search was restricted |
+
+The two project attributes answer different questions, which is why they are separate. `project_shortcodes`
+is inferred from the query — "which projects does this query touch". `project_restriction` is stated by the
+caller — "which project was this search scoped to". A cross-project query has several of the first and none
+of the second.
+
+!!! note "Why the restriction is an IRI, not a shortcode"
+    `limitToProject` arrives from the request as a `ProjectIri`, and a project IRI created after the
+    shortcode-shaped ones were retired is `http://rdfh.ch/projects/<base64-UUID>`. Turning it into a
+    shortcode needs a project lookup on the pre-parse path of every Gravsearch. So for older projects the
+    IRI ends in the shortcode and lines up with `project_shortcodes` by eye, and for newer ones it does
+    not — a known limitation. To find every trace for one project, filter on `project_shortcodes`.
+
+!!! note "Shortcodes come from data IRIs too, not only ontology IRIs"
+    A project shortcode is carried by both `…/ontology/0803/incunabula/simple/v2#book` and
+    `http://rdfh.ch/0803/c5058f3a`, and the derivation reads both. That is what makes the attribute useful
+    on the internally generated searches ([§7](#not-every-captured-query-came-from-a-researcher)) — incoming
+    links, still-image representations, incoming regions — whose queries reference built-in ontologies
+    exclusively and interpolate the target resource IRI. Reading ontology IRIs alone would leave every one
+    of those spans blank. Only the shortcode reaches the span, never the IRI it came from.
 
 On a failed or interrupted stage span you may also see:
 
@@ -136,7 +159,7 @@ them as broken instrumentation, and do not mistake one for another.
 | **Empty result** | parse → type_inspection → prequery.generate → prequery.execute present; **no** `mainquery.*`, **no** `result_transform` | The prequery returned zero main resources, so there was nothing to fetch — "no rows", not an error | All present spans are `OK`; root has its shape attributes |
 | **Parse failure** | root + `gravsearch.parse` only, parse span is `ERROR` | The Gravsearch string was malformed; the pipeline never started | Only the parse span exists and it is `ERROR` (`gravsearch.parse: <Class>`) |
 | **Interruption / timeout** | early stages present, later stages absent, **last open span + root are `ERROR`** | The request fiber was interrupted (client disconnect, timeout, cancellation) mid-query | `gravsearch.exit_reason = interrupted` on the open span and the root |
-| **Shape-less early interrupt** | root present but **without `gravsearch.query.shape` / `gravsearch.shape.*`**, little or nothing below it | Interrupted (or failed) *before* parse completed, so the shape was never derived | Missing shape attributes **and** `exit_reason = interrupted` / `ERROR` on the root — not a broken shape derivation |
+| **Shape-less early interrupt** | root present but **without `gravsearch.query.shape` / `gravsearch.shape.*` / `gravsearch.project_shortcodes`**, little or nothing below it | Interrupted (or failed) *before* parse completed, so neither the shape nor the target project was ever derived | Missing shape attributes **and** `exit_reason = interrupted` / `ERROR` on the root — not a broken shape derivation. Note the difference from an *empty* `project_shortcodes`, which means the derivation ran and found no project |
 
 How to tell them apart quickly:
 

--- a/docs/observability/instrumentation-recipe.md
+++ b/docs/observability/instrumentation-recipe.md
@@ -130,9 +130,17 @@ Split the cardinality deliberately:
 | Composite shape label | `gravsearch.query.shape` = `resource-list\|has_filter\|patterns:4-7\|joins:1` | Bounded (enums + bucketed counts) | **Span attribute, safe as a metric label** |
 | Per-flag booleans | `gravsearch.shape.has_filter` = `true` | Bounded (fixed flag set) | Span attribute (for TraceQL filtering) |
 | Ontology predicate names | `gravsearch.schema_predicates` = `hasTitle,isPartOf` | Higher (but ontology-bounded, never instance IRIs) | **Span attribute only — never a metric label** |
+| Bounded projection of an identifier | `gravsearch.project_shortcodes` = `0803` | Bounded (one value per project) | **Span attribute only — never a metric label** |
 
 Bucket open-ended counts (pattern count, join count) into ranges (`0`, `1`, `2-3`, `4-7`, `8+`) so
 the shape label stays bounded. Set the shape on the root immediately after parse succeeds.
+
+The no-instance-IRIs rule bans the **IRI**, not everything derivable from one. A bounded projection of
+an identifier is fine and often the most useful attribute on the span — the project shortcode in
+`…/ontology/0803/…` or `http://rdfh.ch/0803/c5058f3a` is one value per project, so it groups and
+filters cleanly while the IRI it came from never leaves the payload event. Apply the same test to any
+projection: is the value set bounded by something that grows with the *deployment* (projects,
+ontologies, endpoints) rather than with *traffic* (resources, users, literals)?
 
 ## 6. Capture the raw payload as an event
 

--- a/docs/observability/traceql-recipes.md
+++ b/docs/observability/traceql-recipes.md
@@ -57,7 +57,7 @@ operator (`>>` returns the right-hand spans that are descendants of the left):
 { span:name = "gravsearch" && span:duration > 2s } >> { span:name = "gravsearch.mainquery.execute" }
 ```
 
-## 4. Filter by query shape
+## 4. Filter by query shape or target project
 
 The root span carries per-flag booleans, so you can isolate query *kinds* without any user data.
 Slow queries that use a FILTER:
@@ -77,6 +77,25 @@ Match on the composite shape label (regex is fully anchored — wrap with `.*`):
 
 ```traceql
 { span:name = "gravsearch" && span.gravsearch.query.shape =~ ".*has_union.*" }
+```
+
+Slow queries touching one project. `gravsearch.project_shortcodes` is a comma-separated set, so match
+it as a regex rather than for equality — a cross-project query lists several:
+
+```traceql
+{ span:name = "gravsearch" && span.gravsearch.project_shortcodes =~ ".*0803.*" && span:duration > 2s }
+```
+
+Searches the client explicitly scoped to a project, as opposed to queries that merely reference it:
+
+```traceql
+{ span:name = "gravsearch" && span.gravsearch.project_restriction = "http://rdfh.ch/projects/0803" }
+```
+
+Cross-project queries — those referencing more than one project, a shape worth knowing about on its own:
+
+```traceql
+{ span:name = "gravsearch" && span.gravsearch.project_shortcodes =~ ".*,.*" }
 ```
 
 ## 5. Errors and interruptions

--- a/grafana-dashboards/dsp-api/README.md
+++ b/grafana-dashboards/dsp-api/README.md
@@ -51,7 +51,7 @@ here — use the Gravsearch dashboard / Tempo for tail latency.
 | 4 Avg duration — global | Mean duration over time (deploy-regression line) | `[$smoothing]` |
 | 5 Avg duration by route | Mean duration per route over time | `[$smoothing]` |
 | 6 Routes ranked by avg duration | Slowest routes now + how often they run | `$__range` |
-| 7 Slowest Gravsearch queries (traces) | Individual slow gravsearch executions, their target project + the query | Tempo |
+| 7 Slowest Gravsearch queries (traces) | Individual slow gravsearch executions, their target + scoped project, + the query | Tempo |
 
 ### Query-shape rationale (don't "simplify" these away)
 
@@ -82,6 +82,14 @@ here — use the Gravsearch dashboard / Tempo for tail latency.
   link remains the way to the full, untruncated query. The `span.environment` predicate must stay in,
   or an `event.`-scoped search crosses environments. The threshold default is `2s` — the p95 of the
   `gravsearch` span baseline (PRD REQ-3.1: baseline-anchored, not an arbitrary constant).
+- **Panel 7's two project columns are not redundant** (DEV-7031). **Project**
+  (`gravsearch.project_shortcodes`) is *inferred* from the query's IRIs — which projects it touches.
+  **Scoped to** (`gravsearch.project_restriction`) is *stated* by the caller — the project the request
+  limited the search to. Both are worth showing: dsp-app's Advanced Search always sends
+  `limitToProject` (`advanced-search-results.component.ts`), and it is the most Gravsearch-heavy flow
+  there is, so on a slow trace the pair tells you whether a researcher ran a project-scoped search or
+  a query that merely references the project. Empty **Scoped to** means unrestricted, not unknown; it
+  holds an IRI rather than a shortcode, so for newer projects it will not visually match **Project**.
 - **Panel 7 keeps the text filter even though a project attribute now exists** (DEV-7031). The
   **Project** column selects `span.gravsearch.project_shortcodes`, but the *filter* deliberately still
   matches the query text: a TraceQL attribute predicate does not match a span that lacks the attribute,
@@ -99,8 +107,8 @@ here — use the Gravsearch dashboard / Tempo for tail latency.
   steady throughput; daytime layers heavier human-driven search/admin/ontology calls on top. Excluding
   `/health`+`/version` barely moves it. A per-route-group average (Route group filter) separates "are
   reads fast" from "are searches fast".
-- Panel 7's **Project** column is live (DEV-7031): `gravsearch.project_shortcodes` is a bounded, sorted,
-  comma-separated set on the `gravsearch` root span, and stays off the Alloy spanmetrics dimension list
-  (which selects only `gravsearch.query.shape`, `stack`, `domain`, `environment`), so it adds no Prometheus
-  label. Remaining follow-up: once traces from before that release have aged out of retention, switch the
+- Panel 7's **Project** and **Scoped to** columns are live (DEV-7031): `gravsearch.project_shortcodes` is a
+  bounded, sorted, comma-separated set and `gravsearch.project_restriction` a single project IRI, both on the
+  `gravsearch` root span, and both stay off the Alloy spanmetrics dimension list (which selects only
+  `gravsearch.query.shape`, `stack`, `domain`, `environment`), so neither adds a Prometheus label. Remaining follow-up: once traces from before that release have aged out of retention, switch the
   project filter from the query text to the attribute — see the panel-7 bullet above for why not yet.

--- a/grafana-dashboards/dsp-api/README.md
+++ b/grafana-dashboards/dsp-api/README.md
@@ -51,7 +51,7 @@ here — use the Gravsearch dashboard / Tempo for tail latency.
 | 4 Avg duration — global | Mean duration over time (deploy-regression line) | `[$smoothing]` |
 | 5 Avg duration by route | Mean duration per route over time | `[$smoothing]` |
 | 6 Routes ranked by avg duration | Slowest routes now + how often they run | `$__range` |
-| 7 Slowest Gravsearch queries (traces) | Individual slow gravsearch executions + the query | Tempo |
+| 7 Slowest Gravsearch queries (traces) | Individual slow gravsearch executions, their target project + the query | Tempo |
 
 ### Query-shape rationale (don't "simplify" these away)
 
@@ -82,6 +82,15 @@ here — use the Gravsearch dashboard / Tempo for tail latency.
   link remains the way to the full, untruncated query. The `span.environment` predicate must stay in,
   or an `event.`-scoped search crosses environments. The threshold default is `2s` — the p95 of the
   `gravsearch` span baseline (PRD REQ-3.1: baseline-anchored, not an arbitrary constant).
+- **Panel 7 keeps the text filter even though a project attribute now exists** (DEV-7031). The
+  **Project** column selects `span.gravsearch.project_shortcodes`, but the *filter* deliberately still
+  matches the query text: a TraceQL attribute predicate does not match a span that lacks the attribute,
+  so filtering on it would return nothing until the release carrying the instrumentation is deployed,
+  and would keep hiding every older trace still in retention. The column has no such window — it simply
+  fills in as new traces arrive. Two consequences to know: the filter matches **ontology IRIs only**, so
+  it misses dsp-api's internal searches (incoming links, still-image representations, incoming regions)
+  whose queries name only built-in ontologies, while the column covers them because the attribute is
+  derived from resource IRIs too. Read the column rather than trusting the filter for those.
 
 ### Notes
 
@@ -90,6 +99,8 @@ here — use the Gravsearch dashboard / Tempo for tail latency.
   steady throughput; daytime layers heavier human-driven search/admin/ontology calls on top. Excluding
   `/health`+`/version` barely moves it. A per-route-group average (Route group filter) separates "are
   reads fast" from "are searches fast".
-- Follow-up (DEV-7032): emit a bounded `gravsearch.project_shortcodes` span attribute so panel 7 can show
-  a Project column. It must be a set (Gravsearch is cross-project) and stay off the Alloy spanmetrics
-  dimension list.
+- Panel 7's **Project** column is live (DEV-7031): `gravsearch.project_shortcodes` is a bounded, sorted,
+  comma-separated set on the `gravsearch` root span, and stays off the Alloy spanmetrics dimension list
+  (which selects only `gravsearch.query.shape`, `stack`, `domain`, `environment`), so it adds no Prometheus
+  label. Remaining follow-up: once traces from before that release have aged out of retention, switch the
+  project filter from the query text to the attribute — see the panel-7 bullet above for why not yet.

--- a/grafana-dashboards/dsp-api/dsp-api-response-duration.json
+++ b/grafana-dashboards/dsp-api/dsp-api-response-duration.json
@@ -630,7 +630,7 @@
         "spec": {
           "id": 7,
           "title": "Slowest Gravsearch queries (traces)",
-          "description": "Individual gravsearch executions slower than the Duration ≥ threshold, from Tempo traces (service DSP_svc_api), scoped to the selected environment/stack. Sorted slowest first. To read the actual SPARQL/Gravsearch query: click the Trace ID → in the trace view select the 'gravsearch' span → Events → 'gravsearch.query' → db.query.text (verbatim, untruncated). Tempo returns the most recent matches above the threshold (limit 100), then this table sorts them by duration. Set 'Project shortcode (Gravsearch)' to filter to one project's queries (matches the ontology IRIs in the query text, host-agnostic; empty = all projects). The 'Query (preview)' column shows the start of the query inline (filtering on the event surfaces it); click the Trace ID for the full, untruncated text. A rendered Project column needs the follow-up span attribute (DEV-7032/DEV-7031).",
+          "description": "Individual gravsearch executions slower than the Duration ≥ threshold, from Tempo traces (service DSP_svc_api), scoped to the selected environment/stack. Sorted slowest first. To read the actual SPARQL/Gravsearch query: click the Trace ID → in the trace view select the 'gravsearch' span → Events → 'gravsearch.query' → db.query.text (verbatim, untruncated). Tempo returns the most recent matches above the threshold (limit 100), then this table sorts them by duration. Set 'Project shortcode (Gravsearch)' to filter to one project's queries (matches the ontology IRIs in the query text, host-agnostic; empty = all projects). The 'Query (preview)' column shows the start of the query inline (filtering on the event surfaces it); click the Trace ID for the full, untruncated text. The 'Project' column is the gravsearch.project_shortcodes span attribute (DEV-7031): the projects a query references, read from its ontology IRIs and its resource IRIs alike, so it is populated for dsp-api's internal searches (incoming links, still-image representations, incoming regions) as well. It is blank on traces recorded before that instrumentation was deployed. Note that the 'Project shortcode (Gravsearch)' variable still filters on the query text, so it matches ontology IRIs only; prefer reading the Project column over trusting that filter for internal searches.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -650,7 +650,7 @@
                       "version": "v0",
                       "spec": {
                         "queryType": "traceql",
-                        "query": "{ span:name = \"gravsearch\" && span.environment =~ \"${environment:regex}\" && span.stack =~ \"${stack:regex}\" && span:duration > ${gsthreshold} && event.db.query.text =~ \".*ontology/${project}.*\" } | select(span:duration, span.gravsearch.query.shape, span.gravsearch.schema_predicates)",
+                        "query": "{ span:name = \"gravsearch\" && span.environment =~ \"${environment:regex}\" && span.stack =~ \"${stack:regex}\" && span:duration > ${gsthreshold} && event.db.query.text =~ \".*ontology/${project}.*\" } | select(span:duration, span.gravsearch.query.shape, span.gravsearch.schema_predicates, span.gravsearch.project_shortcodes)",
                         "limit": 100,
                         "tableType": "spans"
                       }
@@ -675,12 +675,14 @@
                       "indexByName": {
                         "Duration": 0,
                         "Start time": 1,
-                        "gravsearch.query.shape": 2,
-                        "gravsearch.schema_predicates": 3,
-                        "stack": 4,
-                        "Spans traceIdHidden": 5
+                        "gravsearch.project_shortcodes": 2,
+                        "gravsearch.query.shape": 3,
+                        "gravsearch.schema_predicates": 4,
+                        "stack": 5,
+                        "Spans traceIdHidden": 6
                       },
                       "renameByName": {
+                        "gravsearch.project_shortcodes": "Project",
                         "gravsearch.query.shape": "Shape",
                         "gravsearch.schema_predicates": "Predicates",
                         "db.query.text": "Query (preview)"

--- a/grafana-dashboards/dsp-api/dsp-api-response-duration.json
+++ b/grafana-dashboards/dsp-api/dsp-api-response-duration.json
@@ -630,7 +630,7 @@
         "spec": {
           "id": 7,
           "title": "Slowest Gravsearch queries (traces)",
-          "description": "Individual gravsearch executions slower than the Duration ≥ threshold, from Tempo traces (service DSP_svc_api), scoped to the selected environment/stack. Sorted slowest first. To read the actual SPARQL/Gravsearch query: click the Trace ID → in the trace view select the 'gravsearch' span → Events → 'gravsearch.query' → db.query.text (verbatim, untruncated). Tempo returns the most recent matches above the threshold (limit 100), then this table sorts them by duration. Set 'Project shortcode (Gravsearch)' to filter to one project's queries (matches the ontology IRIs in the query text, host-agnostic; empty = all projects). The 'Query (preview)' column shows the start of the query inline (filtering on the event surfaces it); click the Trace ID for the full, untruncated text. The 'Project' column is the gravsearch.project_shortcodes span attribute (DEV-7031): the projects a query references, read from its ontology IRIs and its resource IRIs alike, so it is populated for dsp-api's internal searches (incoming links, still-image representations, incoming regions) as well. It is blank on traces recorded before that instrumentation was deployed. Note that the 'Project shortcode (Gravsearch)' variable still filters on the query text, so it matches ontology IRIs only; prefer reading the Project column over trusting that filter for internal searches.",
+          "description": "Individual gravsearch executions slower than the Duration ≥ threshold, from Tempo traces (service DSP_svc_api), scoped to the selected environment/stack. Sorted slowest first. To read the actual SPARQL/Gravsearch query: click the Trace ID → in the trace view select the 'gravsearch' span → Events → 'gravsearch.query' → db.query.text (verbatim, untruncated). Tempo returns the most recent matches above the threshold (limit 100), then this table sorts them by duration. Set 'Project shortcode (Gravsearch)' to filter to one project's queries (matches the ontology IRIs in the query text, host-agnostic; empty = all projects). The 'Query (preview)' column shows the start of the query inline (filtering on the event surfaces it); click the Trace ID for the full, untruncated text. The 'Project' column is the gravsearch.project_shortcodes span attribute (DEV-7031): the projects a query references, read from its ontology IRIs and its resource IRIs alike, so it is populated for dsp-api's internal searches (incoming links, still-image representations, incoming regions) as well. It is blank on traces recorded before that instrumentation was deployed. The 'Scoped to' column is gravsearch.project_restriction: the project the request explicitly limited the search to, so a row with a value there was a project-scoped search rather than a query that merely references the project. Advanced Search in dsp-app always sends one; most other callers do not, and empty means unrestricted rather than unknown. It is a project IRI, not a shortcode, so for projects created after shortcode-shaped IRIs were retired it will not visually match the Project column \u2014 see the runbook. Note that the 'Project shortcode (Gravsearch)' variable still filters on the query text, so it matches ontology IRIs only; prefer reading the Project column over trusting that filter for internal searches.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -650,7 +650,7 @@
                       "version": "v0",
                       "spec": {
                         "queryType": "traceql",
-                        "query": "{ span:name = \"gravsearch\" && span.environment =~ \"${environment:regex}\" && span.stack =~ \"${stack:regex}\" && span:duration > ${gsthreshold} && event.db.query.text =~ \".*ontology/${project}.*\" } | select(span:duration, span.gravsearch.query.shape, span.gravsearch.schema_predicates, span.gravsearch.project_shortcodes)",
+                        "query": "{ span:name = \"gravsearch\" && span.environment =~ \"${environment:regex}\" && span.stack =~ \"${stack:regex}\" && span:duration > ${gsthreshold} && event.db.query.text =~ \".*ontology/${project}.*\" } | select(span:duration, span.gravsearch.query.shape, span.gravsearch.schema_predicates, span.gravsearch.project_shortcodes, span.gravsearch.project_restriction)",
                         "limit": 100,
                         "tableType": "spans"
                       }
@@ -676,13 +676,15 @@
                         "Duration": 0,
                         "Start time": 1,
                         "gravsearch.project_shortcodes": 2,
-                        "gravsearch.query.shape": 3,
-                        "gravsearch.schema_predicates": 4,
-                        "stack": 5,
-                        "Spans traceIdHidden": 6
+                        "gravsearch.project_restriction": 3,
+                        "gravsearch.query.shape": 4,
+                        "gravsearch.schema_predicates": 5,
+                        "stack": 6,
+                        "Spans traceIdHidden": 7
                       },
                       "renameByName": {
                         "gravsearch.project_shortcodes": "Project",
+                        "gravsearch.project_restriction": "Scoped to",
                         "gravsearch.query.shape": "Shape",
                         "gravsearch.schema_predicates": "Predicates",
                         "db.query.text": "Query (preview)"

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/GravsearchQueryShapeSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/GravsearchQueryShapeSpec.scala
@@ -176,9 +176,10 @@ class GravsearchQueryShapeSpec extends ZIOSpecDefault {
             |    ?book a knora-api:Resource .
             |    ?book knora-api:isPartOf <http://rdfh.ch/0803/SECRETINSTANCEID> .
             |}""".stripMargin
+        val shortcodes = shortcodesOf(query)
         assertTrue(
-          shortcodesOf(query) == Seq("0803"),
-          !shortcodesOf(query).exists(_.contains("SECRETINSTANCEID")),
+          shortcodes == Seq("0803"),
+          !shortcodes.exists(_.contains("SECRETINSTANCEID")),
         )
       },
     )

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/GravsearchQueryShapeSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/GravsearchQueryShapeSpec.scala
@@ -39,7 +39,13 @@ class GravsearchQueryShapeSpec extends ZIOSpecDefault {
   private def shapeOf(query: String, resultType: QueryResultType) =
     SearchResponderV2.queryShape(GravsearchParser.parseQuery(query), resultType)
 
+  private def shortcodesOf(query: String) =
+    SearchResponderV2.projectShortcodes(GravsearchParser.parseQuery(query))
+
   override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("SearchResponderV2 query derivations")(queryShapeSuite, projectShortcodesSuite)
+
+  private def queryShapeSuite =
     suite("SearchResponderV2.queryShape")(
       test("is invariant under a change to a FILTER literal (never encodes user data)") {
         val shapeA = shapeOf(
@@ -85,6 +91,94 @@ class GravsearchQueryShapeSpec extends ZIOSpecDefault {
         assertTrue(
           shape.predicates.contains("title"),
           !shape.predicates.exists(_.contains("SECRETINSTANCEID")),
+        )
+      },
+    )
+
+  private def projectShortcodesSuite =
+    suite("SearchResponderV2.projectShortcodes")(
+      test("a single-project query reports that project's shortcode") {
+        assertTrue(shortcodesOf(bookQueryWithTitleFilter("anything")) == Seq("0803"))
+      },
+      test("a cross-project query reports every project it references, sorted and de-duplicated") {
+        // Gravsearch can span projects, so the honest shape is a set — not one "primary" project.
+        val query =
+          """PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+            |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+            |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?book knora-api:isMainResource true .
+            |    ?book incunabula:title ?title .
+            |} WHERE {
+            |    ?book a incunabula:book .
+            |    ?book a knora-api:Resource .
+            |    ?book incunabula:title ?title .
+            |    ?thing a anything:Thing .
+            |    ?thing anything:hasText ?text .
+            |}""".stripMargin
+        assertTrue(shortcodesOf(query) == Seq("0001", "0803"))
+      },
+      test("a query over built-in ontologies only reports no project") {
+        // knora-api / salsah-gui carry no project code, so they drop out and the attribute is empty.
+        // Empty is a real answer here ("no project identifiable"), distinct from the attribute being absent.
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?region knora-api:isMainResource true .
+            |} WHERE {
+            |    ?region a knora-api:Region .
+            |    ?region a knora-api:Resource .
+            |    ?region knora-api:hasGeometry ?geom .
+            |}""".stripMargin
+        assertTrue(shortcodesOf(query).isEmpty)
+      },
+      test("an internally generated search reports the project of the interpolated resource IRI") {
+        // The shape of `searchIncomingLinksV2` and friends: built-in ontologies only, with the target
+        // resource IRI interpolated in. Reading ontology IRIs alone would leave every such span blank,
+        // which is why the derivation reads data IRIs too.
+        val query =
+          """PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?incomingRes knora-api:isMainResource true .
+            |    ?incomingRes ?incomingProp <http://rdfh.ch/0803/c5058f3a> .
+            |} WHERE {
+            |    ?incomingRes a knora-api:Resource .
+            |    ?incomingRes ?incomingProp <http://rdfh.ch/0803/c5058f3a> .
+            |    <http://rdfh.ch/0803/c5058f3a> a knora-api:Resource .
+            |    ?incomingProp knora-api:objectType knora-api:Resource .
+            |}""".stripMargin
+        assertTrue(shortcodesOf(query) == Seq("0803"))
+      },
+      test("one project referenced in mixed case is reported once, normalised") {
+        // The project-ID pattern is `\p{XDigit}{4}`, so either case parses. An ontology IRI's code has
+        // already been through `Shortcode` (upper-cased) but a data IRI's is the raw capture, so reading
+        // the raw project code would report this single project as `00FF,00ff`.
+        val query =
+          """PREFIX images: <http://0.0.0.0:3333/ontology/00ff/images/simple/v2#>
+            |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?img knora-api:isMainResource true .
+            |} WHERE {
+            |    ?img a images:bild .
+            |    ?img a knora-api:Resource .
+            |    ?img knora-api:isPartOf <http://rdfh.ch/00ff/abc123> .
+            |}""".stripMargin
+        assertTrue(shortcodesOf(query) == Seq("00FF"))
+      },
+      test("only the shortcode is reported, never the instance IRI it was taken from") {
+        val query =
+          """PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+            |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+            |CONSTRUCT {
+            |    ?book knora-api:isMainResource true .
+            |} WHERE {
+            |    ?book a incunabula:book .
+            |    ?book a knora-api:Resource .
+            |    ?book knora-api:isPartOf <http://rdfh.ch/0803/SECRETINSTANCEID> .
+            |}""".stripMargin
+        assertTrue(
+          shortcodesOf(query) == Seq("0803"),
+          !shortcodesOf(query).exists(_.contains("SECRETINSTANCEID")),
         )
       },
     )

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2GravsearchSpanE2ESpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2GravsearchSpanE2ESpec.scala
@@ -21,6 +21,7 @@ import org.knora.webapi.E2EZSpec
 import org.knora.webapi.SchemaRendering
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.sharedtestdata.SharedTestDataADM.anonymousUser
+import org.knora.webapi.sharedtestdata.SharedTestDataADM.incunabulaProjectIri
 import org.knora.webapi.testservices.InMemoryTracing
 import org.knora.webapi.testservices.SpanAssertions
 
@@ -49,6 +50,9 @@ class SearchResponderV2GravsearchSpanE2ESpec extends E2EZSpec {
   )
 
   private val shapeKey = AttributeKey.stringKey("gravsearch.query.shape")
+
+  private val projectShortcodesKey  = AttributeKey.stringKey("gravsearch.project_shortcodes")
+  private val projectRestrictionKey = AttributeKey.stringKey("gravsearch.project_restriction")
 
   // The wire keys the runbook tells engineers to look for — asserted as literals, not imported from
   // production, so a rename shows up here as a failing test rather than silently following along.
@@ -169,6 +173,38 @@ class SearchResponderV2GravsearchSpanE2ESpec extends E2EZSpec {
       } yield SpanAssertions.hasSpan(spans, "gravsearch") &&
         SpanAssertions.hasNoAttributeKey(spans, "gravsearch", shapeKey) &&
         SpanAssertions.hasEventWithAttribute(spans, "gravsearch", queryEvent, queryTextKey, unparseable)
+    },
+    test("the root span carries the target project shortcodes, and no restriction when unrestricted (DEV-7031)") {
+      for {
+        spans <- spansAfter(runGravsearch(bookByTitleQuery(existingTitle)))
+      } yield SpanAssertions.hasAttribute(spans, "gravsearch", projectShortcodesKey, "0803") &&
+        SpanAssertions.hasNoAttributeKey(spans, "gravsearch", projectRestrictionKey)
+    },
+    test("a project-restricted search records the restriction as the project IRI it was given (DEV-7031)") {
+      // Recorded as the IRI, not a shortcode: `limitToProject` arrives as a `ProjectIri` and resolving it
+      // would need a project lookup. Incunabula's IRI is shortcode-shaped, so it happens to read as one
+      // here; a project created after those were retired carries a base64 UUID instead.
+      for {
+        spans <- spansAfter(
+                   ZIO.serviceWithZIO[SearchResponderV2](
+                     _.gravsearchV2(
+                       bookByTitleQuery(existingTitle),
+                       SchemaRendering.default,
+                       anonymousUser,
+                       Some(incunabulaProjectIri),
+                     ),
+                   ),
+                 )
+      } yield SpanAssertions.hasAttribute(spans, "gravsearch", projectShortcodesKey, "0803") &&
+        SpanAssertions.hasAttribute(spans, "gravsearch", projectRestrictionKey, "http://rdfh.ch/projects/0803")
+    },
+    test("a query that fails to parse carries no project attribute at all, rather than an empty one") {
+      // Locks the absent-vs-empty distinction the attribute relies on: empty means "no project
+      // identifiable", absent means the derivation never ran. A parse failure is the latter.
+      for {
+        spans <- spansAfter(runGravsearch(unparseable).either)
+      } yield SpanAssertions.hasSpan(spans, "gravsearch") &&
+        SpanAssertions.hasNoAttributeKey(spans, "gravsearch", projectShortcodesKey)
     },
     test("only the root span carries the event, so the stage-span no-events contract stays meaningful") {
       // Keeps `SearchResponderV2StageSpanSpec`'s `getEvents.isEmpty` assertion honest: it locks the

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -114,6 +114,10 @@ trait SearchResponderV2 {
   protected final def recordQueryOnRoot(query: IRI): UIO[Unit] =
     SearchResponderV2.recordQueryOnRoot(tracing, query)
 
+  /** Sets `gravsearch.project_shortcodes` + `gravsearch.project_restriction` on the root span. */
+  protected final def setProjectsOnRoot(query: ConstructQuery, limitToProject: Option[ProjectIri]): UIO[Unit] =
+    SearchResponderV2.setProjectsOnRoot(tracing, query, limitToProject)
+
   /**
    * Performs a search using a Gravsearch query provided by the client.
    *
@@ -139,6 +143,7 @@ trait SearchResponderV2 {
         _ <- recordQueryOnRoot(query)
         q <- stageSpan("gravsearch.parse")(ZIO.attempt(GravsearchParser.parseQuery(query)))
         _ <- setShapeOnRoot(q, SearchResponderV2.QueryResultType.ResourceList)
+        _ <- setProjectsOnRoot(q, limitToProject)
         r <- gravsearchV2(q, rendering, user, limitToProject)
       } yield r
     }
@@ -157,6 +162,7 @@ trait SearchResponderV2 {
         _ <- recordQueryOnRoot(query)
         q <- stageSpan("gravsearch.parse")(ZIO.attempt(GravsearchParser.parseQuery(query)))
         _ <- setShapeOnRoot(q, SearchResponderV2.QueryResultType.Count)
+        _ <- setProjectsOnRoot(q, limitToProject)
         r <- gravsearchCountV2(q, user, limitToProject)
       } yield r
     }
@@ -1560,6 +1566,109 @@ object SearchResponderV2 {
 
   private def bucket(n: Int): String =
     if (n == 0) "0" else if (n == 1) "1" else if (n <= 3) "2-3" else if (n <= 7) "4-7" else "8+"
+
+  // ---- target projects (DEV-7031) -----------------------------------------------------------------
+
+  /**
+   * Sets the two target-project attributes on the current (root) span:
+   *
+   *   - `gravsearch.project_shortcodes` — the projects the query itself refers to, derived from its
+   *     IRIs (see [[projectShortcodes]]). Always set, empty string included: an empty value means
+   *     "no project identifiable" (a query over built-in ontologies only), which is a different fact
+   *     from the attribute being absent (interrupted before parse — see the runbook's shape-less
+   *     early interrupt topology).
+   *   - `gravsearch.project_restriction` — the project the request was explicitly scoped to. Set
+   *     only when there was one, so absence means "unrestricted" without needing a sentinel value.
+   *
+   * They answer different questions and so are two attributes rather than one plus a flag: the first
+   * is "which projects does this query touch", inferred; the second is "which project was this
+   * search scoped to", stated by the caller. A cross-project query has several of the former and
+   * none of the latter.
+   *
+   * The restriction is recorded as the `ProjectIri` exactly as received, **not** as a shortcode:
+   * `limitToProject` arrives from the query string as an IRI, and a modern project IRI is
+   * `http://rdfh.ch/projects/<base64-UUID>` — resolving it to a shortcode would need a project
+   * lookup, i.e. a second abstract member on this trait and a repository call on the pre-parse path
+   * of every Gravsearch request. So this column does not join against `project_shortcodes` for
+   * projects created after shortcode-shaped IRIs were retired; that is a known limitation, not an
+   * oversight.
+   *
+   * Both values are bounded — a shortcode set and a project IRI, never the IRIs they came from — but
+   * bounded is not metric-safe: keep them off the Alloy `otelcol.connector.spanmetrics` dimension
+   * list, exactly like `gravsearch.schema_predicates`.
+   */
+  def setProjectsOnRoot(tracing: Tracing, query: ConstructQuery, limitToProject: Option[ProjectIri]): UIO[Unit] =
+    tracing.getCurrentSpanUnsafe.map { span =>
+      val _ = span.setAttribute("gravsearch.project_shortcodes", projectShortcodes(query).mkString(","))
+      limitToProject.foreach { project =>
+        val _ = span.setAttribute("gravsearch.project_restriction", project.value)
+      }
+    }
+
+  /**
+   * The sorted, de-duplicated shortcodes of every project the query's IRIs belong to.
+   *
+   * Derived from **all** Knora IRIs in the query, not only the ontology ones. Both kinds carry the
+   * shortcode — `…/ontology/0803/incunabula/simple/v2#book` and `http://rdfh.ch/0803/c5058f3a`
+   * alike — and the data IRIs are the *only* source for the internally generated searches (incoming
+   * links, still-image representations, incoming regions): those queries reference built-in
+   * ontologies exclusively and interpolate the target resource IRI, so reading ontology IRIs alone
+   * would leave every one of their spans blank.
+   *
+   * Only the shortcode reaches the span, never the IRI it was taken from, so this stays inside the
+   * "no instance IRIs as span attributes" rule of the instrumentation recipe.
+   *
+   * Normalised through `Shortcode` rather than read off [[SmartIri.getProjectCode]] directly, and
+   * that is load-bearing: `getProjectCode` returns the raw path segment, which for an *ontology* IRI
+   * has already been through `Shortcode` (upper-cased) but for a *data* IRI is the regex capture
+   * verbatim — and the project-ID pattern is `\p{XDigit}{4}`, which accepts either case. A query
+   * mixing `…/ontology/082a/…` with `http://rdfh.ch/082a/…` would otherwise report `082A,082a`:
+   * one project, two entries.
+   *
+   * Built-in ontologies (`knora-api`, `salsah-gui`, …) carry no project code and drop out on their
+   * own. Shared ontologies report `0000`, the shared-ontologies project, which is the truthful
+   * answer for a query that references them.
+   */
+  def projectShortcodes(query: ConstructQuery): Seq[String] =
+    queryIris(query).flatMap(_.getProjectShortcode.toOption.toList).map(_.value).distinct.sorted
+
+  /** Every IRI mentioned anywhere in the query: CONSTRUCT clause, FROM clause and WHERE clause. */
+  private def queryIris(query: ConstructQuery): Seq[SmartIri] =
+    query.constructClause.statements.flatMap(statementIris) ++
+      query.fromClause.map(_.defaultGraph.iri).toList ++
+      flattenPatterns(query.whereClause.patterns).flatMap(patternIris)
+
+  /** The IRIs in a statement's subject, predicate and object positions. */
+  private def statementIris(statement: StatementPattern): Seq[SmartIri] =
+    Seq(statement.subj, statement.pred, statement.obj).collect { case IriRef(iri, _) => iri }
+
+  /**
+   * The IRIs referenced by a single already-flattened WHERE pattern. Group nodes (OPTIONAL / UNION /
+   * MINUS / FILTER NOT EXISTS) hold no IRIs of their own and fall through to the catch-all —
+   * `flattenPatterns` already yields their children alongside them.
+   */
+  private def patternIris(pattern: QueryPattern): Seq[SmartIri] =
+    pattern match {
+      case statement: StatementPattern => statementIris(statement)
+      case FilterPattern(expression)   => expressionIris(expression)
+      case BindPattern(_, expression)  => expressionIris(expression)
+      case ValuesPattern(_, values)    => values.toSeq.map(_.iri)
+      case _                           => Seq.empty
+    }
+
+  /** Every IRI referenced anywhere in an expression tree (FILTER, BIND). */
+  private def expressionIris(expression: Expression): Seq[SmartIri] =
+    expression match {
+      case IriRef(iri, _)                            => Seq(iri)
+      case FunctionCallExpression(functionIri, args) => functionIri.iri +: args.flatMap(expressionIris)
+      case CompareExpression(l, _, r)                => expressionIris(l) ++ expressionIris(r)
+      case AndExpression(l, r)                       => expressionIris(l) ++ expressionIris(r)
+      case OrExpression(l, r)                        => expressionIris(l) ++ expressionIris(r)
+      case ArithmeticExpression(l, _, r)             => expressionIris(l) ++ expressionIris(r)
+      case CoalesceFunction(args)                    => args.flatMap(expressionIris)
+      case RegexFunction(textExpr, _, _)             => expressionIris(textExpr)
+      case _                                         => Seq.empty
+    }
 }
 
 object SearchResponderV2Live {


### PR DESCRIPTION
[DEV-7031](https://linear.app/dasch/issue/DEV-7031)

## Summary

- The `gravsearch` root span now carries the **target project(s)** as two bounded attributes, so a slow trace says *whose data* it was reading without anyone eyeballing the query text.
- `gravsearch.project_shortcodes` — sorted, de-duplicated shortcodes of the projects the query refers to. `gravsearch.project_restriction` — the `ProjectIri` the request was explicitly scoped to, when it was.
- Panel 7 of **DSP-API — Response Duration** gains a **Project** column reading the first attribute.

## Motivation

Panel 7 could show how slow a Gravsearch was, its shape, and (via the `gravsearch.query` event) the verbatim query — but not which project it targeted. That was recoverable only by reading shortcodes out of ontology IRIs by eye, which a Grafana table cannot select into a column.

## Changes

**Instrumentation** (`SearchResponderV2`)

`setProjectsOnRoot` sits beside `setShapeOnRoot`, called from both string entry points after parse.

Two attributes rather than one plus a flag: "which projects does this query touch" is *inferred* from the query, "which project was this search scoped to" is *stated* by the caller, and a cross-project query has several of the first and none of the second.

Shortcodes come from **all** Knora IRIs, not only ontology ones. dsp-api's internal searches — incoming links, still-image representations, incoming regions — reference built-in ontologies exclusively and interpolate the target resource IRI, so reading ontology IRIs alone would leave every one of their spans blank. Only the shortcode reaches the span, never the IRI behind it.

**Challenges and decisions**

- **Derived via `getProjectShortcode`, not `getProjectCode`.** The latter returns the raw path segment — already upper-cased for an ontology IRI, but the verbatim regex capture for a data IRI — and the project-ID pattern is `\p{XDigit}{4}`, which accepts either case. A query mixing `…/ontology/082a/…` with `http://rdfh.ch/082a/…` would have reported `082A,082a`: one project, two entries. There is a test that fails against the raw code.
- **The restriction is an IRI, not a shortcode.** `limitToProject` arrives from the query string as a `ProjectIri`, and a project IRI created after the shortcode-shaped ones were retired is `http://rdfh.ch/projects/<base64-UUID>`. Resolving it would mean a second abstract member on the `SearchResponderV2` trait plus a repository call on the pre-parse path of every Gravsearch. So the column does not join against `project_shortcodes` for newer projects — a documented limitation, not an oversight.
- **Empty vs. absent is load-bearing.** `project_shortcodes` is always set; an empty value means "no project identifiable" (built-in ontologies only), while an absent attribute means the derivation never ran (interrupted before parse). A test locks both.
- **Panel 7 keeps its query-text filter.** The issue sketched switching the `${project}` variable to the new attribute. A TraceQL attribute predicate does not match a span lacking the attribute, so filtering on it would return nothing until this release is deployed, and would keep hiding every older trace still in retention. The column has no such window. Switching the filter is the remaining follow-up, recorded in the dashboards README.

**Cardinality** — no ops-deploy change needed, and that is the point: the Alloy `otelcol.connector.spanmetrics` dimension list on `ops-deploy` main is exactly `gravsearch.query.shape`, `stack`, `domain`, `environment`. Neither new attribute is on it, so no new Prometheus label. `dsp-gravsearch.json` consumes only `gravsearch_query_shape`, confirming it from the consumer side.

**Docs** — runbook §4 gets both attributes plus why they are two; §7 records that the shape-less-early-interrupt topology lacks the project attribute too. TraceQL recipes §4 gains project filters (regex, not equality — the value is a set). The instrumentation recipe gains a bounded-projection row, since its "never set instance IRIs as attributes" rule would otherwise read as forbidding this change, when what it bans is the IRI itself and not a bounded value derived from one.

## Test Plan

> [!IMPORTANT]
> **No test, compile or format gate was run locally.** This machine has neither `bazel` nor Nix (`just check` exits 127 on a missing binary), Docker is not running, and no Metals/BSP server is live — a deliberate `val x: Int = "string"` probe returned no IDE diagnostics, so an empty diagnostic list proves nothing here. **CI is the first real gate for this PR.**

Compensating hand-verification: every AST case-class arity checked against `SparqlQuery.scala`; `SmartIri.getProjectShortcode`, `Shortcode.value` and `StringValue` visibility confirmed; all five new test queries checked for declared prefixes; scalafmt's 120-column limit and `align.preset = most` arrow columns checked programmatically; dashboard JSON validated with `jq` plus layout-`ElementReference`-to-`elements` and panel-id-uniqueness checks per `grafana-dashboards/CLAUDE.md`.

Tests added — `GravsearchQueryShapeSpec` (pure derivation): single-project; cross-project (several shortcodes, sorted and de-duplicated); built-in-ontology-only (no project); the internal-search shape (built-in ontologies plus an interpolated resource IRI); one project in mixed case reported once; only the shortcode reported, never the instance IRI.

`SearchResponderV2GravsearchSpanE2ESpec` (spans, isolated JVM target): shortcodes on the root span with no restriction when unrestricted; the restriction carrying the project IRI when scoped; no project attribute at all on a parse failure.

## Screenshots

The Project column only populates for traces recorded after this ships, so a screenshot now would show it empty. Worth capturing once the release is deployed.
