### PR TITLE
refactor: migrate list-node read queries to interpolated SPARQL DSL (DEV-7205)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetListNodeQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetListNodeQuery.scala
@@ -5,15 +5,21 @@
 
 package org.knora.webapi.slice.resources.repo
 
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ConstructQuery
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
 
-object GetListNodeQuery extends QueryBuilderHelper {
-  def build(nodeIri: ListIri): ConstructQuery =
-    val (node, p, o) = (toRdfIri(nodeIri), variable("p"), variable("o"))
-    Queries.CONSTRUCT(node.has(p, o)).prefix(KnoraBase.NS).where(node.isA(KnoraBase.ListNode).andHas(p, o))
+object GetListNodeQuery {
+  def build(nodeIri: ListIri): Construct = {
+    val node = Iri.unsafeFrom(nodeIri.value)
+    Construct(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |CONSTRUCT { $node ?p ?o . }
+               |WHERE {
+               |  $node a knora-base:ListNode ;
+               |        ?p ?o .
+               |}""".render,
+    )
+  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetListNodeWithChildrenQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetListNodeWithChildrenQuery.scala
@@ -5,23 +5,22 @@
 
 package org.knora.webapi.slice.resources.repo
 
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ConstructQuery
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
 
-object GetListNodeWithChildrenQuery extends QueryBuilderHelper {
-  def build(nodeIri: ListIri): ConstructQuery =
-    val (node, p, o) = (variable("node"), variable("p"), variable("o"))
-    val startNode    = toRdfIri(nodeIri)
-    Queries
-      .CONSTRUCT(node.has(p, o))
-      .prefix(KnoraBase.NS)
-      .where(
-        startNode
-          .has(zeroOrMore(KnoraBase.hasSubListNode), node)
-          .and(node.isA(KnoraBase.ListNode).andHas(p, o)),
-      )
+object GetListNodeWithChildrenQuery {
+  def build(nodeIri: ListIri): Construct = {
+    val startNode = Iri.unsafeFrom(nodeIri.value)
+    Construct(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |CONSTRUCT { ?node ?p ?o . }
+               |WHERE {
+               |  $startNode knora-base:hasSubListNode* ?node .
+               |  ?node a knora-base:ListNode ;
+               |        ?p ?o .
+               |}""".render,
+    )
+  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetParentNodeQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetParentNodeQuery.scala
@@ -5,23 +5,22 @@
 
 package org.knora.webapi.slice.resources.repo
 
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ConstructQuery
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
 
-object GetParentNodeQuery extends QueryBuilderHelper {
-  def build(nodeIri: ListIri): ConstructQuery =
-    val node      = toRdfIri(nodeIri)
-    val (s, p, o) = spo
-    Queries
-      .CONSTRUCT(s.has(p, o))
-      .prefix(KnoraBase.NS)
-      .where(
-        s.isA(KnoraBase.ListNode)
-          .andHas(KnoraBase.hasSubListNode, node)
-          .andHas(p, o),
-      )
+object GetParentNodeQuery {
+  def build(nodeIri: ListIri): Construct = {
+    val node = Iri.unsafeFrom(nodeIri.value)
+    Construct(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |CONSTRUCT { ?s ?p ?o . }
+               |WHERE {
+               |  ?s a knora-base:ListNode ;
+               |     knora-base:hasSubListNode $node ;
+               |     ?p ?o .
+               |}""".render,
+    )
+  }
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetListNodeQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetListNodeQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.resources.repo
 
+import org.apache.jena.query.QueryFactory
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -14,42 +15,51 @@ import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 @RunWith(classOf[DspZTestJUnitRunner])
 class GetListNodeQuerySpec extends ZIOSpecDefault {
 
+  private def canonical(query: String): String = {
+    val parsed = QueryFactory.create(query)
+    parsed.getPrefixMapping.clearNsPrefixMap()
+    parsed.toString
+  }
+
   private val testNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/test-node")
 
   override def spec: Spec[TestEnvironment, Any] = suite("GetListNodeQuerySpec")(
     test("should produce correct CONSTRUCT query for list node") {
-      val actual = GetListNodeQuery.build(testNodeIri).getQueryString
+      val actual = GetListNodeQuery.build(testNodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { <http://rdfh.ch/lists/0001/test-node> ?p ?o . }
             |WHERE { <http://rdfh.ch/lists/0001/test-node> a knora-base:ListNode ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
     test("should produce correct query for different node IRI") {
       val differentNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/another-node")
-      val actual           = GetListNodeQuery.build(differentNodeIri).getQueryString
+      val actual           = GetListNodeQuery.build(differentNodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { <http://rdfh.ch/lists/0001/another-node> ?p ?o . }
             |WHERE { <http://rdfh.ch/lists/0001/another-node> a knora-base:ListNode ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
     test("should produce correct query for node with different project") {
       val nodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0803/book-list-node")
-      val actual  = GetListNodeQuery.build(nodeIri).getQueryString
+      val actual  = GetListNodeQuery.build(nodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { <http://rdfh.ch/lists/0803/book-list-node> ?p ?o . }
             |WHERE { <http://rdfh.ch/lists/0803/book-list-node> a knora-base:ListNode ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
   )

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetListNodeWithChildrenQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetListNodeWithChildrenQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.resources.repo
 
+import org.apache.jena.query.QueryFactory
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -14,45 +15,54 @@ import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 @RunWith(classOf[DspZTestJUnitRunner])
 class GetListNodeWithChildrenQuerySpec extends ZIOSpecDefault {
 
+  private def canonical(query: String): String = {
+    val parsed = QueryFactory.create(query)
+    parsed.getPrefixMapping.clearNsPrefixMap()
+    parsed.toString
+  }
+
   private val testNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/test-node")
 
   override def spec: Spec[TestEnvironment, Any] = suite("GetListNodeWithChildrenQuerySpec")(
     test("should produce correct CONSTRUCT query for list node with children") {
-      val actual = GetListNodeWithChildrenQuery.build(testNodeIri).getQueryString
+      val actual = GetListNodeWithChildrenQuery.build(testNodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { ?node ?p ?o . }
             |WHERE { <http://rdfh.ch/lists/0001/test-node> knora-base:hasSubListNode* ?node .
             |?node a knora-base:ListNode ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
     test("should produce correct query for different node IRI") {
       val differentNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/parent-node")
-      val actual           = GetListNodeWithChildrenQuery.build(differentNodeIri).getQueryString
+      val actual           = GetListNodeWithChildrenQuery.build(differentNodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { ?node ?p ?o . }
             |WHERE { <http://rdfh.ch/lists/0001/parent-node> knora-base:hasSubListNode* ?node .
             |?node a knora-base:ListNode ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
     test("should produce correct query for node with different project") {
       val nodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0803/book-list-root")
-      val actual  = GetListNodeWithChildrenQuery.build(nodeIri).getQueryString
+      val actual  = GetListNodeWithChildrenQuery.build(nodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { ?node ?p ?o . }
             |WHERE { <http://rdfh.ch/lists/0803/book-list-root> knora-base:hasSubListNode* ?node .
             |?node a knora-base:ListNode ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
   )

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetParentNodeQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetParentNodeQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.resources.repo
 
+import org.apache.jena.query.QueryFactory
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -14,45 +15,54 @@ import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
 @RunWith(classOf[DspZTestJUnitRunner])
 class GetParentNodeQuerySpec extends ZIOSpecDefault {
 
+  private def canonical(query: String): String = {
+    val parsed = QueryFactory.create(query)
+    parsed.getPrefixMapping.clearNsPrefixMap()
+    parsed.toString
+  }
+
   private val testNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/test-node")
 
   override def spec: Spec[TestEnvironment, Any] = suite("GetParentNodeQuerySpec")(
     test("should produce correct CONSTRUCT query for parent node") {
-      val actual = GetParentNodeQuery.build(testNodeIri).getQueryString
+      val actual = GetParentNodeQuery.build(testNodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { ?s ?p ?o . }
             |WHERE { ?s a knora-base:ListNode ;
             |    knora-base:hasSubListNode <http://rdfh.ch/lists/0001/test-node> ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
     test("should produce correct query for different node IRI") {
       val differentNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/child-node")
-      val actual           = GetParentNodeQuery.build(differentNodeIri).getQueryString
+      val actual           = GetParentNodeQuery.build(differentNodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { ?s ?p ?o . }
             |WHERE { ?s a knora-base:ListNode ;
             |    knora-base:hasSubListNode <http://rdfh.ch/lists/0001/child-node> ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
     test("should produce correct query for node with different project") {
       val nodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0803/book-category")
-      val actual  = GetParentNodeQuery.build(nodeIri).getQueryString
+      val actual  = GetParentNodeQuery.build(nodeIri).sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |CONSTRUCT { ?s ?p ?o . }
             |WHERE { ?s a knora-base:ListNode ;
             |    knora-base:hasSubListNode <http://rdfh.ch/lists/0803/book-category> ;
             |    ?p ?o . }
             |""".stripMargin,
+        ),
       )
     },
   )


### PR DESCRIPTION
### Description

Stacked on #4295. Migrates the list-node read batch from RDF4J SparqlBuilder to the typed interpolated SPARQL DSL:

- `GetListNodeQuery` (CONSTRUCT one node)
- `GetListNodeWithChildrenQuery` (CONSTRUCT node and all descendants via `knora-base:hasSubListNode*`)
- `GetParentNodeQuery` (CONSTRUCT the parent of a node)

Builders return `Construct` directly instead of an RDF4J `ConstructQuery`. Callers in `ListsResponder` and `ResourceUtilV2` already go through `triplestore.query(...)` and need no change. Type checks, variable names and the zero-or-more property path are preserved; the specs compare the new output with the untouched legacy rendering through Jena canonical form.

### Verification

- `bazel test //modules/webapi:test --test_filter='.*(GetListNode|GetListNodeWithChildren|GetParentNode)QuerySpec.*'` (9 tests passed)
- `ReadResourcesServiceLiveSpec` and `ExportServiceSpec` (pull in `ListsResponder`) pass
- `just check`

Part of DEV-7150. Fixes DEV-7205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
