### PR TITLE
refactor: make the ontology label/comment and GUI-element change queries read as whole SPARQL templates (DEV-7227)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangeClassLabelsOrCommentsQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangeClassLabelsOrCommentsQuery.scala
@@ -23,14 +23,15 @@ object ChangeClassLabelsOrCommentsQuery {
     lastModificationDate: LastModificationDate,
   ): UIO[Update] =
     Clock.instant.map { now =>
-      val ontology     = Iri.unsafeFrom(resourceClassIri.ontologyIri.toInternalSchema.toIri)
-      val classIri     = Iri.unsafeFrom(resourceClassIri.toInternalSchema.toIri)
-      val predicate    = Iri.unsafeFrom(labelOrComment.toString)
-      val previousDate = Literal.dateTime(lastModificationDate.value)
-      val currentDate  = Literal.dateTime(now)
+      val ontology          = Iri.unsafeFrom(resourceClassIri.ontologyIri.toInternalSchema.toIri)
+      val classIri          = Iri.unsafeFrom(resourceClassIri.toInternalSchema.toIri)
+      val labelOrCommentIri = Iri.unsafeFrom(labelOrComment.toString) // rdfs:label or rdfs:comment
+      val previousDate      = Literal.dateTime(lastModificationDate.value)
+      val currentDate       = Literal.dateTime(now)
 
+      // One <class> rdfs:label|rdfs:comment "..."@lang . triple per new value.
       val newValueTriples = newValues
-        .map(v => sparql"$classIri $predicate ${Literal.langString(v.value, v.language.value)} .")
+        .map(v => sparql"$classIri $labelOrCommentIri ${Literal.langString(v.value, v.language.value)} .")
         .joinLines
 
       Update(
@@ -42,7 +43,7 @@ object ChangeClassLabelsOrCommentsQuery {
                  |DELETE {
                  |  GRAPH $ontology {
                  |    $ontology knora-base:lastModificationDate $previousDate .
-                 |    $classIri $predicate ?oldValues .
+                 |    $classIri $labelOrCommentIri ?oldValues .
                  |  }
                  |}
                  |INSERT {
@@ -55,7 +56,7 @@ object ChangeClassLabelsOrCommentsQuery {
                  |  $ontology a owl:Ontology ;
                  |    knora-base:lastModificationDate $previousDate .
                  |  $classIri ?p ?o .
-                 |  OPTIONAL { $classIri $predicate ?oldValues . }
+                 |  OPTIONAL { $classIri $labelOrCommentIri ?oldValues . }
                  |}""".render,
       )
     }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyGuiElementQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyGuiElementQuery.scala
@@ -39,99 +39,81 @@ object ChangePropertyGuiElementQuery {
     val previousDate  = Literal.dateTime(lastModificationDate)
     val currentDate   = Literal.dateTime(currentTime)
 
-    val parts = List(
-      Some(deleteOld(ontology, property, linkProperty, previousDate)),
-      Option.when(guiElement.isDefined || guiAttributes.nonEmpty)(
-        insertNew(ontology, property, linkProperty, guiElement, guiAttributes, previousDate),
-      ),
-      Some(updateTimestamp(ontology, previousDate, currentDate)),
-    ).flatten
+    // A link property's link value property carries the same GUI element and attributes,
+    // so it is cleared and re-set alongside the property itself.
+    val deleteLinkPropertyGui = linkProperty.whenSome { lp =>
+      sparql"""|$lp salsah-gui:guiElement ?oldLinkValuePropertyGuiElement .
+               |$lp salsah-gui:guiAttribute ?oldLinkValuePropertyGuiAttribute ."""
+    }
+    val matchLinkPropertyGui = linkProperty.whenSome { lp =>
+      sparql"""|OPTIONAL { $lp salsah-gui:guiElement ?oldLinkValuePropertyGuiElement . }
+               |OPTIONAL { $lp salsah-gui:guiAttribute ?oldLinkValuePropertyGuiAttribute . }"""
+    }
 
-    Update(Fragment.join(parts, Fragment.raw(";\n")).render)
+    /** The new `salsah-gui:guiElement` triple (if any) plus one triple per new gui attribute. */
+    def insertGuiTriples(subject: Iri): Fragment =
+      (guiElement.map(e => sparql"$subject salsah-gui:guiElement $e .").toList :::
+        guiAttributes.map(a => sparql"$subject salsah-gui:guiAttribute $a .")).joinLines
+
+    val deleteOldGui =
+      sparql"""|$prefixes
+               |
+               |DELETE {
+               |  GRAPH $ontology {
+               |    $property salsah-gui:guiElement ?oldGuiElement .
+               |    $property salsah-gui:guiAttribute ?oldGuiAttribute .
+               |    $deleteLinkPropertyGui
+               |  }
+               |}
+               |WHERE {
+               |  GRAPH $ontology {
+               |    $ontology a owl:Ontology ;
+               |      knora-base:lastModificationDate $previousDate .
+               |    OPTIONAL { $property salsah-gui:guiElement ?oldGuiElement . }
+               |    OPTIONAL { $property salsah-gui:guiAttribute ?oldGuiAttribute . }
+               |    $matchLinkPropertyGui
+               |  }
+               |}"""
+
+    // Omitted entirely when there is nothing to set (the GUI element was only removed).
+    val insertNewGui = Option.when(guiElement.isDefined || guiAttributes.nonEmpty)(
+      sparql"""|$prefixes
+               |
+               |INSERT {
+               |  GRAPH $ontology {
+               |    ${insertGuiTriples(property)}
+               |    ${linkProperty.whenSome(insertGuiTriples)}
+               |  }
+               |}
+               |WHERE {
+               |  GRAPH $ontology {
+               |    $ontology a owl:Ontology ;
+               |      knora-base:lastModificationDate $previousDate .
+               |  }
+               |}""",
+    )
+
+    val updateLastModificationDate =
+      sparql"""|$prefixes
+               |
+               |DELETE {
+               |  GRAPH $ontology {
+               |    $ontology knora-base:lastModificationDate $previousDate .
+               |  }
+               |}
+               |INSERT {
+               |  GRAPH $ontology {
+               |    $ontology knora-base:lastModificationDate $currentDate .
+               |  }
+               |}
+               |WHERE {
+               |  GRAPH $ontology {
+               |    $ontology a owl:Ontology ;
+               |      knora-base:lastModificationDate $previousDate .
+               |  }
+               |}"""
+
+    val statements = List(Some(deleteOldGui), insertNewGui, Some(updateLastModificationDate)).flatten
+    Update(Fragment.join(statements, Fragment.raw(";\n")).render)
   }
-
-  private def deleteOld(
-    ontology: Iri,
-    property: Iri,
-    linkProperty: Option[Iri],
-    previousDate: Literal,
-  ): Fragment = {
-    def deleteTriples(subject: Iri, elementVar: Variable, attributeVar: Variable): Fragment =
-      sparql"""|$subject salsah-gui:guiElement $elementVar .
-               |$subject salsah-gui:guiAttribute $attributeVar ."""
-
-    def optionalPatterns(subject: Iri, elementVar: Variable, attributeVar: Variable): Fragment =
-      sparql"""|OPTIONAL { $subject salsah-gui:guiElement $elementVar . }
-               |OPTIONAL { $subject salsah-gui:guiAttribute $attributeVar . }"""
-
-    val oldGuiElement            = Variable("oldGuiElement")
-    val oldGuiAttribute          = Variable("oldGuiAttribute")
-    val oldLinkValueGuiElement   = Variable("oldLinkValuePropertyGuiElement")
-    val oldLinkValueGuiAttribute = Variable("oldLinkValuePropertyGuiAttribute")
-
-    sparql"""|$prefixes
-             |
-             |DELETE {
-             |  GRAPH $ontology {
-             |    ${deleteTriples(property, oldGuiElement, oldGuiAttribute)}
-             |    ${linkProperty.whenSome(deleteTriples(_, oldLinkValueGuiElement, oldLinkValueGuiAttribute))}
-             |  }
-             |}
-             |WHERE {
-             |  GRAPH $ontology {
-             |    $ontology a owl:Ontology ;
-             |      knora-base:lastModificationDate $previousDate .
-             |    ${optionalPatterns(property, oldGuiElement, oldGuiAttribute)}
-             |    ${linkProperty.whenSome(optionalPatterns(_, oldLinkValueGuiElement, oldLinkValueGuiAttribute))}
-             |  }
-             |}"""
-  }
-
-  private def insertNew(
-    ontology: Iri,
-    property: Iri,
-    linkProperty: Option[Iri],
-    guiElement: Option[Iri],
-    guiAttributes: List[Literal],
-    previousDate: Literal,
-  ): Fragment = {
-    def insertTriples(subject: Iri): Fragment =
-      (guiElement.map(iri => sparql"$subject salsah-gui:guiElement $iri .").toList :::
-        guiAttributes.map(attr => sparql"$subject salsah-gui:guiAttribute $attr .")).joinLines
-
-    sparql"""|$prefixes
-             |
-             |INSERT {
-             |  GRAPH $ontology {
-             |    ${insertTriples(property)}
-             |    ${linkProperty.whenSome(insertTriples)}
-             |  }
-             |}
-             |WHERE {
-             |  GRAPH $ontology {
-             |    $ontology a owl:Ontology ;
-             |      knora-base:lastModificationDate $previousDate .
-             |  }
-             |}"""
-  }
-
-  private def updateTimestamp(ontology: Iri, previousDate: Literal, currentDate: Literal): Fragment =
-    sparql"""|$prefixes
-             |
-             |DELETE {
-             |  GRAPH $ontology {
-             |    $ontology knora-base:lastModificationDate $previousDate .
-             |  }
-             |}
-             |INSERT {
-             |  GRAPH $ontology {
-             |    $ontology knora-base:lastModificationDate $currentDate .
-             |  }
-             |}
-             |WHERE {
-             |  GRAPH $ontology {
-             |    $ontology a owl:Ontology ;
-             |      knora-base:lastModificationDate $previousDate .
-             |  }
-             |}"""
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyLabelsOrCommentsQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyLabelsOrCommentsQuery.scala
@@ -27,14 +27,22 @@ object ChangePropertyLabelsOrCommentsQuery {
       val ontology          = Iri.unsafeFrom(propertyIri.ontologyIri.toInternalSchema.toIri)
       val property          = Iri.unsafeFrom(propertyIri.toInternalSchema.toIri)
       val linkValueProperty = maybeLinkValuePropertyIri.map(iri => Iri.unsafeFrom(iri.toInternalSchema.toIri))
-      val predicate         = Iri.unsafeFrom(labelOrComment.toString)
+      val labelOrCommentIri = Iri.unsafeFrom(labelOrComment.toString) // rdfs:label or rdfs:comment
       val previousDate      = Literal.dateTime(lastModificationDate.value)
       val currentDate       = Literal.dateTime(now)
 
+      // One <subject> rdfs:label|rdfs:comment "..."@lang . triple per new value.
       def newValueTriples(subject: Iri): Fragment =
         newValues
-          .map(v => sparql"$subject $predicate ${Literal.langString(v.value, v.language.value)} .")
+          .map(v => sparql"$subject $labelOrCommentIri ${Literal.langString(v.value, v.language.value)} .")
           .joinLines
+
+      // A link property's link value property carries the same labels/comments,
+      // so its old values are replaced alongside the property's own.
+      val linkValueDelete = linkValueProperty.whenSome(p => sparql"$p $labelOrCommentIri ?oldLinkValueValues .")
+      val linkValueInsert = linkValueProperty.whenSome(newValueTriples)
+      val linkValueWhere  =
+        linkValueProperty.whenSome(p => sparql"OPTIONAL { $p $labelOrCommentIri ?oldLinkValueValues . }")
 
       Update(
         sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
@@ -45,22 +53,22 @@ object ChangePropertyLabelsOrCommentsQuery {
                  |DELETE {
                  |  GRAPH $ontology {
                  |    $ontology knora-base:lastModificationDate $previousDate .
-                 |    $property $predicate ?oldValues .
-                 |    ${linkValueProperty.whenSome(iri => sparql"$iri $predicate ?oldLinkValueValues .")}
+                 |    $property $labelOrCommentIri ?oldValues .
+                 |    $linkValueDelete
                  |  }
                  |}
                  |INSERT {
                  |  GRAPH $ontology {
                  |    $ontology knora-base:lastModificationDate $currentDate .
                  |    ${newValueTriples(property)}
-                 |    ${linkValueProperty.whenSome(newValueTriples)}
+                 |    $linkValueInsert
                  |  }
                  |}
                  |WHERE {
                  |  $ontology a owl:Ontology ;
                  |    knora-base:lastModificationDate $previousDate .
-                 |  OPTIONAL { $property $predicate ?oldValues . }
-                 |  ${linkValueProperty.whenSome(iri => sparql"OPTIONAL { $iri $predicate ?oldLinkValueValues . }")}
+                 |  OPTIONAL { $property $labelOrCommentIri ?oldValues . }
+                 |  $linkValueWhere
                  |}""".render,
       )
     }

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyGuiElementQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyGuiElementQuerySpec.scala
@@ -142,5 +142,32 @@ class ChangePropertyGuiElementQuerySpec extends ZIOSpecDefault {
       val expected = deleteOldQuery + ";\n" + updateTimestampQuery
       assertTrue(canonical(actual.sparql) == canonical(expected))
     },
+    test("no guiElement, no guiAttributes (delete only), with link value property") {
+      val actual = ChangePropertyGuiElementQuery.build(
+        ontologyIri = ontologyIri,
+        propertyIri = propertyIri,
+        maybeLinkValuePropertyIri = Some(linkValuePropertyIri),
+        maybeNewGuiElement = None,
+        newGuiAttributes = Set.empty,
+        lastModificationDate = lastModDate,
+        currentTime = currentTime,
+      )
+
+      val deleteOldQuery = prefixes +
+        """
+          |DELETE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything#hasText> salsah-gui:guiElement ?oldGuiElement .
+          |<http://www.knora.org/ontology/0001/anything#hasText> salsah-gui:guiAttribute ?oldGuiAttribute .
+          |<http://www.knora.org/ontology/0001/anything#hasTextValue> salsah-gui:guiElement ?oldLinkValuePropertyGuiElement .
+          |<http://www.knora.org/ontology/0001/anything#hasTextValue> salsah-gui:guiAttribute ?oldLinkValuePropertyGuiAttribute . } }
+          |WHERE { GRAPH <http://www.knora.org/ontology/0001/anything> { <http://www.knora.org/ontology/0001/anything> a owl:Ontology ;
+          |    knora-base:lastModificationDate "2023-08-01T10:30:00Z"^^xsd:dateTime .
+          |OPTIONAL { <http://www.knora.org/ontology/0001/anything#hasText> salsah-gui:guiElement ?oldGuiElement . }
+          |OPTIONAL { <http://www.knora.org/ontology/0001/anything#hasText> salsah-gui:guiAttribute ?oldGuiAttribute . }
+          |OPTIONAL { <http://www.knora.org/ontology/0001/anything#hasTextValue> salsah-gui:guiElement ?oldLinkValuePropertyGuiElement . }
+          |OPTIONAL { <http://www.knora.org/ontology/0001/anything#hasTextValue> salsah-gui:guiAttribute ?oldLinkValuePropertyGuiAttribute . } } }""".stripMargin
+
+      val expected = deleteOldQuery + ";\n" + updateTimestampQuery
+      assertTrue(canonical(actual.sparql) == canonical(expected))
+    },
   )
 }


### PR DESCRIPTION
Follow-up to #4301 (DEV-7210). Resolves DEV-7227. Stacked on #4316.

## Why

Review feedback on #4301: the migrated queries were fragmented into many small `Fragment` pieces assembled programmatically, so the SPARQL shape was no longer visible. A bit of repetition is acceptable if it reads better.

## What

- `ChangePropertyGuiElementQuery` was the real offender: three private fragment builders with nested local defs parameterised over both the subject IRI and the variable names. It is now three full per-statement templates (`deleteOldGui`, optional `insertNewGui`, `updateLastModificationDate`) inside `build`, with the variable names written literally, a shared `prefixes` fragment, two named fragments for the optional link-value property and one `insertGuiTriples(subject)` helper for the 0..n gui triples. The three statements are still joined with `;`, since the statement count and order are pinned by the legacy output.
- `ChangePropertyLabelsOrCommentsQuery` keeps its single template but hoists the three inline link-value lambdas into named fragments above it (`linkValueDelete`, `linkValueInsert`, `linkValueWhere`).
- `ChangeClassLabelsOrCommentsQuery` only renames the `predicate` hole to `labelOrCommentIri`; it already was one template.

The un-GRAPHed WHERE in the label/comment queries and the `GRAPH <ontology>` WHERE in the GUI-element query are deliberately left as they were; the fixtures pin them.

## Verification

The rendered SPARQL is canonically unchanged: all three specs pass with their legacy fixtures untouched. One test is added for the delete-only GUI-element case with a link-value property, which exercises the interaction of the optional INSERT statement with the optional link-value fragments. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
