### PR TITLE
fix(dsp-api): local stack bring-up starts what it names (DEV-7199)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 .docker
 .env
 **/.DS_Store
-salsah1/project
 modules/webapi/project
 modules/webapi/_fuseki/run
 webapi-it

--- a/README.md
+++ b/README.md
@@ -69,25 +69,26 @@ See [docs/Readme.md](docs/Readme.md).
 
 ### Run DSP-API
 
-Create a test repository, load some test data into the triplestore, and start DSP-API:
+Run both commands inside the [Nix dev shell](#nix), which provides `just` and `bazel`.
+
+Create a test repository and load some test data into the triplestore:
 
 ```shell
-just stack-init-test
+just init-db-test
 ```
 
-Open [http://localhost:4200/](http://localhost:4200) in a web browser.
+Build the images from your checkout and start the stack:
 
-On first installation, errors similar to the following can come up:
-
-```text
-error decoding 'Volumes[0]': invalid spec: :/fuseki:delegated: empty section between colons
+```shell
+just stack-up
 ```
 
-To solve this, you need to deactivate Docker Compose V2. This can be done in Docker Desktop either by unchecking the "Use Docker Compose V2" flag under "Preferences > General" or by running
+DSP-API listens on [http://localhost:3333](http://localhost:3333), and DSP-APP on
+[http://localhost:4200](http://localhost:4200).
 
-```text
-docker-compose disable-v2
-```
+If the bring-up fails with a `mounts denied` error, add the repository directory to
+Docker Desktop's file-sharing allowlist. See
+[Setting up Docker](docs/05-internals/development/building-and-running.md#setting-up-docker).
 
 Shut down DSP-API:
 

--- a/docs/05-internals/development/building-and-running.md
+++ b/docs/05-internals/development/building-and-running.md
@@ -7,6 +7,19 @@
    ![screenshot 'Docker Desktop'](figures/dockerPreferences.png)
    The stack's memory usage is limited to ~20GB, though it should only use that much during heavy workloads. You should
    be good to go in any case if you allocate 22GB or more.
+3. Add the dsp-api repository directory to Docker Desktop's file-sharing allowlist, under
+   Settings > Resources > File Sharing.
+
+   The `app` service bind-mounts `app-config.dev.json` from the repository. When the
+   repository sits outside the allowlist, Docker refuses the mount:
+
+   ```text
+   Error response from daemon: mounts denied:
+   The path .../app-config.dev.json is not shared from the host and is not known to Docker.
+   ```
+
+   The error names only the mount, not the service. Recipes that exclude `app`, such as
+   `just stack-without-app`, never touch that mount and therefore need no allowlist entry.
 
 ## Running the stack
 
@@ -20,7 +33,7 @@ With Docker installed and configured,
 
    to initialize Fuseki's dsp-repo dataset with loading some test data into the triplestore 
 
-1. Start the entire knora-stack (fuseki (db), sipi, api, salsah1) with the following command:
+1. Start the entire dsp-stack (fuseki (db), sipi, ingest, api, app, alloy) with the following command:
 
    ```bash
    just stack-up

--- a/justfile
+++ b/justfile
@@ -170,10 +170,12 @@ stack-start:
     ./modules/webapi/scripts/wait-for-db.sh
     @echo "Stack started"
 
-# Start Stack without API for development
-stack-start-dev: stack-start
-    @echo "Stopping API"
-    docker compose down api
+# Start Stack without API for development: fuseki, sipi, ingest and alloy
+stack-start-dev:
+    @echo "Starting Stack without API"
+    docker compose stop api app
+    docker compose up -d db sipi ingest alloy
+    ./modules/webapi/scripts/wait-for-db.sh
     @echo "Stack started without API"
 
 # Start stack and pull latest images before starting
@@ -268,7 +270,7 @@ structurizer:
 
 ## DSP stack (local dev)
 
-# starts the dsp-stack: fuseki, sipi, api and app
+# starts the dsp-stack: fuseki, sipi, ingest, api, app and alloy
 stack-up: docker-build
     docker compose -f docker-compose.yml up -d db
     ./modules/webapi/scripts/wait-for-db.sh
@@ -279,7 +281,7 @@ stack-up: docker-build
 stack-up-fast: docker-build-dsp-api-image
     docker compose -f docker-compose.yml up -d
 
-# starts the dsp-stack using the 'dsp-repo' repository: fuseki, sipi, api
+# starts the dsp-stack using the 'dsp-repo' repository: fuseki, sipi, ingest, api, app and alloy
 stack-up-ci: docker-build
     docker compose -f docker-compose.yml up -d
 
@@ -336,18 +338,25 @@ stack-down-delete-volumes: clean-local-tmp clean-sipi-tmp
 stack-config:
     docker compose -f docker-compose.yml config
 
-# starts the dsp-stack without dsp-api: fuseki and sipi only
-stack-without-api: stack-up
-    docker compose -f docker-compose.yml stop api
+# starts the dsp-stack without dsp-api: fuseki, sipi, ingest and alloy
+stack-without-api: docker-build
+    docker compose -f docker-compose.yml stop api app
+    docker compose -f docker-compose.yml up -d db sipi ingest alloy
+    ./modules/webapi/scripts/wait-for-db.sh
 
-# starts the dsp-stack without dsp-app
-stack-without-app: stack-up
+# starts the dsp-stack without dsp-app: fuseki, sipi, ingest, api and alloy
+stack-without-app: docker-build
     docker compose -f docker-compose.yml stop app
+    docker compose -f docker-compose.yml up -d db
+    ./modules/webapi/scripts/wait-for-db.sh
+    docker compose -f docker-compose.yml up -d db sipi ingest api alloy
+    ./modules/webapi/scripts/wait-for-api.sh
 
-# starts the dsp-stack without dsp-api and sipi: fuseki only
-stack-without-api-and-sipi: stack-up
-    docker compose -f docker-compose.yml stop api
-    docker compose -f docker-compose.yml stop sipi
+# starts the dsp-stack without dsp-api and sipi: fuseki, ingest and alloy
+stack-without-api-and-sipi: docker-build
+    docker compose -f docker-compose.yml stop api sipi app
+    docker compose -f docker-compose.yml up -d db ingest alloy
+    ./modules/webapi/scripts/wait-for-db.sh
 
 # starts only fuseki
 stack-db-only:

--- a/justfile
+++ b/justfile
@@ -10,12 +10,31 @@ scalafmt_targets := "//modules/bagit:bagit //modules/bagit:test //modules/jwt:jw
 default:
     @just --list
 
+# Aborts with the dev-shell activation command when bazel is missing from PATH.
+# flake.nix sets no marker variable, so the guard tests for the executable itself.
+[private]
+require-bazel:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v bazel >/dev/null 2>&1; then exit 0; fi
+    echo "ERROR: 'bazel' is not on PATH." >&2
+    echo "This repository builds through Bazel inside the Nix dev shell." >&2
+    echo "" >&2
+    echo "Enter the dev shell, then re-run:" >&2
+    echo "    nix develop" >&2
+    echo "" >&2
+    echo "Or run the recipe through it directly:" >&2
+    echo "    nix develop --command just <recipe>" >&2
+    echo "" >&2
+    echo "With direnv installed, run 'direnv allow' once in the repository root." >&2
+    exit 1
+
 alias ssl := stack-start-latest
 alias stop := stack-stop
 alias ssd := stack-start-dev
 
 # Format Scala (scalafmt via Bazel) and apply license headers
-fmt:
+fmt: require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     for t in {{scalafmt_targets}}; do bazel run "$t.format"; done
@@ -26,37 +45,37 @@ fmt:
 # Locally FLAGS is empty (dev never contacts the remote backend) and the recipes run as before.
 
 # Run unit tests for dsp-api (webapi only; use `test-unit` for the full pure-JVM suite)
-test *FLAGS='':
+test *FLAGS='': require-bazel
     bazel test //modules/webapi:test {{FLAGS}}
 
 # Run all pure-JVM unit tests (matches the CI `unit-tests` job; RBE-safe: runs remotely + result-caches)
-test-unit *FLAGS='':
+test-unit *FLAGS='': require-bazel
     bazel test //modules/webapi:test //modules/ingest:test //modules/bagit:test //modules/jwt:test //modules/shacl-validator:test //modules/sparql-builder:test {{FLAGS}}
 
 # Load the :latest/pinned sipi, ingest and fuseki images into the local Docker daemon (needed by test-it/test-e2e/test-ingest-integration)
-docker-load-test-images *FLAGS='':
+docker-load-test-images *FLAGS='': require-bazel
     bazel run {{FLAGS}} //modules/sipi:load
     bazel run {{FLAGS}} //modules/ingest:load
     bazel run {{FLAGS}} //modules/fuseki:load
 
 # Run integration tests for dsp-api
-test-it *FLAGS='': (docker-load-test-images FLAGS)
+test-it *FLAGS='': require-bazel (docker-load-test-images FLAGS)
     bazel test //modules/test-it:test //modules/test-it:test_gravsearch_span {{FLAGS}}
 
 # Run End-2-End tests for dsp-api
-test-e2e *FLAGS='': (docker-load-test-images FLAGS)
+test-e2e *FLAGS='': require-bazel (docker-load-test-images FLAGS)
     bazel test //modules/test-e2e:test {{FLAGS}}
 
 # Run unit tests for ingest
-test-ingest *FLAGS='':
+test-ingest *FLAGS='': require-bazel
     bazel test //modules/ingest:test {{FLAGS}}
 
 # Run integration tests for ingest
-test-ingest-integration *FLAGS='': (docker-load-test-images FLAGS)
+test-ingest-integration *FLAGS='': require-bazel (docker-load-test-images FLAGS)
     bazel test //modules/test-ingest-integration:test {{FLAGS}}
 
 # Check Scala formatting (scalafmt via Bazel) + license headers (CI gate, no writes)
-check *FLAGS='':
+check *FLAGS='': require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     # scalafmt format-test runs LOCALLY (no {{FLAGS}}): `bazel run <t>.format-test` diffs the
@@ -66,7 +85,7 @@ check *FLAGS='':
     bazel test {{FLAGS}} //tools/license:spdx_header_check //tools/lint:no_relative_imports
 
 # Insert any missing Apache-2.0 SPDX headers into Scala files (replaces sbt headerCreateAll)
-header-fix:
+header-fix: require-bazel
     bazel run //tools/license:fix
 
 ## Scala language intelligence (Metals MCP)
@@ -82,7 +101,7 @@ header-fix:
 # and a bazel_binary wrapper (tools/metals/bazel-bsp-wrapper.sh, set in .bazelproject) that patches
 # bazel-bsp's struct-returning aspect on each invocation. So compile/get-usages work. Vendored patch,
 # not a rules_scala issue; tracked at scalameta/metals#8268. See docs/development/dsp-api-metals-mcp.md.
-metals-bootstrap:
+metals-bootstrap: require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     test -f .bazelproject || { echo "ERROR: .bazelproject missing (should be committed)"; exit 1; }
@@ -98,7 +117,7 @@ docker-image-tag:
     @tools/workspace_status.sh | awk '/^STABLE_GIT_VERSION /{print $2}'
 
 # Build the knora-api image with Bazel + load it into the local Docker daemon (:latest and :<version>)
-docker-build-dsp-api-image *FLAGS='':
+docker-build-dsp-api-image *FLAGS='': require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     TAG=$(just docker-image-tag)
@@ -107,7 +126,7 @@ docker-build-dsp-api-image *FLAGS='':
     echo "Loaded daschswiss/knora-api: latest + $TAG"
 
 # Build the knora-sipi image with Bazel + load it into the local Docker daemon (:latest and :<version>)
-docker-build-sipi-image *FLAGS='':
+docker-build-sipi-image *FLAGS='': require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     TAG=$(just docker-image-tag)
@@ -116,7 +135,7 @@ docker-build-sipi-image *FLAGS='':
     echo "Loaded daschswiss/knora-sipi: latest + $TAG"
 
 # Build the dsp-ingest image with Bazel + load it into the local Docker daemon (:latest and :<version>)
-docker-build-ingest-image *FLAGS='':
+docker-build-ingest-image *FLAGS='': require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     TAG=$(just docker-image-tag)
@@ -128,21 +147,21 @@ docker-build-ingest-image *FLAGS='':
 docker-build *FLAGS='': (docker-build-dsp-api-image FLAGS) (docker-build-sipi-image FLAGS) (docker-build-ingest-image FLAGS)
 
 # Build + publish the multi-arch knora-api image with Bazel (tags: latest + <version>)
-docker-publish-dsp-api-image *FLAGS='':
+docker-publish-dsp-api-image *FLAGS='': require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     TAG=$(just docker-image-tag)
     bazel run {{FLAGS}} //modules/webapi:push -- -t latest -t "$TAG"
 
 # Build + publish the multi-arch knora-sipi image with Bazel (tags: latest + <version>)
-docker-publish-sipi-image *FLAGS='':
+docker-publish-sipi-image *FLAGS='': require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     TAG=$(just docker-image-tag)
     bazel run {{FLAGS}} //modules/sipi:push -- -t latest -t "$TAG"
 
 # Build + publish the multi-arch dsp-ingest image with Bazel (tags: latest + <version>)
-docker-publish-ingest-image *FLAGS='':
+docker-publish-ingest-image *FLAGS='': require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     TAG=$(just docker-image-tag)
@@ -152,12 +171,12 @@ docker-publish-ingest-image *FLAGS='':
 docker-publish *FLAGS='': (docker-publish-dsp-api-image FLAGS) (docker-publish-sipi-image FLAGS) (docker-publish-ingest-image FLAGS) (docker-publish-fuseki-image FLAGS)
 
 # Build the Fuseki image with Bazel + load it into the local Docker daemon (at :latest)
-docker-build-fuseki-image *FLAGS='':
+docker-build-fuseki-image *FLAGS='': require-bazel
     bazel run {{FLAGS}} //modules/fuseki:load
 
 # Build + publish the multi-arch Fuseki image to Docker Hub with Bazel (tags: latest + <version>).
 # The Fuseki image is versioned by release-please (git version), same as the other three images.
-docker-publish-fuseki-image *FLAGS='':
+docker-publish-fuseki-image *FLAGS='': require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     TAG=$(just docker-image-tag)
@@ -212,7 +231,7 @@ stack-init-test: && stack-start
     just init-db-test
 
 # Run API locally against the dev Fuseki (requires VPN)
-run-with-dev-db:
+run-with-dev-db: require-bazel
     #!/usr/bin/env bash
     set -euo pipefail
     if [ ! -f .env ]; then


### PR DESCRIPTION
Fixes DEV-7199

## Motivation

`just stack-without-app` did not bring up the stack without the app. It depended on
`stack-up`, which runs an unqualified `docker compose up -d`, and stopped `app`
afterwards. All six services share one Compose project, so exclusion depended on the
excluded service starting successfully first. A host path missing from Docker Desktop's
file-sharing allowlist therefore aborted the bring-up of `api`, `sipi` and `ingest` —
the services that were the goal — and the error named only the mount:

```text
Error response from daemon: mounts denied:
The path .../app-config.dev.json is not shared from the host and is not known to Docker.
```

`stack-without-api` and `stack-without-api-and-sipi` shared the design. So did
`stack-start-dev`, which left the `app` container holding port 4200 against a local
Angular dev server.

Separately, recipes needing `bazel` failed with a bare `command not found` outside the
Nix dev shell, and three setup instructions described a stack that no longer exists —
one of them telling the reader to disable Docker Compose V2, which breaks the justfile.

## Summary

- Each subtractive stack recipe now starts exactly the services it names.
- A missing `bazel` now prints the command that activates the Nix dev shell.
- The setup documents describe the stack as it is.

## Key Changes

### Stack recipes

`stack-without-app`, `stack-without-api`, `stack-without-api-and-sipi` and
`stack-start-dev` each stop the services they exclude, then pass their own service list
to `docker compose up -d`, then wait only for a service they actually start. None of the
four starts `app`, so none can hit its bind mount. `stack-up` and `stack-up-ci` keep the
full service set; their docstrings gain the `ingest` and `alloy` they always started.

The two `without-api` recipes no longer poll port 3333 for 360 seconds before stopping
the `api` they exclude — they inherited `wait-for-api.sh` from `stack-up`.

### Bazel guard

A private `require-bazel` recipe tests for the executable and aborts with the activation
command. The 20 recipes that invoke `bazel` directly take it as a first dependency, so
`docker-build`, `stack-up`, `test-it` and the rest inherit it. It tests for the
executable, not an environment variable: `flake.nix` sets no marker.

### Documentation

The README's first-run command becomes `just init-db-test` then `just stack-up`, so the
reader runs images built from their own checkout rather than published `:latest` ones.
The Compose V2 instruction is replaced by a pointer to a new Docker Desktop file-sharing
note. `building-and-running.md` lists the six services `docker-compose.yml` defines,
instead of `salsah1`.

## Challenges and Decisions

### An explicit service list is not enough on its own

**Problem:** Replacing "start everything, then stop one" with an explicit
`docker compose up -d <subset>` passed every cold bring-up test.

**Tried:** The explicit list alone. Measured warm, it fails: `up -d` on a subset is
purely additive and never stops an already-running excluded container. After a prior
`just stack-up`, `just stack-start-dev` still left `app` holding port 4200 — the exact
failure the change set out to remove.

**Solution:** A leading `docker compose stop` for the excluded services. `stop` and `up`
fail differently — only `up` creates a container and resolves its mounts — so the stop
restores guaranteed exclusion without reintroducing the mount failure. It exits 0 when
the container does not exist.

### Guarding on the tool, not the environment

`flake.nix` sets only `PS1`, `SSL_CERT_FILE` and `PATH`, so there is no reliable
dev-shell marker to test. The guard tests `command -v bazel`. CI is unaffected: every CI
job already wraps its bazel recipes in `nix develop --command`.

## Gotchas

- **`just --dry-run` cannot test a shebang recipe's behaviour.** It prints the script
  text, which contains the guard's own error strings — grepping that output proves the
  wiring, not that the guard fires. Run the recipe with and without `bazel` on `PATH`.
- **`docker compose up -d <subset>` never stops anything.** Any recipe that promises a
  service is absent must say so explicitly.
- **A `just` shebang recipe needs a writable `TMPDIR`.** Without one it fails with an IO
  error naming the recipe, which reads like a recipe bug.

## Test Plan

Every recipe was run against a real Docker daemon and its resulting service set
enumerated, both cold and warm (after a full `stack-up`).

- [x] `stack-without-app` → `db sipi ingest api alloy`; port 4200 free; `/health` 200
- [x] `stack-without-api` → `db sipi ingest alloy`; returns without the 360 s API poll
- [x] `stack-without-api-and-sipi` → `db ingest alloy`; port 4200 free
- [x] `stack-start-dev` → `db sipi ingest alloy`; ports 4200 and 3333 free
- [x] All four warm, after a full `stack-up`: each ends with exactly its named set
- [x] Guard fires with exit 1 and the `nix develop` message when `bazel` is absent
- [x] Guard is transparent when `bazel` is present; `just check` runs in the dev shell
- [x] All 20 bazel-calling recipes guarded; `docker-image-tag` correctly not guarded
- [x] `just check` and `just markdownlint` pass

Not verified automatically: the `mounts denied` reproduction needs a Docker Desktop
file-sharing change, per the PRD.

## Follow-up

`stack-without-api` and `stack-without-api-and-sipi` still depend on the full
`docker-build`, which builds the dsp-api image neither recipe starts. Out of scope per
the PRD; it wastes a cached build rather than breaking a bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)