### PR TITLE
chore: bump sipi to v8.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -306,23 +306,23 @@ use_repo(image_versions, "dsp_image_versions")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v6.4.1), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v8.0.0), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v6.4.1 index carries a `v8`
+# index/variant matching — the arm64 entry of the v8.0.0 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. These two
 # digests are the SOLE source of the sipi version: the /version endpoint reads
 # the tag from the image's own `org.opencontainers.image.version` OCI label
 # (//tools/buildinfo:oci_config_label), so there is no duplicated tag string to
 # keep in sync. To bump, see "Bumping the SIPI version" in CLAUDE.md.
-# Index digest: sha256:e1d751b5a1df1b6274769da28c8cc5f050bf506cd23617523d80b5e3d64ab980
+# Index digest: sha256:8cb1098a3fdf2383c5bb3f382f46a1fe58dad4cfed0a56c7aa8c5e06f5ac5e85
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:84918319f5b76a9263e10b5ad031763913b7319bafc68742900dcd021a7b7baa",
+    digest = "sha256:6fb699b38b21e992719c03d3308e97a1fd4a755758fcb17e966a9c3293539ffd",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:da59ebcdb71a7779e60b037438a45f7851d3dd96c83e3e20569774df684ed520",
+    digest = "sha256:069a1955331576d27df0b9efd11711b807228a52449c9532e46a0c9c2df0d5b5",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(


### PR DESCRIPTION
## What

Bump the upstream Sipi base image from `v6.4.1` to `daschswiss/sipi:v8.0.0`.

The two per-arch `oci.pull` digests in `MODULE.bazel` are the sole source of the
Sipi version — the `/version` endpoint reads the tag from the pulled image's own
`org.opencontainers.image.version` OCI label, so there is no duplicated tag
string to keep in sync.

Digests for `daschswiss/sipi:v8.0.0`:

- amd64: `sha256:6fb699b38b21e992719c03d3308e97a1fd4a755758fcb17e966a9c3293539ffd`
- arm64: `sha256:069a1955331576d27df0b9efd11711b807228a52449c9532e46a0c9c2df0d5b5`
- index: `sha256:8cb1098a3fdf2383c5bb3f382f46a1fe58dad4cfed0a56c7aa8c5e06f5ac5e85`

## Verification

`just docker-build-sipi-image` — Bazel pulls the new digests and builds the OCI
image successfully (build completed; only the local Docker-daemon load step is
environment-dependent).

## Follow-up

Sync the same Sipi version in the **ops-deploy** repo when deploying the DSP
release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)