### PR TITLE
feat: transform file values for pre-ingested assets in the import pipeline (DEV-6939)

### DIFF
--- a/docs/03-endpoints/api-v3/project-data-import.md
+++ b/docs/03-endpoints/api-v3/project-data-import.md
@@ -101,6 +101,8 @@ curl --request DELETE \
 - **Project and ontologies must already exist**: The import assumes class and property IRIs in the payload resolve
   against ontologies already in the triplestore.
 - **Create-only**: Re-importing requires deleting the project's data graph first, which is out of scope for this API.
-- **No assets**: Binary assets are not part of the import; only RDF data is handled.
+- **Assets must be pre-ingested**: The import does not ingest binary assets. File values must reference assets already
+  present in dsp-ingest. The import fetches their metadata by internal filename and rejects an asset that is not yet
+  ingested. 3D file values (`DDDFileValue`) are not yet supported.
 - **JSON-LD only**: Other RDF serializations are not accepted.
 - **Single instance**: Task state is held in memory per instance (same constraint as migration import/export).

--- a/modules/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/core/LayersLive.scala
@@ -129,9 +129,9 @@ object LayersLive { self =>
       ListsResponder.layer,
       OntologyModule.layer,
       OntologyResponderV2.layer,
-      // OntologyTransformer belongs to the ontology slice but depends on StandoffMappingService (standoff slice), so it
-      // is wired here rather than inside OntologyModule. No layer cycle: standoff services depend on the lean
-      // StandoffEntityInfoService, not on OntologyResponderV2.
+      // OntologyTransformer belongs to the ontology slice but depends on StandoffMappingService (standoff slice) and
+      // SipiService (store.iiif slice), so it is wired here rather than inside OntologyModule. No layer cycle: standoff
+      // services depend on the lean StandoffEntityInfoService, not on OntologyResponderV2.
       OntologyTransformer.layer,
       otelLayer,
       PermissionUtilADMLive.layer,

--- a/modules/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -2087,7 +2087,9 @@ case class StillImageExternalFileValueContentV2(
  * Constructs [[StillImageFileValueContentV2]] objects based on JSON-LD input.
  */
 object StillImageExternalFileValueContentV2 {
-  private val fakeInfo = FileInfo(
+  // Placeholder metadata persisted for external IIIF file values (no real ingest asset). The import pipeline's
+  // OntologyTransformer.emitExternalFileValue reads this same value to stay in parity with the create path.
+  val fakeInfo: FileInfo = FileInfo(
     "internalFilename",
     FileMetadataSipiResponse(
       Some("originalFilename"),

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClient.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClient.scala
@@ -7,6 +7,7 @@ package org.knora.webapi.slice.admin.domain.service
 
 import sttp.capabilities.zio.ZioStreams
 import sttp.client4.*
+import sttp.model.StatusCode
 import zio.Task
 import zio.ZIO
 import zio.ZLayer
@@ -19,6 +20,7 @@ import zio.stream.ZSink
 import java.io.IOException
 import scala.concurrent.duration.DurationInt
 
+import dsp.errors.NotFoundException
 import org.knora.webapi.config.DspIngestConfig
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
 import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
@@ -72,9 +74,12 @@ final class DspIngestClientLive(
       _        <- ZIO.logInfo(s"asset info for $shortcode/$assetId")
       _        <- ZIO.logDebug(s"Response from ingest: ${response.code}")
       _        <- ZIO.logDebug(s"Response from ingest body: ${response.body.fold(identity, identity)}")
-      result   <- ZIO
-                  .fromEither(response.body.flatMap(str => str.fromJson[AssetInfoResponse]))
-                  .mapError(err => new IOException(s"Error parsing response: $err"))
+      result   <- if (response.code == StatusCode.NotFound)
+                  ZIO.fail(NotFoundException(s"Asset $assetId not found in project $shortcode"))
+                else
+                  ZIO
+                    .fromEither(response.body.flatMap(str => str.fromJson[AssetInfoResponse]))
+                    .mapError(err => new IOException(s"Error parsing response: $err"))
     } yield result
 
   def exportProject(shortcode: Shortcode, outputFile: Path): Task[Option[Path]] =
@@ -86,7 +91,7 @@ final class DspIngestClientLive(
                  }
       response <- request.send(backend)
       result   <-
-        if (response.code == sttp.model.StatusCode.NotFound) ZIO.none
+        if (response.code == StatusCode.NotFound) ZIO.none
         else if (!response.code.isSuccess)
           ZIO.fail(new IOException(s"Export asset from ingest project $shortcode failed, code: ${response.code}"))
         else ZIO.some(outputFile)

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -57,6 +57,7 @@ import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
 import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
+import org.knora.webapi.slice.common.PlaceholderIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
@@ -693,8 +694,9 @@ final class OntologyTransformer(
 
     for {
       // Reject unsupported classes before any fetch, so the rejection path stays hermetic (never calls ingest).
-      _ <- ZIO.foreachDiscard(fileValues)(rejectUnsupportedFileValue(model, _))
-      _ <- ZIO.foreachDiscard(fileValues)(convertFileValue(model, ctx, _))
+      _                <- ZIO.foreachDiscard(fileValues)(rejectUnsupportedFileValue(model, _))
+      allowPlaceholder <- AppConfig.features(_.allowPlaceholder)
+      _                <- ZIO.foreachDiscard(fileValues)(convertFileValue(model, ctx, _, allowPlaceholder))
     } yield ()
   }
 
@@ -719,28 +721,103 @@ final class OntologyTransformer(
       .collect { case n if n.isURIResource => n.asResource.getURI }
 
   /** Converts one file value: external values reproduce the create-path placeholders; the rest fetch from ingest. */
-  private def convertFileValue(model: Model, ctx: ConversionContext, v: Resource): Task[Unit] =
-    typeIriOf(model, v) match {
-      case Some(KnoraBase.StillImageExternalFileValue) =>
-        ZIO.attempt(emitExternalFileValue(model, v))
-      case Some(cls) =>
-        for {
-          filename <- ZIO.attempt(requireFilename(model, v))
-          assetId  <- ZIO.fromEither(AssetId.fromFilename(filename)).mapError(new IllegalArgumentException(_))
-          meta     <- sipiService
-                    .getFileMetadataFromDspIngest(ctx.attachedToProject.shortcode, assetId)
-                    .mapError {
-                      case NotFoundException(_) =>
-                        new IllegalArgumentException(
-                          s"Asset '$filename' referenced by $v was not found in dsp-ingest; it must be " +
-                            s"pre-ingested before import",
-                        )
-                      case e => e
-                    }
-          _ <- ZIO.attempt(emitFileValue(model, v, cls, filename, meta))
-        } yield ()
-      case None =>
-        ZIO.fail(new IllegalArgumentException(s"FileValue $v has no rdf:type"))
+  private def convertFileValue(
+    model: Model,
+    ctx: ConversionContext,
+    v: Resource,
+    allowPlaceholder: Boolean,
+  ): Task[Unit] =
+    for {
+      _ <- rejectPlaceholderLegalMetadata(model, v, allowPlaceholder)
+      _ <- typeIriOf(model, v) match {
+             case Some(KnoraBase.StillImageExternalFileValue) =>
+               ZIO.attempt(emitExternalFileValue(model, v))
+             case Some(cls) =>
+               ZIO.attempt(requireFilename(model, v)).flatMap { filename =>
+                 if (filename == PlaceholderIri.instance.value)
+                   convertPlaceholderFileValue(model, v, cls, allowPlaceholder)
+                 else convertIngestedFileValue(model, ctx, v, cls, filename)
+               }
+             case None =>
+               ZIO.fail(new IllegalArgumentException(s"FileValue $v has no rdf:type"))
+           }
+    } yield ()
+
+  /**
+   * Rejects a file value carrying the placeholder sentinel (`urn:dasch:placeholder`) in a string-valued legal-metadata
+   * field (`hasCopyrightHolder` / `hasAuthorship`) when the `allow-placeholder` switch is off, mirroring the create
+   * path's [[FileValueV2.placeholderFields]] gate. When the switch is on it is a no-op — the legal metadata passes
+   * through untouched, exactly as on the create path. A placeholder `hasLicense` is an IRI object, so it is already
+   * rejected earlier by stage 1's IRI rewrite ("Couldn't parse IRI") in every environment; it is listed here too so
+   * a malformed literal-valued license sentinel is still caught.
+   */
+  private def rejectPlaceholderLegalMetadata(model: Model, v: Resource, allowPlaceholder: Boolean): Task[Unit] =
+    if (allowPlaceholder) ZIO.unit
+    else {
+      val sentinel        = PlaceholderIri.instance.value
+      val legalPredicates = List(KnoraBase.HasCopyrightHolder, KnoraBase.HasAuthorship, KnoraBase.HasLicense)
+      val hasSentinel     = legalPredicates.exists { p =>
+        v.listProperties(model.createProperty(p)).asScala.exists { stmt =>
+          val obj = stmt.getObject
+          (obj.isLiteral && obj.asLiteral.getLexicalForm == sentinel) ||
+          (obj.isURIResource && obj.asResource.getURI == sentinel)
+        }
+      }
+      if (hasSentinel)
+        ZIO.fail(
+          new IllegalArgumentException(
+            s"FileValue $v references the placeholder sentinel '$sentinel' in its legal metadata, " +
+              s"which is not allowed on this server",
+          ),
+        )
+      else ZIO.unit
+    }
+
+  /** Fetches the ingest metadata for a real pre-ingested asset and emits its file value. */
+  private def convertIngestedFileValue(
+    model: Model,
+    ctx: ConversionContext,
+    v: Resource,
+    cls: String,
+    filename: String,
+  ): Task[Unit] =
+    for {
+      assetId <- ZIO.fromEither(AssetId.fromFilename(filename)).mapError(new IllegalArgumentException(_))
+      meta    <- sipiService
+                .getFileMetadataFromDspIngest(ctx.attachedToProject.shortcode, assetId)
+                .mapError {
+                  case NotFoundException(_) =>
+                    new IllegalArgumentException(
+                      s"Asset '$filename' referenced by $v was not found in dsp-ingest; it must be " +
+                        s"pre-ingested before import",
+                    )
+                  case e => e
+                }
+      _ <- ZIO.attempt(emitFileValue(model, v, cls, filename, meta))
+    } yield ()
+
+  /**
+   * Handles a file value that references the placeholder sentinel (`urn:dasch:placeholder`), mirroring the create
+   * path's `allow-placeholder` deployment policy: rejected when the switch is off (production), otherwise emitted
+   * without an ingest fetch, with the sentinel as every asset field (as `ValueContentV2.placeholderFileInfo` does).
+   */
+  private def convertPlaceholderFileValue(
+    model: Model,
+    v: Resource,
+    cls: String,
+    allowPlaceholder: Boolean,
+  ): Task[Unit] =
+    if (!allowPlaceholder)
+      ZIO.fail(
+        new IllegalArgumentException(
+          s"FileValue $v references the placeholder sentinel '${PlaceholderIri.instance.value}', " +
+            s"which is not allowed on this server",
+        ),
+      )
+    else {
+      val placeholder = PlaceholderIri.instance.value
+      val meta        = FileMetadataSipiResponse(None, None, placeholder, None, None, None, None, None)
+      ZIO.attempt(emitFileValue(model, v, cls, placeholder, meta))
     }
 
   /** The internal filename from the naive-renamed `knora-base#fileValueHasFilename`, or throws a descriptive error. */

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -673,7 +673,7 @@ final class OntologyTransformer(
    * `ValueContentV2.getFileInfo`: read the naive-renamed `knora-base#fileValueHasFilename`, parse the `AssetId`, call
    * `getFileMetadataFromDspIngest`, then emit the base fields plus the type-specific dimensions.
    * `StillImageExternalFileValue` reproduces the create-path `fakeInfo` placeholder literals without a fetch.
-   * `DDDFileValue` has no create-path parity and is rejected. The naive `fileValueHasFilename` /
+   * `DDDFileValue` and the abstract `FileValue` have no create-path parity and are rejected. The naive `fileValueHasFilename` /
    * `stillImageFileValueHasExternalUrl` predicates are dropped; `valueHasString` is derived downstream in
    * [[addValueHasString]] from the emitted `internalFilename`.
    *
@@ -698,21 +698,29 @@ final class OntologyTransformer(
       .sortBy(_.getURI)
 
     for {
-      // Reject DDDFileValue before any fetch, so the rejection path stays hermetic (never calls the ingest service).
-      _ <- ZIO.foreachDiscard(fileValues)(rejectDddFileValue(model, _))
+      // Reject unsupported classes before any fetch, so the rejection path stays hermetic (never calls ingest).
+      _ <- ZIO.foreachDiscard(fileValues)(rejectUnsupportedFileValue(model, _))
       _ <- ZIO.foreachDiscard(fileValues)(convertFileValue(model, ctx, _))
     } yield ()
   }
 
-  /** Rejects a `DDDFileValue`, which has no create-path content type or write-model variant (REQ-8.3). */
-  private def rejectDddFileValue(model: Model, v: Resource): Task[Unit] = {
+  /**
+   * Rejects file-value classes with no create-path parity, before any ingest fetch: `DDDFileValue` (no create-path
+   * content type or write-model variant, REQ-8.3) and the abstract `FileValue` (never a valid concrete instance
+   * type). `FileValueClasses` includes both, so this pre-pass keeps them out of [[convertFileValue]].
+   */
+  private def rejectUnsupportedFileValue(model: Model, v: Resource): Task[Unit] = {
     val rdfType = model.createProperty(Rdf.Type)
-    val isDdd   = Option(v.getProperty(rdfType))
+    val typeIri = Option(v.getProperty(rdfType))
       .map(_.getObject)
-      .exists(n => n.isURIResource && n.asResource.getURI == KnoraBase.DDDFileValue)
-    if (isDdd)
-      ZIO.fail(new IllegalArgumentException(s"DDDFileValue $v is not yet implemented in the import pipeline"))
-    else ZIO.unit
+      .collect { case n if n.isURIResource => n.asResource.getURI }
+    typeIri match {
+      case Some(KnoraBase.DDDFileValue) =>
+        ZIO.fail(new IllegalArgumentException(s"DDDFileValue $v is not yet implemented in the import pipeline"))
+      case Some(KnoraBase.FileValue) =>
+        ZIO.fail(new IllegalArgumentException(s"FileValue $v is abstract and cannot be a concrete file value"))
+      case _ => ZIO.unit
+    }
   }
 
   /** Converts one file value: external values reproduce the create-path placeholders; the rest fetch from ingest. */

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -37,6 +37,7 @@ import java.nio.file.Path
 import java.time.Instant
 import scala.jdk.CollectionConverters.*
 
+import dsp.errors.NotFoundException
 import dsp.valueobjects.UuidUtil
 import org.knora.webapi.config.AppConfig
 import org.knora.webapi.messages.OntologyConstants.KnoraBase
@@ -54,11 +55,14 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
 import org.knora.webapi.slice.admin.domain.service.ProjectService
+import org.knora.webapi.slice.api.admin.model.MaintenanceRequests.AssetId
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
 import org.knora.webapi.slice.common.jena.RdfDataMgr
 import org.knora.webapi.slice.standoff.service.StandoffMappingService
+import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
+import org.knora.webapi.store.iiif.api.SipiService
 
 final case class TransformerError(message: String)
 
@@ -81,6 +85,7 @@ final class OntologyTransformer(
   sf: StringFormatter,
   standoffMappingService: StandoffMappingService,
   idSource: IdSource,
+  sipiService: SipiService,
 ) { self =>
 
   /**
@@ -127,11 +132,14 @@ final class OntologyTransformer(
       _     <- ZIO.attempt(addValueMetadata(model, ctx, now))
       // addTextValueType must precede convertRichtextValues: the latter drops textValueAsXml, the FormattedText vs
       // UnformattedText signal. Do not reorder these two.
-      _    <- ZIO.attempt(addTextValueType(model))
-      _    <- ZIO.attempt(convertDateValues(model))
-      _    <- ZIO.attempt(convertLinkValues(model))
-      _    <- ZIO.attempt(convertGeomValues(model))
-      _    <- convertRichtextValues(model, now)
+      _ <- ZIO.attempt(addTextValueType(model))
+      _ <- ZIO.attempt(convertDateValues(model))
+      _ <- ZIO.attempt(convertLinkValues(model))
+      _ <- ZIO.attempt(convertGeomValues(model))
+      _ <- convertRichtextValues(model, now)
+      // convertFileValues must precede addValueHasString: it emits internalFilename, from which the string
+      // pass derives valueHasString. It is a real effect (it fetches file metadata from dsp-ingest).
+      _    <- convertFileValues(model, ctx)
       _    <- ZIO.attempt(addValueHasString(model))
       kb   <- tempFile("onto-transformer-kb-", ".nq")
       graph = ProjectService.projectDataNamedGraphV2(ctx.attachedToProject)
@@ -660,6 +668,164 @@ final class OntologyTransformer(
   }
 
   /**
+   * For every value node whose `rdf:type` is a concrete `knora-base` file-value class, emit the file-specific triples
+   * the resource-create/write path persists. Non-external values fetch their metadata from dsp-ingest, mirroring
+   * `ValueContentV2.getFileInfo`: read the naive-renamed `knora-base#fileValueHasFilename`, parse the `AssetId`, call
+   * `getFileMetadataFromDspIngest`, then emit the base fields plus the type-specific dimensions.
+   * `StillImageExternalFileValue` reproduces the create-path `fakeInfo` placeholder literals without a fetch.
+   * `DDDFileValue` has no create-path parity and is rejected. The naive `fileValueHasFilename` /
+   * `stillImageFileValueHasExternalUrl` predicates are dropped; `valueHasString` is derived downstream in
+   * [[addValueHasString]] from the emitted `internalFilename`.
+   *
+   * Runs as a real effect (it calls the ingest service). Materialises the node list before mutating, since it adds
+   * triples into the same model it iterates. Rejections use `ZIO.fail`; synchronous model mutation is wrapped in
+   * `ZIO.attempt` — every failure stays in the `Throwable` channel that `restructure`'s `.mapError` turns into a
+   * `TransformerError`.
+   */
+  private def convertFileValues(model: Model, ctx: ConversionContext): Task[Unit] = {
+    val rdfType = model.createProperty(Rdf.Type)
+
+    val fileValues = model
+      .listSubjects()
+      .asScala
+      .filter { s =>
+        isValue(s) &&
+        Option(s.getProperty(rdfType))
+          .map(_.getObject)
+          .exists(n => n.isURIResource && KnoraBase.FileValueClasses.contains(n.asResource.getURI))
+      }
+      .toList
+      .sortBy(_.getURI)
+
+    for {
+      // Reject DDDFileValue before any fetch, so the rejection path stays hermetic (never calls the ingest service).
+      _ <- ZIO.foreachDiscard(fileValues)(rejectDddFileValue(model, _))
+      _ <- ZIO.foreachDiscard(fileValues)(convertFileValue(model, ctx, _))
+    } yield ()
+  }
+
+  /** Rejects a `DDDFileValue`, which has no create-path content type or write-model variant (REQ-8.3). */
+  private def rejectDddFileValue(model: Model, v: Resource): Task[Unit] = {
+    val rdfType = model.createProperty(Rdf.Type)
+    val isDdd   = Option(v.getProperty(rdfType))
+      .map(_.getObject)
+      .exists(n => n.isURIResource && n.asResource.getURI == KnoraBase.DDDFileValue)
+    if (isDdd)
+      ZIO.fail(new IllegalArgumentException(s"DDDFileValue $v is not yet implemented in the import pipeline"))
+    else ZIO.unit
+  }
+
+  /** Converts one file value: external values reproduce the create-path placeholders; the rest fetch from ingest. */
+  private def convertFileValue(model: Model, ctx: ConversionContext, v: Resource): Task[Unit] = {
+    val rdfType = model.createProperty(Rdf.Type)
+    val typeIri = Option(v.getProperty(rdfType))
+      .map(_.getObject)
+      .collect { case n if n.isURIResource => n.asResource.getURI }
+
+    typeIri match {
+      case Some(KnoraBase.StillImageExternalFileValue) =>
+        ZIO.attempt(emitExternalFileValue(model, v))
+      case Some(cls) =>
+        for {
+          filename <- requireFilename(model, v)
+          assetId  <- ZIO.fromEither(AssetId.fromFilename(filename)).mapError(new IllegalArgumentException(_))
+          meta     <- sipiService
+                    .getFileMetadataFromDspIngest(ctx.attachedToProject.shortcode, assetId)
+                    .mapError {
+                      case NotFoundException(_) =>
+                        new IllegalArgumentException(
+                          s"Asset '$filename' referenced by $v was not found in dsp-ingest; it must be " +
+                            s"pre-ingested before import",
+                        )
+                      case e => e
+                    }
+          _ <- ZIO.attempt(emitFileValue(model, v, cls, filename, meta))
+        } yield ()
+      case None =>
+        ZIO.fail(new IllegalArgumentException(s"FileValue $v has no rdf:type"))
+    }
+  }
+
+  /** The internal filename from the naive-renamed `knora-base#fileValueHasFilename`, or a descriptive failure. */
+  private def requireFilename(model: Model, v: Resource): Task[String] = {
+    val fileValueHasFilename = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "fileValueHasFilename")
+    Option(v.getProperty(fileValueHasFilename))
+      .map(_.getObject)
+      .collect { case n if n.isLiteral => n.asLiteral.getLexicalForm }
+      .filter(_.nonEmpty) match {
+      case Some(filename) => ZIO.succeed(filename)
+      case None           => ZIO.fail(new IllegalArgumentException(s"FileValue $v has no fileValueHasFilename"))
+    }
+  }
+
+  /** Emits the base file-value triples plus the type-specific dimensions, and drops the naive filename predicate. */
+  private def emitFileValue(
+    model: Model,
+    v: Resource,
+    cls: String,
+    filename: String,
+    meta: FileMetadataSipiResponse,
+  ): Unit = {
+    val fileValueHasFilename = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "fileValueHasFilename")
+    val internalFilename     = model.createProperty(KnoraBase.InternalFilename)
+    val internalMimeType     = model.createProperty(KnoraBase.InternalMimeType)
+    val originalFilename     = model.createProperty(KnoraBase.OriginalFilename)
+    val originalMimeType     = model.createProperty(KnoraBase.OriginalMimeType)
+    val dimX                 = model.createProperty(KnoraBase.DimX)
+    val dimY                 = model.createProperty(KnoraBase.DimY)
+
+    v.removeAll(fileValueHasFilename)
+    v.addProperty(internalFilename, filename)
+    v.addProperty(internalMimeType, meta.internalMimeType)
+    meta.originalFilename.foreach(v.addProperty(originalFilename, _))
+    meta.originalMimeType.foreach(v.addProperty(originalMimeType, _))
+
+    val _ = cls match {
+      // StillImage dims are required; the create path uses width/height.getOrElse(0) (StillImageFileValueContentV2).
+      case KnoraBase.StillImageFileValue =>
+        v.addProperty(dimX, intLiteral(model, meta.width.getOrElse(0)))
+        v.addProperty(dimY, intLiteral(model, meta.height.getOrElse(0)))
+      // Document dims are optional; emit only when ingest supplies them. numpages/pageCount is never persisted (plan D2).
+      case KnoraBase.DocumentFileValue =>
+        meta.width.foreach(w => v.addProperty(dimX, intLiteral(model, w)))
+        meta.height.foreach(h => v.addProperty(dimY, intLiteral(model, h)))
+      // Other (MovingImage/Audio/Text/Archive/StillImageVector): base fields only.
+      case _ => ()
+    }
+  }
+
+  /**
+   * Emits `externalUrl` plus the create-path `fakeInfo` placeholder literals for a `StillImageExternalFileValue`
+   * (`StillImageExternalFileValueContentV2`), and drops the naive `stillImageFileValueHasExternalUrl`. No ingest fetch.
+   */
+  private def emitExternalFileValue(model: Model, v: Resource): Unit = {
+    val src =
+      model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "stillImageFileValueHasExternalUrl")
+    val externalUrl      = model.createProperty(KnoraBase.ExternalUrl)
+    val internalFilename = model.createProperty(KnoraBase.InternalFilename)
+    val internalMimeType = model.createProperty(KnoraBase.InternalMimeType)
+    val originalFilename = model.createProperty(KnoraBase.OriginalFilename)
+    val originalMimeType = model.createProperty(KnoraBase.OriginalMimeType)
+
+    val url = Option(v.getProperty(src))
+      .map(_.getObject)
+      .collect {
+        case n if n.isLiteral     => n.asLiteral.getLexicalForm
+        case n if n.isURIResource => n.asResource.getURI
+      }
+      .getOrElse(
+        throw new IllegalArgumentException(s"StillImageExternalFileValue $v has no stillImageFileValueHasExternalUrl"),
+      )
+
+    v.removeAll(src)
+    v.addProperty(externalUrl, url)
+    v.addProperty(internalFilename, "internalFilename")
+    v.addProperty(internalMimeType, "internalMimeType")
+    v.addProperty(originalFilename, "originalFilename")
+    val _ = v.addProperty(originalMimeType, "originalMimeType")
+  }
+
+  /**
    * Derive the plain-text `knora-base:valueHasString` from each value's content. Scalar values use the lexical form
    * of their content literal; `ListValue` falls back to the list-node IRI, `RegionPreviewValue` to the region IRI,
    * and `IntervalValue` composes its two decimal bounds as `"$start - $end"`. `TextValue` (from the stage-1 rename),
@@ -683,6 +849,15 @@ final class OntologyTransformer(
       KnoraBase.GeonameValue -> KnoraBase.ValueHasGeonameCode,
       KnoraBase.TimeValue    -> KnoraBase.ValueHasTimeStamp,
       KnoraBase.GeomValue    -> KnoraBase.ValueHasGeometry,
+      // Every concrete file value derives valueHasString from its internalFilename (external uses the placeholder).
+      KnoraBase.StillImageFileValue         -> KnoraBase.InternalFilename,
+      KnoraBase.StillImageExternalFileValue -> KnoraBase.InternalFilename,
+      KnoraBase.StillImageVectorFileValue   -> KnoraBase.InternalFilename,
+      KnoraBase.MovingImageFileValue        -> KnoraBase.InternalFilename,
+      KnoraBase.AudioFileValue              -> KnoraBase.InternalFilename,
+      KnoraBase.TextFileValue               -> KnoraBase.InternalFilename,
+      KnoraBase.DocumentFileValue           -> KnoraBase.InternalFilename,
+      KnoraBase.ArchiveFileValue            -> KnoraBase.InternalFilename,
     ).map { case (cls, prop) => cls -> model.createProperty(prop) }
 
     def iriOf(v: Resource, p: Property): Option[String] =
@@ -743,6 +918,6 @@ final class OntologyTransformer(
 }
 
 object OntologyTransformer {
-  val layer: ZLayer[StringFormatter & StandoffMappingService & IdSource, Nothing, OntologyTransformer] =
+  val layer: ZLayer[StringFormatter & StandoffMappingService & IdSource & SipiService, Nothing, OntologyTransformer] =
     ZLayer.derive[OntologyTransformer]
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -700,8 +700,8 @@ final class OntologyTransformer(
 
   /**
    * Rejects file-value classes with no create-path parity, before any ingest fetch: `DDDFileValue` (no create-path
-   * content type or write-model variant, REQ-8.3) and the abstract `FileValue` (never a valid concrete instance
-   * type). `FileValueClasses` includes both, so this pre-pass keeps them out of [[convertFileValue]].
+   * content type or write-model variant) and the abstract `FileValue` (never a valid concrete instance type).
+   * `FileValueClasses` includes both, so this pre-pass keeps them out of [[convertFileValue]].
    */
   private def rejectUnsupportedFileValue(model: Model, v: Resource): Task[Unit] =
     typeIriOf(model, v) match {
@@ -780,7 +780,8 @@ final class OntologyTransformer(
       case KnoraBase.StillImageFileValue =>
         v.addProperty(dimX, intLiteral(model, meta.width.getOrElse(0)))
         v.addProperty(dimY, intLiteral(model, meta.height.getOrElse(0)))
-      // Document dims are optional; emit only when ingest supplies them. numpages/pageCount is never persisted (plan D2).
+      // Document dims are optional; emit only when ingest supplies them. numpages/pageCount is never persisted —
+      // the shipped write path only ever emits None for it, so emitting it here would diverge from create parity.
       case KnoraBase.DocumentFileValue =>
         meta.width.foreach(w => v.addProperty(dimX, intLiteral(model, w)))
         meta.height.foreach(h => v.addProperty(dimY, intLiteral(model, h)))

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/OntologyTransformer.scala
@@ -51,6 +51,7 @@ import org.knora.webapi.messages.util.PermissionUtilADM
 import org.knora.webapi.messages.util.standoff.StandoffStringUtil
 import org.knora.webapi.messages.util.standoff.StandoffTagUtilV2
 import org.knora.webapi.messages.v2.responder.standoffmessages.*
+import org.knora.webapi.messages.v2.responder.valuemessages.StillImageExternalFileValueContentV2
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.admin.domain.service.KnoraUserRepo
@@ -683,17 +684,10 @@ final class OntologyTransformer(
    * `TransformerError`.
    */
   private def convertFileValues(model: Model, ctx: ConversionContext): Task[Unit] = {
-    val rdfType = model.createProperty(Rdf.Type)
-
     val fileValues = model
       .listSubjects()
       .asScala
-      .filter { s =>
-        isValue(s) &&
-        Option(s.getProperty(rdfType))
-          .map(_.getObject)
-          .exists(n => n.isURIResource && KnoraBase.FileValueClasses.contains(n.asResource.getURI))
-      }
+      .filter(s => isValue(s) && typeIriOf(model, s).exists(KnoraBase.FileValueClasses.contains))
       .toList
       .sortBy(_.getURI)
 
@@ -709,33 +703,29 @@ final class OntologyTransformer(
    * content type or write-model variant, REQ-8.3) and the abstract `FileValue` (never a valid concrete instance
    * type). `FileValueClasses` includes both, so this pre-pass keeps them out of [[convertFileValue]].
    */
-  private def rejectUnsupportedFileValue(model: Model, v: Resource): Task[Unit] = {
-    val rdfType = model.createProperty(Rdf.Type)
-    val typeIri = Option(v.getProperty(rdfType))
-      .map(_.getObject)
-      .collect { case n if n.isURIResource => n.asResource.getURI }
-    typeIri match {
+  private def rejectUnsupportedFileValue(model: Model, v: Resource): Task[Unit] =
+    typeIriOf(model, v) match {
       case Some(KnoraBase.DDDFileValue) =>
         ZIO.fail(new IllegalArgumentException(s"DDDFileValue $v is not yet implemented in the import pipeline"))
       case Some(KnoraBase.FileValue) =>
         ZIO.fail(new IllegalArgumentException(s"FileValue $v is abstract and cannot be a concrete file value"))
       case _ => ZIO.unit
     }
-  }
 
-  /** Converts one file value: external values reproduce the create-path placeholders; the rest fetch from ingest. */
-  private def convertFileValue(model: Model, ctx: ConversionContext, v: Resource): Task[Unit] = {
-    val rdfType = model.createProperty(Rdf.Type)
-    val typeIri = Option(v.getProperty(rdfType))
+  /** The concrete `rdf:type` IRI of a value node, if it has one. */
+  private def typeIriOf(model: Model, v: Resource): Option[String] =
+    Option(v.getProperty(model.createProperty(Rdf.Type)))
       .map(_.getObject)
       .collect { case n if n.isURIResource => n.asResource.getURI }
 
-    typeIri match {
+  /** Converts one file value: external values reproduce the create-path placeholders; the rest fetch from ingest. */
+  private def convertFileValue(model: Model, ctx: ConversionContext, v: Resource): Task[Unit] =
+    typeIriOf(model, v) match {
       case Some(KnoraBase.StillImageExternalFileValue) =>
         ZIO.attempt(emitExternalFileValue(model, v))
       case Some(cls) =>
         for {
-          filename <- requireFilename(model, v)
+          filename <- ZIO.attempt(requireFilename(model, v))
           assetId  <- ZIO.fromEither(AssetId.fromFilename(filename)).mapError(new IllegalArgumentException(_))
           meta     <- sipiService
                     .getFileMetadataFromDspIngest(ctx.attachedToProject.shortcode, assetId)
@@ -752,18 +742,15 @@ final class OntologyTransformer(
       case None =>
         ZIO.fail(new IllegalArgumentException(s"FileValue $v has no rdf:type"))
     }
-  }
 
-  /** The internal filename from the naive-renamed `knora-base#fileValueHasFilename`, or a descriptive failure. */
-  private def requireFilename(model: Model, v: Resource): Task[String] = {
+  /** The internal filename from the naive-renamed `knora-base#fileValueHasFilename`, or throws a descriptive error. */
+  private def requireFilename(model: Model, v: Resource): String = {
     val fileValueHasFilename = model.createProperty(KnoraBase.KnoraBasePrefixExpansion + "fileValueHasFilename")
     Option(v.getProperty(fileValueHasFilename))
       .map(_.getObject)
       .collect { case n if n.isLiteral => n.asLiteral.getLexicalForm }
-      .filter(_.nonEmpty) match {
-      case Some(filename) => ZIO.succeed(filename)
-      case None           => ZIO.fail(new IllegalArgumentException(s"FileValue $v has no fileValueHasFilename"))
-    }
+      .filter(_.nonEmpty)
+      .getOrElse(throw new IllegalArgumentException(s"FileValue $v has no fileValueHasFilename"))
   }
 
   /** Emits the base file-value triples plus the type-specific dimensions, and drops the naive filename predicate. */
@@ -825,12 +812,15 @@ final class OntologyTransformer(
         throw new IllegalArgumentException(s"StillImageExternalFileValue $v has no stillImageFileValueHasExternalUrl"),
       )
 
+    // Read the placeholder metadata from the create-path source so the two stay in parity.
+    val info = StillImageExternalFileValueContentV2.fakeInfo
+
     v.removeAll(src)
     v.addProperty(externalUrl, url)
-    v.addProperty(internalFilename, "internalFilename")
-    v.addProperty(internalMimeType, "internalMimeType")
-    v.addProperty(originalFilename, "originalFilename")
-    val _ = v.addProperty(originalMimeType, "originalMimeType")
+    v.addProperty(internalFilename, info.filename)
+    v.addProperty(internalMimeType, info.metadata.internalMimeType)
+    info.metadata.originalFilename.foreach(v.addProperty(originalFilename, _))
+    val _ = info.metadata.originalMimeType.foreach(v.addProperty(originalMimeType, _))
   }
 
   /**

--- a/modules/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueContentV2Spec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueContentV2Spec.scala
@@ -9,10 +9,13 @@ import org.junit.runner.RunWith
 import zio.Task
 import zio.ZIO
 import zio.ZLayer
+import zio.test.Assertion.failsWithA
 import zio.test.Spec
 import zio.test.ZIOSpecDefault
+import zio.test.assert
 import zio.test.assertTrue
 
+import dsp.errors.NotFoundException
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.messages.util.rdf.JsonLDUtil
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
@@ -42,6 +45,14 @@ class ValueContentV2Spec extends ZIOSpecDefault {
             } yield assertTrue(ingested.metadata == expected)
           },
         ).provide(mockSipi()),
+        suite("Given the asset is not ingested")(
+          test("When dsp-ingest returns a 404, then it fails with a descriptive NotFoundException") {
+            for {
+              exit <- ValueContentV2.getFileInfo(shortcode0001, jsonLdObj).exit
+              msg   = exit.causeOption.flatMap(_.failureOption).map(_.getMessage).getOrElse("")
+            } yield assert(exit)(failsWithA[NotFoundException]) && assertTrue(msg.contains("not found in dsp-ingest"))
+          },
+        ).provide(mockSipiNotFound()),
       ),
       suite("GeomValueContentV2.parsePoints")(
         test("parses a rectangle geometry into its list of points") {
@@ -95,6 +106,18 @@ class ValueContentV2Spec extends ZIOSpecDefault {
       assetId: AssetId,
     ): Task[FileMetadataSipiResponse] =
       ZIO.succeed(expected)
+
+    // The following are unsupported operations because they are not used in the test
+    def getTextFileRequest(fileUrl: String, senderName: String): Task[String] =
+      ZIO.dieMessage("unsupported operation")
+  })
+
+  private def mockSipiNotFound() = ZLayer.succeed(new SipiService {
+    override def getFileMetadataFromDspIngest(
+      shortcode: KnoraProject.Shortcode,
+      assetId: AssetId,
+    ): Task[FileMetadataSipiResponse] =
+      ZIO.fail(NotFoundException("asset missing"))
 
     // The following are unsupported operations because they are not used in the test
     def getTextFileRequest(fileUrl: String, senderName: String): Task[String] =

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/admin/domain/service/DspIngestClientLiveSpec.scala
@@ -36,13 +36,16 @@ import zio.json.EncoderOps
 import zio.json.JsonEncoder
 import zio.json.ast.Json
 import zio.nio.file.Files
+import zio.test.Assertion.failsWithA
 import zio.test.Spec
 import zio.test.TestAspect
 import zio.test.TestEnvironment
 import zio.test.ZIOSpecDefault
+import zio.test.assert
 import zio.test.assertTrue
 
 import dsp.errors.BadCredentialsException
+import dsp.errors.NotFoundException
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.IRI
 import org.knora.webapi.config.DspIngestConfig
@@ -94,34 +97,44 @@ class DspIngestClientSpec extends ZIOSpecDefault {
     } yield assertTrue(contentIsDownloaded)
   })
 
-  private val getAssetInfoSuite = suite("getAssetInfo")(test("should return the assetInfo") {
-    implicit val encoder: JsonEncoder[AssetInfoResponse] = DeriveJsonEncoder.gen[AssetInfoResponse]
-    val assetId                                          = AssetId.unsafeFrom("4sAf4AmPeeg-ZjDn3Tot1Zt")
-    val expectedUrl                                      = s"/projects/$testShortcode/assets/$assetId"
-    val expected                                         = AssetInfoResponse(
-      internalFilename = s"$assetId.txt",
-      originalInternalFilename = s"$assetId.txt.orig",
-      originalFilename = "test.txt",
-      checksumOriginal = "bfd3192ea04d5f42d79836cf3b8fbf17007bab71",
-      checksumDerivative = "17bab70071fbf8b3fc63897d24f5d40ae2913dfb",
-      internalMimeType = Some("text/plain"),
-      originalMimeType = Some("text/plain"),
-    )
-    for {
-      // given
-      _ <- HttpMockServer.stub.getResponseJsonBody(expectedUrl, 200, expected)
+  private val getAssetInfoSuite = suite("getAssetInfo")(
+    test("should return the assetInfo") {
+      implicit val encoder: JsonEncoder[AssetInfoResponse] = DeriveJsonEncoder.gen[AssetInfoResponse]
+      val assetId                                          = AssetId.unsafeFrom("4sAf4AmPeeg-ZjDn3Tot1Zt")
+      val expectedUrl                                      = s"/projects/$testShortcode/assets/$assetId"
+      val expected                                         = AssetInfoResponse(
+        internalFilename = s"$assetId.txt",
+        originalInternalFilename = s"$assetId.txt.orig",
+        originalFilename = "test.txt",
+        checksumOriginal = "bfd3192ea04d5f42d79836cf3b8fbf17007bab71",
+        checksumDerivative = "17bab70071fbf8b3fc63897d24f5d40ae2913dfb",
+        internalMimeType = Some("text/plain"),
+        originalMimeType = Some("text/plain"),
+      )
+      for {
+        // given
+        _ <- HttpMockServer.stub.getResponseJsonBody(expectedUrl, 200, expected)
 
-      // when
-      assetInfo <- withDspIngestClient(_.getAssetInfo(testShortcode, assetId))
+        // when
+        assetInfo <- withDspIngestClient(_.getAssetInfo(testShortcode, assetId))
 
-      // then
-      mockJwt <- getTokenForDspIngest
-      _       <- HttpMockServer.verify.request(
-             getRequestedFor(urlPathEqualTo(expectedUrl))
-               .withHeader("Authorization", equalTo(s"Bearer $mockJwt")),
-           )
-    } yield assertTrue(assetInfo == expected)
-  })
+        // then
+        mockJwt <- getTokenForDspIngest
+        _       <- HttpMockServer.verify.request(
+               getRequestedFor(urlPathEqualTo(expectedUrl))
+                 .withHeader("Authorization", equalTo(s"Bearer $mockJwt")),
+             )
+      } yield assertTrue(assetInfo == expected)
+    },
+    test("should fail with NotFoundException when the asset does not exist (404)") {
+      val assetId     = AssetId.unsafeFrom("4sAf4AmPeeg-ZjDn3Tot1Zt")
+      val expectedUrl = s"/projects/$testShortcode/assets/$assetId"
+      for {
+        _    <- HttpMockServer.stub.getResponse(expectedUrl, aResponse().withStatus(404))
+        exit <- withDspIngestClient(_.getAssetInfo(testShortcode, assetId)).exit
+      } yield assert(exit)(failsWithA[NotFoundException])
+    },
+  )
 
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("DspIngestClientLive")(

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -45,6 +45,7 @@ import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
 import org.knora.webapi.slice.admin.domain.model.RestrictedView
 import org.knora.webapi.slice.admin.domain.model.UserIri
 import org.knora.webapi.slice.admin.domain.service.ProjectService
+import org.knora.webapi.slice.common.PlaceholderIri
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
@@ -1836,6 +1837,72 @@ class OntologyTransformerSpec extends ZIOSpecDefault {
         _    <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
         exit <- runTransformStage2Failure(fileValueJsonLd("DDDFileValue", filenameInner("testasset.gltf")))
       } yield assertTrue(messageOf(exit).contains("not yet implemented"))
+    },
+    test("a placeholder-sentinel filename emits a placeholder file value when allow-placeholder is on") {
+      val placeholder = PlaceholderIri.instance.value
+      for {
+        _   <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
+        res <- runTransformStage2(
+                 fileValueJsonLd("StillImageFileValue", filenameInner(placeholder)),
+                 expectedStage2SingleValue(
+                   "testFile",
+                   "StillImageFileValue",
+                   s"""knora-base:internalFilename "$placeholder" ;
+                      |     knora-base:internalMimeType "$placeholder" ;
+                      |     knora-base:dimX             0 ;
+                      |     knora-base:dimY             0""".stripMargin,
+                   placeholder,
+                 ),
+               )
+      } yield res
+    },
+    test("a placeholder-sentinel filename is rejected when allow-placeholder is off") {
+      ZIO.withConfigProvider(TestAppConfig.provider("app.features.allow-placeholder" -> false)) {
+        for {
+          _    <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
+          exit <- runTransformStage2Failure(
+                    fileValueJsonLd("StillImageFileValue", filenameInner(PlaceholderIri.instance.value)),
+                  )
+        } yield assertTrue(messageOf(exit).contains("placeholder sentinel"))
+      }
+    },
+    test("a placeholder sentinel in legal metadata is rejected when allow-placeholder is off") {
+      val sentinel = PlaceholderIri.instance.value
+      ZIO.withConfigProvider(TestAppConfig.provider("app.features.allow-placeholder" -> false)) {
+        for {
+          _    <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
+          exit <- runTransformStage2Failure(
+                    fileValueJsonLd(
+                      "StillImageFileValue",
+                      s"""${filenameInner("testasset.jp2")},
+                         |    "${knoraApi}hasCopyrightHolder": "$sentinel",
+                         |    "${knoraApi}hasAuthorship": "$sentinel"""".stripMargin,
+                    ),
+                  )
+        } yield assertTrue(messageOf(exit).contains("legal metadata"))
+      }
+    },
+    test("a placeholder sentinel in legal metadata passes through when allow-placeholder is on") {
+      val sentinel = PlaceholderIri.instance.value
+      runTransformStage2(
+        fileValueJsonLd(
+          "StillImageFileValue",
+          s"""${filenameInner("testasset.jp2")},
+             |    "${knoraApi}hasCopyrightHolder": "$sentinel"""".stripMargin,
+        ),
+        expectedStage2SingleValue(
+          "testFile",
+          "StillImageFileValue",
+          s"""knora-base:internalFilename   "testasset.jp2" ;
+             |     knora-base:internalMimeType   "image/jp2" ;
+             |     knora-base:originalFilename   "test2.tiff" ;
+             |     knora-base:originalMimeType   "image/tiff" ;
+             |     knora-base:dimX               512 ;
+             |     knora-base:dimY               256 ;
+             |     knora-base:hasCopyrightHolder "$sentinel"""".stripMargin,
+          "testasset.jp2",
+        ),
+      )
     },
     test("a DDDFileValue rejects the whole batch before any other file value is fetched") {
       // Hermetic rejection: assertNoInteraction fails on any ingest call, so a message of "not yet implemented"

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -1783,6 +1783,54 @@ class OntologyTransformerSpec extends ZIOSpecDefault {
            |}]""".stripMargin
       runTransformStage2Failure(jsonLd).map(exit => assertTrue(messageOf(exit).contains("has no fileValueHasFilename")))
     },
+    test("StillImageFileValue with no ingest width/height falls back to dimX/dimY 0") {
+      val noDimsMeta = FileMetadataSipiResponse(
+        originalFilename = None,
+        originalMimeType = None,
+        internalMimeType = "image/jp2",
+        width = None,
+        height = None,
+        numpages = None,
+        duration = None,
+        fps = None,
+      )
+      for {
+        _ <- ZIO.serviceWithZIO[SipiServiceMock](
+               _.setReturnValue(SipiMockMethodName.GetFileMetadataFromDspIngest, ZIO.succeed(noDimsMeta)),
+             )
+        res <- runTransformStage2(
+                 fileValueJsonLd("StillImageFileValue", filenameInner("testasset.jp2")),
+                 expectedStage2SingleValue(
+                   "testFile",
+                   "StillImageFileValue",
+                   s"""knora-base:internalFilename "testasset.jp2" ;
+                      |     knora-base:internalMimeType "image/jp2" ;
+                      |     knora-base:dimX             0 ;
+                      |     knora-base:dimY             0""".stripMargin,
+                   "testasset.jp2",
+                 ),
+               )
+      } yield res
+    },
+    test("invalid fileValueHasFilename is rejected before any ingest fetch") {
+      // "ab" (stripped at the first '.') fails AssetId's ^[a-zA-Z0-9-_]{4,}$ regex, so the parse fails before the
+      // fetch. assertNoInteraction proves no ingest call happened (else the message would be "No interaction expected").
+      for {
+        _    <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
+        exit <- runTransformStage2Failure(fileValueJsonLd("StillImageFileValue", filenameInner("ab.jp2")))
+        msg   = messageOf(exit)
+      } yield assertTrue(
+        exit.isFailure,
+        !msg.contains("was not found in dsp-ingest"),
+        !msg.contains("No interaction expected"),
+      )
+    },
+    test("abstract FileValue is rejected with no ingest interaction") {
+      for {
+        _    <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
+        exit <- runTransformStage2Failure(fileValueJsonLd("FileValue", filenameInner("testasset.jp2")))
+      } yield assertTrue(messageOf(exit).contains("abstract"))
+    },
     test("DDDFileValue is rejected as not yet implemented with no ingest interaction") {
       for {
         _    <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/OntologyTransformerSpec.scala
@@ -24,6 +24,7 @@ import java.time.Instant
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
 
+import dsp.errors.NotFoundException
 import dsp.valueobjects.UuidUtil
 import org.knora.testrunner.DspZTestJUnitRunner
 import org.knora.webapi.InternalSchema
@@ -52,6 +53,9 @@ import org.knora.webapi.slice.common.jena.ModelOps
 import org.knora.webapi.slice.resources.repo.service.value.queries.InsertValueQueryBuilder
 import org.knora.webapi.slice.standoff.service.StandoffMappingService
 import org.knora.webapi.slice.standoff.service.StandoffMappingServiceInMemory
+import org.knora.webapi.store.iiif.api.FileMetadataSipiResponse
+import org.knora.webapi.store.iiif.impl.SipiServiceMock
+import org.knora.webapi.store.iiif.impl.SipiServiceMock.SipiMockMethodName
 
 @RunWith(classOf[DspZTestJUnitRunner])
 class OntologyTransformerSpec extends ZIOSpecDefault {
@@ -1627,6 +1631,194 @@ class OntologyTransformerSpec extends ZIOSpecDefault {
     },
   )
 
+  private def fileValueJsonLd(valueClass: String, inner: String): String =
+    resourceWithValueJsonLd(s"${onto}testFile", s"$knoraApi$valueClass", inner)
+
+  private def filenameInner(filename: String): String =
+    s""""${knoraApi}fileValueHasFilename": { "@type": "${xsd}string", "@value": "$filename" }"""
+
+  private val fileValuesStage2 = suite("Stage 2 — file values")(
+    test("StillImageFileValue emits base fields + dimX/dimY and drops fileValueHasFilename") {
+      runTransformStage2(
+        fileValueJsonLd("StillImageFileValue", filenameInner("testasset.jp2")),
+        expectedStage2SingleValue(
+          "testFile",
+          "StillImageFileValue",
+          s"""knora-base:internalFilename "testasset.jp2" ;
+             |     knora-base:internalMimeType "image/jp2" ;
+             |     knora-base:originalFilename "test2.tiff" ;
+             |     knora-base:originalMimeType "image/tiff" ;
+             |     knora-base:dimX             512 ;
+             |     knora-base:dimY             256""".stripMargin,
+          "testasset.jp2",
+        ),
+      )
+    },
+    test("DocumentFileValue emits base fields + optional dimX/dimY and no pageCount") {
+      runTransformStage2(
+        fileValueJsonLd("DocumentFileValue", filenameInner("testasset.pdf")),
+        expectedStage2SingleValue(
+          "testFile",
+          "DocumentFileValue",
+          s"""knora-base:internalFilename "testasset.pdf" ;
+             |     knora-base:internalMimeType "image/jp2" ;
+             |     knora-base:originalFilename "test2.tiff" ;
+             |     knora-base:originalMimeType "image/tiff" ;
+             |     knora-base:dimX             512 ;
+             |     knora-base:dimY             256""".stripMargin,
+          "testasset.pdf",
+        ),
+      )
+    },
+    test("AudioFileValue (Other) emits base fields only — no dimX/dimY/duration/fps") {
+      runTransformStage2(
+        fileValueJsonLd("AudioFileValue", filenameInner("testasset.mp3")),
+        expectedStage2SingleValue(
+          "testFile",
+          "AudioFileValue",
+          s"""knora-base:internalFilename "testasset.mp3" ;
+             |     knora-base:internalMimeType "image/jp2" ;
+             |     knora-base:originalFilename "test2.tiff" ;
+             |     knora-base:originalMimeType "image/tiff"""".stripMargin,
+          "testasset.mp3",
+        ),
+      )
+    },
+    test("StillImageExternalFileValue reproduces fakeInfo placeholders with no ingest fetch") {
+      val url = "https://iiif.example.org/image.jp2"
+      for {
+        _   <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
+        res <- runTransformStage2(
+                 fileValueJsonLd(
+                   "StillImageExternalFileValue",
+                   s""""${knoraApi}stillImageFileValueHasExternalUrl": { "@type": "${xsd}anyURI", "@value": "$url" }""",
+                 ),
+                 expectedStage2SingleValue(
+                   "testFile",
+                   "StillImageExternalFileValue",
+                   s"""knora-base:externalUrl      "$url" ;
+                      |     knora-base:internalFilename "internalFilename" ;
+                      |     knora-base:internalMimeType "internalMimeType" ;
+                      |     knora-base:originalFilename "originalFilename" ;
+                      |     knora-base:originalMimeType "originalMimeType"""".stripMargin,
+                   "internalFilename",
+                 ),
+               )
+      } yield res
+    },
+    test("payload legal metadata (copyright/license/authorship) passes through unchanged") {
+      runTransformStage2(
+        fileValueJsonLd(
+          "StillImageFileValue",
+          s"""${filenameInner("testasset.jp2")},
+             |    "${knoraApi}hasCopyrightHolder": "DaSCH",
+             |    "${knoraApi}hasLicense": { "@id": "http://rdfh.ch/licenses/cc-by-4.0" },
+             |    "${knoraApi}hasAuthorship": "Jane Doe"""".stripMargin,
+        ),
+        expectedStage2SingleValue(
+          "testFile",
+          "StillImageFileValue",
+          s"""knora-base:internalFilename  "testasset.jp2" ;
+             |     knora-base:internalMimeType  "image/jp2" ;
+             |     knora-base:originalFilename  "test2.tiff" ;
+             |     knora-base:originalMimeType  "image/tiff" ;
+             |     knora-base:dimX              512 ;
+             |     knora-base:dimY              256 ;
+             |     knora-base:hasCopyrightHolder "DaSCH" ;
+             |     knora-base:hasLicense        <http://rdfh.ch/licenses/cc-by-4.0> ;
+             |     knora-base:hasAuthorship     "Jane Doe"""".stripMargin,
+          "testasset.jp2",
+        ),
+      )
+    },
+    test("optional ingest fields absent → no originalFilename/originalMimeType/dimX/dimY") {
+      val minimalMeta = FileMetadataSipiResponse(
+        originalFilename = None,
+        originalMimeType = None,
+        internalMimeType = "application/pdf",
+        width = None,
+        height = None,
+        numpages = None,
+        duration = None,
+        fps = None,
+      )
+      for {
+        _ <- ZIO.serviceWithZIO[SipiServiceMock](
+               _.setReturnValue(SipiMockMethodName.GetFileMetadataFromDspIngest, ZIO.succeed(minimalMeta)),
+             )
+        res <- runTransformStage2(
+                 fileValueJsonLd("DocumentFileValue", filenameInner("testasset.pdf")),
+                 expectedStage2SingleValue(
+                   "testFile",
+                   "DocumentFileValue",
+                   s"""knora-base:internalFilename "testasset.pdf" ;
+                      |     knora-base:internalMimeType "application/pdf"""".stripMargin,
+                   "testasset.pdf",
+                 ),
+               )
+      } yield res
+    },
+    test("un-ingested asset is rejected with a descriptive TransformerError") {
+      for {
+        _ <- ZIO.serviceWithZIO[SipiServiceMock](
+               _.setReturnValue(SipiMockMethodName.GetFileMetadataFromDspIngest, ZIO.fail(NotFoundException("nope"))),
+             )
+        exit <- runTransformStage2Failure(fileValueJsonLd("StillImageFileValue", filenameInner("testasset.jp2")))
+      } yield assertTrue(messageOf(exit).contains("was not found in dsp-ingest"))
+    },
+    test("missing fileValueHasFilename is rejected with a descriptive TransformerError") {
+      val jsonLd =
+        s"""
+           |[{
+           |    "@id": "$resourceIri",
+           |    "@type": "${onto}Example",
+           |    "rdfs:label": "test",
+           |    "${onto}testFile": {
+           |      "@id": "$valueIri",
+           |      "@type": "${knoraApi}StillImageFileValue"
+           |    },
+           |    "@context": {
+           |       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+           |    }
+           |}]""".stripMargin
+      runTransformStage2Failure(jsonLd).map(exit => assertTrue(messageOf(exit).contains("has no fileValueHasFilename")))
+    },
+    test("DDDFileValue is rejected as not yet implemented with no ingest interaction") {
+      for {
+        _    <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
+        exit <- runTransformStage2Failure(fileValueJsonLd("DDDFileValue", filenameInner("testasset.gltf")))
+      } yield assertTrue(messageOf(exit).contains("not yet implemented"))
+    },
+    test("a DDDFileValue rejects the whole batch before any other file value is fetched") {
+      // Hermetic rejection: assertNoInteraction fails on any ingest call, so a message of "not yet implemented"
+      // (not "No interaction expected") proves the ordinary StillImageFileValue was never fetched.
+      val jsonLd =
+        s"""
+           |[{
+           |    "@id": "$resourceIri",
+           |    "@type": "${onto}Example",
+           |    "rdfs:label": "test",
+           |    "${onto}testFile": {
+           |      "@id": "$valueIri",
+           |      "@type": "${knoraApi}StillImageFileValue",
+           |      ${filenameInner("ordinaryasset.jp2")}
+           |    },
+           |    "${onto}testDdd": {
+           |      "@id": "$valueIri2",
+           |      "@type": "${knoraApi}DDDFileValue",
+           |      ${filenameInner("ddd.gltf")}
+           |    },
+           |    "@context": {
+           |       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+           |    }
+           |}]""".stripMargin
+      for {
+        _    <- ZIO.serviceWithZIO[SipiServiceMock](_.assertNoInteraction)
+        exit <- runTransformStage2Failure(jsonLd)
+      } yield assertTrue(messageOf(exit).contains("not yet implemented"))
+    },
+  )
+
   override def spec = suite("OntologyTransformerSpec")(
     simpleScalarValues,
     iriRefValues,
@@ -1645,11 +1837,13 @@ class OntologyTransformerSpec extends ZIOSpecDefault {
     geomStage2,
     intervalStage2,
     dateValueRejections,
+    fileValuesStage2,
   ).provide(
     OntologyTransformer.layer,
     StringFormatter.test,
     TestAppConfig.layer(),
     IdSourceInMemory.layer,
     standoffMappingServiceStub,
+    SipiServiceMock.layer,
   )
 }


### PR DESCRIPTION
[DEV-6939](https://linear.app/dasch/issue/DEV-6939) · parent DEV-6937

## Summary
- Add a `convertFileValues` stage-2 pass that produces `knora-base` file values for **pre-ingested** assets. The import payload references each asset by its internal filename; the pass fetches the file metadata from dsp-ingest (by filename and project shortcode) and emits the same triples the resource-create path persists.
- Fix `DspIngestClient.getAssetInfo` to map a 404 to `NotFoundException` instead of an opaque `IOException`.

## Changes
### Transformer (feat)
- New `convertFileValues` pass, sequenced between `convertRichtextValues` and `addValueHasString` (so `internalFilename` exists before the string pass derives `valueHasString`).
- Per-class emission: `StillImageFileValue` (required `dimX`/`dimY`), `DocumentFileValue` (optional `dimX`/`dimY`), the Other classes — `MovingImage`/`Audio`/`Text`/`Archive`/`StillImageVector` (base fields only), and `StillImageExternalFileValue` (create-path `fakeInfo` placeholder literals, no ingest fetch).
- Rejects un-ingested assets, missing/invalid filenames, and `DDDFileValue` (no create-path parity), all as descriptive `TransformerError`s. `DDDFileValue` is rejected before any fetch (hermetic).
- `valueHasString = internalFilename` derived via the `addValueHasString` `literalContent` map.
- `SipiService` injected as a constructor field; `ZLayer.derive` picks it up (only the layer type ascription changes — no `OntologyModule`/`LayersLive` edits, `SipiServiceLive.layer` is already provided).
- `duration`, `fps`, and `pageCount`/`numpages` are **not** emitted — parity with the shipped create/write path.

### dsp-ingest 404 (fix)
- `getAssetInfo` maps a 404 to `NotFoundException`. This also makes the existing create-path remap in `ValueContentV2.fileInfoFromExternal` reachable (previously dead), so an un-ingested asset yields a descriptive message.

## Test Plan
- `bazel test //modules/webapi:test --test_filter='.*(OntologyTransformerSpec|DspIngestClientSpec).*'` — pass.
- `just check` (scalafmt + license headers) — pass.
- New `fileValuesStage2` suite (10 cases): per-class happy paths, external no-fetch (`assertNoInteraction`), legal-metadata pass-through, optional-field absence, three rejection paths, and multi-value hermeticity.
- New `DspIngestClientSpec` case: 404 → `NotFoundException`.

## Follow-ups (not in this PR)
- The create-path `NotFoundException` branch (`ValueMessagesV2.fileInfoFromExternal`) is now reachable but still lacks a dedicated test — natural follow-up.
- Plan decision D3 needs back-end/SHACL confirmation: the external file value reproduces the create-path `fakeInfo` placeholder literals; confirm the `knora-base` data-shapes accept them.
- At bulk scale the pass issues one sequential dsp-ingest round-trip per asset; batching/parallelising (with per-node model isolation, since the Jena `Model` is not concurrent-safe) is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)