### PR TITLE
refactor: migrate list-node deletion and existence-check queries to interpolated SPARQL DSL (DEV-7207)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/AskListNameInProjectExistsQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/AskListNameInProjectExistsQuery.scala
@@ -4,25 +4,26 @@
  */
 
 package org.knora.webapi.slice.resources.repo
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.PropertyPathBuilder
 
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject.ProjectIri
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListName
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 
-object AskListNameInProjectExistsQuery extends QueryBuilderHelper {
+object AskListNameInProjectExistsQuery {
 
   def build(name: ListName, projectIri: ProjectIri): Ask = {
-    val rootNodeVar = variable("rootNode")
-    val nodeVar     = variable("node")
-    val askPattern  = rootNodeVar
-      .has(RDF.TYPE, KnoraBase.ListNode)
-      .andHas(KnoraBase.attachedToProject, toRdfIri(projectIri))
-      .andHas(PropertyPathBuilder.of(KnoraBase.hasSubListNode).zeroOrMore().build(), nodeVar)
-      .and(nodeVar.has(KnoraBase.listNodeName, name.value))
-    Ask(s"ASK ${askPattern.getQueryString} ")
+    val project  = Iri.unsafeFrom(projectIri.value)
+    val listName = Literal.string(name.value)
+    Ask(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |ASK {
+               |  ?rootNode a knora-base:ListNode ;
+               |    knora-base:attachedToProject $project ;
+               |    knora-base:hasSubListNode* ?node .
+               |  ?node knora-base:listNodeName $listName .
+               |}""".render,
+    )
   }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteNodeQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/DeleteNodeQuery.scala
@@ -4,38 +4,51 @@
  */
 
 package org.knora.webapi.slice.resources.repo
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ModifyQuery
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
 
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.admin.domain.model.KnoraProject
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
+import org.knora.webapi.slice.admin.domain.service.ProjectService
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
-object DeleteNodeQuery extends QueryBuilderHelper {
-  def buildForChildNode(nodeIri: ListIri, project: KnoraProject): ModifyQuery =
-    val node               = toRdfIri(nodeIri)
-    val (parentNode, p, o) = (variable("parentNode"), variable("p"), variable("o"))
-    Queries
-      .MODIFY()
-      .prefix(KnoraBase.NS, RDF.NS)
-      .delete(node.has(p, o), parentNode.has(KnoraBase.hasSubListNode, node))
-      .from(graphIri(project))
-      .where(
-        node
-          .isA(KnoraBase.ListNode)
-          .andHas(p, o)
-          .and(parentNode.isA(KnoraBase.ListNode).andHas(KnoraBase.hasSubListNode, node)),
-      )
+object DeleteNodeQuery {
 
-  def buildForRootNode(nodeIri: ListIri, project: KnoraProject): ModifyQuery =
-    val node   = toRdfIri(nodeIri)
-    val (p, o) = (variable("p"), variable("o"))
-    Queries
-      .MODIFY()
-      .prefix(KnoraBase.NS, RDF.NS)
-      .delete(node.has(p, o))
-      .from(graphIri(project))
-      .where(node.isA(KnoraBase.ListNode).andHas(p, o))
+  def buildForChildNode(nodeIri: ListIri, project: KnoraProject): Update = {
+    val graph = Iri.unsafeFrom(ProjectService.projectDataNamedGraphV2(project).value)
+    val node  = Iri.unsafeFrom(nodeIri.value)
+    Update(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |DELETE {
+               |  GRAPH $graph {
+               |    $node ?p ?o .
+               |    ?parentNode knora-base:hasSubListNode $node .
+               |  }
+               |}
+               |WHERE {
+               |  $node a knora-base:ListNode ;
+               |    ?p ?o .
+               |  ?parentNode a knora-base:ListNode ;
+               |    knora-base:hasSubListNode $node .
+               |}""".render,
+    )
+  }
+
+  def buildForRootNode(nodeIri: ListIri, project: KnoraProject): Update = {
+    val graph = Iri.unsafeFrom(ProjectService.projectDataNamedGraphV2(project).value)
+    val node  = Iri.unsafeFrom(nodeIri.value)
+    Update(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |DELETE {
+               |  GRAPH $graph {
+               |    $node ?p ?o .
+               |  }
+               |}
+               |WHERE {
+               |  $node a knora-base:ListNode ;
+               |    ?p ?o .
+               |}""".render,
+    )
+  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/IsNodeUsedQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/IsNodeUsedQuery.scala
@@ -5,31 +5,28 @@
 
 package org.knora.webapi.slice.resources.repo
 
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
-
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.SalsahGui
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 
-object IsNodeUsedQuery extends QueryBuilderHelper {
+object IsNodeUsedQuery {
 
   def build(nodeIri: ListIri): Ask = {
-    val s = variable("s")
-    // Pattern 1: Check if used in salsah-gui:guiAttribute
-    val guiAttributePattern = s.has(SalsahGui.guiAttribute, Rdf.literalOf(s"hlist=<$nodeIri>")).getQueryString
-    // Pattern 2: Check if used in knora-base:valueHasListNode
-    val valueHasListNodePattern = s.has(KnoraBase.valueHasListNode, toRdfIri(nodeIri)).getQueryString
-    Ask(s"""
-           |ASK
-           |WHERE {
-           |  {
-           |    $guiAttributePattern
-           |  } UNION {
-           |    $valueHasListNodePattern
-           |  }
-           |}
-           |""".stripMargin)
+    val node = Iri.unsafeFrom(nodeIri.value)
+    // The gui attribute references the node as a string of the form `hlist=<nodeIri>`.
+    val guiAttributeValue = Literal.string(s"hlist=<${nodeIri.value}>")
+    Ask(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>
+               |
+               |ASK
+               |WHERE {
+               |  {
+               |    ?s salsah-gui:guiAttribute $guiAttributeValue .
+               |  } UNION {
+               |    ?s knora-base:valueHasListNode $node .
+               |  }
+               |}""".render,
+    )
   }
 }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/AskListNameInProjectExistsQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/AskListNameInProjectExistsQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.resources.repo
 
+import org.apache.jena.query.QueryFactory
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -16,6 +17,12 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Ask
 @RunWith(classOf[DspZTestJUnitRunner])
 class AskListNameInProjectExistsQuerySpec extends ZIOSpecDefault {
 
+  private def canonical(query: String): String = {
+    val parsed = QueryFactory.create(query)
+    parsed.getPrefixMapping.clearNsPrefixMap()
+    parsed.toString
+  }
+
   private val testListName    = ListName.unsafeFrom("testList")
   private val testProjectIri  = ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001")
   private val testListName2   = ListName.unsafeFrom("my-special-list")
@@ -26,22 +33,24 @@ class AskListNameInProjectExistsQuerySpec extends ZIOSpecDefault {
       val actual: Ask = AskListNameInProjectExistsQuery.build(testListName, testProjectIri)
 
       assertTrue(
-        actual.sparql ==
+        canonical(actual.sparql) == canonical(
           """ASK { ?rootNode <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.knora.org/ontology/knora-base#ListNode> ;
             |    <http://www.knora.org/ontology/knora-base#attachedToProject> <http://rdfh.ch/projects/0001> ;
             |    <http://www.knora.org/ontology/knora-base#hasSubListNode>* ?node .
             |?node <http://www.knora.org/ontology/knora-base#listNodeName> "testList" . } """.stripMargin,
+        ),
       )
     },
     test("should produce correct ASK query with list name containing hyphens") {
       val actual: Ask = AskListNameInProjectExistsQuery.build(testListName2, testProjectIri2)
 
       assertTrue(
-        actual.sparql ==
+        canonical(actual.sparql) == canonical(
           """ASK { ?rootNode <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.knora.org/ontology/knora-base#ListNode> ;
             |    <http://www.knora.org/ontology/knora-base#attachedToProject> <http://rdfh.ch/projects/0042> ;
             |    <http://www.knora.org/ontology/knora-base#hasSubListNode>* ?node .
             |?node <http://www.knora.org/ontology/knora-base#listNodeName> "my-special-list" . } """.stripMargin,
+        ),
       )
     },
     test("should produce correct ASK query with list name containing special characters") {
@@ -49,11 +58,12 @@ class AskListNameInProjectExistsQuerySpec extends ZIOSpecDefault {
       val actual: Ask     = AskListNameInProjectExistsQuery.build(specialListName, testProjectIri)
 
       assertTrue(
-        actual.sparql ==
+        canonical(actual.sparql) == canonical(
           """ASK { ?rootNode <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.knora.org/ontology/knora-base#ListNode> ;
             |    <http://www.knora.org/ontology/knora-base#attachedToProject> <http://rdfh.ch/projects/0001> ;
             |    <http://www.knora.org/ontology/knora-base#hasSubListNode>* ?node .
             |?node <http://www.knora.org/ontology/knora-base#listNodeName> "list_with_underscores_123" . } """.stripMargin,
+        ),
       )
     },
     test("should produce correct ASK query with different project shortcode") {
@@ -62,11 +72,12 @@ class AskListNameInProjectExistsQuerySpec extends ZIOSpecDefault {
       val actual: Ask = AskListNameInProjectExistsQuery.build(listName, projectIri)
 
       assertTrue(
-        actual.sparql ==
+        canonical(actual.sparql) == canonical(
           """ASK { ?rootNode <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.knora.org/ontology/knora-base#ListNode> ;
             |    <http://www.knora.org/ontology/knora-base#attachedToProject> <http://rdfh.ch/projects/00FF> ;
             |    <http://www.knora.org/ontology/knora-base#hasSubListNode>* ?node .
             |?node <http://www.knora.org/ontology/knora-base#listNodeName> "images" . } """.stripMargin,
+        ),
       )
     },
   )

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteNodeQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/DeleteNodeQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.resources.repo
 
+import org.apache.jena.update.UpdateFactory
 import org.junit.runner.RunWith
 import zio.NonEmptyChunk
 import zio.test.*
@@ -18,6 +19,12 @@ import org.knora.webapi.slice.admin.domain.model.RestrictedView
 
 @RunWith(classOf[DspZTestJUnitRunner])
 class DeleteNodeQuerySpec extends ZIOSpecDefault {
+
+  private def canonical(query: String): String = {
+    val update = UpdateFactory.create(query)
+    update.getPrefixMapping.clearNsPrefixMap()
+    update.toString
+  }
 
   private val testProject = KnoraProject(
     ProjectIri.unsafeFrom("http://rdfh.ch/projects/0001"),
@@ -38,9 +45,9 @@ class DeleteNodeQuerySpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment, Any] = suite("DeleteNodeQuerySpec")(
     suite("buildForChildNode")(
       test("should produce correct query for deleting child node") {
-        val actual = DeleteNodeQuery.buildForChildNode(testNodeIri, testProject).getQueryString
+        val actual = DeleteNodeQuery.buildForChildNode(testNodeIri, testProject).sparql
         assertTrue(
-          actual ==
+          canonical(actual) == canonical(
             """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
               |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/lists/0001/test-node> ?p ?o .
@@ -49,13 +56,14 @@ class DeleteNodeQuerySpec extends ZIOSpecDefault {
               |    ?p ?o .
               |?parentNode a knora-base:ListNode ;
               |    knora-base:hasSubListNode <http://rdfh.ch/lists/0001/test-node> . }""".stripMargin,
+          ),
         )
       },
       test("should produce correct query for different node IRI") {
         val differentNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/another-node")
-        val actual           = DeleteNodeQuery.buildForChildNode(differentNodeIri, testProject).getQueryString
+        val actual           = DeleteNodeQuery.buildForChildNode(differentNodeIri, testProject).sparql
         assertTrue(
-          actual ==
+          canonical(actual) == canonical(
             """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
               |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/lists/0001/another-node> ?p ?o .
@@ -64,6 +72,7 @@ class DeleteNodeQuerySpec extends ZIOSpecDefault {
               |    ?p ?o .
               |?parentNode a knora-base:ListNode ;
               |    knora-base:hasSubListNode <http://rdfh.ch/lists/0001/another-node> . }""".stripMargin,
+          ),
         )
       },
       test("should produce correct query for different project") {
@@ -81,9 +90,9 @@ class DeleteNodeQuerySpec extends ZIOSpecDefault {
           Set.empty,
         )
         val nodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0803/book-list-node")
-        val actual  = DeleteNodeQuery.buildForChildNode(nodeIri, otherProject).getQueryString
+        val actual  = DeleteNodeQuery.buildForChildNode(nodeIri, otherProject).sparql
         assertTrue(
-          actual ==
+          canonical(actual) == canonical(
             """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
               |DELETE { GRAPH <http://www.knora.org/data/0803/incunabula> { <http://rdfh.ch/lists/0803/book-list-node> ?p ?o .
@@ -92,31 +101,34 @@ class DeleteNodeQuerySpec extends ZIOSpecDefault {
               |    ?p ?o .
               |?parentNode a knora-base:ListNode ;
               |    knora-base:hasSubListNode <http://rdfh.ch/lists/0803/book-list-node> . }""".stripMargin,
+          ),
         )
       },
     ),
     suite("buildForRootNode")(
       test("should produce correct query for deleting root node") {
-        val actual = DeleteNodeQuery.buildForRootNode(testNodeIri, testProject).getQueryString
+        val actual = DeleteNodeQuery.buildForRootNode(testNodeIri, testProject).sparql
         assertTrue(
-          actual ==
+          canonical(actual) == canonical(
             """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
               |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/lists/0001/test-node> ?p ?o . } }
               |WHERE { <http://rdfh.ch/lists/0001/test-node> a knora-base:ListNode ;
               |    ?p ?o . }""".stripMargin,
+          ),
         )
       },
       test("should produce correct query for different node IRI") {
         val differentNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/root-node")
-        val actual           = DeleteNodeQuery.buildForRootNode(differentNodeIri, testProject).getQueryString
+        val actual           = DeleteNodeQuery.buildForRootNode(differentNodeIri, testProject).sparql
         assertTrue(
-          actual ==
+          canonical(actual) == canonical(
             """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
               |DELETE { GRAPH <http://www.knora.org/data/0001/anything> { <http://rdfh.ch/lists/0001/root-node> ?p ?o . } }
               |WHERE { <http://rdfh.ch/lists/0001/root-node> a knora-base:ListNode ;
               |    ?p ?o . }""".stripMargin,
+          ),
         )
       },
       test("should produce correct query for different project") {
@@ -134,14 +146,15 @@ class DeleteNodeQuerySpec extends ZIOSpecDefault {
           Set.empty,
         )
         val nodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0803/root-book-list")
-        val actual  = DeleteNodeQuery.buildForRootNode(nodeIri, otherProject).getQueryString
+        val actual  = DeleteNodeQuery.buildForRootNode(nodeIri, otherProject).sparql
         assertTrue(
-          actual ==
+          canonical(actual) == canonical(
             """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
               |DELETE { GRAPH <http://www.knora.org/data/0803/incunabula> { <http://rdfh.ch/lists/0803/root-book-list> ?p ?o . } }
               |WHERE { <http://rdfh.ch/lists/0803/root-book-list> a knora-base:ListNode ;
               |    ?p ?o . }""".stripMargin,
+          ),
         )
       },
     ),

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/IsNodeUsedQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/IsNodeUsedQuerySpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.resources.repo
+
+import org.apache.jena.query.QueryFactory
+import org.junit.runner.RunWith
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+import org.knora.webapi.slice.admin.domain.model.ListProperties.ListIri
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class IsNodeUsedQuerySpec extends ZIOSpecDefault {
+
+  private def canonical(query: String): String = {
+    val parsed = QueryFactory.create(query)
+    parsed.getPrefixMapping.clearNsPrefixMap()
+    parsed.toString
+  }
+
+  private val testNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0001/test-node")
+
+  override def spec: Spec[TestEnvironment, Any] = suite("IsNodeUsedQuerySpec")(
+    test("should produce correct ASK query for a node IRI") {
+      val actual = IsNodeUsedQuery.build(testNodeIri).sparql
+      assertTrue(
+        canonical(actual) == canonical(
+          """ASK
+            |WHERE {
+            |  {
+            |    ?s <http://www.knora.org/ontology/salsah-gui#guiAttribute> "hlist=<http://rdfh.ch/lists/0001/test-node>" .
+            |  } UNION {
+            |    ?s <http://www.knora.org/ontology/knora-base#valueHasListNode> <http://rdfh.ch/lists/0001/test-node> .
+            |  }
+            |}""".stripMargin,
+        ),
+      )
+    },
+    test("should produce correct ASK query for a different node IRI") {
+      val differentNodeIri = ListIri.unsafeFrom("http://rdfh.ch/lists/0803/another-node")
+      val actual           = IsNodeUsedQuery.build(differentNodeIri).sparql
+      assertTrue(
+        canonical(actual) == canonical(
+          """ASK
+            |WHERE {
+            |  {
+            |    ?s <http://www.knora.org/ontology/salsah-gui#guiAttribute> "hlist=<http://rdfh.ch/lists/0803/another-node>" .
+            |  } UNION {
+            |    ?s <http://www.knora.org/ontology/knora-base#valueHasListNode> <http://rdfh.ch/lists/0803/another-node> .
+            |  }
+            |}""".stripMargin,
+        ),
+      )
+    },
+  )
+}


### PR DESCRIPTION
### Description

Stacked on #4298. Migrates the last list-node batch from RDF4J SparqlBuilder to the typed interpolated SPARQL DSL:

- `DeleteNodeQuery` (child-node and root-node variants; DELETE inside the project graph)
- `IsNodeUsedQuery` (ASK with UNION over `salsah-gui:guiAttribute "hlist=<node>"` and `knora-base:valueHasListNode`)
- `AskListNameInProjectExistsQuery` (ASK with `knora-base:hasSubListNode*` from project root nodes to a node with the given name)

`DeleteNodeQuery` returns `Update` directly; the two Ask builders no longer stitch RDF4J fragments into an `s"..."` string. The caller `ListsResponder` needs no change. With this batch the list-node repo queries are fully migrated.

`IsNodeUsedQuery` had no rendering spec; it now has one with the legacy output captured before the migration. All specs compare through Jena canonical form against untouched legacy strings.

### Note for review

The legacy `DeleteNodeQuery` scoped only the DELETE template to the project graph (`.from(graph)` on an RDF4J `MODIFY` emits neither `WITH` nor `USING`) and left the WHERE clause unscoped. This PR reproduces that as-is, since it is a port and not a behaviour change. `ChangeParentNodeQuery` in #4298 uses `WITH <graph>`, which scopes both. Aligning `DeleteNodeQuery` to `WITH` is a plausible follow-up but should be its own decision.

### Verification

- `bazel test //modules/webapi:test --test_filter='.*(DeleteNode|IsNodeUsed|AskListNameInProjectExists)QuerySpec.*'` (12 tests passed)
- `ReadResourcesServiceLiveSpec` and `ExportServiceSpec` (wire `ListsResponder`) pass
- `just check`

Part of DEV-7150. Fixes DEV-7207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
