### PR TITLE
feat(import): permit existing list nodes and require project ontologies (DEV-6942)

### DIFF
--- a/docs/03-endpoints/api-v3/project-data-import.md
+++ b/docs/03-endpoints/api-v3/project-data-import.md
@@ -4,8 +4,9 @@ The project data import API creates a new project's data graph from a [knora-api
 JSON-LD payload. The server transforms the payload into the internal knora-base representation, validates it, and
 streams it into the triplestore.
 
-The data import handles **instance data only** — the resources and their values. The project and its ontologies
-must already exist on the instance, and the project's data graph must not exist yet (create-only).
+The data import handles **instance data only** — the resources and their values. The project and at least one of its
+ontologies must already exist on the instance. The project's data graph must contain no data other than list nodes
+(create-only): a graph holding only list nodes is permitted, because list-using projects carry their list nodes there.
 
 ## Endpoints
 
@@ -74,10 +75,15 @@ The import is **asynchronous**. Triggering an import returns `202 Accepted` with
 Poll the status endpoint until `status` is `completed` or `failed`.
 The `status` field is one of: `in_progress`, `completed`, `failed`.
 
-The import is **create-only**: if the project already has a data graph, the request is rejected with
-`409 Conflict` and error code `data_graph_exists`. The precondition is checked synchronously when the import is
-triggered and re-verified immediately before the upload. Updating or extending an existing data graph is not
+The import is **create-only**: if the project's data graph already holds data other than list nodes, the request is
+rejected with `409 Conflict` and error code `data_graph_exists`. A graph containing only list nodes is permitted —
+list-using projects carry their list nodes in the data graph. The precondition is checked synchronously when the
+import is triggered and re-verified immediately before the upload. Updating or extending an existing data graph is not
 possible with this API.
+
+The project must have **at least one ontology**. A project with no ontologies is rejected synchronously with
+`409 Conflict` and error code `project_ontologies_missing`. This check runs **before** the create-only check: a
+project with no ontologies is rejected whatever its data graph holds, so the list-node exception is not reached.
 
 Only **one data-graph import** can exist at a time. Attempting to create a second returns `409 Conflict` with the
 existing task's `id` in the error details. Delete the previous task before triggering a new one.
@@ -89,6 +95,10 @@ The upload to Fuseki is **atomic** — if the upload fails, no partial data is w
 Before anything is written to the triplestore, the transformed data is SHACL-validated against the knora-base data
 shapes. The project's ontologies are fetched from the triplestore to support the validation. Validation failure
 fails the task with a descriptive error message and leaves the triplestore untouched.
+
+The presence of at least one project ontology is checked synchronously at trigger time
+(`409 project_ontologies_missing`, see [Key Behaviors](#key-behaviors)). The task also re-checks it as a backstop
+before validation.
 
 ## Typical Workflow
 
@@ -117,7 +127,8 @@ curl --request DELETE \
 
 - **Project and ontologies must already exist**: The import assumes class and property IRIs in the payload resolve
   against ontologies already in the triplestore.
-- **Create-only**: Re-importing requires deleting the project's data graph first, which is out of scope for this API.
+- **Create-only**: The data graph must contain no data other than list nodes. Re-importing requires deleting the
+  project's data graph first, which is out of scope for this API.
 - **Assets must be pre-ingested**: The import does not ingest binary assets. File values must reference assets already
   present in dsp-ingest. The import fetches their metadata by internal filename and rejects an asset that is not yet
   ingested. 3D file values (`DDDFileValue`) are not yet supported.

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportE2ESpec.scala
@@ -28,8 +28,8 @@ import org.knora.webapi.testservices.TestApiClient
 @RunWith(classOf[DspZTestJUnitRunner])
 class ProjectDataImportE2ESpec extends E2EZSpec {
 
-  // The incunabula project with its ontology but WITHOUT any project data — the data graph must not exist yet
-  // for the create-only import to succeed.
+  // The incunabula project with its ontology but WITHOUT any project data - the create-only import needs a data
+  // graph holding no data other than list nodes, which an empty graph satisfies.
   override def rdfDataObjects: List[RdfDataObject] = List(incunabulaRdfOntology)
 
   private val projectIri  = incunabulaProjectIri.value

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportListsOnlyE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportListsOnlyE2ESpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.api.v3.projects
+
+import org.junit.runner.RunWith
+import sttp.client4.*
+import sttp.model.*
+import zio.*
+import zio.json.ast.Json
+import zio.test.*
+
+import java.nio.charset.StandardCharsets
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.E2EZSpec
+import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
+import org.knora.webapi.slice.`export`.domain.DataTaskId
+import org.knora.webapi.slice.`export`.domain.DataTaskStatus
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.Shortcode
+import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.ValueIri
+import org.knora.webapi.testservices.TestApiClient
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class ProjectDataImportListsOnlyE2ESpec extends E2EZSpec {
+
+  // Incunabula with its ontology AND a data graph pre-seeded with ONLY list nodes. The create-only precondition
+  // excludes list-node subjects, so a lists-only graph counts as absent and the import is permitted (REQ-9.2).
+  override def rdfDataObjects: List[RdfDataObject] = List(
+    incunabulaRdfOntology,
+    RdfDataObject("test_data/project_data/incunabula-lists-only-data.ttl", "http://www.knora.org/data/0803/incunabula"),
+  )
+
+  private val projectIri  = incunabulaProjectIri.value
+  private val jsonLdType  = MediaType.unsafeApply("application", "ld+json")
+  private val resourceIri = ResourceIri.makeNew(Shortcode.unsafeFrom("0803"))
+  private val valueIri    = ValueIri.makeNew(resourceIri)
+
+  private val onto     = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#"
+  private val knoraApi = "http://api.knora.org/ontology/knora-api/v2#"
+
+  /** A minimal knora-api data graph: one incunabula book with a title value. */
+  private val dataGraphJsonLd =
+    s"""
+       |[{
+       |    "@id": "$resourceIri",
+       |    "@type": "${onto}book",
+       |    "rdfs:label": "Imported book",
+       |    "${onto}title": {
+       |      "@id": "$valueIri",
+       |      "@type": "${knoraApi}TextValue",
+       |      "${knoraApi}valueAsString": "An imported title"
+       |    },
+       |    "@context": {
+       |       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+       |    }
+       |}]""".stripMargin
+
+  // The on-behalf-of project user: a member of incunabula, not a system admin, active, with project-wide create rights.
+  private val memberUsername = incunabulaMemberUser.username
+
+  override val e2eSpec: Spec[env, Any] = suite("Project Data Import — lists-only precondition E2E")(
+    test("import into a project whose data graph holds only list nodes (REQ-9.2)") {
+      for {
+        triggerResponse <- TestApiClient.postBinary[DataTaskStatusResponse](
+                             uri"/v3/projects/$projectIri/data-imports?onBehalfOfUser=$memberUsername",
+                             dataGraphJsonLd.getBytes(StandardCharsets.UTF_8),
+                             jsonLdType,
+                             rootUser,
+                           )
+        importStatus <- ZIO.fromEither(triggerResponse.body).mapError(new RuntimeException(_))
+        pollResult   <- pollImportUntilDone(importStatus.id).retry(Schedule.spaced(500.millis) && Schedule.recurs(60))
+        // Delete the completed task: the single-task import mutex is per-JVM, so a leftover task would block other
+        // import specs sharing the test JVM.
+        deleteResponse <-
+          TestApiClient
+            .deleteJson[Json](uri"/v3/projects/$projectIri/data-imports/${importStatus.id.value}", rootUser)
+      } yield assertTrue(
+        triggerResponse.code == StatusCode.Accepted,
+        pollResult.status == DataTaskStatus.Completed,
+        deleteResponse.code == StatusCode.NoContent,
+      )
+    },
+  )
+
+  private def pollImportUntilDone(importId: DataTaskId) =
+    TestApiClient
+      .getJson[DataTaskStatusResponse](uri"/v3/projects/$projectIri/data-imports/${importId.value}", rootUser)
+      .flatMap(r => ZIO.fromEither(r.body).mapError(new RuntimeException(_)))
+      .flatMap { status =>
+        status.status match {
+          case DataTaskStatus.Completed => ZIO.succeed(status)
+          case DataTaskStatus.Failed    => ZIO.succeed(status)
+          case _                        => ZIO.fail(new RuntimeException("Import still in progress"))
+        }
+      }
+}

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportListsOnlyE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportListsOnlyE2ESpec.scala
@@ -63,7 +63,7 @@ class ProjectDataImportListsOnlyE2ESpec extends E2EZSpec {
   // The on-behalf-of project user: a member of incunabula, not a system admin, active, with project-wide create rights.
   private val memberUsername = incunabulaMemberUser.username
 
-  override val e2eSpec: Spec[env, Any] = suite("Project Data Import — lists-only precondition E2E")(
+  override val e2eSpec: Spec[env, Any] = suite("Project Data Import - lists-only precondition E2E")(
     test("import into a project whose data graph holds only list nodes (REQ-9.2)") {
       for {
         triggerResponse <- TestApiClient.postBinary[DataTaskStatusResponse](

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportOntologyMissingE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportOntologyMissingE2ESpec.scala
@@ -44,7 +44,7 @@ class ProjectDataImportOntologyMissingE2ESpec extends E2EZSpec {
     description = List(Description.unsafeFrom(StringLiteralV2.from("A project with no ontologies"))),
   )
 
-  override val e2eSpec: Spec[env, Any] = suite("Project Data Import — ontology-missing precondition E2E")(
+  override val e2eSpec: Spec[env, Any] = suite("Project Data Import - ontology-missing precondition E2E")(
     test("reject an import into a project with no ontologies, synchronously (REQ-9.1)") {
       for {
         project <- TestApiClient

--- a/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportOntologyMissingE2ESpec.scala
+++ b/modules/test-e2e/src/test/scala/org/knora/webapi/slice/api/v3/projects/ProjectDataImportOntologyMissingE2ESpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.api.v3.projects
+
+import org.junit.runner.RunWith
+import sttp.client4.*
+import sttp.model.*
+import zio.json.ast.Json
+import zio.test.*
+
+import java.nio.charset.StandardCharsets
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.E2EZSpec
+import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
+import org.knora.webapi.sharedtestdata.SharedTestDataADM.*
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
+import org.knora.webapi.slice.api.admin.model.ProjectOperationResponseADM
+import org.knora.webapi.slice.api.admin.model.ProjectsEndpointsRequestsAndResponses.ProjectCreateRequest
+import org.knora.webapi.testservices.ResponseOps.*
+import org.knora.webapi.testservices.TestAdminApiClient
+import org.knora.webapi.testservices.TestApiClient
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class ProjectDataImportOntologyMissingE2ESpec extends E2EZSpec {
+
+  // No ontology data is loaded. The test creates a fresh project instead of reusing a shared one: a shared project's
+  // ontology leaks across specs via the in-memory ontology cache in the shared test JVM, so it never reads as
+  // ontology-free. A freshly created project has a unique IRI that no spec ever loads, so its ontology set is always
+  // empty.
+  override def rdfDataObjects: List[RdfDataObject] = List.empty
+
+  private val jsonLdType = MediaType.unsafeApply("application", "ld+json")
+  // The precondition fails before the body is read, so the payload content is irrelevant.
+  private val payload = "[]".getBytes(StandardCharsets.UTF_8)
+
+  private val createProjectReq = ProjectCreateRequest(
+    shortname = Shortname.unsafeFrom("ontomissing"),
+    shortcode = Shortcode.unsafeFrom("4123"),
+    description = List(Description.unsafeFrom(StringLiteralV2.from("A project with no ontologies"))),
+  )
+
+  override val e2eSpec: Spec[env, Any] = suite("Project Data Import — ontology-missing precondition E2E")(
+    test("reject an import into a project with no ontologies, synchronously (REQ-9.1)") {
+      for {
+        project <- TestApiClient
+                     .postJson[ProjectOperationResponseADM, ProjectCreateRequest](
+                       uri"/admin/projects",
+                       createProjectReq,
+                       rootUser,
+                     )
+                     .flatMap(_.assert200)
+                     .map(_.project)
+        projectIri = project.id
+        // Add an eligible non-sysadmin member. A freshly created project already grants its ProjectMember group
+        // project-wide create rights (default administrative permission), so membership alone makes the user eligible.
+        // Without this the on-behalf-of user fails the eligibility check (G1 order) before reaching the ontology check.
+        _        <- TestAdminApiClient.addUserToProject(normalUser.userIri, projectIri, rootUser).flatMap(_.assert200)
+        response <- TestApiClient.postBinary[Json](
+                      uri"/v3/projects/${projectIri.value}/data-imports?onBehalfOfUser=${normalUser.username}",
+                      payload,
+                      jsonLdType,
+                      rootUser,
+                    )
+      } yield assertTrue(
+        response.code == StatusCode.Conflict,
+        response.body.exists(_.toString.contains("project_ontologies_missing")),
+      )
+    },
+  )
+}

--- a/modules/test-it/src/test/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsSemanticsSpec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsSemanticsSpec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.`export`.domain
+
+import org.junit.runner.RunWith
+import zio.*
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.E2EZSpec
+import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
+import org.knora.webapi.slice.admin.domain.model.KnoraProject
+import org.knora.webapi.slice.admin.domain.model.KnoraProject.*
+import org.knora.webapi.slice.admin.domain.model.RestrictedView
+import org.knora.webapi.store.triplestore.api.TriplestoreService
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
+
+/**
+ * Exercises the create-only precondition query against a live triplestore. Proves that `ProjectDataGraphExistsQuery`
+ * treats a lists-only graph as absent (false) and any non-list data as present (true). Each case uses its own project
+ * data graph (distinct shortname), so the cases are independent of order.
+ */
+@RunWith(classOf[DspZTestJUnitRunner])
+class ProjectDataGraphExistsSemanticsSpec extends E2EZSpec {
+
+  private val triplestore = ZIO.serviceWithZIO[TriplestoreService]
+
+  private val baseProject = KnoraProject(
+    ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001"),
+    Shortname.unsafeFrom("shortname"),
+    Shortcode.unsafeFrom("0001"),
+    None,
+    NonEmptyChunk(Description.unsafeFrom(StringLiteralV2.from("Test project"))),
+    List.empty,
+    None,
+    Status.Active,
+    SelfJoin.CannotJoin,
+    RestrictedView.default,
+    Set.empty,
+    Set.empty,
+  )
+
+  private def project(shortname: String): KnoraProject =
+    baseProject.copy(shortname = Shortname.unsafeFrom(shortname))
+
+  private def graphOf(shortname: String): String = s"http://www.knora.org/data/0001/$shortname"
+
+  private val kb   = "http://www.knora.org/ontology/knora-base#"
+  private val rdfs = "http://www.w3.org/2000/01/rdf-schema#"
+
+  private def listNode(subject: String): String =
+    s"""<$subject> a <${kb}ListNode> ;
+       |  <${kb}listNodeName> "a list node" ;
+       |  <${rdfs}label> "A list node" .""".stripMargin
+
+  private def resource(subject: String): String =
+    s"""<$subject> a <http://www.knora.org/ontology/0001/anything#Thing> ;
+       |  <${rdfs}label> "A thing" .""".stripMargin
+
+  private def seed(shortname: String, triples: String): Update =
+    Update(
+      s"""INSERT DATA {
+         |  GRAPH <${graphOf(shortname)}> {
+         |    $triples
+         |  }
+         |}""".stripMargin,
+    )
+
+  private def dataGraphExists(shortname: String) =
+    triplestore(_.query(ProjectDataGraphExistsQuery.build(project(shortname))))
+
+  override val e2eSpec: Spec[env, Any] = suite("ProjectDataGraphExistsQuery against a live triplestore")(
+    test("returns false for an empty project data graph") {
+      dataGraphExists("emptygraph").map(exists => assertTrue(!exists))
+    },
+    test("returns false for a graph containing only list nodes (REQ-9.2)") {
+      for {
+        _ <- triplestore(
+               _.query(
+                 seed(
+                   "listsonly",
+                   s"${listNode("http://rdfh.ch/lists/0001/n1")}\n${listNode("http://rdfh.ch/lists/0001/n2")}",
+                 ),
+               ),
+             )
+        exists <- dataGraphExists("listsonly")
+      } yield assertTrue(!exists)
+    },
+    test("returns true for a graph containing a non-list resource") {
+      for {
+        _      <- triplestore(_.query(seed("realdata", resource("http://rdfh.ch/0001/a-thing"))))
+        exists <- dataGraphExists("realdata")
+      } yield assertTrue(exists)
+    },
+    test("returns true for a graph mixing list nodes and a resource (production shape)") {
+      for {
+        _ <- triplestore(
+               _.query(
+                 seed(
+                   "mixedgraph",
+                   s"${listNode("http://rdfh.ch/lists/0001/m1")}\n${resource("http://rdfh.ch/0001/m-thing")}",
+                 ),
+               ),
+             )
+        exists <- dataGraphExists("mixedgraph")
+      } yield assertTrue(exists)
+    },
+  )
+}

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/V3ErrorCode.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/V3ErrorCode.scala
@@ -31,6 +31,8 @@ enum V3ErrorCode(val template: String):
   case import_exists      extends V3ErrorCode("Import '{id}' exists for project '{projectIri}'.")
   case import_in_progress extends V3ErrorCode("Import '{id}' in progress for project '{projectIri}'.")
   case data_graph_exists  extends V3ErrorCode("The data graph for project '{projectIri}' already exists.")
+  case project_ontologies_missing
+      extends V3ErrorCode("The project '{projectIri}' has no ontologies in the triplestore.")
   // V3ErrorCode.BadRequest errors
   case invalid_ontology_mapping_iri extends V3ErrorCode("Invalid OntologyMappingIri: '{iri}'.")
   case on_behalf_of_user_ineligible
@@ -43,7 +45,7 @@ object V3ErrorCode:
     property_not_found.type | on_behalf_of_user_not_found.type
 
   type Conflicts = export_exists.type | export_failed.type | export_in_progress.type | import_exists.type |
-    import_in_progress.type | data_graph_exists.type
+    import_in_progress.type | data_graph_exists.type | project_ontologies_missing.type
 
   given Schema[V3ErrorCode] = Schema.derivedEnumeration[V3ErrorCode].defaultStringBased
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsEndpoints.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsEndpoints.scala
@@ -164,8 +164,9 @@ class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
     )
 
   // import a project data graph
-  // Two distinct 409s: `import_exists` (a previous data-graph import task still exists — the per-kind task mutex)
-  // and `data_graph_exists` (the create-only precondition — the project already has a data graph).
+  // Three distinct 409s: `import_exists` (a previous data-graph import task still exists — the per-kind task mutex),
+  // `data_graph_exists` (the create-only precondition — the project already holds data other than list nodes), and
+  // `project_ontologies_missing` (the project has no ontologies, so no data can be imported).
   val postProjectIriDataImports = self.base
     .secured(
       oneOf(
@@ -175,7 +176,11 @@ class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
           V3ErrorCode.on_behalf_of_user_not_found,
         ),
         badRequestVariant,
-        conflictVariant(V3ErrorCode.import_exists, V3ErrorCode.data_graph_exists),
+        conflictVariant(
+          V3ErrorCode.import_exists,
+          V3ErrorCode.data_graph_exists,
+          V3ErrorCode.project_ontologies_missing,
+        ),
       ),
     )
     .post
@@ -198,7 +203,8 @@ class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
       "Initiates an import of a project's data graph from a knora-api JSON-LD payload. " +
         "The import will be performed asynchronously, and the response will contain an import ID that can be used to check the status of the import. " +
         "Every imported resource and value is attributed to the `onBehalfOfUser`, not the triggering admin. " +
-        "The import is create-only: it fails if the project already has a data graph. " +
+        "The import is create-only: it fails with 409 `data_graph_exists` if the project data graph already holds data other than list nodes. A graph containing only list nodes is permitted. " +
+        "The project must have at least one ontology: an ontology-less project is rejected with 409 `project_ontologies_missing`, evaluated before the create-only check. " +
         "An import can only be triggered when no other data-graph import exists.",
     )
 

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsEndpoints.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsEndpoints.scala
@@ -164,8 +164,8 @@ class V3ProjectsEndpoints(base: V3BaseEndpoint) extends EndpointHelper { self =>
     )
 
   // import a project data graph
-  // Three distinct 409s: `import_exists` (a previous data-graph import task still exists — the per-kind task mutex),
-  // `data_graph_exists` (the create-only precondition — the project already holds data other than list nodes), and
+  // Three distinct 409s: `import_exists` (a previous data-graph import task still exists - the per-kind task mutex),
+  // `data_graph_exists` (the create-only precondition - the project already holds data other than list nodes), and
   // `project_ontologies_missing` (the project has no ontologies, so no data can be imported).
   val postProjectIriDataImports = self.base
     .secured(

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsRestService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsRestService.scala
@@ -165,21 +165,10 @@ final class V3ProjectsRestService(
     .unlessZIO(AppConfig.features(_.allowProjectDataImport))
     .unit
 
-  private def dataGraphExistsConflict(projectIri: ProjectIri): Conflict =
-    Conflict(
-      data_graph_exists,
-      data_graph_exists.template.replace("{projectIri}", projectIri.value),
-      Map("projectIri" -> projectIri.value),
-    )
-
-  // Keyed on the project only: this rejection is raised before any import task exists, so it cannot use the generic
-  // `conflict` helper (which needs a DataTaskId). Mirrors `dataGraphExistsConflict`.
-  private def projectOntologiesMissing(projectIri: ProjectIri): Conflict =
-    Conflict(
-      project_ontologies_missing,
-      project_ontologies_missing.template.replace("{projectIri}", projectIri.value),
-      Map("projectIri" -> projectIri.value),
-    )
+  // Keyed on the project only: these rejections are raised before any import task exists, so they cannot use the
+  // generic `conflict` helper (which needs a DataTaskId).
+  private def conflictOnProject(code: Conflicts, projectIri: ProjectIri): Conflict =
+    Conflict(code, code.template.replace("{projectIri}", projectIri.value), Map("projectIri" -> projectIri.value))
 
   // Request-phase rejections for the on-behalf-of user are raised before any task exists, so they cannot use the
   // generic `conflict`/`notFound` helpers (which need a DataTaskId). They are keyed on the project and the supplied
@@ -248,13 +237,26 @@ final class V3ProjectsRestService(
       // import task: an ontology-less project is rejected at trigger time. Ordered before the create-only check
       // (G1 order). `getOntologyGraphsForProject` reads the in-memory ontology cache, so this is cheap.
       _ <- ZIO
-             .fail(projectOntologiesMissing(projectIri))
-             .whenZIO(projectService.getOntologyGraphsForProject(project).orDie.map(_.isEmpty))
+             .fail(conflictOnProject(project_ontologies_missing, projectIri))
+             .whenZIO(
+               projectService
+                 .getOntologyGraphsForProject(project)
+                 .orDieWith(e =>
+                   new IllegalStateException(s"Ontology-existence check failed for project '${projectIri.value}'.", e),
+                 )
+                 .map(_.isEmpty),
+             )
       // Create-only precondition (synchronous, so the client receives a real 409). It is re-verified inside the
       // import task immediately before the upload.
       _ <- ZIO
-             .fail(dataGraphExistsConflict(projectIri))
-             .whenZIO(dataImportService.dataGraphExists(project).orDie)
+             .fail(conflictOnProject(data_graph_exists, projectIri))
+             .whenZIO(
+               dataImportService
+                 .dataGraphExists(project)
+                 .orDieWith(e =>
+                   new IllegalStateException(s"Create-only check failed for project '${projectIri.value}'.", e),
+                 ),
+             )
       state <-
         dataImportService
           .importDataGraph(project = project, createdBy = user, onBehalfOf = onBehalfOf, stream = stream)

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsRestService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/api/v3/projects/V3ProjectsRestService.scala
@@ -41,6 +41,7 @@ import org.knora.webapi.slice.api.v3.V3ErrorCode.import_in_progress
 import org.knora.webapi.slice.api.v3.V3ErrorCode.import_not_found
 import org.knora.webapi.slice.api.v3.V3ErrorCode.on_behalf_of_user_ineligible
 import org.knora.webapi.slice.api.v3.V3ErrorCode.on_behalf_of_user_not_found
+import org.knora.webapi.slice.api.v3.V3ErrorCode.project_ontologies_missing
 import org.knora.webapi.slice.api.v3.V3ErrorInfo
 
 final class V3ProjectsRestService(
@@ -171,6 +172,15 @@ final class V3ProjectsRestService(
       Map("projectIri" -> projectIri.value),
     )
 
+  // Keyed on the project only: this rejection is raised before any import task exists, so it cannot use the generic
+  // `conflict` helper (which needs a DataTaskId). Mirrors `dataGraphExistsConflict`.
+  private def projectOntologiesMissing(projectIri: ProjectIri): Conflict =
+    Conflict(
+      project_ontologies_missing,
+      project_ontologies_missing.template.replace("{projectIri}", projectIri.value),
+      Map("projectIri" -> projectIri.value),
+    )
+
   // Request-phase rejections for the on-behalf-of user are raised before any task exists, so they cannot use the
   // generic `conflict`/`notFound` helpers (which need a DataTaskId). They are keyed on the project and the supplied
   // identifier — the only value available for a not-found user (G4).
@@ -234,6 +244,12 @@ final class V3ProjectsRestService(
       // On-behalf-of user: malformed identifier (400), then not-found (404), then eligibility (400). Runs after the
       // project-exists check and before the create-only precondition (G1 order).
       onBehalfOf <- resolveOnBehalfOfUser(projectIri, onBehalfOfUser)
+      // Ontology-existence precondition (synchronous, so the client receives a real 409). Hoisted from the async
+      // import task: an ontology-less project is rejected at trigger time. Ordered before the create-only check
+      // (G1 order). `getOntologyGraphsForProject` reads the in-memory ontology cache, so this is cheap.
+      _ <- ZIO
+             .fail(projectOntologiesMissing(projectIri))
+             .whenZIO(projectService.getOntologyGraphsForProject(project).orDie.map(_.isEmpty))
       // Create-only precondition (synchronous, so the client receives a real 409). It is re-verified inside the
       // import task immediately before the upload.
       _ <- ZIO

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsQuery.scala
@@ -7,17 +7,23 @@ package org.knora.webapi.slice.`export`.domain
 
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 
 object ProjectDataGraphExistsQuery extends QueryBuilderHelper {
 
-  /** ASK whether the project's data named graph contains any triples. */
+  /**
+   * ASK whether the project's data named graph contains any data other than list nodes. List-using projects carry
+   * their list nodes in the project data graph, so a subject typed `knora-base:ListNode` is excluded — the create-only
+   * precondition treats a lists-only graph as absent.
+   */
   def build(project: KnoraProject): Ask = {
     val (s, p, o) = spo
+    val pattern   = s.has(p, o).filterNotExists(s.isA(Vocabulary.KnoraBase.ListNode)).from(graphIri(project))
     Ask(s"""
            |ASK
            |WHERE {
-           |  ${s.has(p, o).from(graphIri(project)).getQueryString}
+           |  ${pattern.getQueryString}
            |}
            |""".stripMargin)
   }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsQuery.scala
@@ -14,7 +14,7 @@ object ProjectDataGraphExistsQuery extends QueryBuilderHelper {
 
   /**
    * ASK whether the project's data named graph contains any data other than list nodes. List-using projects carry
-   * their list nodes in the project data graph, so a subject typed `knora-base:ListNode` is excluded — the create-only
+   * their list nodes in the project data graph, so a subject typed `knora-base:ListNode` is excluded - the create-only
    * precondition treats a lists-only graph as absent.
    */
   def build(project: KnoraProject): Ask = {

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/ProjectDataImportService.scala
@@ -24,7 +24,8 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService
 /**
  * Imports a project's data graph from a knora-api JSON-LD payload: transforms it to knora-base NQuads (assigned to
  * the project's data named graph), SHACL-validates the result against the project's ontologies fetched from the
- * triplestore, and streams it into the triplestore. Create-only: the project's data graph must not exist yet.
+ * triplestore, and streams it into the triplestore. Create-only: the project's data graph must contain no data other
+ * than list nodes.
  */
 final class ProjectDataImportService(
   state: DataTaskState,
@@ -36,7 +37,7 @@ final class ProjectDataImportService(
   triplestore: TriplestoreService,
 ) { self =>
 
-  /** Whether the project's data named graph already contains any triples (create-only precondition, R7). */
+  /** Whether the project's data named graph already contains data other than list nodes (create-only precondition, R7). */
   def dataGraphExists(project: KnoraProject): Task[Boolean] =
     triplestore.query(ProjectDataGraphExistsQuery.build(project))
 
@@ -91,10 +92,10 @@ final class ProjectDataImportService(
         _ <- validate(taskId, project, Path.fromJava(transformed))
         _ <- ZIO.logInfo(s"$taskId: Validation passed for project '${project.id}'")
 
-        // Re-verify the create-only precondition immediately before the upload: a data graph may have appeared
+        // Re-verify the create-only precondition immediately before the upload: non-list data may have appeared
         // since the synchronous check in the RestService (e.g. via a concurrent migration import). This narrows but
         // does not fully close the race window — acceptable for an admin-only, single-in-flight-task operation.
-        // Wording kept aligned with `V3ErrorCode.data_graph_exists`.
+        // Wording kept aligned with `V3ErrorCode.data_graph_exists` ("exists" now means "holds non-list data").
         _ <- ZIO
                .fail(new RuntimeException(s"The data graph for project '${project.id}' already exists."))
                .whenZIO(dataGraphExists(project))
@@ -119,8 +120,10 @@ final class ProjectDataImportService(
    */
   private def validate(taskId: DataTaskId, project: KnoraProject, dataFile: Path): ZIO[Scope, Throwable, Unit] = for {
     graphs <- projectService.getOntologyGraphsForProject(project)
-    _      <- ZIO
-           .fail(new RuntimeException(s"Project '${project.id}' has no ontologies in the triplestore."))
+    // Backstop for the synchronous `project_ontologies_missing` check in the RestService: defends against a project
+    // whose ontologies vanish between trigger and validation. Message aligned with `V3ErrorCode.project_ontologies_missing`.
+    _ <- ZIO
+           .fail(new RuntimeException(s"The project '${project.id}' has no ontologies in the triplestore."))
            .when(graphs.isEmpty)
     _             <- ZIO.logInfo(s"$taskId: Fetching ontologies '${graphs.map(_.value).mkString(",")}' for validation")
     tempDir       <- storage.tempDataImportScoped(taskId)

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/export/domain/ProjectDataGraphExistsQuerySpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.`export`.domain
+
+import org.junit.runner.RunWith
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.TestDataFactory
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class ProjectDataGraphExistsQuerySpec extends ZIOSpecDefault {
+
+  override def spec: Spec[TestEnvironment, Any] = suite("ProjectDataGraphExistsQuerySpec")(
+    // Exact-string regression guard for the create-only precondition. The ASK excludes list-node subjects
+    // (`FILTER NOT EXISTS { ?s a knora-base:ListNode }`) inside the project data graph, so a lists-only graph
+    // answers false. The `?s ?p ?o` base triple stays present: rdf4j 5.2.2 drops a FILTER NOT EXISTS that is the
+    // only WHERE pattern (issue #5561, fixed 5.3.0).
+    test("build excludes list-node subjects, scoped to the project data graph") {
+      val expected =
+        """
+          |ASK
+          |WHERE {
+          |  GRAPH <http://www.knora.org/data/0001/shortname> { ?s ?p ?o .
+          |FILTER NOT EXISTS { ?s a <http://www.knora.org/ontology/knora-base#ListNode> . } }
+          |}
+          |""".stripMargin
+      assertTrue(ProjectDataGraphExistsQuery.build(TestDataFactory.someProject).sparql == expected)
+    },
+  )
+}

--- a/test_data/project_data/incunabula-lists-only-data.ttl
+++ b/test_data/project_data/incunabula-lists-only-data.ttl
@@ -1,0 +1,20 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+
+# A lists-only project data graph for the incunabula project (shortcode 0803). Every subject is typed
+# `a knora-base:ListNode`, exactly as CreateListNodeQuery writes list nodes. The create-only precondition
+# excludes list-node subjects, so this graph counts as "no data other than list nodes" and an import is allowed.
+
+<http://rdfh.ch/lists/0803/testlist>
+    a                            knora-base:ListNode ;
+    knora-base:isRootNode        true ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0803> ;
+    knora-base:hasSubListNode    <http://rdfh.ch/lists/0803/testlist01> ;
+    rdfs:label                   "Incunabula test list"@en .
+
+<http://rdfh.ch/lists/0803/testlist01>
+    a                           knora-base:ListNode ;
+    knora-base:listNodeName     "node 01" ;
+    knora-base:hasRootNode      <http://rdfh.ch/lists/0803/testlist> ;
+    knora-base:listNodePosition 0 ;
+    rdfs:label                  "Node 01"@en .


### PR DESCRIPTION
[DEV-6942](https://linear.app/dasch/issue/DEV-6942)

## Summary
- Loosen the create-only import precondition so a project whose data graph holds only list nodes can still be imported (REQ-9.2).
- Reject an import into a project with no ontologies synchronously with `409 project_ontologies_missing`, instead of only as an async task failure (REQ-9.1).
- The single-concurrent-import mutex, the project-existence check, and on-behalf-of user validation are unchanged.

## Changes
**Create-only, list-node aware (REQ-9.2)**
- `ProjectDataGraphExistsQuery`: the ASK excludes list-node subjects via `FILTER NOT EXISTS { ?s a knora-base:ListNode }`, scoped to the project data graph. Both call sites inherit it through `dataGraphExists`.
- Doc comments reworded to "no data other than list nodes".

**Synchronous ontology precondition (REQ-9.1)**
- New `project_ontologies_missing` conflict code, added to the `Conflicts` union and the endpoint's per-endpoint `conflictVariant` (never the shared envelope).
- `V3ProjectsRestService.triggerProjectDataImportCreate`: a synchronous ontology check after on-behalf-of resolution and before the create-only check (G1 order).
- The async backstop in `validate` is kept, its message aligned with the new error.

**Docs**: `project-data-import.md` states the list-node exception, the ontology-missing rejection, and the precedence (the ontology check runs before the list-node exception).

## Test Plan
All green locally:
- Unit (`//modules/webapi:test`): `ProjectDataGraphExistsQuerySpec` asserts the exact generated SPARQL.
- Integration (`//modules/test-it:test`): `ProjectDataGraphExistsSemanticsSpec` against a live triplestore - lists-only returns false, real and mixed data return true (4 cases).
- E2E (`//modules/test-e2e:test`): `ProjectDataImportListsOnlyE2ESpec` (lists-only import to completed), `ProjectDataImportOntologyMissingE2ESpec` (fresh project rejected 409 project_ontologies_missing), plus the existing `ProjectDataImportE2ESpec` regression. 11 tests total.
- Commands: `bazel test //modules/webapi:test`; `//modules/test-it:test --test_filter=ProjectDataGraphExistsSemanticsSpec`; `//modules/test-e2e:test --test_filter=ProjectDataImport`.

## Scope notes
- Test scope was set to "Core E2E" by the issue owner. The plan's `project_not_found` and `import_exists` regression E2Es and the G1-order multi-failure assertion were intentionally not added: the query semantics are covered at the unit and integration layers, and the concurrent `import_exists` case is timing-dependent at the E2E level.
- Follow-up (not in this PR): the async backstop failure message in `ProjectDataImportService` is a hand-typed string that duplicates the `V3ErrorCode` template, kept in sync only by a comment. Centralizing it - or a test tying the two together - would remove the drift risk. This is a pre-existing pattern that this change extends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
