### PR TITLE
refactor: name the link-value property variables in DeletePropertyQuery by their position (DEV-7226)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuery.scala
@@ -26,10 +26,8 @@ object DeletePropertyQuery {
       val previousDate      = Literal.dateTime(lmd.value)
       val currentDate       = Literal.dateTime(now)
 
-      // The rendered variable names are intentionally kept as in the previous builder,
-      // where the predicate position renders as ?linkValuePropertyObj and vice versa.
       def linkValueTriple(iri: Iri): Fragment =
-        sparql"$iri ?linkValuePropertyObj ?linkValuePropertyPred ."
+        sparql"$iri ?linkValuePropertyPred ?linkValuePropertyObj ."
 
       val update = Update(
         sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuerySpec.scala
@@ -53,14 +53,14 @@ class DeletePropertyQuerySpec extends ZIOSpecDefault {
                 |PREFIX anything: <http://www.knora.org/ontology/0001/anything#>
                 |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
                 |anything:hasTestProperty ?propertyPred ?propertyObj .
-                |anything:hasTestPropertyValue ?linkValuePropertyObj ?linkValuePropertyPred . } }
+                |anything:hasTestPropertyValue ?linkValuePropertyPred ?linkValuePropertyObj . } }
                 |INSERT { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> knora-base:lastModificationDate "1970-01-01T00:00:00Z"^^xsd:dateTime . } }
                 |WHERE { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
                 |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
                 |anything:hasTestProperty a owl:ObjectProperty ;
                 |    ?propertyPred ?propertyObj .
                 |FILTER NOT EXISTS { ?s ?p anything:hasTestProperty . }
-                |anything:hasTestPropertyValue ?linkValuePropertyObj ?linkValuePropertyPred . }""".stripMargin,
+                |anything:hasTestPropertyValue ?linkValuePropertyPred ?linkValuePropertyObj . }""".stripMargin,
             ),
           )
         }


### PR DESCRIPTION
Follow-up to #4300 (DEV-7209). Resolves DEV-7226. Stacked on #4315.

## What

The legacy RDF4J builder of `DeletePropertyQuery` had the two fresh variables of the link-value property triple swapped, so the predicate position rendered as `?linkValuePropertyObj` and the object position as `?linkValuePropertyPred`. #4300 kept the rendered names so the canonical comparison against the legacy output stayed exact, and flagged the rename as a trivial follow-up.

This renames them to `?linkValuePropertyPred ?linkValuePropertyObj` and drops the explanatory comment. Both variables are unbound anywhere else in the query, so the semantics are unchanged. The two spec fixtures are updated to the new names (this is the one intentional deviation from the legacy rendering).

Not included: the unscoped `WHERE` in `DeleteClassQuery` / `DeletePropertyQuery` flagged in #4300. That is a semantic question (repo-wide reference guard vs ontology-graph precondition), not a cosmetic one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
