### PR TITLE
fix(admin): whole-subject findAll query with resilient skip-and-log (DEV-6798)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/AbstractEntityRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/AbstractEntityRepo.scala
@@ -10,6 +10,7 @@ import org.eclipse.rdf4j.model.vocabulary.RDF
 import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.`var` as variable
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable
 import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern
@@ -17,8 +18,10 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfSubject
 import zio.Chunk
+import zio.Exit
 import zio.IO
 import zio.NonEmptyChunk
+import zio.Ref
 import zio.Task
 import zio.ZIO
 import zio.stream.ZStream
@@ -60,7 +63,7 @@ abstract class AbstractEntityRepo[E <: EntityWithId[Id], Id <: StringValue](
 
   override def findAll(): Task[Chunk[E]] = {
     val sub = variable("s")
-    findAllByQuery(Construct(entityQuery(tripleP(sub), graphP(sub)).getQueryString))
+    findAllResilient(findAllQuery(sub))
   }
 
   override def findById(id: Id): Task[Option[E]] = {
@@ -103,6 +106,21 @@ abstract class AbstractEntityRepo[E <: EntityWithId[Id], Id <: StringValue](
   protected def findAllByPattern(pattern: RdfSubject => GraphPattern): Task[Chunk[E]] =
     findAllByQuery(findByPatternQuery(pattern))
 
+  // Whole-subject query: fetches every triple of every subject of `resourceClass` in one shot instead of
+  // enumerating each known property (required triples + N OPTIONAL blocks), which is O(N) per subject and
+  // becomes a cross-product for classes with many optional properties. Over-fetching unrelated predicates
+  // on the same subject is benign; `findAllResilient` skips (rather than fails) any subject whose fetched
+  // triples don't map cleanly onto `E`.
+  private[service] def findAllQuery(sub: Variable): Construct = {
+    val p       = variable("p")
+    val o       = variable("o")
+    val pattern = sub.isA(Rdf.iri(resourceClass.toString)).andHas(p, o)
+    val query   = Queries
+      .CONSTRUCT(sub.has(p, o))
+      .where(pattern.from(namedGraphIri))
+    Construct(query.getQueryString)
+  }
+
   private[service] def findByPatternQuery(pattern: RdfSubject => GraphPattern): Construct = {
     val s = variable("s")
     // The caller's pattern is the most selective part of the query (e.g. a shortcode lookup) and must
@@ -122,6 +140,34 @@ abstract class AbstractEntityRepo[E <: EntityWithId[Id], Id <: StringValue](
     runQuery(construct).flatMap(
       ZStream.fromIterator(_).mapZIO(mapper.toEntity(_).mapError(TriplestoreResponseException.apply)).runCollect,
     )
+
+  // Resilient collector used only by `findAll`: a single unmappable subject (missing required property,
+  // malformed value, or a mapper defect) is skipped and logged rather than failing the whole batch.
+  // Fiber interruption is re-propagated, never swallowed as a skip - a blanket catchAllCause/.sandbox would
+  // also catch interruption, which must instead cancel the outer `findAll()` effect.
+  private def findAllResilient(construct: Construct): Task[Chunk[E]] =
+    runQuery(construct).flatMap { resources =>
+      for {
+        skippedRef  <- Ref.make(0)
+        resultChunk <- ZStream
+                         .fromIterator(resources)
+                         .mapZIO { r =>
+                           mapper.toEntity(r).mapError(TriplestoreResponseException.apply).exit.flatMap {
+                             case Exit.Success(e)                    => ZIO.some(e)
+                             case Exit.Failure(c) if c.isInterrupted => ZIO.refailCause(c)
+                             case Exit.Failure(c)                    =>
+                               skippedRef.update(_ + 1) *>
+                                 ZIO.logWarningCause("skipping unmappable entity in findAll", c).as(None)
+                           }
+                         }
+                         .collectSome
+                         .runCollect
+        skipped <- skippedRef.get
+        _       <- ZIO
+               .logWarning(s"findAll skipped $skipped of ${resultChunk.length + skipped} subjects")
+               .when(skipped > 0)
+      } yield resultChunk
+    }
 
   private def runQuery(construct: Construct): Task[Iterator[RdfResource]] = for {
     model     <- triplestore.queryRdfModel(construct)

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/AbstractEntityRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/AbstractEntityRepo.scala
@@ -106,11 +106,9 @@ abstract class AbstractEntityRepo[E <: EntityWithId[Id], Id <: StringValue](
   protected def findAllByPattern(pattern: RdfSubject => GraphPattern): Task[Chunk[E]] =
     findAllByQuery(findByPatternQuery(pattern))
 
-  // Whole-subject query: fetches every triple of every subject of `resourceClass` in one shot instead of
-  // enumerating each known property (required triples + N OPTIONAL blocks), which is O(N) per subject and
-  // becomes a cross-product for classes with many optional properties. Over-fetching unrelated predicates
-  // on the same subject is benign; `findAllResilient` skips (rather than fails) any subject whose fetched
-  // triples don't map cleanly onto `E`.
+  // Fetches every triple of every matching subject in one CONSTRUCT instead of enumerating each known
+  // property (required triples + N OPTIONAL blocks): the per-property shape becomes a cross-product for
+  // classes with many optional properties. Over-fetching unrelated predicates on the same subject is benign.
   private[service] def findAllQuery(sub: Variable): Construct = {
     val p       = variable("p")
     val o       = variable("o")
@@ -141,10 +139,9 @@ abstract class AbstractEntityRepo[E <: EntityWithId[Id], Id <: StringValue](
       ZStream.fromIterator(_).mapZIO(mapper.toEntity(_).mapError(TriplestoreResponseException.apply)).runCollect,
     )
 
-  // Resilient collector used only by `findAll`: a single unmappable subject (missing required property,
-  // malformed value, or a mapper defect) is skipped and logged rather than failing the whole batch.
-  // Fiber interruption is re-propagated, never swallowed as a skip - a blanket catchAllCause/.sandbox would
-  // also catch interruption, which must instead cancel the outer `findAll()` effect.
+  // An unmappable subject (missing required property, malformed value, or a mapper defect) is skipped and
+  // logged rather than failing the whole batch. Interruption is re-propagated explicitly: a blanket
+  // catchAllCause/.sandbox would also catch interruption, which must instead cancel the outer `findAll()`.
   private def findAllResilient(construct: Construct): Task[Chunk[E]] =
     runQuery(construct).flatMap { resources =>
       for {

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/AbstractEntityRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/service/AbstractEntityRepo.scala
@@ -156,8 +156,15 @@ abstract class AbstractEntityRepo[E <: EntityWithId[Id], Id <: StringValue](
                              case Exit.Success(e)                    => ZIO.some(e)
                              case Exit.Failure(c) if c.isInterrupted => ZIO.refailCause(c)
                              case Exit.Failure(c)                    =>
-                               skippedRef.update(_ + 1) *>
-                                 ZIO.logWarningCause("skipping unmappable entity in findAll", c).as(None)
+                               r.getSubjectIri.flatMap { subjectIri =>
+                                 skippedRef.update(_ + 1) *>
+                                   ZIO
+                                     .logWarningCause(
+                                       s"skipping unmappable entity in findAll (subject=${subjectIri.value})",
+                                       c,
+                                     )
+                                     .as(None)
+                               }
                            }
                          }
                          .collectSome

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/AdministrativePermissionRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/AdministrativePermissionRepoLiveSpec.scala
@@ -17,6 +17,7 @@ import zio.test.*
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.messages.OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.admin.AdminConstants
 import org.knora.webapi.slice.admin.domain.model.AdministrativePermission
 import org.knora.webapi.slice.admin.domain.model.AdministrativePermissionPart
 import org.knora.webapi.slice.admin.domain.model.AdministrativePermissionRepo
@@ -104,5 +105,46 @@ class AdministrativePermissionRepoLiveSpec extends ZIOSpecDefault {
           .head == s"ProjectResourceCreateAllPermission|ProjectAdminGroupRestrictedPermission knora-admin:Creator,knora-admin:UnknownUser,${groupIri.value}",
       )
     },
+    suite("findAll resilience")(
+      test("skip (not die on) an AP subject that is missing knora-admin:forGroup/forProject") {
+        // `.map(_.head)` on `getObjectIrisConvert[GroupIri](KnoraAdmin.ForGroup)` throws NoSuchElementException
+        // as a defect when the property is absent - findAllResilient must skip it, not let `findAll()` die.
+        val brokenTrig =
+          s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+              |@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+              |
+              |<${AdminConstants.permissionsDataNamedGraph.value}> {
+              |  <http://rdfh.ch/permissions/missingForGroup> a knora-admin:AdministrativePermission ;
+              |    knora-base:hasPermissions "ProjectResourceCreateAllPermission" .
+              |}
+              |""".stripMargin
+        for {
+          _      <- TriplestoreServiceInMemory.setDataSetFromTriG(brokenTrig)
+          exit   <- repo(_.findAll()).exit
+          result <- repo(_.findAll())
+        } yield assertTrue(exit.isSuccess, result.isEmpty)
+      },
+      test("skip (not die on) an AP subject with an unparseable hasPermissions token") {
+        // `parsePermission`'s `case _ => ZIO.die(...)` branch fires for a token that is neither
+        // `Array(simplePermission)` nor `Array(restricted, irisStr)` - e.g. three space-separated parts.
+        // findAllResilient must skip this defect and log it too.
+        val brokenTrig =
+          s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+              |@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+              |
+              |<${AdminConstants.permissionsDataNamedGraph.value}> {
+              |  <http://rdfh.ch/permissions/malformedToken> a knora-admin:AdministrativePermission ;
+              |    knora-admin:forGroup <${groupIri.value}> ;
+              |    knora-admin:forProject <${projectIri.value}> ;
+              |    knora-base:hasPermissions "this is not valid" .
+              |}
+              |""".stripMargin
+        for {
+          _      <- TriplestoreServiceInMemory.setDataSetFromTriG(brokenTrig)
+          exit   <- repo(_.findAll()).exit
+          result <- repo(_.findAll())
+        } yield assertTrue(exit.isSuccess, result.isEmpty)
+      },
+    ),
   ).provide(AdministrativePermissionRepoLive.layer, TriplestoreServiceInMemory.emptyLayer, StringFormatter.test)
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/AdministrativePermissionRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/AdministrativePermissionRepoLiveSpec.scala
@@ -107,8 +107,8 @@ class AdministrativePermissionRepoLiveSpec extends ZIOSpecDefault {
     },
     suite("findAll resilience")(
       test("skip (not die on) an AP subject that is missing knora-admin:forGroup/forProject") {
-        // `.map(_.head)` on `getObjectIrisConvert[GroupIri](KnoraAdmin.ForGroup)` throws NoSuchElementException
-        // as a defect when the property is absent - findAllResilient must skip it, not let `findAll()` die.
+        // A missing forGroup makes the mapper's `.map(_.head)` throw as a defect (not a typed RdfError);
+        // findAllResilient must still skip it rather than let `findAll()` die.
         val brokenTrig =
           s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
               |@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
@@ -125,9 +125,8 @@ class AdministrativePermissionRepoLiveSpec extends ZIOSpecDefault {
         } yield assertTrue(exit.isSuccess, result.isEmpty)
       },
       test("skip (not die on) an AP subject with an unparseable hasPermissions token") {
-        // `parsePermission`'s `case _ => ZIO.die(...)` branch fires for a token that is neither
-        // `Array(simplePermission)` nor `Array(restricted, irisStr)` - e.g. three space-separated parts.
-        // findAllResilient must skip this defect and log it too.
+        // An unparseable hasPermissions token hits `parsePermission`'s `ZIO.die` branch - a defect, not a
+        // typed error; findAllResilient must skip it too.
         val brokenTrig =
           s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
               |@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/CachingEntityRepoSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/CachingEntityRepoSpec.scala
@@ -126,9 +126,8 @@ class CachingEntityRepoSpec extends ZIOSpecDefault {
         )
       },
       test("an interrupted findAll does not silently return a partial list") {
-        // TestMapper.toEntity interrupts itself when it sees TestRepo.interruptSentinel as the name. This
-        // must propagate out of findAllResilient's per-subject Exit-handling as a genuine interruption of the
-        // outer findAll() effect, not be treated like an ordinary mapping failure and skipped.
+        // TestMapper interrupts itself on TestRepo.interruptSentinel; findAllResilient must let that
+        // interruption propagate out of its per-subject Exit-handling instead of skipping it like a failure.
         val trig =
           s"""|<${TestRepo.namedGraph}> {
               |  <https://example.com/interrupt/1> a <${TestRepo.resourceClass}> ;

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/CachingEntityRepoSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/CachingEntityRepoSpec.scala
@@ -10,6 +10,8 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import org.junit.runner.RunWith
+import zio.Chunk
+import zio.Exit
 import zio.IO
 import zio.NonEmptyChunk
 import zio.ZIO
@@ -85,6 +87,65 @@ class CachingEntityRepoSpec extends ZIOSpecDefault {
         cacheEmpty <- checkAllEntitiesRemovedFromCache(entities)
       } yield assertTrue(actual2.isEmpty, actual3.isEmpty, cacheEmpty)
     },
+    suite("findAll resilience")(
+      test("empty class extent returns Chunk.empty before any built-in append") {
+        for {
+          _        <- TriplestoreServiceInMemory.setDataSetFromTriG("")
+          entities <- repo(_.findAll())
+        } yield assertTrue(entities.isEmpty)
+      },
+      test("a foreign-class subject in the same named graph is not returned") {
+        val trig =
+          s"""|<${TestRepo.namedGraph}> {
+              |  <https://example.com/foreign-and-valid/1> a <${TestRepo.resourceClass}> ;
+              |    <${TestRepo.property}> "valid" .
+              |  <https://example.com/foreign-and-valid/2> a <https://example.com/class/other> ;
+              |    <${TestRepo.property}> "foreign" .
+              |}
+              |""".stripMargin
+        for {
+          _        <- TriplestoreServiceInMemory.setDataSetFromTriG(trig)
+          entities <- repo(_.findAll())
+        } yield assertTrue(
+          entities == Chunk(TestEntity(TestId("https://example.com/foreign-and-valid/1"), "valid")),
+        )
+      },
+      test("a subject with an extra unrelated predicate and a second rdf:type maps correctly") {
+        val trig =
+          s"""|<${TestRepo.namedGraph}> {
+              |  <https://example.com/over-fetch/1> a <${TestRepo.resourceClass}>, <https://example.com/class/other> ;
+              |    <${TestRepo.property}> "overFetched" ;
+              |    <https://example.com/prop/#extra> "unrelated" .
+              |}
+              |""".stripMargin
+        for {
+          _        <- TriplestoreServiceInMemory.setDataSetFromTriG(trig)
+          entities <- repo(_.findAll())
+        } yield assertTrue(
+          entities == Chunk(TestEntity(TestId("https://example.com/over-fetch/1"), "overFetched")),
+        )
+      },
+      test("an interrupted findAll does not silently return a partial list") {
+        // TestMapper.toEntity interrupts itself when it sees TestRepo.interruptSentinel as the name. This
+        // must propagate out of findAllResilient's per-subject Exit-handling as a genuine interruption of the
+        // outer findAll() effect, not be treated like an ordinary mapping failure and skipped.
+        val trig =
+          s"""|<${TestRepo.namedGraph}> {
+              |  <https://example.com/interrupt/1> a <${TestRepo.resourceClass}> ;
+              |    <${TestRepo.property}> "valid" .
+              |  <https://example.com/interrupt/2> a <${TestRepo.resourceClass}> ;
+              |    <${TestRepo.property}> "${TestRepo.interruptSentinel}" .
+              |}
+              |""".stripMargin
+        for {
+          _    <- TriplestoreServiceInMemory.setDataSetFromTriG(trig)
+          exit <- repo(_.findAll()).exit
+        } yield assertTrue(exit match {
+          case Exit.Failure(cause) => cause.isInterrupted
+          case Exit.Success(_)     => false
+        })
+      },
+    ) @@ TestAspect.sequential,
   ).provide(
     TriplestoreServiceInMemory.emptyLayer,
     CacheManager.layer,
@@ -111,6 +172,7 @@ final case class TestMapper()                         extends RdfEntityMapper[Te
     for {
       id   <- resource.getSubjectIri
       name <- resource.getStringLiteralOrFail[String](TestRepo.property)(using Right(_))
+      _    <- ZIO.interrupt.when(name == TestRepo.interruptSentinel)
     } yield TestEntity(TestId(id.value), name)
 }
 
@@ -119,13 +181,15 @@ final case class TestRepo(
   cache: EntityCache[TestId, TestEntity],
 ) extends CachingEntityRepo(triplestore, TestMapper(), cache) {
   override protected def resourceClass: ParsedIRI           = ParsedIRI.create(TestRepo.resourceClass)
-  override protected def namedGraphIri: Iri                 = Rdf.iri("https://example.com/namedGraph")
+  override protected def namedGraphIri: Iri                 = Rdf.iri(TestRepo.namedGraph)
   override protected def entityProperties: EntityProperties = EntityProperties(NonEmptyChunk(TestRepo.propertyIri))
 }
 
 object TestRepo {
-  val property: String      = "https://example.com/prop/#name"
-  val propertyIri: Iri      = Rdf.iri(property)
-  val resourceClass: String = "https://example.com/class/test-entity"
-  val layer                 = ZLayer.derive[TestRepo]
+  val property: String          = "https://example.com/prop/#name"
+  val propertyIri: Iri          = Rdf.iri(property)
+  val resourceClass: String     = "https://example.com/class/test-entity"
+  val namedGraph: String        = "https://example.com/namedGraph"
+  val interruptSentinel: String = "__INTERRUPT__"
+  val layer                     = ZLayer.derive[TestRepo]
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/DefaultObjectAccessPermissionRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/DefaultObjectAccessPermissionRepoLiveSpec.scala
@@ -125,10 +125,8 @@ class DefaultObjectAccessPermissionRepoLiveSpec extends ZIOSpecDefault {
     },
     suite("findAll resilience")(
       test("skip (not die on) a DOAP subject that is missing knora-admin:forProject") {
-        // DefaultObjectAccessPermissionRepoLive's mapper does
-        // `resource.getObjectIrisConvert[ProjectIri](KnoraAdmin.ForProject).map(_.head)` - an empty Chunk's
-        // `.head` throws NoSuchElementException as a defect, not a typed RdfError. findAllResilient must
-        // catch that defect via `.exit`, skip the subject, and log it - not let `findAll()` die.
+        // A missing forProject makes the mapper's `.map(_.head)` throw as a defect (not a typed RdfError);
+        // findAllResilient must catch it via `.exit` and skip rather than let `findAll()` die.
         val brokenTrig =
           s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
               |@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/DefaultObjectAccessPermissionRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/DefaultObjectAccessPermissionRepoLiveSpec.scala
@@ -18,6 +18,7 @@ import zio.test.*
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.messages.OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.admin.AdminConstants
 import org.knora.webapi.slice.admin.domain.model.DefaultObjectAccessPermission
 import org.knora.webapi.slice.admin.domain.model.DefaultObjectAccessPermission.DefaultObjectAccessPermissionPart
 import org.knora.webapi.slice.admin.domain.model.DefaultObjectAccessPermission.ForWhat
@@ -122,5 +123,27 @@ class DefaultObjectAccessPermissionRepoLiveSpec extends ZIOSpecDefault {
           .head == s"RV ${groupIri.value}|V knora-admin:Creator,knora-admin:UnknownUser",
       )
     },
+    suite("findAll resilience")(
+      test("skip (not die on) a DOAP subject that is missing knora-admin:forProject") {
+        // DefaultObjectAccessPermissionRepoLive's mapper does
+        // `resource.getObjectIrisConvert[ProjectIri](KnoraAdmin.ForProject).map(_.head)` - an empty Chunk's
+        // `.head` throws NoSuchElementException as a defect, not a typed RdfError. findAllResilient must
+        // catch that defect via `.exit`, skip the subject, and log it - not let `findAll()` die.
+        val brokenTrig =
+          s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+              |@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+              |
+              |<${AdminConstants.permissionsDataNamedGraph.value}> {
+              |  <http://rdfh.ch/permissions/missingForProject> a knora-admin:DefaultObjectAccessPermission ;
+              |    knora-base:hasPermissions "V knora-admin:UnknownUser" .
+              |}
+              |""".stripMargin
+        for {
+          _      <- TriplestoreServiceInMemory.setDataSetFromTriG(brokenTrig)
+          exit   <- repo(_.findAll()).exit
+          result <- repo(_.findAll())
+        } yield assertTrue(exit.isSuccess, result.isEmpty)
+      },
+    ),
   ).provide(DefaultObjectAccessPermissionRepoLive.layer, TriplestoreServiceInMemory.emptyLayer, StringFormatter.test)
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraGroupRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraGroupRepoLiveSpec.scala
@@ -87,8 +87,6 @@ class KnoraGroupRepoLiveSpec extends ZIOSpecDefault {
       } yield assertTrue(userGroup.sortBy(_.id.value) == builtInGroups.sortBy(_.id.value))
     },
     test("skip a group subject missing a required property (groupName), and still return the valid ones") {
-      // "missingGroupName" has no knora-admin:groupName triple, so the mapper fails with a
-      // (non-defect) LiteralNotPresent RdfError. findAllResilient must skip it, not fail the whole batch.
       val brokenTriples = Rdf
         .iri("http://rdfh.ch/groups/0001/missingGroupName")
         .has(RDF.TYPE, Vocabulary.KnoraAdmin.UserGroup)

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraGroupRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraGroupRepoLiveSpec.scala
@@ -5,6 +5,11 @@
 
 package org.knora.webapi.slice.admin.repo.service
 
+import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.vocabulary.XSD
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import org.junit.runner.RunWith
 import zio.Chunk
 import zio.Ref
@@ -20,13 +25,17 @@ import zio.test.check
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.TestDataFactory.UserGroup.*
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.slice.admin.AdminConstants.adminDataNamedGraph
 import org.knora.webapi.slice.admin.domain.model.GroupIri
 import org.knora.webapi.slice.admin.domain.model.GroupName
 import org.knora.webapi.slice.admin.domain.model.KnoraGroup
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.service.KnoraGroupRepo
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary
 import org.knora.webapi.slice.common.repo.service.AbstractInMemoryCrudRepository
 import org.knora.webapi.slice.infrastructure.CacheManager
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.api.TriplestoreServiceInMemory
 
 final case class KnoraGroupRepoInMemory(groups: Ref[Chunk[KnoraGroup]])
@@ -76,6 +85,28 @@ class KnoraGroupRepoLiveSpec extends ZIOSpecDefault {
       for {
         userGroup <- KnoraGroupRepo(_.findAll())
       } yield assertTrue(userGroup.sortBy(_.id.value) == builtInGroups.sortBy(_.id.value))
+    },
+    test("skip a group subject missing a required property (groupName), and still return the valid ones") {
+      // "missingGroupName" has no knora-admin:groupName triple, so the mapper fails with a
+      // (non-defect) LiteralNotPresent RdfError. findAllResilient must skip it, not fail the whole batch.
+      val brokenTriples = Rdf
+        .iri("http://rdfh.ch/groups/0001/missingGroupName")
+        .has(RDF.TYPE, Vocabulary.KnoraAdmin.UserGroup)
+        .andHas(Vocabulary.KnoraAdmin.status, Rdf.literalOf(true))
+        .andHas(Vocabulary.KnoraAdmin.hasSelfJoinEnabled, Rdf.literalOf(false))
+      val brokenQuery = Update(
+        Queries
+          .INSERT_DATA(brokenTriples)
+          .into(Rdf.iri(adminDataNamedGraph.value))
+          .prefix(prefix(RDF.NS), prefix(Vocabulary.KnoraAdmin.NS), prefix(XSD.NS)),
+      )
+      for {
+        _         <- KnoraGroupRepo(_.save(testUserGroup))
+        _         <- ZIO.serviceWithZIO[TriplestoreService](_.query(brokenQuery))
+        userGroup <- KnoraGroupRepo(_.findAll())
+      } yield assertTrue(
+        userGroup.sortBy(_.id.value) == (builtInGroups ++ Chunk(testUserGroup)).sortBy(_.id.value),
+      )
     },
   )
 

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.admin.repo.service
 
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.`var` as variable
 import org.junit.runner.RunWith
 import zio.Chunk
 import zio.NonEmptyChunk
@@ -116,6 +117,87 @@ class KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
         for {
           projects <- KnoraProjectRepo(_.findAll())
         } yield assertTrue(projects.sortBy(_.id.value) == builtInProjects.sortBy(_.id.value))
+      },
+      test("skip a subject missing a required property, log the skip, and still return the valid ones") {
+        // "missingShortname" has no knora-admin:projectShortname triple, so the mapper fails with a
+        // (non-defect) LiteralNotPresent RdfError. findAllResilient must skip it, not fail the whole batch.
+        val brokenTrig =
+          s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+              |
+              |<${AdminConstants.adminDataNamedGraph.value}> {
+              |  <http://rdfh.ch/projects/missingShortname> a knora-admin:knoraProject ;
+              |    knora-admin:projectShortcode "9999" ;
+              |    knora-admin:projectDescription "Broken project"@en ;
+              |    knora-admin:status true ;
+              |    knora-admin:hasSelfJoinEnabled false .
+              |}
+              |""".stripMargin
+        for {
+          _        <- TriplestoreServiceInMemory.setDataSetFromTriG(someProjectTrig + brokenTrig)
+          projects <- KnoraProjectRepo(_.findAll())
+        } yield assertTrue(
+          projects.sortBy(_.id.value) == (Chunk(someProject) ++ builtInProjects).sortBy(_.id.value),
+        )
+      },
+      test("skip a subject with a malformed required value, log the skip, and still return the valid ones") {
+        // "malformedShortcode" carries an invalid knora-admin:projectShortcode (not a 4-digit hex value), so
+        // Shortcode.from fails with a ConversionError RdfError. Same skip-and-log contract as a missing property.
+        val brokenTrig =
+          s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+              |
+              |<${AdminConstants.adminDataNamedGraph.value}> {
+              |  <http://rdfh.ch/projects/malformedShortcode> a knora-admin:knoraProject ;
+              |    knora-admin:projectShortcode "not-a-shortcode" ;
+              |    knora-admin:projectShortname "brokenproject" ;
+              |    knora-admin:projectDescription "Broken project"@en ;
+              |    knora-admin:status true ;
+              |    knora-admin:hasSelfJoinEnabled false .
+              |}
+              |""".stripMargin
+        for {
+          _        <- TriplestoreServiceInMemory.setDataSetFromTriG(someProjectTrig + brokenTrig)
+          projects <- KnoraProjectRepo(_.findAll())
+        } yield assertTrue(
+          projects.sortBy(_.id.value) == (Chunk(someProject) ++ builtInProjects).sortBy(_.id.value),
+        )
+      },
+      test("not return a foreign-class subject in the same named graph") {
+        // findAllQuery's `?s a <resourceClass>` anchor must still filter out subjects of a different class,
+        // even though the whole-subject CONSTRUCT no longer enumerates properties one by one.
+        val foreignClassTrig =
+          s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+              |
+              |<${AdminConstants.adminDataNamedGraph.value}> {
+              |  <http://rdfh.ch/groups/9999> a knora-admin:UserGroup ;
+              |    knora-admin:groupName "not a project" .
+              |}
+              |""".stripMargin
+        for {
+          _        <- TriplestoreServiceInMemory.setDataSetFromTriG(someProjectTrig + foreignClassTrig)
+          projects <- KnoraProjectRepo(_.findAll())
+        } yield assertTrue(
+          projects.sortBy(_.id.value) == (Chunk(someProject) ++ builtInProjects).sortBy(_.id.value),
+          !projects.exists(_.id.value == "http://rdfh.ch/groups/9999"),
+        )
+      },
+      test("map a subject with an extra unrelated predicate and a second rdf:type correctly") {
+        // Whole-subject fetch over-fetches: an unrelated predicate and a second rdf:type on the same subject
+        // must survive into the model without breaking `getResourcesRdfType` or the mapper.
+        val extraPredicateTrig =
+          s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
+              |@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+              |
+              |<${AdminConstants.adminDataNamedGraph.value}> {
+              |  <http://rdfh.ch/projects/1234> knora-base:unrelatedPredicate "unrelated value" ;
+              |    a knora-base:Resource .
+              |}
+              |""".stripMargin
+        for {
+          _        <- TriplestoreServiceInMemory.setDataSetFromTriG(someProjectTrig + extraPredicateTrig)
+          projects <- KnoraProjectRepo(_.findAll())
+        } yield assertTrue(
+          projects.sortBy(_.id.value) == (Chunk(someProject) ++ builtInProjects).sortBy(_.id.value),
+        )
       },
     ),
     suite("findBy ...")(
@@ -229,6 +311,21 @@ class KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
               |OPTIONAL { ?s knora-admin:hasDataLicense ?n12 . }
               |OPTIONAL { ?s knora-admin:hasDataCopyrightHolder ?n13 . }
               |OPTIONAL { ?s knora-admin:hasDefaultDataAuthorship ?n14 . } } }
+              |""".stripMargin
+        } yield assertTrue(query.sparql == expected)
+      },
+    ),
+    suite("findAllQuery")(
+      // Pins the generated whole-subject SPARQL for findAll: CONSTRUCT { ?s ?p ?o } scoped to the admin
+      // named graph, anchored by `?s a knora-admin:knoraProject`. No property enumeration, no OPTIONALs.
+      test("build a whole-subject CONSTRUCT scoped to the named graph") {
+        for {
+          repo    <- ZIO.service[KnoraProjectRepoLive]
+          query    = repo.findAllQuery(variable("s"))
+          expected =
+            """CONSTRUCT { ?s ?p ?o . }
+              |WHERE { GRAPH <http://www.knora.org/data/admin> { ?s a <http://www.knora.org/ontology/knora-admin#knoraProject> ;
+              |    ?p ?o . } }
               |""".stripMargin
         } yield assertTrue(query.sparql == expected)
       },

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraProjectRepoLiveSpec.scala
@@ -119,8 +119,6 @@ class KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
         } yield assertTrue(projects.sortBy(_.id.value) == builtInProjects.sortBy(_.id.value))
       },
       test("skip a subject missing a required property, log the skip, and still return the valid ones") {
-        // "missingShortname" has no knora-admin:projectShortname triple, so the mapper fails with a
-        // (non-defect) LiteralNotPresent RdfError. findAllResilient must skip it, not fail the whole batch.
         val brokenTrig =
           s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
               |
@@ -140,8 +138,6 @@ class KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
         )
       },
       test("skip a subject with a malformed required value, log the skip, and still return the valid ones") {
-        // "malformedShortcode" carries an invalid knora-admin:projectShortcode (not a 4-digit hex value), so
-        // Shortcode.from fails with a ConversionError RdfError. Same skip-and-log contract as a missing property.
         val brokenTrig =
           s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
               |
@@ -162,8 +158,8 @@ class KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
         )
       },
       test("not return a foreign-class subject in the same named graph") {
-        // findAllQuery's `?s a <resourceClass>` anchor must still filter out subjects of a different class,
-        // even though the whole-subject CONSTRUCT no longer enumerates properties one by one.
+        // The whole-subject CONSTRUCT dropped per-property enumeration, so the `?s a <resourceClass>` anchor
+        // is now solely responsible for excluding subjects of other classes.
         val foreignClassTrig =
           s"""|@prefix knora-admin: <http://www.knora.org/ontology/knora-admin#> .
               |
@@ -316,8 +312,7 @@ class KnoraProjectRepoLiveSpec extends ZIOSpecDefault {
       },
     ),
     suite("findAllQuery")(
-      // Pins the generated whole-subject SPARQL for findAll: CONSTRUCT { ?s ?p ?o } scoped to the admin
-      // named graph, anchored by `?s a knora-admin:knoraProject`. No property enumeration, no OPTIONALs.
+      // Golden-pins the whole-subject findAll SPARQL: no per-property enumeration, no OPTIONALs.
       test("build a whole-subject CONSTRUCT scoped to the named graph") {
         for {
           repo    <- ZIO.service[KnoraProjectRepoLive]

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraUserRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraUserRepoLiveSpec.scala
@@ -189,6 +189,33 @@ class KnoraUserRepoLiveSpec extends ZIOSpecDefault {
           users <- KnoraUserRepo(_.findAll())
         } yield assertTrue(users.sortBy(_.id.value) == builtInUsers.sortBy(_.id.value))
       },
+      test("skip a user subject missing a required property (username), and still return the valid ones") {
+        // "missingUsername" has no knora-admin:username triple, so the mapper fails with a
+        // (non-defect) LiteralNotPresent RdfError. findAllResilient must skip it, not fail the whole batch.
+        val brokenTriples = Rdf
+          .iri("http://rdfh.ch/users/missingUsername")
+          .has(RDF.TYPE, Vocabulary.KnoraAdmin.User)
+          .andHas(Vocabulary.KnoraAdmin.email, Rdf.literalOf("broken@example.com"))
+          .andHas(Vocabulary.KnoraAdmin.givenName, Rdf.literalOf("Broken"))
+          .andHas(Vocabulary.KnoraAdmin.familyName, Rdf.literalOf("User"))
+          .andHas(Vocabulary.KnoraAdmin.preferredLanguage, Rdf.literalOf("en"))
+          .andHas(Vocabulary.KnoraAdmin.status, Rdf.literalOf(true))
+          .andHas(Vocabulary.KnoraAdmin.password, Rdf.literalOf("hash"))
+          .andHas(Vocabulary.KnoraAdmin.isInSystemAdminGroup, Rdf.literalOf(false))
+        val brokenQuery = Update(
+          Queries
+            .INSERT_DATA(brokenTriples)
+            .into(Rdf.iri(adminDataNamedGraph.value))
+            .prefix(prefix(RDF.NS), prefix(Vocabulary.KnoraAdmin.NS), prefix(XSD.NS)),
+        )
+        for {
+          _     <- storeUsersInTripleStore(testUser)
+          _     <- ZIO.serviceWithZIO[TriplestoreService](_.query(brokenQuery))
+          users <- KnoraUserRepo(_.findAll())
+        } yield assertTrue(
+          users.sortBy(_.id.value) == (builtInUsers ++ Chunk(testUser)).sortBy(_.id.value),
+        )
+      },
     ),
     suite("save")(
       test("should create and find user") {

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraUserRepoLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/repo/service/KnoraUserRepoLiveSpec.scala
@@ -190,8 +190,6 @@ class KnoraUserRepoLiveSpec extends ZIOSpecDefault {
         } yield assertTrue(users.sortBy(_.id.value) == builtInUsers.sortBy(_.id.value))
       },
       test("skip a user subject missing a required property (username), and still return the valid ones") {
-        // "missingUsername" has no knora-admin:username triple, so the mapper fails with a
-        // (non-defect) LiteralNotPresent RdfError. findAllResilient must skip it, not fail the whole batch.
         val brokenTriples = Rdf
           .iri("http://rdfh.ch/users/missingUsername")
           .has(RDF.TYPE, Vocabulary.KnoraAdmin.User)


### PR DESCRIPTION
[DEV-6798](https://linear.app/dasch/issue/DEV-6798)

## Summary

`GET /admin/projects` was the slowest admin GET route in the platform (~865 ms mean on prod, p95 ≈ 2.09 s) because `AbstractEntityRepo.findAll()` generated an unrestricted CONSTRUCT with 5 required triples plus 10 OPTIONAL left-joins over every project — producing a cross-product (~29k–69k solution rows for ~49–59 projects). This PR implements **Phase 1 only** of the approved plan (`dasch-specs/specs/2026-07-24-sparql-performance-remediation/03-fix-admin-projects-findall-plan.md`): replace the whole-*class* fetch with a whole-*subject* fetch, and make `findAll()` resilient to malformed data instead of silently/catastrophically failing.

## Changes

**Query shape** (`AbstractEntityRepo.scala`)
- New `findAllQuery`: `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <namedGraphIri> { ?s a <resourceClass> ; ?p ?o } }` — no OPTIONAL blocks, no cross-product, scoped via `.from(namedGraphIri)` exactly like the existing builder.
- `findById`/`findByPattern`/`findByPatternQuery` are untouched — the existing pinned golden for `findByPatternQuery` still passes unmodified.
- Pinned golden spec added for the new `findAllQuery` string (`KnoraProjectRepoLiveSpec`).

**Resilience** (`findAllResilient`)
- `findAll()` now uses a new private collector that maps each subject and **skips-and-logs** (via `ZIO.logWarningCause`, full `Cause` preserved) any subject that fails to map — missing/malformed required property, or a mapper defect (e.g. the `.head`-on-empty-`Chunk` defects in `DefaultObjectAccessPermissionRepoLive`/`AdministrativePermissionRepoLive`) — while **re-propagating fiber interruption** rather than treating it as a skip.
- Skip-log messages name the subject IRI (per this repo's documented leniency convention).
- Emits an aggregate `findAll skipped N of M subjects` warning when N > 0 (the alerting signal for silent data loss), never a missing-vs-malformed severity split (deliberately, per the plan).
- The shared `findAllByQuery` used by `findByPattern` is untouched.

**Tests** — missing-required-property skip, malformed-value skip, mapper-defect skip (DOAP + AdministrativePermission, including the `parsePermission` `ZIO.die`), genuine fiber-interruption propagation (not swallowed as a skip), foreign-class-subject exclusion, over-fetch tolerance (extra predicate + second `rdf:type`), empty-extent handling, plus repo-specific resilience tests for Project/User/Group/DOAP/AdministrativePermission.

## Benchmark evidence (read-only against stage, 2026-08-26)

| Repo | OLD median (warm) | NEW median (warm) | Speedup | Parity |
|---|---|---|---|---|
| KnoraProject | 1.262s | 0.114s | **11.1×** | pass (69,444 old rows / 2,317 new triples, 59 subjects; no excluded/extra) |
| KnoraUser | 0.107s | 0.114s | ~noise (small extent, 290 subjects) | pass (0 excluded) |
| KnoraGroup | 0.061s | 0.060s | ~noise (15 subjects) | pass (0 excluded) |
| DefaultObjectAccessPermission | 0.087s | 0.084s | ~noise (158 subjects) | pass (0 excluded) |
| AdministrativePermission | 0.078s | 0.077s | ~noise (118 subjects) | pass (0 excluded) |

Result-set parity passed cleanly for all 5 production repos (no subject excluded by the old required-property join was missed by the new mapper's skip semantics; no unexpected extra entities; no built-in-IRI duplicates). The `/admin/projects` win is the one the plan targets and is decisive (11×, ~865ms → low-hundreds-of-ms class). The other 4 repos' ±1–7ms deltas are within WAN/HTTP round-trip noise to stage at their current small extents (15–290 subjects) — not a measured regression, but called out here for visibility per the plan's explicit "do not ship a regression silently" gate. The architectural fix (removing the OPTIONAL cross-product risk) still applies to all 6 inheritors uniformly, since `findAll()` is a shared base-class method with no per-repo toggle.

## Phase 2 (not in this PR)

Cache warming (scoped `putIfAbsent` warming of the per-id `EntityCache` from a `findAll()` pass) is explicitly gated on evidence per the plan — it was not built. A follow-up should confirm whether a real caller issues a `findAll()`-then-per-`findById` (`1 + N`) sequence before building it.

## Test Plan
- `bazel test //modules/webapi:test --test_filter='.*(KnoraProjectRepoLiveSpec|CachingEntityRepoSpec|DefaultObjectAccessPermissionRepoLiveSpec|AdministrativePermissionRepoLiveSpec|KnoraUserRepoLiveSpec|KnoraGroupRepoLiveSpec).*'` — passes.
- `just fmt` / `just check` — clean.
- Reviewed by scala-zio, performance, and consistency reviewer passes; one confirmed Warning (skip-log missing subject IRI) fixed; test-coverage gap for User/Group closed.
🤖 Generated with [Claude Code](https://claude.com/claude-code)