### PR TITLE
fix: label knora-base:Region "Image Annotation" in the UI (DEV-6853)

### DIFF
--- a/modules/webapi/src/main/resources/knora-ontologies/knora-base.ttl
+++ b/modules/webapi/src/main/resources/knora-ontologies/knora-base.ttl
@@ -20,7 +20,7 @@
     rdf:type           owl:Ontology ;
     rdfs:label         "The Knora base ontology"@en ;
     :attachedToProject knora-admin:SystemProject ;
-    :ontologyVersion   "knora-base v53" .
+    :ontologyVersion   "knora-base v54" .
 
 
 #################################################################
@@ -151,7 +151,7 @@
                             "Color"@en,
                             "Couleur"@fr,
                             "Colore"@it ;
-    rdfs:comment            """Specifies the color of a region."""@en ;
+    rdfs:comment            """Specifies the color of an annotation."""@en ;
     salsah-gui:guiAttribute "ncolors=8"^^xsd:string ;
     :objectClassConstraint  :ColorValue ;
     :subjectClassConstraint :Region ;
@@ -1911,10 +1911,10 @@
 
 :Region
     rdf:type           owl:Class ;
-    rdfs:label         "Region"@de,
-                       "Region"@en,
-                       "Région"@fr,
-                       "Regione"@it ;
+    rdfs:label         "Bildannotation"@de,
+                       "Image Annotation"@en,
+                       "Annotation d'image"@fr,
+                       "Annotazione immagine"@it ;
     rdfs:subClassOf    :Resource,
                        [ rdf:type        owl:Restriction ;
                          owl:onProperty  :hasColor ;
@@ -1933,7 +1933,7 @@
                          owl:minCardinality "0"^^xsd:nonNegativeInteger ] ;
     :resourceIcon      "region.gif"^^xsd:string ;
     :canBeInstantiated true ;
-    rdfs:comment       "Represents a geometric region of a resource. The geometry is represented currently as JSON string."@en .
+    rdfs:comment       "An annotation of a region of an image resource"@en .
 
 
 ###  http://www.knora.org/ontology/knora-base#Representation

--- a/modules/webapi/src/main/scala/org/knora/webapi/package.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/package.scala
@@ -14,7 +14,7 @@ package object webapi {
    * The version of `knora-base` and of the other built-in ontologies that this version of Knora requires.
    * Must be the same as the object of `knora-base:ontologyVersion` in the `knora-base` ontology being used.
    */
-  val KnoraBaseVersion: Int          = 53
+  val KnoraBaseVersion: Int          = 54
   val KnoraBaseVersionString: String = s"$versionPrefix$KnoraBaseVersion"
 
   /**

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/RepositoryUpdatePlan.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/RepositoryUpdatePlan.scala
@@ -38,6 +38,7 @@ object RepositoryUpdatePlan {
       PluginForKnoraBaseVersion(versionNumber = 51, plugin = new MigrateOnlyBuiltInGraphs()),
       PluginForKnoraBaseVersion(versionNumber = 52, plugin = new MigrateOnlyBuiltInGraphs()),
       PluginForKnoraBaseVersion(versionNumber = 53, plugin = new MigrateOnlyBuiltInGraphs()),
+      PluginForKnoraBaseVersion(versionNumber = 54, plugin = new MigrateOnlyBuiltInGraphs()),
     )
 
   /**

--- a/test_data/generated_test_data/ontologyR2RV2/knoraApiOntologySimple.jsonld
+++ b/test_data/generated_test_data/ontologyR2RV2/knoraApiOntologySimple.jsonld
@@ -704,7 +704,7 @@
             "@id": "knora-api:MovingImageRepresentation"
         },
         {
-            "rdfs:label": "Region",
+            "rdfs:label": "Image Annotation",
             "rdfs:subClassOf": [
                 {
                     "@id": "knora-api:Resource"
@@ -780,7 +780,7 @@
                     "owl:cardinality": 1
                 }
             ],
-            "rdfs:comment": "Represents a geometric region of a resource. The geometry is represented currently as JSON string.",
+            "rdfs:comment": "An annotation of a region of an image resource",
             "@type": "owl:Class",
             "knora-api:resourceIcon": "region.gif",
             "@id": "knora-api:Region"
@@ -1414,7 +1414,7 @@
             "rdfs:subPropertyOf": {
                 "@id": "knora-api:hasValue"
             },
-            "rdfs:comment": "Specifies the color of a region.",
+            "rdfs:comment": "Specifies the color of an annotation.",
             "@type": "owl:DatatypeProperty",
             "knora-api:subjectType": {
                 "@id": "knora-api:Region"

--- a/test_data/generated_test_data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/test_data/generated_test_data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -4177,7 +4177,7 @@
         },
         {
             "knora-api:isResourceClass": true,
-            "rdfs:label": "Region",
+            "rdfs:label": "Image Annotation",
             "knora-api:resourceIcon": "region.gif",
             "knora-api:canBeInstantiated": true,
             "rdfs:subClassOf": [
@@ -4364,7 +4364,7 @@
                     "knora-api:isInherited": true
                 }
             ],
-            "rdfs:comment": "Represents a geometric region of a resource. The geometry is represented currently as JSON string.",
+            "rdfs:comment": "An annotation of a region of an image resource",
             "@type": "owl:Class",
             "@id": "knora-api:Region"
         },
@@ -8914,7 +8914,7 @@
             "knora-api:subjectType": {
                 "@id": "knora-api:Region"
             },
-            "rdfs:comment": "Specifies the color of a region."
+            "rdfs:comment": "Specifies the color of an annotation."
         },
         {
             "rdfs:label": "Comment",

--- a/test_data/generated_test_data/ontologyR2RV2/knoraApiSimpleHasColor.jsonld
+++ b/test_data/generated_test_data/ontologyR2RV2/knoraApiSimpleHasColor.jsonld
@@ -8,7 +8,7 @@
             "rdfs:subPropertyOf": {
                 "@id": "knora-api:hasValue"
             },
-            "rdfs:comment": "Specifies the color of a region.",
+            "rdfs:comment": "Specifies the color of an annotation.",
             "@type": "owl:DatatypeProperty",
             "knora-api:subjectType": {
                 "@id": "knora-api:Region"

--- a/test_data/generated_test_data/ontologyR2RV2/knoraApiWithValueObjectsHasColor.jsonld
+++ b/test_data/generated_test_data/ontologyR2RV2/knoraApiWithValueObjectsHasColor.jsonld
@@ -20,7 +20,7 @@
             "knora-api:subjectType": {
                 "@id": "knora-api:Region"
             },
-            "rdfs:comment": "Specifies the color of a region."
+            "rdfs:comment": "Specifies the color of an annotation."
         }
     ],
     "knora-api:attachedToProject": {


### PR DESCRIPTION
[DEV-6853](https://linear.app/dasch/issue/DEV-6853)

### Description

Bug fix — a leftover from [DEV-4393](https://linear.app/dasch/issue/DEV-4393) ("Unifying wording regarding annotations"), which renamed the annotation vocabulary in `knora-base` but missed the `knora-base:Region` class label itself.

**Current behaviour:** `Region` is the only annotation class that was never renamed, so a user opening an image annotation sees a heading **REGION** sitting directly above a property labelled **"Annotation of"** — and a tooltip reading *"Represents a geometric region of a resource…"*.

| Entity | `rdfs:label` (en) before | after |
| -- | -- | -- |
| `knora-api:AudioSegment` | Audio Annotation | *unchanged* |
| `knora-api:VideoSegment` | Video Annotation | *unchanged* |
| `knora-api:isRegionOf` | Annotation of | *unchanged* |
| `knora-api:Region` | **Region** | **Image Annotation** |

The convention agreed in [DEV-6300](https://linear.app/dasch/issue/DEV-6300) is *"Annotations in the user space, Regions in the ttl ontology files"* — and `rdfs:label` **is** user space, since dsp-app renders it verbatim.

### Changes

`knora-base.ttl`
- `:Region rdfs:label` → `"Bildannotation"@de`, `"Image Annotation"@en`, `"Annotation d'image"@fr`, `"Annotazione immagine"@it` — the shape the Audio/Video siblings already use.
- `:Region rdfs:comment` → *"An annotation of a region of an image resource"*, worded exactly like `:AudioSegment` / `:VideoSegment` ("An annotation of an audio resource"). The dropped *"The geometry is represented currently as JSON string"* is a developer detail that the tooltip should not carry; `:hasGeometry` still documents it.
- `:hasColor rdfs:comment` → *"Specifies the color of an annotation."*
- `:ontologyVersion` → `knora-base v54`.

`package.scala` — `KnoraBaseVersion` 53 → 54.

`RepositoryUpdatePlan.scala` — `PluginForKnoraBaseVersion(54, MigrateOnlyBuiltInGraphs())`.

Generated ontology fixtures — the label and both comments: `knoraApiOntologySimple`, `knoraApiOntologyWithValueObjects`, and also `knoraApiSimpleHasColor` / `knoraApiWithValueObjectsHasColor`, which carry the `hasColor` comment too.

### Out of scope

Every internal use stays "region": the `knora-base:Region` IRI, all `isRegionOf*` IRIs, `Constants.Region`, `region.gif`. `RegionPreviewValue` is handled by [DEV-6846](https://linear.app/dasch/issue/DEV-6846). The dsp-app half of DEV-6853 (the `highlightRegion` i18n key and the hardcoded `'Region'` in `ontology-edit.service.ts`) is a separate PR.

### Breaking change?

No. Labels and comments only — no IRI, cardinality, or class-hierarchy change, so no data migration. Existing `Region` instances are untouched; only how they are named in the UI changes.

### Note for review

**No new upgrade plugin, but I did register the version.** The ticket notes that `RepositoryUpdater.scala:109` falls back to `MigrateOnlyBuiltInGraphs` when no plugin matches, which is true — the explicit entry is not strictly required. I added it anyway because the last three bumps (51, 52, and 53 in #4193, the DEV-4393-family precedent) all did, and an explicit line documents the bump instead of relying on a silent fallback. Happy to drop it if you prefer the shorter diff.

### Test plan

- `knora-base.ttl` parses clean (rdflib, 1852 triples) and reports the four new labels, both comments, and `knora-base v54`.
- All four JSON-LD fixtures parse.
- **Not run locally:** Scala compile and the test suites — `direnv` is not yet approved in the worktree this was built in. Leaving that to CI; `OntologyFormatsE2ESpec` is the one to watch, since it compares the served ontology against the regenerated fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)