### PR TITLE
feat(dsp-api): MigrateSizes command for backfilling missing mime types (DEV-7124)

### DIFF
--- a/modules/ingest/BUILD.bazel
+++ b/modules/ingest/BUILD.bazel
@@ -159,6 +159,14 @@ scala_binary(
     runtime_deps = [":ingest"],
 )
 
+# One-off sidecar originalMimeType backfill; not part of the service startup.
+scala_binary(
+    name = "migrate-mime-types",
+    main_class = "swiss.dasch.MigrateMimeTypes",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":ingest"],
+)
+
 scala_junit_test(
     name = "test",
     srcs = glob(["src/test/scala/**/*.scala"]),

--- a/modules/ingest/src/main/scala/swiss/dasch/MigrateMimeTypes.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/MigrateMimeTypes.scala
@@ -15,27 +15,28 @@ import swiss.dasch.infrastructure.*
 import zio.*
 
 /**
- * One-off migration backfilling `sizeOriginal`/`sizeDerivative` into every `.info` sidecar in the store.
- * Reads `STORAGE_ASSET_DIR` like the service does, so point it at the same volume.
+ * One-off migration backfilling `originalMimeType` into every `.info` sidecar that lacks it, derived
+ * from `originalFilename`'s extension. Reads `STORAGE_ASSET_DIR` like the service does, so point it at
+ * the same volume.
  *
  * Locally, via Bazel:
  *
  * {{{
- *   bazel run //modules/ingest:migrate-sizes            # whole asset store
- *   bazel run //modules/ingest:migrate-sizes -- 0801    # a single project
+ *   bazel run //modules/ingest:migrate-mime-types            # whole asset store
+ *   bazel run //modules/ingest:migrate-mime-types -- 0801    # a single project
  * }}}
  *
  * Against a deployed image, swapping only the main class out of the image's own entrypoint:
  */
-// docker compose run --rm --no-deps --entrypoint java ingest -cp '/sipi/lib/*' swiss.dasch.MigrateSizes
-object MigrateSizes extends ZIOAppDefault {
+// docker compose run --rm --no-deps --entrypoint java ingest -cp '/sipi/lib/*' swiss.dasch.MigrateMimeTypes
+object MigrateMimeTypes extends ZIOAppDefault {
 
   override val bootstrap: Layer[Config.Error, ServiceConfig & JwtConfig & StorageConfig] =
     Configuration.layer >+> Logger.layer
 
   private def migrate(shortcodes: Chunk[String]) =
     for {
-      migration <- ZIO.service[AssetSizeMigrationService]
+      migration <- ZIO.service[AssetMimeTypeMigrationService]
       report    <- shortcodes match {
                   case Chunk() => migration.migrateAll()
                   case codes   =>
@@ -46,7 +47,7 @@ object MigrateSizes extends ZIOAppDefault {
                           .mapError(e => IllegalArgumentException(s"Invalid project shortcode '$code': $e"))
                           .flatMap(migration.migrateProject)
                       }
-                      .map(_.fold(AssetSizeMigrationReport.zero)(_ + _))
+                      .map(_.fold(AssetMimeTypeMigrationReport.zero)(_ + _))
                 }
     } yield report
 
@@ -59,7 +60,7 @@ object MigrateSizes extends ZIOAppDefault {
     } yield exitCode)
       .provideSome[ZIOAppArgs](
         AssetInfoServiceLive.layer,
-        AssetSizeMigrationService.layer,
+        AssetMimeTypeMigrationService.layer,
         Configuration.layer,
         Db.dataSourceLive,
         FileChecksumServiceLive.layer,

--- a/modules/ingest/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
@@ -52,6 +52,9 @@ final private case class AssetInfoFileContent(
 
   def withSizes(original: Option[SizeInBytes], derivative: Option[SizeInBytes]): AssetInfoFileContent =
     copy(sizeOriginal = original, sizeDerivative = derivative)
+
+  def withOriginalMimeType(mimeType: MimeType): AssetInfoFileContent =
+    copy(originalMimeType = Some(mimeType.value))
 }
 
 private object AssetInfoFileContent {
@@ -103,6 +106,13 @@ trait AssetInfoService {
    * — checksums included — untouched. A file that is not on disk is logged and its size left absent.
    */
   def updateSizes(infoFile: Path, original: Path, derivative: Path): Task[Unit]
+
+  /**
+   * Fills in `originalMimeType` from `originalFilename`'s extension, leaving every other field
+   * untouched. A sidecar that already has the field, or whose extension is unknown, is left as it is;
+   * the returned value says which happened.
+   */
+  def backfillOriginalMimeType(infoFile: Path): Task[MimeTypeBackfillOutcome]
   def createAssetInfo(asset: Asset): IO[IOException, AssetInfo]
 }
 
@@ -115,13 +125,16 @@ object AssetInfoService {
     ZIO.serviceWithZIO[AssetInfoService](_.updateAssetInfoForDerivative(derivative))
   def updateSizes(infoFile: Path, original: Path, derivative: Path): ZIO[AssetInfoService, Throwable, Unit] =
     ZIO.serviceWithZIO[AssetInfoService](_.updateSizes(infoFile, original, derivative))
+  def backfillOriginalMimeType(infoFile: Path): ZIO[AssetInfoService, Throwable, MimeTypeBackfillOutcome] =
+    ZIO.serviceWithZIO[AssetInfoService](_.backfillOriginalMimeType(infoFile))
   def getInfoFilePath(asset: AssetRef): ZIO[AssetInfoService, Nothing, Path] =
     ZIO.serviceWithZIO[AssetInfoService](_.getInfoFilePath(asset))
   def createAssetInfo(asset: Asset): ZIO[AssetInfoService, IOException, AssetInfo] =
     ZIO.serviceWithZIO[AssetInfoService](_.createAssetInfo(asset))
 }
 
-final case class AssetInfoServiceLive(storage: StorageService) extends AssetInfoService {
+final case class AssetInfoServiceLive(storage: StorageService, mimeTypeGuesser: MimeTypeGuesser)
+    extends AssetInfoService {
   override def loadFromFilesystem(infoFile: Path, shortcode: ProjectShortcode): Task[AssetInfo] =
     for {
       content   <- storage.loadJsonFile[AssetInfoFileContent](infoFile)
@@ -208,6 +221,22 @@ final case class AssetInfoServiceLive(storage: StorageService) extends AssetInfo
     sizeDerivative <- sizeIfPresent(derivative, "derivative")
     _              <- storage.saveJsonFile(infoFile, content.withSizes(sizeOriginal, sizeDerivative))
   } yield ()
+
+  override def backfillOriginalMimeType(infoFile: Path): Task[MimeTypeBackfillOutcome] =
+    storage.loadJsonFile[AssetInfoFileContent](infoFile).flatMap { content =>
+      content.originalMimeType match {
+        case Some(_) => ZIO.succeed(MimeTypeBackfillOutcome.AlreadyPresent)
+        case None    =>
+          mimeTypeGuesser.guess(content.originalFilename) match {
+            case Some(mimeType) =>
+              storage
+                .saveJsonFile(infoFile, content.withOriginalMimeType(mimeType))
+                .as(MimeTypeBackfillOutcome.Updated(mimeType))
+            case None =>
+              ZIO.succeed(MimeTypeBackfillOutcome.UnknownExtension(content.originalFilename.value))
+          }
+      }
+    }
 
   private def sizeIfPresent(file: Path, role: String): UIO[Option[SizeInBytes]] =
     SizeInBytes

--- a/modules/ingest/src/main/scala/swiss/dasch/domain/AssetMimeTypeMigrationService.scala
+++ b/modules/ingest/src/main/scala/swiss/dasch/domain/AssetMimeTypeMigrationService.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch.domain
+
+import swiss.dasch.domain.AugmentedPath.ProjectFolder
+import zio.*
+import zio.nio.file.Path
+import zio.stream.ZStream
+
+/** What [[AssetInfoService.backfillOriginalMimeType]] did to one sidecar. */
+enum MimeTypeBackfillOutcome {
+  case Updated(mimeType: MimeType)
+  case AlreadyPresent
+  case UnknownExtension(originalFilename: String)
+}
+
+final case class AssetMimeTypeMigrationReport(
+  found: Int,
+  updated: Int,
+  alreadyPresent: Int,
+  unknownExtension: Int,
+  failed: Int,
+) {
+  def +(other: AssetMimeTypeMigrationReport): AssetMimeTypeMigrationReport =
+    AssetMimeTypeMigrationReport(
+      found + other.found,
+      updated + other.updated,
+      alreadyPresent + other.alreadyPresent,
+      unknownExtension + other.unknownExtension,
+      failed + other.failed,
+    )
+}
+
+object AssetMimeTypeMigrationReport {
+  val zero: AssetMimeTypeMigrationReport              = AssetMimeTypeMigrationReport(0, 0, 0, 0, 0)
+  val oneUpdated: AssetMimeTypeMigrationReport        = AssetMimeTypeMigrationReport(1, 1, 0, 0, 0)
+  val oneAlreadyPresent: AssetMimeTypeMigrationReport = AssetMimeTypeMigrationReport(1, 0, 1, 0, 0)
+  val oneUnknown: AssetMimeTypeMigrationReport        = AssetMimeTypeMigrationReport(1, 0, 0, 1, 0)
+  val oneFailed: AssetMimeTypeMigrationReport         = AssetMimeTypeMigrationReport(1, 0, 0, 0, 1)
+}
+
+/**
+ * Backfills `originalMimeType` into `.info` sidecars written before that field existed, deriving it
+ * from `originalFilename`'s extension via [[MimeTypeGuesser]] — the same mapping the ingest pipeline
+ * uses, so a backfilled sidecar is indistinguishable from a freshly written one and no mime type
+ * outside `SupportedFileType` can enter the store. Every other field, checksums included, is left
+ * alone. Entrypoint: [[swiss.dasch.MigrateMimeTypes]].
+ */
+final case class AssetMimeTypeMigrationService(
+  assetInfoService: AssetInfoService,
+  projectService: ProjectService,
+) {
+
+  /** A failing sidecar (unreadable or unparsable) is logged and counted, so it cannot strand the rest. */
+  def migrateAll(): Task[AssetMimeTypeMigrationReport] =
+    for {
+      _      <- ZIO.logInfo("Collecting sidecars for mime type migration")
+      report <- backfillAll(findAllInfoFiles())
+      _      <- logReport(report)
+    } yield report
+
+  /** [[migrateAll]] limited to one project. */
+  def migrateProject(shortcode: ProjectShortcode): Task[AssetMimeTypeMigrationReport] =
+    for {
+      project <- projectService
+                   .findProject(shortcode)
+                   .someOrFail(IllegalArgumentException(s"Project $shortcode not found"))
+      _      <- ZIO.logInfo(s"Collecting sidecars of $shortcode for mime type migration")
+      report <- backfillAll(findInfoFilesOfProject(project))
+      _      <- logReport(report)
+    } yield report
+
+  private def logReport(report: AssetMimeTypeMigrationReport): UIO[Unit] =
+    ZIO.logInfo(
+      s"Mime type migration finished: ${report.updated} updated, ${report.alreadyPresent} already present, " +
+        s"${report.unknownExtension} unknown extension, ${report.failed} failed of ${report.found}",
+    )
+
+  def findAllInfoFiles(): ZStream[Any, Throwable, Path] =
+    ZStream
+      .fromIterableZIO(projectService.listAllProjects())
+      .flatMap(findInfoFilesOfProject)
+
+  def findInfoFilesOfProject(project: ProjectFolder): ZStream[Any, Throwable, Path] =
+    StorageService.findInPath(project.path, FileFilters.isInfoFile)
+
+  /**
+   * Streamed rather than collected first: the store holds ~10^5 sidecars, and only the running
+   * report needs to be in memory.
+   */
+  private def backfillAll(infoFiles: ZStream[Any, Throwable, Path]): Task[AssetMimeTypeMigrationReport] =
+    infoFiles
+      .mapZIOPar(AssetMimeTypeMigrationService.parallelism)(backfillOne)
+      .runFold(AssetMimeTypeMigrationReport.zero)(_ + _)
+
+  private def backfillOne(infoFile: Path): UIO[AssetMimeTypeMigrationReport] =
+    assetInfoService
+      .backfillOriginalMimeType(infoFile)
+      .flatMap {
+        case MimeTypeBackfillOutcome.Updated(_)                         => ZIO.succeed(AssetMimeTypeMigrationReport.oneUpdated)
+        case MimeTypeBackfillOutcome.AlreadyPresent                     => ZIO.succeed(AssetMimeTypeMigrationReport.oneAlreadyPresent)
+        case MimeTypeBackfillOutcome.UnknownExtension(originalFilename) =>
+          ZIO
+            .logWarning(s"No mime type for extension of '$originalFilename' in $infoFile, left absent")
+            .as(AssetMimeTypeMigrationReport.oneUnknown)
+      }
+      .catchAll(e =>
+        ZIO
+          .logError(s"Failed to backfill sidecar $infoFile: $e")
+          .as(AssetMimeTypeMigrationReport.oneFailed),
+      )
+}
+
+object AssetMimeTypeMigrationService {
+
+  /**
+   * Well above `StorageService.maxParallelism` (10): each unit of work is a small read of a ~450 byte
+   * sidecar plus, at most, a write of the same, so throughput is bound by storage round-trip latency
+   * rather than by bandwidth or CPU.
+   */
+  val parallelism: Int = 50
+
+  val layer = ZLayer.derive[AssetMimeTypeMigrationService]
+}

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/AssetInfoServiceSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/AssetInfoServiceSpec.scala
@@ -160,6 +160,7 @@ class AssetInfoServiceSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("AssetInfoServiceSpec")(findByAssetRefSuite).provide(
       AssetInfoServiceLive.layer,
+      MimeTypeGuesser.layer,
       StorageServiceLive.layer,
       SpecConfigurations.storageConfigLayer,
     )

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/AssetMimeTypeMigrationServiceSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/AssetMimeTypeMigrationServiceSpec.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch.domain
+
+import org.junit.runner.RunWith
+import swiss.dasch.domain.AssetInfoFileTestHelper.*
+import swiss.dasch.domain.AugmentedPath.AssetFolder
+import swiss.dasch.test.SpecConfigurations
+import swiss.dasch.util.TestUtils
+import zio.*
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class AssetMimeTypeMigrationServiceSpec extends ZIOSpecDefault {
+
+  private val migration = ZIO.service[AssetMimeTypeMigrationService]
+
+  private def infoFileOf(assetDir: AssetFolder) = assetDir / s"${assetDir.assetId}.info"
+
+  private def originalMimeTypeOf(assetDir: AssetFolder) =
+    AssetInfoService
+      .findByAssetRef(assetDir.assetRef)
+      .map(_.head.metadata.originalMimeType.map(_.stringValue))
+
+  // The extensions actually present in the store, each mapping to a type SupportedFileType already
+  // defines — the migration must never invent a value outside that set.
+  private val extensionCases = Seq(
+    "jpg"  -> "image/jpeg",
+    "jpeg" -> "image/jpeg",
+    "tif"  -> "image/tiff",
+    "tiff" -> "image/tiff",
+    "png"  -> "image/png",
+    "pdf"  -> "application/pdf",
+    "mp3"  -> "audio/mpeg",
+    "mp4"  -> "video/mp4",
+    "txt"  -> "text/plain",
+    "zip"  -> "application/zip",
+    "csv"  -> "text/csv",
+    "xlsx" -> "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "docx" -> "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "pptx" -> "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "xsl"  -> "application/xslt+xml",
+  )
+
+  private val perExtension = suite("backfills each extension found in the store")(
+    extensionCases.map { case (ext, expected) =>
+      test(s"test.$ext :: $expected") {
+        for {
+          assetDir <- createInfoFile(originalFileExt = ext, derivativeFileExt = "jp2")
+          before   <- originalMimeTypeOf(assetDir)
+          _        <- migration.flatMap(_.migrateProject(testProject))
+          after    <- originalMimeTypeOf(assetDir)
+        } yield assertTrue(before.isEmpty, after == Some(expected))
+      }
+    },
+  )
+
+  private val perExtensionCaseInsensitive =
+    suite("backfills regardless of how the extension is cased")(
+      // 15136 of the sampled sidecars name a ".TIF" original.
+      test("test.TIF :: image/tiff") {
+        for {
+          assetDir <- createInfoFile(originalFileExt = "TIF", derivativeFileExt = "jp2")
+          _        <- migration.flatMap(_.migrateProject(testProject))
+          after    <- originalMimeTypeOf(assetDir)
+        } yield assertTrue(after == Some("image/tiff"))
+      },
+    )
+
+  private val idempotence = suite("leaves a sidecar that already has the field alone")(
+    test("an existing originalMimeType is never overwritten, even a surprising one") {
+      for {
+        assetDir <- createInfoFile(
+                      originalFileExt = "jpg",
+                      derivativeFileExt = "jp2",
+                      customJsonProps = Some(""""originalMimeType" : "image/tiff""""),
+                    )
+        _     <- migration.flatMap(_.migrateProject(testProject))
+        after <- originalMimeTypeOf(assetDir)
+      } yield assertTrue(after == Some("image/tiff"))
+    },
+    test("a second run changes nothing") {
+      for {
+        assetDir <- createInfoFile(originalFileExt = "pdf", derivativeFileExt = "pdf")
+        _        <- migration.flatMap(_.migrateProject(testProject))
+        first    <- originalMimeTypeOf(assetDir)
+        report   <- migration.flatMap(_.migrateProject(testProject))
+        second   <- originalMimeTypeOf(assetDir)
+      } yield assertTrue(
+        first == Some("application/pdf"),
+        second == first,
+        // everything is already filled in by now, so nothing is left to update
+        report.updated == 0,
+        report.alreadyPresent == report.found,
+      )
+    },
+  )
+
+  private val unknownExtension = suite("an extension the guesser does not know")(
+    test("is left absent, logged, and counted rather than failing the run") {
+      for {
+        assetDir <- createInfoFile(originalFileExt = "qqq", derivativeFileExt = "jp2")
+        report   <- migration.flatMap(_.migrateProject(testProject))
+        after    <- originalMimeTypeOf(assetDir)
+        warnings <- ZTestLogger.logOutput.map(_.filter(_.logLevel == LogLevel.Warning).map(_.message()))
+      } yield assertTrue(
+        after.isEmpty,
+        report.unknownExtension >= 1,
+        report.failed == 0,
+        warnings.exists(_ == s"No mime type for extension of 'test.qqq' in ${infoFileOf(assetDir)}, left absent"),
+      )
+    },
+  )
+
+  private val reporting = suite("migrateProject")(
+    test("reports one found per sidecar, with updated and alreadyPresent adding up") {
+      for {
+        _      <- createInfoFile(originalFileExt = "jpg", derivativeFileExt = "jp2")
+        _      <- createInfoFile(originalFileExt = "tif", derivativeFileExt = "jp2")
+        report <- migration.flatMap(_.migrateProject(testProject))
+      } yield assertTrue(
+        // the store is shared across this spec, so assert on the invariant rather than an exact count
+        report.found >= 2,
+        report.updated + report.alreadyPresent + report.unknownExtension + report.failed == report.found,
+        report.failed == 0,
+      )
+    },
+    test("fails for a project that does not exist") {
+      for {
+        result <- migration.flatMap(_.migrateProject(ProjectShortcode.unsafeFrom("9999"))).flip
+      } yield assertTrue(
+        result.isInstanceOf[IllegalArgumentException],
+        result.getMessage == "Project 9999 not found",
+      )
+    },
+  )
+
+  private val discovery = suite("findAllInfoFiles")(
+    test("finds the sidecar of a newly created asset") {
+      for {
+        assetDir  <- createInfoFile(originalFileExt = "pdf", derivativeFileExt = "pdf")
+        infoFiles <- migration.flatMap(_.findAllInfoFiles().runCollect)
+      } yield assertTrue(infoFiles.contains(infoFileOf(assetDir)))
+    },
+  )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("AssetMimeTypeMigrationServiceSpec")(
+      perExtension,
+      perExtensionCaseInsensitive,
+      idempotence,
+      unknownExtension,
+      reporting,
+      discovery,
+    ).provide(
+      AssetInfoServiceLive.layer,
+      AssetMimeTypeMigrationService.layer,
+      FileChecksumServiceLive.layer,
+      MimeTypeGuesser.layer,
+      ProjectRepositoryLive.layer,
+      ProjectService.layer,
+      SpecConfigurations.storageConfigLayer,
+      StorageServiceLive.layer,
+      TestUtils.testDbLayerWithEmptyDb,
+    )
+}

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/AssetSizeMigrationServiceSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/AssetSizeMigrationServiceSpec.scala
@@ -169,6 +169,7 @@ class AssetSizeMigrationServiceSpec extends ZIOSpecDefault {
       refreshGroupSuite,
     ).provide(
       AssetInfoServiceLive.layer,
+      MimeTypeGuesser.layer,
       AssetSizeMigrationService.layer,
       FileChecksumServiceLive.layer,
       ProjectRepositoryLive.layer,

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/BulkIngestServiceSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/BulkIngestServiceSpec.scala
@@ -157,6 +157,7 @@ class BulkIngestServiceSpec extends ZIOSpecDefault {
     postBulkIngestEndpointSuite,
   ) @@ TestAspect.before(deleteProjectFolder)).provide(
     AssetInfoServiceLive.layer,
+    MimeTypeGuesser.layer,
     BulkIngestService.layer,
     FileChecksumServiceLive.layer,
     MockIngestServiceLayer,

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/FileChecksumServiceLiveSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/FileChecksumServiceLiveSpec.scala
@@ -51,6 +51,7 @@ class FileChecksumServiceLiveSpec extends ZIOSpecDefault {
     },
   ).provide(
     AssetInfoServiceLive.layer,
+    MimeTypeGuesser.layer,
     FileChecksumServiceLive.layer,
     StorageServiceLive.layer,
     SpecConfigurations.storageConfigLayer,

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/ImportServiceSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/ImportServiceSpec.scala
@@ -129,6 +129,7 @@ class ImportServiceSpec extends ZIOSpecDefault {
       },
     ).provide(
       AssetInfoServiceLive.layer,
+      MimeTypeGuesser.layer,
       FileChecksumServiceLive.layer,
       ImportServiceLive.layer,
       ProjectService.layer,

--- a/modules/ingest/src/test/scala/swiss/dasch/domain/ProjectServiceSpec.scala
+++ b/modules/ingest/src/test/scala/swiss/dasch/domain/ProjectServiceSpec.scala
@@ -185,6 +185,7 @@ class ProjectServiceSpec extends ZIOSpecDefault {
       ),
     ).provide(
       AssetInfoServiceLive.layer,
+      MimeTypeGuesser.layer,
       FileChecksumServiceLive.layer,
       ProjectService.layer,
       ProjectRepositoryLive.layer,

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/export/api/ExportApiModule.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/export/api/ExportApiModule.scala
@@ -8,6 +8,7 @@ package org.knora.webapi.slice.`export`.api
 import swiss.dasch.config.Configuration.StorageConfig
 import swiss.dasch.domain.AssetInfoService
 import swiss.dasch.domain.AssetInfoServiceLive
+import swiss.dasch.domain.MimeTypeGuesser
 import swiss.dasch.domain.StorageServiceLive
 import zio.URLayer
 import zio.ZLayer
@@ -52,7 +53,7 @@ object ExportApiModule { self =>
     ZLayer
       .service[AppConfig]
       .project(c => StorageConfig(assetDir = c.dspIngest.assetDir, tempDir = c.dspIngest.assetDir)) >>>
-      StorageServiceLive.layer >>> ZLayer.derive[AssetInfoServiceLive]
+      (StorageServiceLive.layer ++ MimeTypeGuesser.layer) >>> ZLayer.derive[AssetInfoServiceLive]
 
   val layer: URLayer[self.Dependencies, self.Provided] =
     (FindResourcesService.layer ++ assetInfoServiceLayer) >+> ExportService.layer

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/export/api/service/ExportServiceSpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/export/api/service/ExportServiceSpec.scala
@@ -12,6 +12,7 @@ import swiss.dasch.domain.AssetId as IngestAssetId
 import swiss.dasch.domain.AssetInfoService
 import swiss.dasch.domain.AssetInfoServiceLive
 import swiss.dasch.domain.AssetRef
+import swiss.dasch.domain.MimeTypeGuesser
 import swiss.dasch.domain.ProjectShortcode as IngestProjectShortcode
 import swiss.dasch.domain.StorageServiceLive
 import zio.*
@@ -116,7 +117,7 @@ class ExportServiceSpec extends ZIOSpecDefault with GoldenTest {
 
   private val assetInfoServiceLayer: ULayer[AssetInfoService] =
     ZLayer.succeed(StorageConfig(assetDir.toString, assetDir.toString)) >>>
-      StorageServiceLive.layer >>> ZLayer.derive[AssetInfoServiceLive]
+      (StorageServiceLive.layer ++ MimeTypeGuesser.layer) >>> ZLayer.derive[AssetInfoServiceLive]
 
   private def assetRefOf(assetId: String): IO[IllegalArgumentException, AssetRef] =
     ZIO


### PR DESCRIPTION
## feat: backfill `originalMimeType` in asset sidecars

Adds a one-off migration that fills in `originalMimeType` on `.info` sidecars written before that
field existed, deriving it from `originalFilename`'s extension.

```
bazel run //modules/ingest:migrate-mime-types            # whole store
bazel run //modules/ingest:migrate-mime-types -- 0801    # one project
```

Structurally a mirror of `MigrateSizes`: same bootstrap, optional shortcode args, non-zero exit on
partial failure. Runs 50 sidecars in parallel (a service-level constant rather than raising the
shared `StorageService.maxParallelism()` of 10, which would affect every other caller), and streams
rather than pre-collecting since the store holds ~10^5 sidecars.

### No new mime types

The value comes from the existing `MimeTypeGuesser`, i.e. the same `SupportedFileType` mapping the
ingest pipeline already uses — so a backfilled sidecar is indistinguishable from a freshly written
one and nothing outside that set can enter the store.

Verified against a production sample of 77,539 sidecars missing the field: all 15 distinct
extensions resolve (0 unresolved), and every value produced already occurs in the store today.
Uppercase variants (`.TIF`, `.JPG` — 15k+ of the sample) work because the guesser lowercases.

### Notes for reviewers

- Sidecars that already have `originalMimeType` are never overwritten, even when the existing value
  contradicts the extension.
- Unknown extensions are logged and counted, never fatal.
- The extension is trusted, not verified against file contents: a mislabelled deposit (a `.jpg` that
  is really a TIFF) gets the extension's mime type. Detecting those is out of scope here.
