### PR TITLE
perf: pin isResourceInUse so candelete skips project-wide scans (DEV-6885)

### DIFF
--- a/docs/development/dsp-api-fuseki-query-execution.md
+++ b/docs/development/dsp-api-fuseki-query-execution.md
@@ -66,6 +66,13 @@ probes — measured on `/v2/metadata`, where "fixing" the order made it 3× slow
 **disconnection**, not earliness. And the converse of this fact also holds — *removing* a path
 can be far more expensive than keeping it (Fact 11).
 
+**Corollary — a connected `subClassOf*` still scales with candidate count.** After pinning
+the incoming-reference probe (Fact 1 corollary), `/v2/resources/candelete` still spent ~1.5s
+of ~1.6s on a 3840-row dokubib hub inside `?otherClass rdfs:subClassOf* knora-base:Resource`
+over 13k incoming subjects. `FILTER NOT EXISTS { GRAPH <g> { ?other a knora-base:LinkValue } }`
+was byte-identical on that hub and the ticket empty case, ~190ms (DEV-6885). The path was
+doing real work (dropping LinkValues); it was just the expensive way to do it.
+
 ## Fact 4 — `MINUS` evaluates its right side without bindings; `FILTER NOT EXISTS` is per-row
 
 An un-scoped `MINUS { ?x knora-base:isDeleted true }` materializes the deleted-set of the whole

--- a/docs/development/dsp-api-fuseki-query-execution.md
+++ b/docs/development/dsp-api-fuseki-query-execution.md
@@ -32,6 +32,16 @@ Evidence: the tile-permission regression — a shortcode restriction placed afte
 made Fuseki evaluate every left-join for every project first (351ms; 7.9ms with the restriction
 hoisted). See DEV-6796.
 
+**Corollary — a bound-object wildcard-predicate loses to any `?s <P> <O>`.** The heuristic
+counts bound terms, not selectivity. `?s ?p <bound>` — the canonical “what points at me”
+probe — has one bound term, so it loses to `?s knora-base:isDeleted false` (two bound terms)
+even when the latter matches every non-deleted subject in the project. Two patterns of the
+same shape tie, and ties keep document order. Consequence: writing the selective pattern first
+is not always enough; sometimes the order has to be *forced* with a subquery barrier the
+optimizer cannot reorder across. Every “find incoming references” query has this shape.
+Measured on `/v2/resources/candelete` (`isResourceInUse`): 1801 ms → 317 ms with the barrier,
+byte-identical results (DEV-6885).
+
 ## Fact 2 — OPTIONAL is a left join, and independent OPTIONALs multiply
 
 Each `OPTIONAL` left-joins against everything matched so far, in document order (Fact 1). Two

--- a/docs/development/dsp-api-fuseki-query-execution.md
+++ b/docs/development/dsp-api-fuseki-query-execution.md
@@ -70,8 +70,38 @@ can be far more expensive than keeping it (Fact 11).
 the incoming-reference probe (Fact 1 corollary), `/v2/resources/candelete` still spent ~1.5s
 of ~1.6s on a 3840-row dokubib hub inside `?otherClass rdfs:subClassOf* knora-base:Resource`
 over 13k incoming subjects. `FILTER NOT EXISTS { GRAPH <g> { ?other a knora-base:LinkValue } }`
-was byte-identical on that hub and the ticket empty case, ~190ms (DEV-6885). The path was
-doing real work (dropping LinkValues); it was just the expensive way to do it.
+dropped reifications in ~190ms on that hub (DEV-6885). The class path was doing real work; it
+was just the expensive way to drop non-resources.
+
+**Do not treat `¬LinkValue` as equivalent to `Resource`.** `knora-base:Resource` and
+`knora-base:Value` are sibling trees (`LinkValue` ⊑ `Value`, not `Resource`). That is a
+write-path invariant, not `owl:disjointWith`, and `Resource ≢ ¬LinkValue` in the TBox.
+`isResourceInUse` asks whether another **non-deleted resource** mentions the target. Branch 1
+is `?other ?p <target>`, so subjects in object-position include:
+
+| Subject class | Typical predicate | Keep? |
+| --- | --- | --- |
+| `Resource` (project subclasses) | `hasLinkTo` subproperties, `hasStandoffLinkTo`, … | yes |
+| `LinkValue` | `rdf:object` / `rdf:subject` | no |
+| `RegionPreviewValue` | `isRegionPreviewOf` | no — the **host** resource is branch 2 |
+| `StandoffLinkTag` | `standoffTagHasLink` | no — and they usually lack `isDeleted false` |
+
+On ordinary `hasLinkTo` hubs, `¬LinkValue` matched the Resource path (117/117 on stage,
+including the 3840-row dokubib hub). That is **not** a proof: a live `RegionPreviewValue` is
+not a `LinkValue`, has `isDeleted false`, and is a value IRI (`…/values/…`).
+`NOT EXISTS LinkValue` alone returns that value IRI as `?other`; `ResourceIri.from` then
+fails and `candelete` reports a conversion error instead of “still referenced by \<host\>”.
+The keep-set that matches the contract **and** the Scala parser is
+`FILTER REGEX(STR(?other), ResourceIri.SparqlRegexPattern)` (`IsResourceInUseQuery`).
+`NOT EXISTS LinkValue` can stay as a cheap extra; it is not what makes the answer correct.
+
+Checked 2026-09-04 on stage project `0854` / `daschland` against a Story that had one live and
+one deleted `annotationPreview` (different target Regions). Live: old Resource-guard and the
+IRI-shape query both returned only the host; `¬LinkValue` alone also returned the live value
+IRI. Deleted: both empty (`isDeleted true` on the value node). **Those instance triples will
+vanish on the next prod→stage mirror — do not treat them as fixtures.** Durable coverage is
+the anything-project IT in `ResourcesResponderV2Spec` (assert `cannotDoReason` contains the
+host IRI, not `/values/` and not “is not a Knora resource IRI”).
 
 ## Fact 4 — `MINUS` evaluates its right side without bindings; `FILTER NOT EXISTS` is per-row
 

--- a/docs/development/dsp-api-sparql-queries.md
+++ b/docs/development/dsp-api-sparql-queries.md
@@ -374,6 +374,25 @@ materialized — but it was 8.6× slower regardless.) Benchmark a simplification
 query as generated, before believing it. See
 [`dsp-api-fuseki-query-execution.md` Fact 11](dsp-api-fuseki-query-execution.md).
 
+### Incoming-reference keep-set is IRI shape, not `¬LinkValue`
+
+`?s ?p <bound>` (“what points at me”) needs a subquery barrier so `isDeleted false` cannot
+win the bound-term heuristic — see
+[`dsp-api-fuseki-query-execution.md` Fact 1 corollary](dsp-api-fuseki-query-execution.md).
+Do **not** then replace `rdfs:subClassOf* knora-base:Resource` with
+`FILTER NOT EXISTS { ?s a knora-base:LinkValue }` and call it equivalent.
+
+`Resource` and `Value` are sibling trees. A live `RegionPreviewValue` (`isRegionPreviewOf`)
+is not a `LinkValue`, sits in object position on branch 1, and is a value IRI. Dropping the
+class path without an IRI-shape filter leaks that value into `?other`; `ResourceIri.from`
+fails and `GET /v2/resources/candelete` looks “protected” for the wrong reason.
+`IsResourceInUseQuery` keeps `ResourceIri.SparqlRegexPattern`. Identity-check any rewrite
+against a **live region preview**, not only `hasLinkTo` hubs. Stage preview instances are
+not durable (they disappear on the next prod mirror); the anything-project IT is.
+
+See the Fact 3 corollary in the engine-facts doc for the class table and the 2026-09-04
+stage check.
+
 ### Negation: `FILTER NOT EXISTS`, not `MINUS`, for per-row guards
 
 `MINUS` evaluates its right side *without* bindings from the left, so an un-scoped

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -1749,6 +1749,69 @@ class ResourcesResponderV2Spec extends E2EZSpec { self =>
           release <- canDeleteRegion
         } yield assertTrue(!protection.canDo.value, release.canDo.value)
       },
+      test("protect a resource referenced by a live incoming link, and release it once the link is deleted") {
+        val targetIri            = ResourceIri.makeNew(anythingProject.shortcode)
+        val sourceIri            = ResourceIri.makeNew(anythingProject.shortcode)
+        val thingClassIri        = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri
+        val linkValuePropertyIri =
+          PropertyIri.unsafeFrom("http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue".toSmartIri)
+        val canDeleteTarget = resourceResponder(
+          _.canDeleteResource(
+            DeleteOrEraseResourceRequestV2(
+              resourceIri = targetIri,
+              resourceClassIri = thingClassIri,
+              maybeLastModificationDate = None,
+              requestingUser = rootUser,
+              apiRequestID = randomUUID,
+            ),
+          ),
+        )
+        val createThing = (iri: ResourceIri, label: String, values: Map[SmartIri, Seq[CreateValueInNewResourceV2]]) =>
+          resourceResponder(
+            _.createResource(
+              CreateResourceRequestV2(
+                CreateResourceV2(
+                  resourceIri = Some(iri),
+                  resourceClassIri = thingClassIri,
+                  label = label,
+                  values = values,
+                  projectADM = anythingProject,
+                ),
+                anythingUser1,
+                randomUUID,
+              ),
+            ),
+          )
+        for {
+          _ <- createThing(targetIri, "candelete link target", Map.empty)
+          _ <- createThing(
+                 sourceIri,
+                 "candelete link source",
+                 Map(
+                   linkValuePropertyIri.smartIri -> Seq(
+                     CreateValueInNewResourceV2(LinkValueContentV2(ApiV2Complex, targetIri)),
+                   ),
+                 ),
+               )
+          protection <- canDeleteTarget
+          source     <- getResource(sourceIri.value)
+          linkValue   = source.findLinkValues(linkValuePropertyIri).head
+          _          <- ZIO.serviceWithZIO[ValuesResponderV2](
+                 _.deleteValueV2(
+                   DeleteValueV2(
+                     sourceIri,
+                     ResourceClassIri.unsafeFrom(thingClassIri),
+                     linkValuePropertyIri,
+                     linkValue.valueIri,
+                     valueTypeIri = OntologyConstants.KnoraApiV2Complex.LinkValue.toSmartIri,
+                     apiRequestId = randomUUID,
+                   ),
+                   anythingUser1,
+                 ),
+               )
+          release <- canDeleteTarget
+        } yield assertTrue(!protection.canDo.value, release.canDo.value)
+      },
       test("reject creating a resource with an inline region preview whose target is not a Region") {
         val propertyIri: SmartIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasRegionPreview".toSmartIri
         val inputResource         = CreateResourceV2(

--- a/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/modules/test-it/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -1747,7 +1747,14 @@ class ResourcesResponderV2Spec extends E2EZSpec { self =>
                  ),
                )
           release <- canDeleteRegion
-        } yield assertTrue(!protection.canDo.value, release.canDo.value)
+          reason   = protection.cannotDoReason.map(_.value).getOrElse("")
+        } yield assertTrue(
+          !protection.canDo.value,
+          reason.contains(previewHostIri.value),
+          !reason.contains("/values/"),
+          !reason.contains("is not a Knora resource IRI"),
+          release.canDo.value,
+        )
       },
       test("protect a resource referenced by a live incoming link, and release it once the link is deleted") {
         val targetIri            = ResourceIri.makeNew(anythingProject.shortcode)
@@ -1810,7 +1817,14 @@ class ResourcesResponderV2Spec extends E2EZSpec { self =>
                  ),
                )
           release <- canDeleteTarget
-        } yield assertTrue(!protection.canDo.value, release.canDo.value)
+          reason   = protection.cannotDoReason.map(_.value).getOrElse("")
+        } yield assertTrue(
+          !protection.canDo.value,
+          reason.contains(sourceIri.value),
+          !reason.contains("/values/"),
+          !reason.contains("is not a Knora resource IRI"),
+          release.canDo.value,
+        )
       },
       test("reject creating a resource with an inline region preview whose target is not a Region") {
         val propertyIri: SmartIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#hasRegionPreview".toSmartIri

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -5,15 +5,6 @@
 
 package org.knora.webapi.responders.v2
 
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.XSD
-import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.PropertyPathBuilder
-import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder
-import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.`var` as variable
-import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import zio.*
 
 import java.time.Instant
@@ -46,7 +37,6 @@ import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.ResourceIri
 import org.knora.webapi.slice.common.StandoffMappingIri
 import org.knora.webapi.slice.common.ValueIri
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.resources.repo.ChangeResourceAuthorshipQuery
 import org.knora.webapi.slice.resources.repo.ChangeResourceMetadataQuery
@@ -55,6 +45,7 @@ import org.knora.webapi.slice.resources.repo.EraseResourceQuery
 import org.knora.webapi.slice.resources.repo.GetAllResourcesInProjectPrequery
 import org.knora.webapi.slice.resources.repo.GetGraphDataQuery
 import org.knora.webapi.slice.resources.repo.GetResourceValueVersionHistoryQuery
+import org.knora.webapi.slice.resources.repo.IsResourceInUseQuery
 import org.knora.webapi.slice.resources.service.ReadResourcesService
 import org.knora.webapi.slice.search.repo.GetIncomingImageLinksGravsearchQuery
 import org.knora.webapi.slice.standoff.service.StandoffMappingService
@@ -364,40 +355,8 @@ final class ResourcesResponderV2(
       prj <- projectService
                .findByShortcode(resourceIri.shortcode)
                .someOrFail(NotFoundException(s"Project ${resourceIri.shortcode} not found"))
-
-      (other, otherClass, p, valueProp, valueNode) =
-        (variable("other"), variable("otherClass"), variable("p"), variable("valueProp"), variable("valueNode"))
-      dataGraph = Rdf.iri(projectService.getDataGraphForProject(prj).value)
-
-      // Branch 1: a non-deleted resource refers to <resource> directly in object position.
-      directBranch = other
-                       .has(p, Rdf.iri(resourceIri.toString))
-                       .andHas(KB.isDeleted, false)
-                       .andIsA(otherClass)
-
-      // Branch 2: a non-deleted resource refers to <resource> through one of its non-deleted value nodes via
-      // isRegionPreviewOf (a region preview points at the Region from a Value node, not from the Resource).
-      viaValueNodeBranch = other
-                             .has(valueProp, valueNode)
-                             .andHas(KB.isDeleted, false)
-                             .andIsA(otherClass)
-                             .and(
-                               valueNode
-                                 .has(KB.isRegionPreviewOf, Rdf.iri(resourceIri.toString))
-                                 .andHas(KB.isDeleted, false),
-                             )
-
-      // Scope both branches to the project data graph; the class-hierarchy guard stays in the default graph so
-      // the rdfs:subClassOf* traversal reaches the ontology (matching the pre-existing single-branch behaviour).
-      inUsePattern           = GraphPatterns.union(directBranch, viaValueNodeBranch).from(dataGraph)
-      subClassOfPropertyPath = PropertyPathBuilder.of(RDFS.SUBCLASSOF).zeroOrMore().build()
-      classConstraintPattern = otherClass.has(subClassOfPropertyPath, KB.Resource)
-
-      query = Queries
-                .SELECT(SparqlBuilder.select(other).distinct())
-                .where(inUsePattern, classConstraintPattern)
-                .prefix(prefix(RDFS.NS), prefix(KB.NS), prefix(XSD.NS))
-      result <- triplestore.query(Select(query))
+      dataGraph = projectService.getDataGraphForProject(prj).value
+      result   <- triplestore.query(Select(IsResourceInUseQuery.build(resourceIri, dataGraph)))
 
       otherResources <-
         ZIO

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -355,15 +355,16 @@ final class ResourcesResponderV2(
       prj <- projectService
                .findByShortcode(resourceIri.shortcode)
                .someOrFail(NotFoundException(s"Project ${resourceIri.shortcode} not found"))
-      dataGraph = projectService.getDataGraphForProject(prj).value
-      result   <- triplestore.query(Select(IsResourceInUseQuery.build(resourceIri, dataGraph)))
-
-      otherResources <-
-        ZIO
-          .foreach(result.results.bindings.map(_.rowMap.get("other")).flatten.toSet)(s =>
-            ZIO.fromEither(ResourceIri.from(s)),
-          )
-          .mapError(DataConversionException.apply)
+      dataGraph      = projectService.getDataGraphForProject(prj).value
+      result        <- triplestore.query(Select(IsResourceInUseQuery.build(resourceIri, dataGraph)))
+      candidates     = result.results.bindings.flatMap(_.rowMap.get("other")).toSet
+      otherResources = candidates.flatMap(ResourceIri.from(_).toOption)
+      dropped        = candidates.diff(otherResources.map(_.value))
+      _             <- ZIO
+             .logWarning(
+               s"isResourceInUse dropped non-resource IRIs pointing at $resourceIri: ${dropped.mkString(", ")}",
+             )
+             .when(dropped.nonEmpty)
     } yield otherResources
 
   /**

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/common/Iris.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/common/Iris.scala
@@ -43,8 +43,15 @@ final case class ResourceIri private (override val value: String, shortcode: Sho
 
 object ResourceIri extends WithFrom[String, ResourceIri] {
 
+  /**
+   * SPARQL `fn:matches` pattern for a resource IRI. Must accept the same strings as [[from]].
+   * Uses `[0-9A-Fa-f]` rather than Java `\p{XDigit}` because SPARQL regex is XQuery.
+   */
+  val SparqlRegexPattern: String =
+    """^http://rdfh\.ch/[0-9A-Fa-f]{4}/[A-Za-z0-9_-]+$"""
+
   private val ResourceIriRegex: Regex =
-    """^http://rdfh\.ch/(\p{XDigit}{4})/([A-Za-z0-9_-]+)$""".r
+    """^http://rdfh\.ch/([0-9A-Fa-f]{4})/([A-Za-z0-9_-]+)$""".r
 
   def makeNew(shortcode: Shortcode): ResourceIri = {
     val id = UuidUtil.base64Encode(UUID.randomUUID)

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuery.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.resources.repo
 
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions
 import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
@@ -22,11 +23,13 @@ import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
  * (two bound terms) above `?s ?p <target>` (one bound term) and opens with a
  * project-wide scan.
  *
- * The class filter is `FILTER NOT EXISTS { GRAPH <g> { ?other a LinkValue } }`,
- * not `rdfs:subClassOf* Resource`. On a 3840-incoming dokubib hub the path was
- * ~1.5s of the remaining ~1.6s; the type check was ~190ms and byte-identical
- * on that hub plus the ticket empty case (DEV-6885). See engine Fact 1 and
- * Fact 3 corollaries.
+ * The keep-set is a resource-shaped IRI (`ResourceIri.SparqlRegexPattern`), not
+ * `rdfs:subClassOf* Resource`. Branch 1 also matches `LinkValue` / preview-value
+ * IRIs in object position; those are `…/values/…` and must not count as "in use".
+ * `FILTER NOT EXISTS { GRAPH <g> { ?other a LinkValue } }` is a cheap extra drop
+ * for reifications. On a 3840-incoming dokubib hub the class path was ~1.5s of
+ * the remaining ~1.6s; the type check was ~190ms (DEV-6885). See engine Fact 1
+ * and Fact 3 corollaries.
  */
 object IsResourceInUseQuery extends QueryBuilderHelper {
 
@@ -62,15 +65,21 @@ object IsResourceInUseQuery extends QueryBuilderHelper {
     val viaBranch = GraphPatterns.and(viaPinned, viaFilters)
 
     // LinkValue is not a Resource. Incoming rdf:object triples on the target's
-    // own outgoing LinkValues must not count as "in use"; a GRAPH-scoped type
-    // check is equivalent to the Resource closure here and does not pay the
-    // per-candidate path walk.
+    // own outgoing LinkValues must not count as "in use".
     val notLinkValue = GraphPatterns.filterNotExists(other.isA(KB.linkValue).from(dataGraph))
+    // Same keep-set the Scala parser requires: resource IRIs, not `…/values/…`.
+    val resourceIriShape =
+      Expressions.regex(Expressions.str(other), Rdf.literalOf(ResourceIri.SparqlRegexPattern))
 
     Queries
       .SELECT(other)
       .distinct()
       .prefix(KB.NS)
-      .where(GraphPatterns.union(directBranch, viaBranch), notLinkValue)
+      .where(
+        GraphPatterns
+          .union(directBranch, viaBranch)
+          .and(notLinkValue)
+          .filter(resourceIriShape),
+      )
   }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuery.scala
@@ -5,7 +5,6 @@
 
 package org.knora.webapi.slice.resources.repo
 
-import org.eclipse.rdf4j.model.vocabulary.RDFS
 import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
@@ -21,20 +20,25 @@ import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
  * Both UNION branches pin their selective pattern in a subquery. Without that
  * barrier, TDB2's bound-term heuristic ranks `?s knora-base:isDeleted false`
  * (two bound terms) above `?s ?p <target>` (one bound term) and opens with a
- * project-wide scan. Measured 1801 ms → 317 ms on the prod-trace resource
- * (DEV-6885). See engine Fact 1 corollary.
+ * project-wide scan.
+ *
+ * The class filter is `FILTER NOT EXISTS { GRAPH <g> { ?other a LinkValue } }`,
+ * not `rdfs:subClassOf* Resource`. On a 3840-incoming dokubib hub the path was
+ * ~1.5s of the remaining ~1.6s; the type check was ~190ms and byte-identical
+ * on that hub plus the ticket empty case (DEV-6885). See engine Fact 1 and
+ * Fact 3 corollaries.
  */
 object IsResourceInUseQuery extends QueryBuilderHelper {
 
   def build(resourceIri: ResourceIri, dataGraphIri: String): SelectQuery = {
-    val (other, otherClass, p, valueProp, valueNode) =
-      (variable("other"), variable("otherClass"), variable("p"), variable("valueProp"), variable("valueNode"))
+    val (other, p, valueProp, valueNode) =
+      (variable("other"), variable("p"), variable("valueProp"), variable("valueNode"))
     val target    = Rdf.iri(resourceIri.value)
     val dataGraph = Rdf.iri(dataGraphIri)
 
     // Branch 1: a non-deleted resource refers to <target> in object position.
     val directPinned  = GraphPatterns.select(other).where(other.has(p, target).from(dataGraph))
-    val directFilters = other.has(KB.isDeleted, false).andIsA(otherClass).from(dataGraph)
+    val directFilters = other.has(KB.isDeleted, false).from(dataGraph)
     val directBranch  = GraphPatterns.and(directPinned, directFilters)
 
     // Branch 2: a non-deleted resource refers to <target> through a non-deleted
@@ -51,21 +55,22 @@ object IsResourceInUseQuery extends QueryBuilderHelper {
       )
     val viaFilters = GraphPatterns
       .and(
-        other.has(KB.isDeleted, false).andIsA(otherClass),
+        other.has(KB.isDeleted, false),
         valueNode.has(KB.isDeleted, false),
       )
       .from(dataGraph)
     val viaBranch = GraphPatterns.and(viaPinned, viaFilters)
 
-    // Class-hierarchy guard stays in the default graph so rdfs:subClassOf* reaches
-    // the ontology. It correctly excludes the target's own outgoing LinkValues
-    // (matched via rdf:subject; LinkValue is not a Resource subclass).
-    val classConstraint = otherClass.has(zeroOrMore(RDFS.SUBCLASSOF), KB.Resource)
+    // LinkValue is not a Resource. Incoming rdf:object triples on the target's
+    // own outgoing LinkValues must not count as "in use"; a GRAPH-scoped type
+    // check is equivalent to the Resource closure here and does not pay the
+    // per-candidate path walk.
+    val notLinkValue = GraphPatterns.filterNotExists(other.isA(KB.linkValue).from(dataGraph))
 
     Queries
       .SELECT(other)
       .distinct()
-      .prefix(RDFS.NS, KB.NS)
-      .where(GraphPatterns.union(directBranch, viaBranch), classConstraint)
+      .prefix(KB.NS)
+      .where(GraphPatterns.union(directBranch, viaBranch), notLinkValue)
   }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuery.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.resources.repo
+
+import org.eclipse.rdf4j.model.vocabulary.RDFS
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
+import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
+
+import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.slice.common.ResourceIri
+import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
+
+/**
+ * Incoming-reference check used by `GET /v2/resources/candelete`.
+ *
+ * Both UNION branches pin their selective pattern in a subquery. Without that
+ * barrier, TDB2's bound-term heuristic ranks `?s knora-base:isDeleted false`
+ * (two bound terms) above `?s ?p <target>` (one bound term) and opens with a
+ * project-wide scan. Measured 1801 ms → 317 ms on the prod-trace resource
+ * (DEV-6885). See engine Fact 1 corollary.
+ */
+object IsResourceInUseQuery extends QueryBuilderHelper {
+
+  def build(resourceIri: ResourceIri, dataGraphIri: String): SelectQuery = {
+    val (other, otherClass, p, valueProp, valueNode) =
+      (variable("other"), variable("otherClass"), variable("p"), variable("valueProp"), variable("valueNode"))
+    val target    = Rdf.iri(resourceIri.value)
+    val dataGraph = Rdf.iri(dataGraphIri)
+
+    // Branch 1: a non-deleted resource refers to <target> in object position.
+    val directPinned  = GraphPatterns.select(other).where(other.has(p, target).from(dataGraph))
+    val directFilters = other.has(KB.isDeleted, false).andIsA(otherClass).from(dataGraph)
+    val directBranch  = GraphPatterns.and(directPinned, directFilters)
+
+    // Branch 2: a non-deleted resource refers to <target> through a non-deleted
+    // value node via isRegionPreviewOf.
+    val viaPinned = GraphPatterns
+      .select(other, valueNode)
+      .where(
+        GraphPatterns
+          .and(
+            valueNode.has(KB.isRegionPreviewOf, target),
+            other.has(valueProp, valueNode),
+          )
+          .from(dataGraph),
+      )
+    val viaFilters = GraphPatterns
+      .and(
+        other.has(KB.isDeleted, false).andIsA(otherClass),
+        valueNode.has(KB.isDeleted, false),
+      )
+      .from(dataGraph)
+    val viaBranch = GraphPatterns.and(viaPinned, viaFilters)
+
+    // Class-hierarchy guard stays in the default graph so rdfs:subClassOf* reaches
+    // the ontology. It correctly excludes the target's own outgoing LinkValues
+    // (matched via rdf:subject; LinkValue is not a Resource subclass).
+    val classConstraint = otherClass.has(zeroOrMore(RDFS.SUBCLASSOF), KB.Resource)
+
+    Queries
+      .SELECT(other)
+      .distinct()
+      .prefix(RDFS.NS, KB.NS)
+      .where(GraphPatterns.union(directBranch, viaBranch), classConstraint)
+  }
+}

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/common/ResourceIriSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/common/ResourceIriSpec.scala
@@ -40,6 +40,17 @@ class ResourceIriSpec extends ZIOSpecDefault {
           assertTrue(actual == Left(s"<$iri> is not a Knora resource IRI"))
         }
       },
+      test("SparqlRegexPattern accepts the same strings as from") {
+        val samples = Seq(
+          validResourceIri,
+          "http://rdfh.ch/0001/thing-with-history/values/xZisRC3jPkcplt1hQQdb-A",
+          "http://example.com/ontology#Foo",
+          "http://www.knora.org/ontology/0001/anything#Thing",
+        )
+        check(Gen.fromIterable(samples)) { iri =>
+          assertTrue(ResourceIri.SparqlRegexPattern.r.matches(iri) == ResourceIri.from(iri).isRight)
+        }
+      },
     ),
     suite("makeNew")(
       test("should create a valid ResourceIri") {

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuerySpec.scala
@@ -22,7 +22,7 @@ class IsResourceInUseQuerySpec extends ZIOSpecDefault {
       val expected    =
         """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
           |SELECT DISTINCT ?other
-          |WHERE { { { SELECT ?other
+          |WHERE { { { { SELECT ?other
           |WHERE { GRAPH <http://www.knora.org/data/0001/anything> { ?other ?p <http://rdfh.ch/0001/a-thing> . } }
           | }
           |GRAPH <http://www.knora.org/data/0001/anything> { ?other knora-base:isDeleted false . } } UNION { { SELECT ?other ?valueNode
@@ -31,7 +31,8 @@ class IsResourceInUseQuerySpec extends ZIOSpecDefault {
           | }
           |GRAPH <http://www.knora.org/data/0001/anything> { ?other knora-base:isDeleted false .
           |?valueNode knora-base:isDeleted false . } }
-          |FILTER NOT EXISTS { GRAPH <http://www.knora.org/data/0001/anything> { ?other a knora-base:LinkValue . } } }
+          |FILTER NOT EXISTS { GRAPH <http://www.knora.org/data/0001/anything> { ?other a knora-base:LinkValue . } }
+          |FILTER ( REGEX( STR( ?other ), "^http://rdfh\\.ch/[0-9A-Fa-f]{4}/[A-Za-z0-9_-]+$" ) ) } }
           |""".stripMargin
       assertTrue(actual == expected)
     },

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuerySpec.scala
@@ -20,21 +20,18 @@ class IsResourceInUseQuerySpec extends ZIOSpecDefault {
       val dataGraph   = "http://www.knora.org/data/0001/anything"
       val actual      = IsResourceInUseQuery.build(resourceIri, dataGraph).getQueryString
       val expected    =
-        """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-          |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+        """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
           |SELECT DISTINCT ?other
           |WHERE { { { SELECT ?other
           |WHERE { GRAPH <http://www.knora.org/data/0001/anything> { ?other ?p <http://rdfh.ch/0001/a-thing> . } }
           | }
-          |GRAPH <http://www.knora.org/data/0001/anything> { ?other knora-base:isDeleted false ;
-          |    a ?otherClass . } } UNION { { SELECT ?other ?valueNode
+          |GRAPH <http://www.knora.org/data/0001/anything> { ?other knora-base:isDeleted false . } } UNION { { SELECT ?other ?valueNode
           |WHERE { GRAPH <http://www.knora.org/data/0001/anything> { ?valueNode knora-base:isRegionPreviewOf <http://rdfh.ch/0001/a-thing> .
           |?other ?valueProp ?valueNode . } }
           | }
-          |GRAPH <http://www.knora.org/data/0001/anything> { ?other knora-base:isDeleted false ;
-          |    a ?otherClass .
+          |GRAPH <http://www.knora.org/data/0001/anything> { ?other knora-base:isDeleted false .
           |?valueNode knora-base:isDeleted false . } }
-          |?otherClass rdfs:subClassOf* knora-base:Resource . }
+          |FILTER NOT EXISTS { GRAPH <http://www.knora.org/data/0001/anything> { ?other a knora-base:LinkValue . } } }
           |""".stripMargin
       assertTrue(actual == expected)
     },

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/IsResourceInUseQuerySpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.resources.repo
+
+import org.junit.runner.RunWith
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.slice.common.ResourceIri
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class IsResourceInUseQuerySpec extends ZIOSpecDefault {
+
+  override def spec: Spec[TestEnvironment, Any] = suite("IsResourceInUseQuery")(
+    test("pins both selective incoming-reference probes in GRAPH-scoped subqueries") {
+      val resourceIri = ResourceIri.unsafeFrom("http://rdfh.ch/0001/a-thing")
+      val dataGraph   = "http://www.knora.org/data/0001/anything"
+      val actual      = IsResourceInUseQuery.build(resourceIri, dataGraph).getQueryString
+      val expected    =
+        """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+          |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+          |SELECT DISTINCT ?other
+          |WHERE { { { SELECT ?other
+          |WHERE { GRAPH <http://www.knora.org/data/0001/anything> { ?other ?p <http://rdfh.ch/0001/a-thing> . } }
+          | }
+          |GRAPH <http://www.knora.org/data/0001/anything> { ?other knora-base:isDeleted false ;
+          |    a ?otherClass . } } UNION { { SELECT ?other ?valueNode
+          |WHERE { GRAPH <http://www.knora.org/data/0001/anything> { ?valueNode knora-base:isRegionPreviewOf <http://rdfh.ch/0001/a-thing> .
+          |?other ?valueProp ?valueNode . } }
+          | }
+          |GRAPH <http://www.knora.org/data/0001/anything> { ?other knora-base:isDeleted false ;
+          |    a ?otherClass .
+          |?valueNode knora-base:isDeleted false . } }
+          |?otherClass rdfs:subClassOf* knora-base:Resource . }
+          |""".stripMargin
+      assertTrue(actual == expected)
+    },
+  )
+}


### PR DESCRIPTION
## Summary

- Pin both `isResourceInUse` UNION branches behind GRAPH-scoped subqueries so TDB2 cannot hoist `isDeleted false` into a project-wide scan. Branch 1 (`?s ?p <target>`) cannot be fixed by text reorder — it has one bound term and loses the heuristic.
- Replace the remaining `rdfs:subClassOf* Resource` guard with a cheap drop of `LinkValue` reifications **plus** `FILTER REGEX(STR(?other), ResourceIri.SparqlRegexPattern)`. `NOT EXISTS LinkValue` is **not** equivalent to the Resource path: a live `RegionPreviewValue` sits in branch 1 object position and is not a `LinkValue`, so without the IRI-shape filter `candelete` failed `ResourceIri.from` instead of naming the host.
- Extract the query into `IsResourceInUseQuery` with a golden SPARQL spec. Behavioural ITs for a live incoming link and a live region preview now assert `cannotDoReason` contains the host/source IRI, not a value IRI or a conversion error.
- Record the bound-object wildcard-predicate trap (Fact 1), the connected-`subClassOf*` candidate-count trap, and the `Resource ≢ ¬LinkValue` keep-set (Fact 3) in `docs/development/dsp-api-fuseki-query-execution.md`.

Fixes [DEV-6885](https://linear.app/dasch/issue/DEV-6885/v2resourcescandelete-isresourceinuse-costs-18s-on-prod-sized-projects).

## Stage verification (2026-09-04, `db.stage.dasch.swiss`)

- **Identity, subquery + Resource guard vs original query:** 665/665 targets across 61 projects, 0 diffs (result sizes 0–3840).
- **Identity, original Resource-guard query vs subquery + `NOT EXISTS LinkValue`:** 117/117 targets on `hasLinkTo` hubs (≥200 incoming refs, plus a spread sample), 0 diffs. That sample did not include live region previews.
- **Live region preview (daschland Story, created for this check; will vanish on the next prod mirror):** `NOT EXISTS LinkValue` alone returned the host **and** the live value IRI. With the ResourceIri regex: host only, matching the old Resource guard. A deleted preview on a different Region did not count (`isDeleted true`).
- **Ticket resource** (`0804/ETGHDnh5…`, 0 rows), COUNT wrap, 1 warmup + 5: **1817 ms → 136 ms**.
- Slowest old queries (LIMC hubs): ~9.3–9.5 s → ~135–145 ms.

## Test plan

- [x] `IsResourceInUseQuerySpec` (pinned query text, including the ResourceIri regex)
- [x] `ResourceIriSpec` — SPARQL pattern matches the same strings as `from`
- [x] `ResourcesResponderV2Spec` — 76 tests; both candelete cases assert the reason names the host/source, not `/values/`
- [x] Stage identity + timing + live-preview keep-set as above