### PR TITLE
refactor: migrate ontology lifecycle and metadata queries to interpolated SPARQL DSL (DEV-7203)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -61,6 +61,11 @@ SparqlBuilder; existing files keep it until they are migrated (verify a migratio
 diffing rendered SPARQL against the old `getQueryString` output). See
 `docs/development/dsp-api-sparql-queries.md`.
 
+- **One explicit template per query.** Prefixes written out in every template, no pulled-out `prefixes` val, no
+  fragment-returning local vals/defs; only typed values are prepared outside the template, and dynamic structure is a
+  closure inside its hole (multi-line is fine). See `docs/development/dsp-api-sparql-queries.md`
+  § Keep the query readable: one explicit template per query.
+
 - **Carve-out — the admin SPARQL passthrough.** `POST /admin/sparql/query` forwards a client-supplied query string to the store on purpose: being transparent is its contract, so it must not parse, validate or rewrite the SPARQL it carries, and no builder applies. This is the only such surface; everything else builds queries. See `docs/03-endpoints/api-admin/sparql-passthrough.md`.
 
 - **Selective patterns before OPTIONALs, in the same flat group.** OPTIONALs are left-joins evaluated in document order; a restriction placed after them is evaluated over the whole class (prod incident DEV-6796: ~150ms → ~700ms tile loads). Beware: `pattern.and(group)` nests (`{ pattern . { … } }`) instead of splicing. See `docs/development/dsp-api-sparql-queries.md` § Pattern Order and Query Performance.

--- a/docs/development/dsp-api-sparql-queries.md
+++ b/docs/development/dsp-api-sparql-queries.md
@@ -41,6 +41,73 @@ the builder until they are migrated. Verify a migration by diffing the rendered 
 against the old builder's `getQueryString` output. Only new *SparqlBuilder* usage is out;
 RDF4J model classes (`org.eclipse.rdf4j.model.*`, `Vocabulary`) remain fine.
 
+## Keep the query readable: one explicit template per query
+
+A reader should be able to read the whole query, top to bottom, inside a single
+`sparql"""|..."""` literal. Every piece of SPARQL text of a query lives in that one template:
+
+- **One template per query.** The only things prepared outside it are typed values: `Iri`,
+  `Variable`, `Literal`, an `Option[Iri]`, a `List[Literal]`. No local `val`/`def` that returns a
+  `Fragment`, no shared `prefixes` fragment, no helper that renders a sub-segment of the query.
+- **Write `PREFIX` declarations literally in every template.**
+- **Dynamic structure is a closure inside the hole.** An optional block is
+  `${maybeX.whenSome(x => sparql"...")}`, a repeated block is
+  `${literals.map(l => sparql"$subject $pred $l .").joinLines}`, a flag-dependent line is
+  `${sparql"...".when(flag)}`, and these nest:
+  `${linkProp.whenSome(lp => literals.map(l => sparql"$lp $pred $l .").joinLines)}`. The closure
+  may span several lines; scalafmt de-indents it out of the `|` margin block, and that is fine.
+  Do not restructure a hole to fit on one line.
+- **Do not duplicate a template to avoid a hole.** Two complete templates selected by `match` are
+  only justified when the query backbone differs (a different query form, or a different grouping
+  that a performance-pinned query depends on), not when a few optional lines differ.
+- **One statement where one statement will do.** If the previous builder emitted several `;`-joined
+  statements only because it could not express one `DELETE ... INSERT ... WHERE`, write one, and
+  prove the equivalence with a data-level test (run the old and the new update on the same Jena
+  dataset and compare). Keep several statements when they are genuinely different migrations.
+
+Bad — the query is spread over a shared prefix val, a pulled-out helper and a duplicated template:
+
+```scala
+private val prefixes = sparql"""|PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                                |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>"""
+
+def newValueTriples(subject: Iri): Fragment =
+  newValues.map(v => sparql"$subject rdfs:comment ${Literal.langString(v.value, v.language.value)} .").joinLines
+
+val query = maybeLinkProp match {
+  case Some(lp) => sparql"""|$prefixes
+                            |INSERT { GRAPH $ontology { ${newValueTriples(property)} ${newValueTriples(lp)} } }
+                            |WHERE { ... }"""
+  case None     => sparql"""|$prefixes
+                            |INSERT { GRAPH $ontology { ${newValueTriples(property)} } }
+                            |WHERE { ... }"""
+}
+```
+
+Good — the same query as one template; only values are prepared outside, the optional part is a
+closure in its hole:
+
+```scala
+val newLiterals = newValues.map(v => Literal.langString(v.value, v.language.value))
+
+val query = sparql"""|PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                    |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                    |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                    |
+                    |INSERT {
+                    |  GRAPH $ontology {
+                    |    ${newLiterals.map(l => sparql"$property rdfs:comment $l .").joinLines}
+                    |    ${maybeLinkProp.whenSome(lp => newLiterals.map(l => sparql"$lp rdfs:comment $l .").joinLines)}
+                    |  }
+                    |}
+                    |WHERE {
+                    |  $ontology a owl:Ontology ;
+                    |    knora-base:lastModificationDate $previousDate .
+                    |}"""
+```
+
+See `ChangePropertyGuiElementQuery` and `ChangePropertyLabelsOrCommentsQuery` for live examples.
+
 ---
 
 The rest of this document covers the **grandfathered** RDF4J SparqlBuilder style — needed

--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1194,7 +1194,7 @@ final class OntologyResponderV2(
                  s"Ontology ${ontologyIri.toComplexSchema} cannot be deleted, because of subjects that refer to it: $sortedSubjects"
                ZIO.fail(BadRequestException(msg))
              }
-        _ <- save(Update(DeleteOntologyQuery.build(ontologyIri)))
+        _ <- save(DeleteOntologyQuery.build(ontologyIri))
       } yield SuccessResponseV2(s"Ontology ${ontologyIri.toComplexSchema} has been deleted")
     IriLocker.runWithIriLock(apiRequestID, ONTOLOGY_CACHE_LOCK_IRI)(deleteTask)
   }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/CheckIriExistsQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/CheckIriExistsQuery.scala
@@ -5,22 +5,16 @@
 
 package org.knora.webapi.slice.ontology.repo
 
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
-
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.messages.SmartIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 
-object CheckIriExistsQuery extends QueryBuilderHelper {
+object CheckIriExistsQuery {
 
-  def build(iri: SmartIri): Ask = build(toRdfIri(iri))
+  def build(iri: SmartIri): Ask = build(iri.toInternalSchema.toIri)
 
-  def build(iri: String): Ask = build(Rdf.iri(iri))
-
-  private def build(iri: Iri) = {
-    val triplePattern = iri.has(variable("p"), variable("o"))
-    val query         = s"""ASK { ${triplePattern.getQueryString} }""".stripMargin
-    Ask(query)
+  def build(iri: String): Ask = {
+    val subject = Iri.unsafeFrom(iri)
+    Ask(sparql"ASK { $subject ?p ?o . }".render)
   }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/CreateOntologyQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/CreateOntologyQuery.scala
@@ -6,23 +6,15 @@
 package org.knora.webapi.slice.ontology.repo
 
 import eu.timepit.refined.types.string.NonEmptyString
-import org.eclipse.rdf4j.model.vocabulary.OWL
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.XSD
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
 import zio.*
 
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
-object CreateOntologyQuery extends QueryBuilderHelper {
+object CreateOntologyQuery {
 
   def build(
     ontologyIri: OntologyIri,
@@ -31,36 +23,34 @@ object CreateOntologyQuery extends QueryBuilderHelper {
     ontologyLabel: String,
     ontologyComment: Option[NonEmptyString],
   ): UIO[(LastModificationDate, Update)] = LastModificationDate.instant.map { lmd =>
-    val ontology = toRdfIri(ontologyIri)
-    val project  = Rdf.iri(projectIri.value)
+    val ontology = Iri.unsafeFrom(ontologyIri.toInternalSchema.toIri)
+    val project  = Iri.unsafeFrom(projectIri.value)
+    val shared   = Literal.bool(isShared)
+    val label    = Literal.string(ontologyLabel)
+    val comment  = ontologyComment.map(c => Literal.string(c.value))
+    val created  = Literal.dateTime(lmd.value)
 
-    val basePattern = ontology
-      .isA(OWL.ONTOLOGY)
-      .andHas(KB.attachedToProject, project)
-      .andHas(KB.isShared, Rdf.literalOf(isShared))
-      .andHas(RDFS.LABEL, Rdf.literalOfType(ontologyLabel, XSD.STRING))
-
-    val withComment = ontologyComment.fold(basePattern) { comment =>
-      basePattern.andHas(RDFS.COMMENT, Rdf.literalOfType(comment.value, XSD.STRING))
-    }
-
-    val insertPattern = withComment.andHas(KB.lastModificationDate, toRdfLiteral(lmd))
-
-    val existingOntologyType = variable("existingOntologyType")
-    val filterNotExists      = GraphPatterns.filterNotExists(ontology.isA(existingOntologyType))
-
-    // Workaround: rdf4j drops FILTER NOT EXISTS when it's the only WHERE pattern.
-    // See https://github.com/eclipse-rdf4j/rdf4j/issues/5561
-    val insertQuery = Queries
-      .MODIFY()
-      .prefix(KB.NS, RDF.NS, RDFS.NS, XSD.NS, OWL.NS)
-      .insert(insertPattern)
-      .into(ontology)
-      .getQueryString
-      .replaceFirst("WHERE \\{\\s*}", "")
-      .strip()
-
-    val sparql = s"$insertQuery\nWHERE { ${filterNotExists.getQueryString} }"
-    (lmd, Update(sparql))
+    val update = Update(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+               |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+               |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+               |
+               |INSERT {
+               |  GRAPH $ontology {
+               |    $ontology a owl:Ontology ;
+               |      knora-base:attachedToProject $project ;
+               |      knora-base:isShared $shared ;
+               |      rdfs:label $label ;
+               |      ${comment.whenSome(c => sparql"rdfs:comment $c ;")}
+               |      knora-base:lastModificationDate $created .
+               |  }
+               |}
+               |WHERE {
+               |  FILTER NOT EXISTS { $ontology a ?existingOntologyType . }
+               |}""".render,
+    )
+    (lmd, update)
   }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeleteOntologyQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeleteOntologyQuery.scala
@@ -5,15 +5,20 @@
 
 package org.knora.webapi.slice.ontology.repo
 
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ModifyQuery
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
-object DeleteOntologyQuery extends QueryBuilderHelper {
-  def build(ontologyIri: OntologyIri): ModifyQuery =
-    val (s, p, o)     = spo
-    val ontologyGraph = toRdfIri(ontologyIri)
-    Queries.MODIFY().delete(s.has(p, o)).from(ontologyGraph).where(s.has(p, o).from(ontologyGraph))
+object DeleteOntologyQuery {
+  def build(ontologyIri: OntologyIri): Update = {
+    val ontologyGraph = Iri.unsafeFrom(ontologyIri.toInternalSchema.toIri)
+    Update(
+      sparql"""|DELETE {
+               |  GRAPH $ontologyGraph { ?s ?p ?o . }
+               |}
+               |WHERE {
+               |  GRAPH $ontologyGraph { ?s ?p ?o . }
+               |}""".render,
+    )
+  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/GetAllOntologiesMetadataQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/GetAllOntologiesMetadataQuery.scala
@@ -5,19 +5,19 @@
 
 package org.knora.webapi.slice.ontology.repo
 
-import org.eclipse.rdf4j.model.vocabulary.OWL
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery
+import org.knora.sparqlbuilder.*
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 
-import org.knora.webapi.slice.common.QueryBuilderHelper
-
-object GetAllOntologiesMetadataQuery extends QueryBuilderHelper {
-  def build: SelectQuery = {
-    val (ontologyGraph, ontologyIri, ontologyPred, ontologyObj) =
-      (variable("ontologyGraph"), variable("ontologyIri"), variable("ontologyPred"), variable("ontologyObj"))
-    Queries
-      .SELECT(ontologyGraph, ontologyIri, ontologyPred, ontologyObj)
-      .prefix(OWL.NS)
-      .where(ontologyIri.isA(OWL.ONTOLOGY).andHas(ontologyPred, ontologyObj).from(ontologyGraph))
-  }
+object GetAllOntologiesMetadataQuery {
+  def build: Select = Select(
+    sparql"""|PREFIX owl: <http://www.w3.org/2002/07/owl#>
+             |
+             |SELECT ?ontologyGraph ?ontologyIri ?ontologyPred ?ontologyObj
+             |WHERE {
+             |  GRAPH ?ontologyGraph {
+             |    ?ontologyIri a owl:Ontology ;
+             |      ?ontologyPred ?ontologyObj .
+             |  }
+             |}""".render,
+  )
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/GetOntologyGraphQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/GetOntologyGraphQuery.scala
@@ -4,15 +4,19 @@
  */
 
 package org.knora.webapi.slice.ontology.repo
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ConstructQuery
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
 
-object GetOntologyGraphQuery extends QueryBuilderHelper {
-  def build(ontologyIri: OntologyIri): ConstructQuery =
-    val (s, p, o)    = spo
-    val graphPattern = s.has(p, o)
-    Queries.CONSTRUCT(graphPattern).where(graphPattern.from(toRdfIri(ontologyIri)))
+object GetOntologyGraphQuery {
+  def build(ontologyIri: OntologyIri): Construct = {
+    val ontologyGraph = Iri.unsafeFrom(ontologyIri.toInternalSchema.toIri)
+    Construct(
+      sparql"""|CONSTRUCT { ?s ?p ?o . }
+               |WHERE {
+               |  GRAPH $ontologyGraph { ?s ?p ?o . }
+               |}""".render,
+    )
+  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/UpdateOntologyMetadataQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/UpdateOntologyMetadataQuery.scala
@@ -6,26 +6,19 @@
 package org.knora.webapi.slice.ontology.repo
 
 import eu.timepit.refined.types.string.NonEmptyString
-import org.eclipse.rdf4j.model.vocabulary.OWL
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.XSD
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri
 import zio.*
 
 import dsp.errors.SparqlGenerationException
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.OntologyIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase as KB
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
 /**
  * Query builder for updating ontology metadata (label and/or comment).
  * When updating a label or comment, the old value is automatically replaced.
  */
-object UpdateOntologyMetadataQuery extends QueryBuilderHelper {
+object UpdateOntologyMetadataQuery {
 
   def build(
     ontologyIri: OntologyIri,
@@ -35,59 +28,40 @@ object UpdateOntologyMetadataQuery extends QueryBuilderHelper {
   ): UIO[Update] =
     ZIO
       .die(SparqlGenerationException("At least one of newLabel or newComment must be provided."))
-      .when(newLabel.isEmpty && newComment.isEmpty) *> {
+      .when(newLabel.isEmpty && newComment.isEmpty) *>
+      Clock.instant.map { now =>
+        val ontology     = Iri.unsafeFrom(ontologyIri.toInternalSchema.toIri)
+        val previousDate = Literal.dateTime(lastModificationDate.value)
+        val currentDate  = Literal.dateTime(now)
+        val label        = newLabel.map(Literal.string)
+        val comment      = newComment.map(c => Literal.string(c.value))
 
-      val (ontology, ontologyNS) = ontologyAndNamespace(ontologyIri)
-      val oldLabel               = variable("oldLabel")
-      val oldComment             = variable("oldComment")
-
-      // Build DELETE patterns - delete old values only if we're replacing them
-      val deletePatterns: List[TriplePattern] = {
-        val labelDelete   = if (newLabel.nonEmpty) List(ontology.has(RDFS.LABEL, oldLabel)) else Nil
-        val commentDelete = if (newComment.nonEmpty) List(ontology.has(RDFS.COMMENT, oldComment)) else Nil
-        val lastModDelete = List(ontology.has(KB.lastModificationDate, toRdfLiteral(lastModificationDate)))
-        labelDelete ::: commentDelete ::: lastModDelete
-      }
-
-      // Build WHERE patterns - label and comment are optional to allow adding them if they don't exist
-      val wherePatterns = {
-        val basePattern = List(
-          ontology
-            .isA(OWL.ONTOLOGY)
-            .andHas(KB.lastModificationDate, toRdfLiteral(lastModificationDate)),
+        Update(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                   |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                   |
+                   |DELETE {
+                   |  GRAPH $ontology {
+                   |    ${sparql"$ontology rdfs:label ?oldLabel .".when(label.isDefined)}
+                   |    ${sparql"$ontology rdfs:comment ?oldComment .".when(comment.isDefined)}
+                   |    $ontology knora-base:lastModificationDate $previousDate .
+                   |  }
+                   |}
+                   |INSERT {
+                   |  GRAPH $ontology {
+                   |    $ontology knora-base:lastModificationDate $currentDate .
+                   |    ${label.whenSome(l => sparql"$ontology rdfs:label $l .")}
+                   |    ${comment.whenSome(c => sparql"$ontology rdfs:comment $c .")}
+                   |  }
+                   |}
+                   |WHERE {
+                   |  $ontology a owl:Ontology ;
+                   |    knora-base:lastModificationDate $previousDate .
+                   |  ${sparql"OPTIONAL { $ontology rdfs:label ?oldLabel . }".when(label.isDefined)}
+                   |  ${sparql"OPTIONAL { $ontology rdfs:comment ?oldComment . }".when(comment.isDefined)}
+                   |}""".render,
         )
-
-        val labelPattern   = if (newLabel.nonEmpty) List(ontology.has(RDFS.LABEL, oldLabel).optional()) else Nil
-        val commentPattern = if (newComment.nonEmpty) List(ontology.has(RDFS.COMMENT, oldComment).optional()) else Nil
-
-        basePattern ::: labelPattern ::: commentPattern
       }
-
-      for {
-        insertPatterns <- buildInsertPatterns(ontology, newLabel, newComment)
-        query           = Queries
-                  .MODIFY()
-                  .prefix(KB.NS, RDFS.NS, XSD.NS, OWL.NS, ontologyNS)
-                  .from(ontology)
-                  .delete(deletePatterns*)
-                  .into(ontology)
-                  .insert(insertPatterns*)
-                  .where(wherePatterns*)
-      } yield Update(query)
-    }
-
-  private def buildInsertPatterns(
-    ontology: Iri,
-    newLabel: Option[String],
-    newComment: Option[NonEmptyString],
-  ): UIO[Seq[TriplePattern]] = Clock.instant.map { now =>
-    val ontologyModPattern = ontology.has(KB.lastModificationDate, toRdfLiteral(now))
-    val labelPattern       = newLabel.map(label => ontology.has(RDFS.LABEL, toRdfLiteral(label))).toList
-    val commentPattern     = newComment.map(comment => ontology.has(RDFS.COMMENT, toRdfLiteral(comment.value))).toList
-
-    ontologyModPattern :: (labelPattern ::: commentPattern)
-  }
-
-  private def toRdfLiteral(str: String): org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral =
-    org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.literalOfType(str, XSD.STRING)
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCache.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/OntologyCache.scala
@@ -439,7 +439,7 @@ final case class OntologyCacheLive(triplestore: TriplestoreService, cacheDataRef
     for {
       // Get all ontology metadata.
       _                           <- ZIO.logDebug(s"Loading ontologies into cache")
-      allOntologyMetadataResponse <- triplestore.select(GetAllOntologiesMetadataQuery.build)
+      allOntologyMetadataResponse <- triplestore.query(GetAllOntologiesMetadataQuery.build)
       allOntologyMetadata          = OntologyHelpers.buildOntologyMetadata(allOntologyMetadataResponse)
 
       knoraBaseOntologyMetadata =

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/CheckIriExistsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/CheckIriExistsQuerySpec.scala
@@ -46,5 +46,9 @@ class CheckIriExistsQuerySpec extends ZIOSpecDefault {
 
       assertTrue(actual.sparql == """ASK { <http://example.org/ontology/test-class-with-hyphen> ?p ?o . }""")
     },
+    test("should reject a String IRI that could break out of the IRIREF") {
+      val result = scala.util.Try(CheckIriExistsQuery.build("http://example.org/a> ?x ?y . <http://example.org/b"))
+      assertTrue(result.isFailure)
+    },
   )
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/CreateOntologyQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/CreateOntologyQuerySpec.scala
@@ -6,6 +6,7 @@
 package org.knora.webapi.slice.ontology.repo
 
 import eu.timepit.refined.types.string.NonEmptyString
+import org.apache.jena.update.UpdateFactory
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -19,6 +20,12 @@ import org.knora.webapi.slice.common.KnoraIris.OntologyIri
 class CreateOntologyQuerySpec extends ZIOSpecDefault {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
+
+  private def canonical(query: String): String = {
+    val update = UpdateFactory.create(query)
+    update.getPrefixMapping.clearNsPrefixMap()
+    update.toString
+  }
 
   private val ontologyIri     = OntologyIri.unsafeFrom("http://www.knora.org/ontology/0001/anything".toSmartIri)
   private val projectIri      = ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001")
@@ -38,7 +45,7 @@ class CreateOntologyQuerySpec extends ZIOSpecDefault {
         .map { case (lmd, update) =>
           val ts = lmd.value.toString
           assertTrue(
-            update.sparql ==
+            canonical(update.sparql) == canonical(
               s"""PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                  |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                  |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -51,6 +58,7 @@ class CreateOntologyQuerySpec extends ZIOSpecDefault {
                  |    rdfs:comment "A test ontology"^^xsd:string ;
                  |    knora-base:lastModificationDate "$ts"^^xsd:dateTime . } }
                  |WHERE { FILTER NOT EXISTS { <http://www.knora.org/ontology/0001/anything> a ?existingOntologyType . } }""".stripMargin,
+            ),
           )
         }
     },
@@ -66,7 +74,7 @@ class CreateOntologyQuerySpec extends ZIOSpecDefault {
         .map { case (lmd, update) =>
           val ts = lmd.value.toString
           assertTrue(
-            update.sparql ==
+            canonical(update.sparql) == canonical(
               s"""PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                  |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                  |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -78,6 +86,7 @@ class CreateOntologyQuerySpec extends ZIOSpecDefault {
                  |    rdfs:label "The anything ontology"^^xsd:string ;
                  |    knora-base:lastModificationDate "$ts"^^xsd:dateTime . } }
                  |WHERE { FILTER NOT EXISTS { <http://www.knora.org/ontology/0001/anything> a ?existingOntologyType . } }""".stripMargin,
+            ),
           )
         }
     },
@@ -105,7 +114,7 @@ class CreateOntologyQuerySpec extends ZIOSpecDefault {
         )
         .map { case (lmd, update) =>
           assertTrue(
-            update.sparql.contains(s""""${lmd.value}"^^xsd:dateTime"""),
+            update.sparql.contains(s""""${lmd.value}"^^<http://www.w3.org/2001/XMLSchema#dateTime>"""),
           )
         }
     },

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/DeleteOntologyQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/DeleteOntologyQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.ontology.repo
 
+import org.apache.jena.update.UpdateFactory
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -18,16 +19,20 @@ class DeleteOntologyQuerySpec extends ZIOSpecDefault {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
+  private def canonical(query: String): String = UpdateFactory.create(query).toString
+
   private val testOntologyIri: OntologyIri =
     OntologyIri.unsafeFrom("http://www.knora.org/ontology/0001/anything".toSmartIri)
 
   override def spec: Spec[TestEnvironment, Any] = suite("DeleteOntologyQuerySpec")(
     suite("build")(
       test("should produce the correct query for deleting an ontology") {
-        val actual = DeleteOntologyQuery.build(testOntologyIri).getQueryString
+        val actual = DeleteOntologyQuery.build(testOntologyIri).sparql
         assertTrue(
-          actual == """DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { ?s ?p ?o . } }
-                      |WHERE { GRAPH <http://www.knora.org/ontology/0001/anything> { ?s ?p ?o . } }""".stripMargin,
+          canonical(actual) == canonical(
+            """DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { ?s ?p ?o . } }
+              |WHERE { GRAPH <http://www.knora.org/ontology/0001/anything> { ?s ?p ?o . } }""".stripMargin,
+          ),
         )
       },
     ),

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/GetAllOntologiesMetadataQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/GetAllOntologiesMetadataQuerySpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.ontology.repo
+
+import org.apache.jena.query.QueryFactory
+import org.junit.runner.RunWith
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class GetAllOntologiesMetadataQuerySpec extends ZIOSpecDefault {
+
+  private def canonical(query: String): String = {
+    val parsed = QueryFactory.create(query)
+    parsed.getPrefixMapping.clearNsPrefixMap()
+    parsed.toString
+  }
+
+  override def spec: Spec[TestEnvironment, Any] = suite("GetAllOntologiesMetadataQuerySpec")(
+    test("should produce the same SELECT query as the legacy builder") {
+      val actual = GetAllOntologiesMetadataQuery.build.sparql
+      assertTrue(
+        canonical(actual) == canonical(
+          """PREFIX owl: <http://www.w3.org/2002/07/owl#>
+            |SELECT ?ontologyGraph ?ontologyIri ?ontologyPred ?ontologyObj
+            |WHERE { GRAPH ?ontologyGraph { ?ontologyIri a owl:Ontology ;
+            |    ?ontologyPred ?ontologyObj . } }""".stripMargin,
+        ),
+      )
+    },
+  )
+}

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/GetOntologyGraphQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/GetOntologyGraphQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.ontology.repo
 
+import org.apache.jena.query.QueryFactory
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -18,17 +19,21 @@ class GetOntologyGraphQuerySpec extends ZIOSpecDefault {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
+  private def canonical(query: String): String = QueryFactory.create(query).toString
+
   private val testOntologyIri: OntologyIri =
     OntologyIri.unsafeFrom("http://www.knora.org/ontology/0001/anything".toSmartIri)
 
   override def spec: Spec[TestEnvironment, Any] = suite("GetOntologyGraphQuerySpec")(
     suite("build")(
       test("should produce the correct CONSTRUCT query for getting an ontology graph") {
-        val actual = GetOntologyGraphQuery.build(testOntologyIri).getQueryString
+        val actual = GetOntologyGraphQuery.build(testOntologyIri).sparql
         assertTrue(
-          actual == """CONSTRUCT { ?s ?p ?o . }
-                      |WHERE { GRAPH <http://www.knora.org/ontology/0001/anything> { ?s ?p ?o . } }
-                      |""".stripMargin,
+          canonical(actual) == canonical(
+            """CONSTRUCT { ?s ?p ?o . }
+              |WHERE { GRAPH <http://www.knora.org/ontology/0001/anything> { ?s ?p ?o . } }
+              |""".stripMargin,
+          ),
         )
       },
     ),

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/UpdateOntologyMetadataQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/UpdateOntologyMetadataQuerySpec.scala
@@ -6,6 +6,7 @@
 package org.knora.webapi.slice.ontology.repo
 
 import eu.timepit.refined.types.string.NonEmptyString
+import org.apache.jena.update.UpdateFactory
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
@@ -23,6 +24,12 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 class UpdateOntologyMetadataQuerySpec extends ZIOSpecDefault {
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
+
+  private def canonical(query: String): String = {
+    val update = UpdateFactory.create(query)
+    update.getPrefixMapping.clearNsPrefixMap()
+    update.toString
+  }
 
   private val testOntologyIri: OntologyIri =
     OntologyIri.unsafeFrom("http://www.knora.org/ontology/0001/anything".toSmartIri)
@@ -42,18 +49,20 @@ class UpdateOntologyMetadataQuerySpec extends ZIOSpecDefault {
           )
           .map { (actual: Update) =>
             assertTrue(
-              actual.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
-                                 |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
-                                 |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel .
-                                 |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
-                                 |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
-                                 |<http://www.knora.org/ontology/0001/anything> rdfs:label "Updated Ontology Label"^^xsd:string . } }
-                                 |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
-                                 |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel . } }""".stripMargin,
+              canonical(actual.sparql) == canonical(
+                """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                  |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                  |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                  |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
+                  |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel .
+                  |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
+                  |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
+                  |<http://www.knora.org/ontology/0001/anything> rdfs:label "Updated Ontology Label"^^xsd:string . } }
+                  |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
+                  |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+                  |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel . } }""".stripMargin,
+              ),
             )
           }
       },
@@ -67,18 +76,20 @@ class UpdateOntologyMetadataQuerySpec extends ZIOSpecDefault {
           )
           .map { (actual: Update) =>
             assertTrue(
-              actual.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
-                                 |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
-                                 |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment .
-                                 |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
-                                 |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
-                                 |<http://www.knora.org/ontology/0001/anything> rdfs:comment "Updated ontology comment"^^xsd:string . } }
-                                 |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
-                                 |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment . } }""".stripMargin,
+              canonical(actual.sparql) == canonical(
+                """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                  |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                  |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                  |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
+                  |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment .
+                  |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
+                  |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
+                  |<http://www.knora.org/ontology/0001/anything> rdfs:comment "Updated ontology comment"^^xsd:string . } }
+                  |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
+                  |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+                  |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment . } }""".stripMargin,
+              ),
             )
           }
       },
@@ -92,21 +103,23 @@ class UpdateOntologyMetadataQuerySpec extends ZIOSpecDefault {
           )
           .map { (actual: Update) =>
             assertTrue(
-              actual.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
-                                 |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
-                                 |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel .
-                                 |<http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment .
-                                 |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
-                                 |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
-                                 |<http://www.knora.org/ontology/0001/anything> rdfs:label "New Label"^^xsd:string .
-                                 |<http://www.knora.org/ontology/0001/anything> rdfs:comment "New comment"^^xsd:string . } }
-                                 |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
-                                 |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel . }
-                                 |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment . } }""".stripMargin,
+              canonical(actual.sparql) == canonical(
+                """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                  |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                  |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                  |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
+                  |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel .
+                  |<http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment .
+                  |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
+                  |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
+                  |<http://www.knora.org/ontology/0001/anything> rdfs:label "New Label"^^xsd:string .
+                  |<http://www.knora.org/ontology/0001/anything> rdfs:comment "New comment"^^xsd:string . } }
+                  |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
+                  |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+                  |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel . }
+                  |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment . } }""".stripMargin,
+              ),
             )
           }
       },
@@ -131,18 +144,20 @@ class UpdateOntologyMetadataQuerySpec extends ZIOSpecDefault {
           )
           .map { (actual: Update) =>
             assertTrue(
-              actual.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
-                                 |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
-                                 |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel .
-                                 |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
-                                 |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
-                                 |<http://www.knora.org/ontology/0001/anything> rdfs:label "Label with \"quotes\" and \'apostrophes\'"^^xsd:string . } }
-                                 |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
-                                 |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel . } }""".stripMargin,
+              canonical(actual.sparql) == canonical(
+                """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                  |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                  |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                  |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
+                  |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel .
+                  |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
+                  |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
+                  |<http://www.knora.org/ontology/0001/anything> rdfs:label "Label with \"quotes\" and \'apostrophes\'"^^xsd:string . } }
+                  |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
+                  |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+                  |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:label ?oldLabel . } }""".stripMargin,
+              ),
             )
           }
       },
@@ -156,18 +171,20 @@ class UpdateOntologyMetadataQuerySpec extends ZIOSpecDefault {
           )
           .map { (actual: Update) =>
             assertTrue(
-              actual.sparql == """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-                                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
-                                 |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
-                                 |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment .
-                                 |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
-                                 |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
-                                 |<http://www.knora.org/ontology/0001/anything> rdfs:comment "Comment with \"quotes\" and newlines\nand tabs\t"^^xsd:string . } }
-                                 |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
-                                 |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
-                                 |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment . } }""".stripMargin,
+              canonical(actual.sparql) == canonical(
+                """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                  |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                  |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                  |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
+                  |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment .
+                  |<http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime . } }
+                  |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime .
+                  |<http://www.knora.org/ontology/0001/anything> rdfs:comment "Comment with \"quotes\" and newlines\nand tabs\t"^^xsd:string . } }
+                  |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
+                  |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+                  |OPTIONAL { <http://www.knora.org/ontology/0001/anything> rdfs:comment ?oldComment . } }""".stripMargin,
+              ),
             )
           }
       },


### PR DESCRIPTION
### Description

Migrates the ontology lifecycle and metadata query batch from RDF4J SparqlBuilder to the typed interpolated SPARQL DSL:

- `CheckIriExistsQuery` (ASK)
- `GetAllOntologiesMetadataQuery` (SELECT)
- `GetOntologyGraphQuery` (CONSTRUCT)
- `CreateOntologyQuery` (INSERT … WHERE FILTER NOT EXISTS)
- `UpdateOntologyMetadataQuery` (DELETE/INSERT with optional label/comment)
- `DeleteOntologyQuery`

Builders return the `TriplestoreService.Queries` wrappers (`Ask`/`Select`/`Construct`/`Update`) instead of RDF4J query objects; the callers in `OntologyResponderV2` and `OntologyCache` are adjusted accordingly. Graph scoping, the `lastModificationDate` precondition/update, the `FILTER NOT EXISTS` guard on create and the `OPTIONAL` label/comment patterns on update are preserved.

`CreateOntologyQuery` no longer needs the string-surgery workaround for RDF4J dropping a lone `FILTER NOT EXISTS` (eclipse-rdf4j/rdf4j#5561).

Label and comment literals are now plain string literals instead of `^^xsd:string`; these are the same RDF 1.1 term, and the Jena canonical comparison in the specs confirms it. `CheckIriExistsQuery.build(String)` now rejects IRIs that could break out of the `<…>` wrapper (previously they produced a malformed query).

### Verification

- `bazel test //modules/webapi:test --test_filter='.*(CheckIriExists|DeleteOntology|GetOntologyGraph|GetAllOntologiesMetadata|CreateOntology|UpdateOntologyMetadata)QuerySpec.*'` (19 tests passed)
- `just check`

Part of DEV-7150. Fixes DEV-7203

## Readability retrofit

This PR also carries the convention docs for the whole stack: a new section "Keep the query readable: one explicit template per query" in `docs/development/dsp-api-sparql-queries.md`, plus pointers in `CONVENTIONS.md`. Every query in the stack was retrofitted to follow it (prefixes literal in each template, no shared prefix fragments, no static sub-segment vals; only value holes and genuinely dynamic structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

