### PR TITLE
chore: enable the admin SPARQL passthrough in run-with-dev-db (DEV-6734)

### DIFF
--- a/justfile
+++ b/justfile
@@ -226,6 +226,7 @@ run-with-dev-db:
     export KNORA_WEBAPI_SIPI_INTERNAL_HOST=iiif.dev.dasch.swiss                                                             
     export KNORA_WEBAPI_SIPI_INTERNAL_PROTOCOL=https                                                                        
     export KNORA_WEBAPI_SIPI_INTERNAL_PORT=443
+    export KNORA_WEBAPI_ALLOW_SPARQL_PASSTHROUGH=true
     bazel run //modules/webapi:app
 
 ## Documentation


### PR DESCRIPTION
## Summary

Enables `KNORA_WEBAPI_ALLOW_SPARQL_PASSTHROUGH=true` in the `run-with-dev-db` justfile recipe, which runs the API locally (`bazel run //modules/webapi:app`) against the remote dev Fuseki.

`docker-compose.yml` already sets this flag to `true` for the containerized local stack, but `run-with-dev-db` did not, so an API run locally via this recipe fell back to the default `false` and never registered the read-only `POST /admin/sparql/query` endpoint (DEV-6734).

This only affects local development (`just run-with-dev-db`) — no production or CI behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)