### PR TITLE
refactor: migrate ontology entity deletion and property-usage count queries to interpolated SPARQL DSL (DEV-7209)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1036,7 +1036,7 @@ final class OntologyResponderV2(
 
       currentTimeAndQuery <- DeleteClassQuery.build(classIri, LastModificationDate.from(lastModificationDate))
       (currentTime, query) = currentTimeAndQuery
-      _                   <- save(Update(query))
+      _                   <- save(query)
       updatedOntology      = ontology.copy(
                           ontologyMetadata = ontology.ontologyMetadata.copy(
                             lastModificationDate = Some(currentTime.value),
@@ -1148,7 +1148,7 @@ final class OntologyResponderV2(
                                LastModificationDate.from(lastModificationDate),
                              )
       (currentTime, query) = currentTimeAndQuery
-      _                   <- save(Update(query))
+      _                   <- save(query)
 
       propertiesToRemoveFromCache = Set(internalPropertyIri) ++ maybeInternalLinkValuePropertyIri
       updatedOntology             =

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/CountPropertyUsedWithClassQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/CountPropertyUsedWithClassQuery.scala
@@ -5,22 +5,16 @@
 
 package org.knora.webapi.slice.ontology.repo
 
-import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery
-import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
-import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf
-
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 
 /**
  * Query to count how many times a property is used with instances of a class or its subclasses.
  * Returns all instances of the class with the count of how often each uses the property.
  */
-object CountPropertyUsedWithClassQuery extends QueryBuilderHelper {
+object CountPropertyUsedWithClassQuery {
 
   /**
    * Build a SELECT query that returns all instances of a class with the count of  how many times they use a specific property.
@@ -30,28 +24,23 @@ object CountPropertyUsedWithClassQuery extends QueryBuilderHelper {
    * @param classIri    the IRI of the class to check instances of
    * @return a Select query
    */
-  def build(propertyIri: PropertyIri, classIri: ResourceClassIri): SelectQuery = {
-    val subject     = variable("subject")
-    val count       = variable("count")
-    val objectVar   = variable("object")
-    val propertyVar = toRdfIri(propertyIri)
-    val classVar    = toRdfIri(classIri)
+  def build(propertyIri: PropertyIri, classIri: ResourceClassIri): Select = {
+    val property = Iri.unsafeFrom(propertyIri.toInternalSchema.toIri)
+    val clazz    = Iri.unsafeFrom(classIri.toInternalSchema.toIri)
 
-    val subjectPattern = subject
-      .isA(classVar)
-      .and(GraphPatterns.minus(subject.has(KnoraBase.isDeleted, Rdf.literalOf(true))))
-
-    val optionalPattern = subject
-      .has(propertyVar, objectVar)
-      .and(GraphPatterns.minus(objectVar.has(KnoraBase.isDeleted, Rdf.literalOf(true))))
-      .optional()
-
-    val whereClause = subjectPattern.and(optionalPattern)
-
-    Queries
-      .SELECT(subject, Expressions.count(objectVar).as(count))
-      .prefix(KnoraBase.NS)
-      .where(whereClause)
-      .groupBy(subject)
+    Select(
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |SELECT ?subject (COUNT(?object) AS ?count)
+               |WHERE {
+               |  ?subject a $clazz .
+               |  MINUS { ?subject knora-base:isDeleted true . }
+               |  OPTIONAL {
+               |    ?subject $property ?object .
+               |    MINUS { ?object knora-base:isDeleted true . }
+               |  }
+               |}
+               |GROUP BY ?subject""".render,
+    )
   }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeleteClassQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeleteClassQuery.scala
@@ -5,71 +5,59 @@
 
 package org.knora.webapi.slice.ontology.repo
 
-import org.eclipse.rdf4j.model.vocabulary.OWL
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.XSD
-import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ModifyQuery
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
 import zio.*
 
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
-object DeleteClassQuery extends QueryBuilderHelper {
+object DeleteClassQuery {
 
   def build(
     classIri: ResourceClassIri,
     lmd: LastModificationDate,
-  ): UIO[(LastModificationDate, ModifyQuery)] =
+  ): UIO[(LastModificationDate, Update)] =
     Clock.instant.map { now =>
-      val (ontology, ontologyNS) = ontologyAndNamespace(classIri)
-      val clazz                  = toRdfIri(classIri)
+      val ontology     = Iri.unsafeFrom(classIri.ontologyIri.toInternalSchema.toIri)
+      val clazz        = Iri.unsafeFrom(classIri.toInternalSchema.toIri)
+      val previousDate = Literal.dateTime(lmd.value)
+      val currentDate  = Literal.dateTime(now)
 
-      val classPred       = variable("classPred")
-      val classObj        = variable("classObj")
-      val restriction     = variable("restriction")
-      val restrictionPred = variable("restrictionPred")
-      val restrictionObj  = variable("restrictionObj")
-      val (s, p, _)       = spo
-
-      val deletePatterns = List(
-        ontology.has(KnoraBase.lastModificationDate, toRdfLiteral(lmd)),
-        clazz.has(classPred, classObj),
-        restriction.has(restrictionPred, restrictionObj),
+      val update = Update(
+        sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                 |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                 |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                 |
+                 |DELETE {
+                 |  GRAPH $ontology {
+                 |    $ontology knora-base:lastModificationDate $previousDate .
+                 |    $clazz ?classPred ?classObj .
+                 |    ?restriction ?restrictionPred ?restrictionObj .
+                 |  }
+                 |}
+                 |INSERT {
+                 |  GRAPH $ontology {
+                 |    $ontology knora-base:lastModificationDate $currentDate .
+                 |  }
+                 |}
+                 |WHERE {
+                 |  $ontology a owl:Ontology ;
+                 |    knora-base:lastModificationDate $previousDate .
+                 |  $clazz a owl:Class .
+                 |  {
+                 |    $clazz ?classPred ?classObj .
+                 |  } UNION {
+                 |    $clazz rdfs:subClassOf ?restriction .
+                 |    ?restriction a owl:Restriction ;
+                 |      ?restrictionPred ?restrictionObj .
+                 |    FILTER ( isBlank(?restriction) )
+                 |  }
+                 |  FILTER NOT EXISTS { ?s ?p $clazz . }
+                 |}""".render,
       )
-
-      val wherePatterns = List(
-        ontology.isA(OWL.ONTOLOGY).andHas(KnoraBase.lastModificationDate, toRdfLiteral(lmd)),
-        clazz.isA(OWL.CLASS),
-        GraphPatterns.union(
-          clazz.has(classPred, classObj),
-          clazz
-            .has(RDFS.SUBCLASSOF, restriction)
-            .filter(Expressions.isBlank(restriction))
-            .and(
-              restriction
-                .isA(OWL.RESTRICTION)
-                .andHas(restrictionPred, restrictionObj),
-            ),
-        ),
-        GraphPatterns.filterNotExists(s.has(p, clazz)),
-      )
-
-      (
-        LastModificationDate.from(now),
-        Queries
-          .MODIFY()
-          .prefix(KnoraBase.NS, XSD.NS, RDF.NS, RDFS.NS, OWL.NS, ontologyNS)
-          .delete(deletePatterns*)
-          .from(ontology)
-          .insert(ontology.has(KnoraBase.lastModificationDate, toRdfLiteral(now)))
-          .into(ontology)
-          .where(wherePatterns*),
-      )
+      (LastModificationDate.from(now), update)
     }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuery.scala
@@ -5,56 +5,53 @@
 
 package org.knora.webapi.slice.ontology.repo
 
-import org.eclipse.rdf4j.model.vocabulary.OWL
-import org.eclipse.rdf4j.model.vocabulary.XSD
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ModifyQuery
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries
-import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns
 import zio.*
 
+import org.knora.sparqlbuilder.*
 import org.knora.webapi.slice.api.v2.ontologies.LastModificationDate
 import org.knora.webapi.slice.common.KnoraIris.PropertyIri
-import org.knora.webapi.slice.common.QueryBuilderHelper
-import org.knora.webapi.slice.common.repo.rdf.Vocabulary.KnoraBase
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
-object DeletePropertyQuery extends QueryBuilderHelper {
+object DeletePropertyQuery {
 
   def build(
     propertyIri: PropertyIri,
     linkValuePropertyIri: Option[PropertyIri],
     lmd: LastModificationDate,
-  ): UIO[(LastModificationDate, ModifyQuery)] =
+  ): UIO[(LastModificationDate, Update)] =
     Clock.instant.map { now =>
-      val ontology = toRdfIri(propertyIri.ontologyIri)
-      val property = toRdfIri(propertyIri)
+      val ontology          = Iri.unsafeFrom(propertyIri.ontologyIri.toInternalSchema.toIri)
+      val property          = Iri.unsafeFrom(propertyIri.toInternalSchema.toIri)
+      val linkValueProperty = linkValuePropertyIri.map(iri => Iri.unsafeFrom(iri.toInternalSchema.toIri))
+      val previousDate      = Literal.dateTime(lmd.value)
+      val currentDate       = Literal.dateTime(now)
 
-      val (propertyPred, propertyObj) =
-        (variable("propertyPred"), variable("propertyObj"))
-      val (linkValuePropertyPred, linkValuePropertyObj) =
-        (variable("linkValuePropertyObj"), variable("linkValuePropertyPred"))
-      val (s, p, _) = spo
-
-      val deletePatterns = List(
-        ontology.has(KnoraBase.lastModificationDate, toRdfLiteral(lmd)),
-        property.has(propertyPred, propertyObj),
-      ) ++ linkValuePropertyIri.toList.map(toRdfIri).map(_.has(linkValuePropertyPred, linkValuePropertyObj))
-
-      val wherePatterns = List(
-        ontology.isA(OWL.ONTOLOGY).andHas(KnoraBase.lastModificationDate, toRdfLiteral(lmd)),
-        property.isA(OWL.OBJECTPROPERTY).andHas(propertyPred, propertyObj),
-        GraphPatterns.filterNotExists(s.has(p, property)),
-      ) ++ linkValuePropertyIri.toList.map(toRdfIri).map(_.has(linkValuePropertyPred, linkValuePropertyObj))
-
-      (
-        LastModificationDate.from(now),
-        Queries
-          .MODIFY()
-          .prefix(KnoraBase.NS, XSD.NS, OWL.NS, NS(propertyIri.ontologyIri))
-          .delete(deletePatterns*)
-          .from(ontology)
-          .insert(ontology.has(KnoraBase.lastModificationDate, toRdfLiteral(now)))
-          .into(ontology)
-          .where(wherePatterns*),
+      val update = Update(
+        sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                 |
+                 |DELETE {
+                 |  GRAPH $ontology {
+                 |    $ontology knora-base:lastModificationDate $previousDate .
+                 |    $property ?propertyPred ?propertyObj .
+                 |    ${linkValueProperty.whenSome(iri => sparql"$iri ?linkValuePropertyPred ?linkValuePropertyObj .")}
+                 |  }
+                 |}
+                 |INSERT {
+                 |  GRAPH $ontology {
+                 |    $ontology knora-base:lastModificationDate $currentDate .
+                 |  }
+                 |}
+                 |WHERE {
+                 |  $ontology a owl:Ontology ;
+                 |    knora-base:lastModificationDate $previousDate .
+                 |  $property a owl:ObjectProperty ;
+                 |    ?propertyPred ?propertyObj .
+                 |  FILTER NOT EXISTS { ?s ?p $property . }
+                 |  ${linkValueProperty.whenSome(iri => sparql"$iri ?linkValuePropertyPred ?linkValuePropertyObj .")}
+                 |}""".render,
       )
+      (LastModificationDate.from(now), update)
     }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/PredicateRepositoryLive.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/service/PredicateRepositoryLive.scala
@@ -31,7 +31,7 @@ final class PredicateRepositoryLive(tripleStore: TriplestoreService, iriConverte
     classIri: ResourceClassIri,
   ): Task[List[(ResourceClassIri, Int)]] =
     tripleStore
-      .select(CountPropertyUsedWithClassQuery.build(propertyIri, classIri))
+      .query(CountPropertyUsedWithClassQuery.build(propertyIri, classIri))
       .map(_.map(row => (row.rowMap("subject"), row.rowMap("count").toInt)).toList)
       .flatMap(row =>
         ZIO.foreach(row) { case (subjectIri, count) =>

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/CountPropertyUsedWithClassQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/CountPropertyUsedWithClassQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.ontology.repo
 
+import org.apache.jena.query.QueryFactory
 import org.junit.runner.RunWith
 import zio.test.*
 
@@ -17,6 +18,12 @@ import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 @RunWith(classOf[DspZTestJUnitRunner])
 class CountPropertyUsedWithClassQuerySpec extends ZIOSpecDefault {
 
+  private def canonical(query: String): String = {
+    val parsed = QueryFactory.create(query)
+    parsed.getPrefixMapping.clearNsPrefixMap()
+    parsed.toString
+  }
+
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   private val testPropertyIri: PropertyIri =
@@ -28,9 +35,9 @@ class CountPropertyUsedWithClassQuerySpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment, Any] = suite("CountPropertyUsedWithClassQuerySpec")(
     test("should produce correct SELECT query counting property usage with class") {
       val query  = CountPropertyUsedWithClassQuery.build(testPropertyIri, testClassIri)
-      val actual = query.getQueryString
+      val actual = query.sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |SELECT ?subject ( COUNT( ?object ) AS ?count )
             |WHERE { ?subject a <http://www.knora.org/ontology/0001/anything#Thing> .
@@ -39,6 +46,7 @@ class CountPropertyUsedWithClassQuerySpec extends ZIOSpecDefault {
             |MINUS { ?object knora-base:isDeleted true . } } }
             |GROUP BY ?subject
             |""".stripMargin,
+        ),
       )
     },
     test("should handle property and class from different ontologies") {
@@ -48,9 +56,9 @@ class CountPropertyUsedWithClassQuerySpec extends ZIOSpecDefault {
         ResourceClassIri.unsafeFrom("http://www.knora.org/ontology/0001/images#Image".toSmartIri)
 
       val query  = CountPropertyUsedWithClassQuery.build(propertyIri, classIri)
-      val actual = query.getQueryString
+      val actual = query.sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |SELECT ?subject ( COUNT( ?object ) AS ?count )
             |WHERE { ?subject a <http://www.knora.org/ontology/0001/images#Image> .
@@ -59,6 +67,7 @@ class CountPropertyUsedWithClassQuerySpec extends ZIOSpecDefault {
             |MINUS { ?object knora-base:isDeleted true . } } }
             |GROUP BY ?subject
             |""".stripMargin,
+        ),
       )
     },
     test("should handle knora-base property and class") {
@@ -68,9 +77,9 @@ class CountPropertyUsedWithClassQuerySpec extends ZIOSpecDefault {
         ResourceClassIri.unsafeFrom("http://www.knora.org/ontology/knora-base#Resource".toSmartIri)
 
       val query  = CountPropertyUsedWithClassQuery.build(propertyIri, classIri)
-      val actual = query.getQueryString
+      val actual = query.sparql
       assertTrue(
-        actual ==
+        canonical(actual) == canonical(
           """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
             |SELECT ?subject ( COUNT( ?object ) AS ?count )
             |WHERE { ?subject a knora-base:Resource .
@@ -79,6 +88,7 @@ class CountPropertyUsedWithClassQuerySpec extends ZIOSpecDefault {
             |MINUS { ?object knora-base:isDeleted true . } } }
             |GROUP BY ?subject
             |""".stripMargin,
+        ),
       )
     },
   )

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/DeleteClassQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/DeleteClassQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.ontology.repo
 
+import org.apache.jena.update.UpdateFactory
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
@@ -21,6 +22,12 @@ import org.knora.webapi.slice.common.KnoraIris.ResourceClassIri
 @RunWith(classOf[DspZTestJUnitRunner])
 class DeleteClassQuerySpec extends ZIOSpecDefault {
 
+  private def canonical(query: String): String = {
+    val update = UpdateFactory.create(query)
+    update.getPrefixMapping.clearNsPrefixMap()
+    update.toString
+  }
+
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
   private val testOntologyIri: OntologyIri =
@@ -35,9 +42,9 @@ class DeleteClassQuerySpec extends ZIOSpecDefault {
       DeleteClassQuery
         .build(testClassIri, testLastModificationDate)
         .map { case (_, query) =>
-          val queryString = query.getQueryString
+          val queryString = query.sparql
           assertTrue(
-            queryString ==
+            canonical(queryString) == canonical(
               """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -56,6 +63,7 @@ class DeleteClassQuerySpec extends ZIOSpecDefault {
                 |    ?restrictionPred ?restrictionObj .
                 |FILTER ( isBLANK( ?restriction ) ) }
                 |FILTER NOT EXISTS { ?s ?p anything:TestClass . } }""".stripMargin,
+            ),
           )
         }
     },

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuerySpec.scala
@@ -5,6 +5,7 @@
 
 package org.knora.webapi.slice.ontology.repo
 
+import org.apache.jena.update.UpdateFactory
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
@@ -20,6 +21,12 @@ import org.knora.webapi.slice.common.KnoraIris.PropertyIri
 
 @RunWith(classOf[DspZTestJUnitRunner])
 class DeletePropertyQuerySpec extends ZIOSpecDefault {
+
+  private def canonical(query: String): String = {
+    val update = UpdateFactory.create(query)
+    update.getPrefixMapping.clearNsPrefixMap()
+    update.toString
+  }
 
   implicit val sf: StringFormatter = StringFormatter.getInitializedTestInstance
 
@@ -37,23 +44,24 @@ class DeletePropertyQuerySpec extends ZIOSpecDefault {
       DeletePropertyQuery
         .build(testPropertyIri, Some(testLinkValuePropertyIri), testLastModificationDate)
         .map { case (_, query) =>
-          val queryString = query.getQueryString
+          val queryString = query.sparql
           assertTrue(
-            queryString ==
+            canonical(queryString) == canonical(
               """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
                 |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
                 |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
                 |anything:hasTestProperty ?propertyPred ?propertyObj .
-                |anything:hasTestPropertyValue ?linkValuePropertyObj ?linkValuePropertyPred . } }
+                |anything:hasTestPropertyValue ?linkValuePropertyPred ?linkValuePropertyObj . } }
                 |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime . } }
                 |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
                 |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
                 |anything:hasTestProperty a owl:ObjectProperty ;
                 |    ?propertyPred ?propertyObj .
                 |FILTER NOT EXISTS { ?s ?p anything:hasTestProperty . }
-                |anything:hasTestPropertyValue ?linkValuePropertyObj ?linkValuePropertyPred . }""".stripMargin,
+                |anything:hasTestPropertyValue ?linkValuePropertyPred ?linkValuePropertyObj . }""".stripMargin,
+            ),
           )
         }
     },
@@ -61,9 +69,9 @@ class DeletePropertyQuerySpec extends ZIOSpecDefault {
       DeletePropertyQuery
         .build(testPropertyIri, None, testLastModificationDate)
         .map { case (_, query) =>
-          val queryString = query.getQueryString
+          val queryString = query.sparql
           assertTrue(
-            queryString ==
+            canonical(queryString) == canonical(
               """PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -76,6 +84,7 @@ class DeletePropertyQuerySpec extends ZIOSpecDefault {
                 |anything:hasTestProperty a owl:ObjectProperty ;
                 |    ?propertyPred ?propertyObj .
                 |FILTER NOT EXISTS { ?s ?p anything:hasTestProperty . } }""".stripMargin,
+            ),
           )
         }
     },


### PR DESCRIPTION
### Description

Stacked on #4299. Migrates the next ontology batch from RDF4J SparqlBuilder to the typed interpolated SPARQL DSL:

- `DeleteClassQuery` (DELETE class triples and blank-node restrictions via UNION + `isBlank`, `FILTER NOT EXISTS` reference guard, `lastModificationDate` bump)
- `DeletePropertyQuery` (DELETE property triples and optional link-value property, `FILTER NOT EXISTS` reference guard, `lastModificationDate` bump)
- `CountPropertyUsedWithClassQuery` (SELECT with `COUNT`, `MINUS` on `isDeleted`, `OPTIONAL`, `GROUP BY`)

The delete builders return `(LastModificationDate, Update)`; the count builder returns `Select`. Callers in `OntologyResponderV2` and `PredicateRepositoryLive` are adjusted. The specs compare against the untouched legacy rendering through Jena canonical form. Entity IRIs are now rendered as full IRIs instead of via a per-ontology prefix; canonically identical.

### Notes for review (pure port, nothing changed on purpose)

- `DeletePropertyQuery` in the legacy had swapped variable names for the link-value triple, rendering `<linkValueProp> ?linkValuePropertyObj ?linkValuePropertyPred`. Both variables are fresh, so this is cosmetic. The port preserves the rendered names so the canonical comparison holds, with a comment at the site. Renaming is a trivial follow-up.
- `DeleteClassQuery` and `DeletePropertyQuery` scope DELETE and INSERT to the ontology graph but leave WHERE unscoped, as the legacy did. The `FILTER NOT EXISTS { ?s ?p <entity> }` guard arguably should be repo-wide; the ontology precondition arguably should not. Flagged, not changed.
- The performance rewrite of `CountPropertyUsedWithClassQuery` tracked in DEV-6826 is out of scope here.

### Verification

- `bazel test //modules/webapi:test --test_filter='.*(DeleteClass|DeleteProperty|CountPropertyUsedWithClass)QuerySpec.*'` (6 tests passed)
- `PredicateRepositoryLiveSpec` and `CardinalityServiceLiveSpec` pass
- `just check`

Part of DEV-7150. Fixes DEV-7209

## Readability retrofit

After review feedback the queries were rewritten in place to the inline-template convention documented in #4295: `DeletePropertyQuery` is one literal template, and its link-value property variables are now named by position (`?linkValuePropertyPred ?linkValuePropertyObj`; the legacy had them swapped). The spec fixtures reflect the rename; this is the one intentional deviation from the legacy rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

