### PR TITLE
refactor: write migrated SPARQL queries as explicit inline templates and document the convention (DEV-7231)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -61,6 +61,11 @@ SparqlBuilder; existing files keep it until they are migrated (verify a migratio
 diffing rendered SPARQL against the old `getQueryString` output). See
 `docs/development/dsp-api-sparql-queries.md`.
 
+- **One explicit template per query.** Prefixes written out in every template, no pulled-out `prefixes` val and no
+  static sub-segment fragments; holes are for values and genuinely dynamic structure only, and two substantially
+  different runtime shapes are two complete templates. See `docs/development/dsp-api-sparql-queries.md`
+  § Keep the query readable: one explicit template per query.
+
 - **Carve-out — the admin SPARQL passthrough.** `POST /admin/sparql/query` forwards a client-supplied query string to the store on purpose: being transparent is its contract, so it must not parse, validate or rewrite the SPARQL it carries, and no builder applies. This is the only such surface; everything else builds queries. See `docs/03-endpoints/api-admin/sparql-passthrough.md`.
 
 - **Selective patterns before OPTIONALs, in the same flat group.** OPTIONALs are left-joins evaluated in document order; a restriction placed after them is evaluated over the whole class (prod incident DEV-6796: ~150ms → ~700ms tile loads). Beware: `pattern.and(group)` nests (`{ pattern . { … } }`) instead of splicing. See `docs/development/dsp-api-sparql-queries.md` § Pattern Order and Query Performance.

--- a/docs/development/dsp-api-sparql-queries.md
+++ b/docs/development/dsp-api-sparql-queries.md
@@ -41,6 +41,69 @@ the builder until they are migrated. Verify a migration by diffing the rendered 
 against the old builder's `getQueryString` output. Only new *SparqlBuilder* usage is out;
 RDF4J model classes (`org.eclipse.rdf4j.model.*`, `Vocabulary`) remain fine.
 
+## Keep the query readable: one explicit template per query
+
+A reader should be able to read the whole query, top to bottom, inside a single
+`sparql"""|..."""` literal. Prefer a bit of repetition over indirection:
+
+- **One whole-query template per query.** For a multi-statement update (`;`-joined),
+  one complete template per statement.
+- **Write `PREFIX` declarations literally in every template.** No shared `prefixes`
+  val or fragment, not even within one file.
+- **Never pull static SPARQL into a local `val`/`def` "sub-segment" fragment.** Write it
+  inline, even when the same lines appear in several queries of the same file.
+- **Holes are for values and for genuinely dynamic structure.** Typed `Iri`, `Variable`
+  and `Literal` holes; plus an optional block (`Fragment.when` / `.unless` / `.whenSome`),
+  a repeated block (`.joinLines` over a collection), or an alternative chosen at runtime.
+  Name such a fragment after the SPARQL it emits and keep it as small as possible; the
+  fixed part around it stays in the template.
+- **If two runtime shapes differ substantially, write two complete templates** (with the
+  repetition that implies) rather than one template threaded with conditional holes. A
+  `whenSome` hole that needs a multi-line lambda inside the template is the signal to
+  split. See `ChangePropertyGuiElementQuery` for both halves of this rule: its optional
+  link-value-property DELETE is two full templates selected by a `match`, while
+  `ChangePropertyLabelsOrCommentsQuery` keeps its optional parts as single-line
+  `whenSome` holes.
+
+Bad — the query is spread over a shared prefix val and a pulled-out skeleton, so no one
+place shows what is sent to the store:
+
+```scala
+private val prefixes = sparql"""|PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                                |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>"""
+
+val whereClause = sparql"""|$ontology a owl:Ontology ;
+                          |  knora-base:lastModificationDate $previousDate ."""
+val optionalComment = maybeComment.whenSome(c => sparql"OPTIONAL { $ontology rdfs:comment $c . }")
+
+val query = sparql"""|$prefixes
+                    |
+                    |DELETE { GRAPH $ontology { $ontology rdfs:comment ?oldComment . } }
+                    |WHERE {
+                    |  $whereClause
+                    |  $optionalComment
+                    |}"""
+```
+
+Good — the same query inline, with only value holes and one short optional hole:
+
+```scala
+val query = sparql"""|PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                    |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                    |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                    |
+                    |DELETE {
+                    |  GRAPH $ontology {
+                    |    $ontology rdfs:comment ?oldComment .
+                    |  }
+                    |}
+                    |WHERE {
+                    |  $ontology a owl:Ontology ;
+                    |    knora-base:lastModificationDate $previousDate .
+                    |  ${maybeComment.whenSome(c => sparql"OPTIONAL { $ontology rdfs:comment $c . }")}
+                    |}"""
+```
+
 ---
 
 The rest of this document covers the **grandfathered** RDF4J SparqlBuilder style — needed

--- a/modules/sparql-builder/README.md
+++ b/modules/sparql-builder/README.md
@@ -56,6 +56,14 @@ val query = sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-ba
                       |}"""
 ```
 
+Fragments are for **dynamic structure only** — an optional block, a repeated block, or an
+alternative chosen at runtime. Never use one to factor out static SPARQL that several
+queries happen to share, and write the `PREFIX` declarations literally in every template:
+one whole-query template a reader can follow top to bottom beats a query assembled from
+named pieces. When two runtime shapes differ substantially, write two complete templates
+rather than threading one template with conditional holes. See
+[the convention](../../docs/development/dsp-api-sparql-queries.md#keep-the-query-readable-one-explicit-template-per-query).
+
 `Fragments` also provides `optional`, `union`, `graph`, `filter`, `filterNotExists`,
 `minus`, `bind`, `values`, and `subquery` for constructs that are themselves dynamic.
 When a construct is fixed, write it directly in the query. The raw monoid (`++`,

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/LegalInfoQueries.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/domain/service/LegalInfoQueries.scala
@@ -17,31 +17,25 @@ private[service] object AuthorshipQueries {
   val authorVar: Variable = Variable("author")
   val countVar: Variable  = Variable("count")
 
-  /**
-   * The graph pattern shared by both queries. The search term is lowercased before it is
-   * turned into a literal, so that it matches the `LCASE(STR(...))` on the left-hand side.
-   */
-  private def graphPattern(projectGraph: Iri, filterAndOrder: FilterAndOrder): Fragment = {
-    val searchFilter = filterAndOrder.filter.whenSome { term =>
-      Fragments.filter(sparql"CONTAINS(LCASE(STR($authorVar)), ${Literal.string(term.toLowerCase)})")
-    }
-    Fragments.graph(sparql"$projectGraph")(
-      sparql"""|?fileValue knora-base:hasAuthorship $authorVar .
-               |$searchFilter""",
-    )
-  }
-
   def authorships(projectGraph: Iri, paging: PageAndSize, filterAndOrder: FilterAndOrder): Select = {
     val order = filterAndOrder.order match {
       case Order.Asc  => sparql"ASC"
       case Order.Desc => sparql"DESC"
+    }
+    // The search term is lowercased before it is turned into a literal, so that it matches the
+    // `LCASE(STR(...))` on the left-hand side.
+    val searchFilter = filterAndOrder.filter.whenSome { term =>
+      Fragments.filter(sparql"CONTAINS(LCASE(STR($authorVar)), ${Literal.string(term.toLowerCase)})")
     }
     Select(
       sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |SELECT DISTINCT $authorVar
                |WHERE {
-               |  ${graphPattern(projectGraph, filterAndOrder)}
+               |  GRAPH $projectGraph {
+               |    ?fileValue knora-base:hasAuthorship $authorVar .
+               |    $searchFilter
+               |  }
                |}
                |ORDER BY $order($authorVar)
                |LIMIT ${Literal.int(paging.size)}
@@ -49,13 +43,21 @@ private[service] object AuthorshipQueries {
     )
   }
 
-  def count(projectGraph: Iri, filterAndOrder: FilterAndOrder): Select =
+  def count(projectGraph: Iri, filterAndOrder: FilterAndOrder): Select = {
+    // Same lowercasing as in `authorships`, so that both queries filter on the same term.
+    val searchFilter = filterAndOrder.filter.whenSome { term =>
+      Fragments.filter(sparql"CONTAINS(LCASE(STR($authorVar)), ${Literal.string(term.toLowerCase)})")
+    }
     Select(
       sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |SELECT (COUNT(DISTINCT $authorVar) AS $countVar)
                |WHERE {
-               |  ${graphPattern(projectGraph, filterAndOrder)}
+               |  GRAPH $projectGraph {
+               |    ?fileValue knora-base:hasAuthorship $authorVar .
+               |    $searchFilter
+               |  }
                |}""".render,
     )
+  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsByPropertyRepo.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/admin/repo/ViewRestrictionsByPropertyRepo.scala
@@ -230,10 +230,6 @@ object ViewRestrictionsByPropertyRepo {
   /** The knora-base ontology, which is not among a project's own and must be fetched explicitly. */
   private[repo] val KnoraBaseOntologyIri: String = OntologyConstants.KnoraBase.KnoraBaseOntologyIri
 
-  private val prefixes =
-    sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-             |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"""
-
   /**
    * `SELECT ?permissions (COUNT(DISTINCT ?value) AS ?cnt) … GROUP BY ?permissions` for ONE property.
    *
@@ -252,23 +248,45 @@ object ViewRestrictionsByPropertyRepo {
   ): Select = {
     val project  = Iri.unsafeFrom(projectIri.value)
     val property = Iri.unsafeFrom(propertyIri)
-    val skeleton =
-      sparql"""|?resource knora-base:attachedToProject $project ;
-               |  knora-base:isDeleted false ;
-               |  $property ?value .
-               |?value knora-base:hasPermissions ?permissions ;
-               |  knora-base:isDeleted false .
-               |FILTER NOT EXISTS { ?value a knora-base:LinkValue . }"""
-    Select(
-      sparql"""|$prefixes
-               |
-               |SELECT ?permissions (COUNT(DISTINCT ?value) AS ?cnt)
-               |WHERE {
-               |  ${narrowedTo(itemType, skeleton)}
-               |}
-               |GROUP BY ?permissions""".render,
-      SparqlTimeout.ViewRestrictions,
-    )
+    itemTypeConstraint(itemType) match {
+      case None =>
+        Select(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |
+                   |SELECT ?permissions (COUNT(DISTINCT ?value) AS ?cnt)
+                   |WHERE {
+                   |  ?resource knora-base:attachedToProject $project ;
+                   |    knora-base:isDeleted false ;
+                   |    $property ?value .
+                   |  ?value knora-base:hasPermissions ?permissions ;
+                   |    knora-base:isDeleted false .
+                   |  FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+                   |}
+                   |GROUP BY ?permissions""".render,
+          SparqlTimeout.ViewRestrictions,
+        )
+      case Some(constraint) =>
+        Select(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |
+                   |SELECT ?permissions (COUNT(DISTINCT ?value) AS ?cnt)
+                   |WHERE {
+                   |  {
+                   |    ?resource knora-base:attachedToProject $project ;
+                   |      knora-base:isDeleted false ;
+                   |      $property ?value .
+                   |    ?value knora-base:hasPermissions ?permissions ;
+                   |      knora-base:isDeleted false .
+                   |    FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+                   |  }
+                   |  $constraint
+                   |}
+                   |GROUP BY ?permissions""".render,
+          SparqlTimeout.ViewRestrictions,
+        )
+    }
   }
 
   /**
@@ -281,6 +299,10 @@ object ViewRestrictionsByPropertyRepo {
    * the pages consumed rows, leaving the resources past that point unreachable by any page number the
    * pagination block admits. [[ViewRestrictionsRepo.resourcePageQuery]] has this shape for the same reason.
    * [[drillDownRowsQuery]] then fetches the rows for exactly this page's IRIs.
+   *
+   * The restriction filter stays inside the inner group, i.e. before the label OPTIONAL is joined in.
+   * Ordering by the label when present and the IRI otherwise keeps unlabelled resources paging
+   * deterministically.
    */
   private[repo] def drillDownResourcePageQuery(
     projectIri: ProjectIri,
@@ -291,33 +313,59 @@ object ViewRestrictionsByPropertyRepo {
   ): Select = {
     val project  = Iri.unsafeFrom(projectIri.value)
     val property = Iri.unsafeFrom(propertyIri)
-    val skeleton =
-      sparql"""|?resource knora-base:attachedToProject $project ;
-               |  knora-base:isDeleted false ;
-               |  $property ?value .
-               |?value knora-base:hasPermissions ?permissions ;
-               |  knora-base:isDeleted false .
-               |FILTER NOT EXISTS { ?value a knora-base:LinkValue . }"""
-    Select(
-      // The restriction filter stays inside the inner group, i.e. before the label OPTIONAL is joined in.
-      // Ordering by the label when present and the IRI otherwise keeps unlabelled resources paging
-      // deterministically.
-      sparql"""|$prefixes
-               |
-               |SELECT DISTINCT ?resource ?labelOrIri
-               |WHERE {
-               |  {
-               |    ${narrowedTo(itemType, skeleton)}
-               |    $onlyRestricted
-               |  }
-               |  OPTIONAL { ?resource rdfs:label ?label . }
-               |  BIND(COALESCE(?label, STR(?resource)) AS ?labelOrIri)
-               |}
-               |ORDER BY ASC(?labelOrIri) ASC(?resource)
-               |LIMIT ${Literal.int(limit)}
-               |OFFSET ${Literal.int(offset)}""".render,
-      SparqlTimeout.ViewRestrictions,
-    )
+    itemTypeConstraint(itemType) match {
+      case None =>
+        Select(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |
+                   |SELECT DISTINCT ?resource ?labelOrIri
+                   |WHERE {
+                   |  {
+                   |    ?resource knora-base:attachedToProject $project ;
+                   |      knora-base:isDeleted false ;
+                   |      $property ?value .
+                   |    ?value knora-base:hasPermissions ?permissions ;
+                   |      knora-base:isDeleted false .
+                   |    FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+                   |    FILTER (!REGEX(?permissions, ${Literal.string(grantsViewToAnonymousRegex)}))
+                   |  }
+                   |  OPTIONAL { ?resource rdfs:label ?label . }
+                   |  BIND(COALESCE(?label, STR(?resource)) AS ?labelOrIri)
+                   |}
+                   |ORDER BY ASC(?labelOrIri) ASC(?resource)
+                   |LIMIT ${Literal.int(limit)}
+                   |OFFSET ${Literal.int(offset)}""".render,
+          SparqlTimeout.ViewRestrictions,
+        )
+      case Some(constraint) =>
+        Select(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |
+                   |SELECT DISTINCT ?resource ?labelOrIri
+                   |WHERE {
+                   |  {
+                   |    {
+                   |      ?resource knora-base:attachedToProject $project ;
+                   |        knora-base:isDeleted false ;
+                   |        $property ?value .
+                   |      ?value knora-base:hasPermissions ?permissions ;
+                   |        knora-base:isDeleted false .
+                   |      FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+                   |    }
+                   |    $constraint
+                   |    FILTER (!REGEX(?permissions, ${Literal.string(grantsViewToAnonymousRegex)}))
+                   |  }
+                   |  OPTIONAL { ?resource rdfs:label ?label . }
+                   |  BIND(COALESCE(?label, STR(?resource)) AS ?labelOrIri)
+                   |}
+                   |ORDER BY ASC(?labelOrIri) ASC(?resource)
+                   |LIMIT ${Literal.int(limit)}
+                   |OFFSET ${Literal.int(offset)}""".render,
+          SparqlTimeout.ViewRestrictions,
+        )
+    }
   }
 
   /**
@@ -339,30 +387,65 @@ object ViewRestrictionsByPropertyRepo {
     val project  = Iri.unsafeFrom(projectIri.value)
     val property = Iri.unsafeFrom(propertyIri)
     val pageIris = Fragment.join(resourceIris.map(Iri.unsafeFrom(_).toFragment), Fragment.raw(", "))
-    val skeleton =
-      sparql"""|?resource knora-base:attachedToProject $project ;
-               |  knora-base:isDeleted false ;
-               |  $property ?value .
-               |?value knora-base:hasPermissions ?permissions ;
-               |  knora-base:isDeleted false .
-               |FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
-               |?resource a ?resClass .
-               |?value knora-base:attachedToUser ?creator .
-               |OPTIONAL { ?resource rdfs:label ?label . }
-               |$optionalFileClass
-               |OPTIONAL { ?value knora-base:valueHasComment ?comment . }"""
-    Select(
-      sparql"""|$prefixes
-               |
-               |SELECT DISTINCT ?resource ?resClass ?value ?creator ?permissions ?fileClass ?comment ?label
-               |WHERE {
-               |  ${narrowedTo(itemType, skeleton)}
-               |  $onlyRestricted
-               |  FILTER (?resource IN ($pageIris))
-               |}
-               |ORDER BY ASC(?label) ASC(?resource) ASC(?value)""".render,
-      SparqlTimeout.ViewRestrictions,
-    )
+    itemTypeConstraint(itemType) match {
+      case None =>
+        Select(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |
+                   |SELECT DISTINCT ?resource ?resClass ?value ?creator ?permissions ?fileClass ?comment ?label
+                   |WHERE {
+                   |  ?resource knora-base:attachedToProject $project ;
+                   |    knora-base:isDeleted false ;
+                   |    $property ?value .
+                   |  ?value knora-base:hasPermissions ?permissions ;
+                   |    knora-base:isDeleted false .
+                   |  FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+                   |  ?resource a ?resClass .
+                   |  ?value knora-base:attachedToUser ?creator .
+                   |  OPTIONAL { ?resource rdfs:label ?label . }
+                   |  OPTIONAL {
+                   |    ?value a ?fileClass .
+                   |    ?fileClass rdfs:subClassOf* knora-base:FileValue .
+                   |  }
+                   |  OPTIONAL { ?value knora-base:valueHasComment ?comment . }
+                   |  FILTER (!REGEX(?permissions, ${Literal.string(grantsViewToAnonymousRegex)}))
+                   |  FILTER (?resource IN ($pageIris))
+                   |}
+                   |ORDER BY ASC(?label) ASC(?resource) ASC(?value)""".render,
+          SparqlTimeout.ViewRestrictions,
+        )
+      case Some(constraint) =>
+        Select(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |
+                   |SELECT DISTINCT ?resource ?resClass ?value ?creator ?permissions ?fileClass ?comment ?label
+                   |WHERE {
+                   |  {
+                   |    ?resource knora-base:attachedToProject $project ;
+                   |      knora-base:isDeleted false ;
+                   |      $property ?value .
+                   |    ?value knora-base:hasPermissions ?permissions ;
+                   |      knora-base:isDeleted false .
+                   |    FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+                   |    ?resource a ?resClass .
+                   |    ?value knora-base:attachedToUser ?creator .
+                   |    OPTIONAL { ?resource rdfs:label ?label . }
+                   |    OPTIONAL {
+                   |      ?value a ?fileClass .
+                   |      ?fileClass rdfs:subClassOf* knora-base:FileValue .
+                   |    }
+                   |    OPTIONAL { ?value knora-base:valueHasComment ?comment . }
+                   |  }
+                   |  $constraint
+                   |  FILTER (!REGEX(?permissions, ${Literal.string(grantsViewToAnonymousRegex)}))
+                   |  FILTER (?resource IN ($pageIris))
+                   |}
+                   |ORDER BY ASC(?label) ASC(?resource) ASC(?value)""".render,
+          SparqlTimeout.ViewRestrictions,
+        )
+    }
   }
 
   /**
@@ -376,105 +459,96 @@ object ViewRestrictionsByPropertyRepo {
   ): Select = {
     val project  = Iri.unsafeFrom(projectIri.value)
     val property = Iri.unsafeFrom(propertyIri)
-    val skeleton =
-      sparql"""|?resource knora-base:attachedToProject $project ;
-               |  knora-base:isDeleted false ;
-               |  $property ?value .
-               |?value knora-base:hasPermissions ?permissions ;
-               |  knora-base:isDeleted false .
-               |FILTER NOT EXISTS { ?value a knora-base:LinkValue . }"""
-    Select(
-      sparql"""|$prefixes
-               |
-               |SELECT (COUNT(DISTINCT ?resource) AS ?cnt)
-               |WHERE {
-               |  ${narrowedTo(itemType, skeleton)}
-               |  $onlyRestricted
-               |}""".render,
-      SparqlTimeout.ViewRestrictions,
-    )
+    itemTypeConstraint(itemType) match {
+      case None =>
+        Select(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |
+                   |SELECT (COUNT(DISTINCT ?resource) AS ?cnt)
+                   |WHERE {
+                   |  ?resource knora-base:attachedToProject $project ;
+                   |    knora-base:isDeleted false ;
+                   |    $property ?value .
+                   |  ?value knora-base:hasPermissions ?permissions ;
+                   |    knora-base:isDeleted false .
+                   |  FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+                   |  FILTER (!REGEX(?permissions, ${Literal.string(grantsViewToAnonymousRegex)}))
+                   |}""".render,
+          SparqlTimeout.ViewRestrictions,
+        )
+      case Some(constraint) =>
+        Select(
+          sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                   |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                   |
+                   |SELECT (COUNT(DISTINCT ?resource) AS ?cnt)
+                   |WHERE {
+                   |  {
+                   |    ?resource knora-base:attachedToProject $project ;
+                   |      knora-base:isDeleted false ;
+                   |      $property ?value .
+                   |    ?value knora-base:hasPermissions ?permissions ;
+                   |      knora-base:isDeleted false .
+                   |    FILTER NOT EXISTS { ?value a knora-base:LinkValue . }
+                   |  }
+                   |  $constraint
+                   |  FILTER (!REGEX(?permissions, ${Literal.string(grantsViewToAnonymousRegex)}))
+                   |}""".render,
+          SparqlTimeout.ViewRestrictions,
+        )
+    }
   }
 
   /*
-   * The four templates above repeat the same WHERE skeleton — a project's current, non-deleted values of
-   * ONE property — rather than sharing it, so that each query can be read as one whole piece of SPARQL.
+   * The four queries above repeat the same WHERE skeleton — a project's current, non-deleted values of ONE
+   * property — rather than sharing it, so that each template can be read as one whole piece of SPARQL.
    *
    * No `?resClass` and no `ProjectClasses` — see the class doc for why, and for the measurement.
    * `attachedToProject` on the resource is the whole project scope this needs. The property IRI is bound in
    * the pattern, not filtered: 1,053ms against 3,060ms on LHTT.
    *
-   * Each template holds its skeleton as a local `skeleton` fragment and hands it to `narrowedTo`, which is
-   * the one place that decides whether the skeleton is wrapped in a group of its own. It is wrapped exactly
-   * when an item-type constraint follows it — the constraint then cannot be merged into the skeleton's
-   * basic graph pattern, nor reordered against its triples — and left bare when there is no constraint, so
-   * no template adds a group that has nothing to separate.
-   */
-
-  /** OPTIONAL `?fileClass`, bound iff the value is (a subclass of) `knora-base:FileValue`. */
-  private val optionalFileClass =
-    sparql"""|OPTIONAL {
-             |  ?value a ?fileClass .
-             |  ?fileClass rdfs:subClassOf* knora-base:FileValue .
-             |}"""
-
-  /**
-   * The WHERE skeleton, narrowed to one kind of value.
+   * Each query is written as two whole templates chosen by whether an item-type constraint applies. The
+   * skeleton is wrapped in a group of its own exactly when a constraint follows it — the constraint then
+   * cannot be merged into the skeleton's basic graph pattern, nor reordered against its triples — and left
+   * bare when there is no constraint, so no template adds a group that has nothing to separate.
    *
-   * `All` has no constraint, so the skeleton is returned exactly as the template wrote it. Every other item
-   * type puts the skeleton in a group of its own and appends the constraint beside it, which keeps the
-   * skeleton a basic graph pattern the constraint can neither be merged into nor reordered against.
+   * The counts deliberately do NOT apply the `!REGEX` restriction filter that the drill-down does: keeping
+   * every permission literal is what makes the property's whole population derivable from the same rows.
    */
-  private def narrowedTo(itemType: ValueItemType, skeleton: Fragment): Fragment =
-    itemTypeConstraint(itemType) match {
-      case None             => skeleton
-      case Some(constraint) =>
-        sparql"""|{
-                 |  $skeleton
-                 |}
-                 |$constraint"""
-    }
 
   /**
    * Narrows to one kind of value. Copied rather than shared with [[ViewRestrictionsRepo]]: reusing it would
    * couple the two repos through the exact seam this split exists to remove, and the fragment is small.
    *
    * `All` has no constraint at all; the group that isolates the skeleton exists only to separate it from a
-   * constraint, so `narrowedTo` omits both.
+   * constraint, so the callers omit both.
    */
-  private def itemTypeConstraint(itemType: ValueItemType): Option[Fragment] = {
-    val isFile =
-      sparql"""|?value a ?fileClass .
-               |?fileClass rdfs:subClassOf* knora-base:FileValue ."""
+  private def itemTypeConstraint(itemType: ValueItemType): Option[Fragment] =
     itemType match {
       case ValueItemType.File =>
         Some(sparql"""|{
-                      |  $isFile
+                      |  ?value a ?fileClass .
+                      |  ?fileClass rdfs:subClassOf* knora-base:FileValue .
                       |}""")
       case ValueItemType.Value =>
         Some(sparql"""|FILTER NOT EXISTS {
-                      |  $isFile
+                      |  ?value a ?fileClass .
+                      |  ?fileClass rdfs:subClassOf* knora-base:FileValue .
                       |}""")
       case ValueItemType.Comment =>
         Some(sparql"?value knora-base:valueHasComment ?comment .")
       case ValueItemType.All => None
     }
-  }
 
   /**
    * Matches a permission literal that grants full view to anonymous users. Copied from
    * [[ViewRestrictionsRepo]] rather than shared, like `itemTypeConstraint` above.
+   *
+   * The drill-down queries use it in a `FILTER(!REGEX(?permissions, …))` to keep only rows restricted from
+   * someone. The authoritative per-audience decision still happens in Scala via `PermissionUtilADM`; the
+   * filter only removes provably-open rows, so it is conservative.
    */
   private val grantsViewToAnonymousRegex = "(^|[|])(V|M|D|CR) [^|]*knora-admin:UnknownUser"
-
-  /**
-   * `FILTER(!REGEX(?permissions, …))` — keep only rows restricted from someone.
-   *
-   * The drill-down lists restrictions, so provably-open values are dropped here. The counts deliberately do
-   * NOT apply this: keeping every literal is what makes the property's whole population derivable from the
-   * same rows. The authoritative per-audience decision still happens in Scala via `PermissionUtilADM`;
-   * this only removes provably-open rows, so it is conservative.
-   */
-  private val onlyRestricted =
-    sparql"FILTER (!REGEX(?permissions, ${Literal.string(grantsViewToAnonymousRegex)}))"
 
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminDataQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/export/domain/AdminDataQuery.scala
@@ -39,43 +39,62 @@ object AdminDataQuery {
     // Sorted so that the rendered VALUES rows are deterministic for a given set of users.
     val userIris = referencedUserIris.toList.map(_.value).sorted.map(Iri.unsafeFrom)
 
-    val projectBranch =
-      sparql"""|$projectIri a knora-admin:knoraProject ;
-               |  ?projectPred ?projectObj ."""
-
-    val projectMembersBranch =
-      sparql"""|$user a knora-admin:User ;
-               |  ?userPred ?userObj ;
-               |  knora-admin:isInProject $projectIri ."""
-
-    // Guarded: Fragments.values requires a non-empty collection.
-    val referencedUsersBranch = Option.when(userIris.nonEmpty)(
-      sparql"""|$user a knora-admin:User ;
-               |  ?userPred ?userObj .
-               |${Fragments.values(user, userIris)}""",
-    )
-
-    val groupsBranch =
-      sparql"""|?group a knora-admin:UserGroup ;
-               |  ?groupPred ?groupObj ;
-               |  knora-admin:belongsToProject $projectIri ."""
-
-    val branches =
-      List(projectBranch, projectMembersBranch) ::: referencedUsersBranch.toList ::: List(groupsBranch)
-
-    Construct(
-      sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
-               |
-               |CONSTRUCT {
-               |  $projectIri ?projectPred ?projectObj .
-               |  $user ?userPred ?userObj .
-               |  ?group ?groupPred ?groupObj .
-               |}
-               |WHERE {
-               |  GRAPH $adminGraph {
-               |    ${Fragments.union(branches*)}
-               |  }
-               |}""".render,
-    )
+    if (userIris.isEmpty) {
+      Construct(
+        sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+                 |
+                 |CONSTRUCT {
+                 |  $projectIri ?projectPred ?projectObj .
+                 |  $user ?userPred ?userObj .
+                 |  ?group ?groupPred ?groupObj .
+                 |}
+                 |WHERE {
+                 |  GRAPH $adminGraph {
+                 |    {
+                 |      $projectIri a knora-admin:knoraProject ;
+                 |        ?projectPred ?projectObj .
+                 |    } UNION {
+                 |      $user a knora-admin:User ;
+                 |        ?userPred ?userObj ;
+                 |        knora-admin:isInProject $projectIri .
+                 |    } UNION {
+                 |      ?group a knora-admin:UserGroup ;
+                 |        ?groupPred ?groupObj ;
+                 |        knora-admin:belongsToProject $projectIri .
+                 |    }
+                 |  }
+                 |}""".render,
+      )
+    } else {
+      Construct(
+        sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+                 |
+                 |CONSTRUCT {
+                 |  $projectIri ?projectPred ?projectObj .
+                 |  $user ?userPred ?userObj .
+                 |  ?group ?groupPred ?groupObj .
+                 |}
+                 |WHERE {
+                 |  GRAPH $adminGraph {
+                 |    {
+                 |      $projectIri a knora-admin:knoraProject ;
+                 |        ?projectPred ?projectObj .
+                 |    } UNION {
+                 |      $user a knora-admin:User ;
+                 |        ?userPred ?userObj ;
+                 |        knora-admin:isInProject $projectIri .
+                 |    } UNION {
+                 |      $user a knora-admin:User ;
+                 |        ?userPred ?userObj .
+                 |      ${Fragments.values(user, userIris)}
+                 |    } UNION {
+                 |      ?group a knora-admin:UserGroup ;
+                 |        ?groupPred ?groupObj ;
+                 |        knora-admin:belongsToProject $projectIri .
+                 |    }
+                 |  }
+                 |}""".render,
+      )
+    }
   }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyGuiElementQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyGuiElementQuery.scala
@@ -15,13 +15,6 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
 object ChangePropertyGuiElementQuery {
 
-  private val prefixes =
-    sparql"""|PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-             |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-             |PREFIX owl: <http://www.w3.org/2002/07/owl#>
-             |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-             |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>"""
-
   def build(
     ontologyIri: OntologyIri,
     propertyIri: PropertyIri,
@@ -39,45 +32,70 @@ object ChangePropertyGuiElementQuery {
     val previousDate  = Literal.dateTime(lastModificationDate)
     val currentDate   = Literal.dateTime(currentTime)
 
-    // A link property's link value property carries the same GUI element and attributes,
-    // so it is cleared and re-set alongside the property itself.
-    val deleteLinkPropertyGui = linkProperty.whenSome { lp =>
-      sparql"""|$lp salsah-gui:guiElement ?oldLinkValuePropertyGuiElement .
-               |$lp salsah-gui:guiAttribute ?oldLinkValuePropertyGuiAttribute ."""
-    }
-    val matchLinkPropertyGui = linkProperty.whenSome { lp =>
-      sparql"""|OPTIONAL { $lp salsah-gui:guiElement ?oldLinkValuePropertyGuiElement . }
-               |OPTIONAL { $lp salsah-gui:guiAttribute ?oldLinkValuePropertyGuiAttribute . }"""
-    }
-
     /** The new `salsah-gui:guiElement` triple (if any) plus one triple per new gui attribute. */
     def insertGuiTriples(subject: Iri): Fragment =
       (guiElement.map(e => sparql"$subject salsah-gui:guiElement $e .").toList :::
         guiAttributes.map(a => sparql"$subject salsah-gui:guiAttribute $a .")).joinLines
 
-    val deleteOldGui =
-      sparql"""|$prefixes
-               |
-               |DELETE {
-               |  GRAPH $ontology {
-               |    $property salsah-gui:guiElement ?oldGuiElement .
-               |    $property salsah-gui:guiAttribute ?oldGuiAttribute .
-               |    $deleteLinkPropertyGui
-               |  }
-               |}
-               |WHERE {
-               |  GRAPH $ontology {
-               |    $ontology a owl:Ontology ;
-               |      knora-base:lastModificationDate $previousDate .
-               |    OPTIONAL { $property salsah-gui:guiElement ?oldGuiElement . }
-               |    OPTIONAL { $property salsah-gui:guiAttribute ?oldGuiAttribute . }
-               |    $matchLinkPropertyGui
-               |  }
-               |}"""
+    // A link property's link value property carries the same GUI element and attributes,
+    // so it is cleared and re-set alongside the property itself. The two shapes differ too
+    // much for conditional holes, so each is written out as its own complete statement.
+    val deleteOldGui = linkProperty match {
+      case Some(lp) =>
+        sparql"""|PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                 |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                 |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>
+                 |
+                 |DELETE {
+                 |  GRAPH $ontology {
+                 |    $property salsah-gui:guiElement ?oldGuiElement .
+                 |    $property salsah-gui:guiAttribute ?oldGuiAttribute .
+                 |    $lp salsah-gui:guiElement ?oldLinkValuePropertyGuiElement .
+                 |    $lp salsah-gui:guiAttribute ?oldLinkValuePropertyGuiAttribute .
+                 |  }
+                 |}
+                 |WHERE {
+                 |  GRAPH $ontology {
+                 |    $ontology a owl:Ontology ;
+                 |      knora-base:lastModificationDate $previousDate .
+                 |    OPTIONAL { $property salsah-gui:guiElement ?oldGuiElement . }
+                 |    OPTIONAL { $property salsah-gui:guiAttribute ?oldGuiAttribute . }
+                 |    OPTIONAL { $lp salsah-gui:guiElement ?oldLinkValuePropertyGuiElement . }
+                 |    OPTIONAL { $lp salsah-gui:guiAttribute ?oldLinkValuePropertyGuiAttribute . }
+                 |  }
+                 |}"""
+      case None =>
+        sparql"""|PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                 |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                 |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                 |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                 |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>
+                 |
+                 |DELETE {
+                 |  GRAPH $ontology {
+                 |    $property salsah-gui:guiElement ?oldGuiElement .
+                 |    $property salsah-gui:guiAttribute ?oldGuiAttribute .
+                 |  }
+                 |}
+                 |WHERE {
+                 |  GRAPH $ontology {
+                 |    $ontology a owl:Ontology ;
+                 |      knora-base:lastModificationDate $previousDate .
+                 |    OPTIONAL { $property salsah-gui:guiElement ?oldGuiElement . }
+                 |    OPTIONAL { $property salsah-gui:guiAttribute ?oldGuiAttribute . }
+                 |  }
+                 |}"""
+    }
 
     // Omitted entirely when there is nothing to set (the GUI element was only removed).
     val insertNewGui = Option.when(guiElement.isDefined || guiAttributes.nonEmpty)(
-      sparql"""|$prefixes
+      sparql"""|PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+               |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+               |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>
                |
                |INSERT {
                |  GRAPH $ontology {
@@ -94,7 +112,11 @@ object ChangePropertyGuiElementQuery {
     )
 
     val updateLastModificationDate =
-      sparql"""|$prefixes
+      sparql"""|PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+               |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+               |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>
                |
                |DELETE {
                |  GRAPH $ontology {

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyLabelsOrCommentsQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ChangePropertyLabelsOrCommentsQuery.scala
@@ -24,25 +24,20 @@ object ChangePropertyLabelsOrCommentsQuery {
     lastModificationDate: LastModificationDate,
   ): UIO[Update] =
     Clock.instant.map { now =>
-      val ontology          = Iri.unsafeFrom(propertyIri.ontologyIri.toInternalSchema.toIri)
-      val property          = Iri.unsafeFrom(propertyIri.toInternalSchema.toIri)
-      val linkValueProperty = maybeLinkValuePropertyIri.map(iri => Iri.unsafeFrom(iri.toInternalSchema.toIri))
+      val ontology = Iri.unsafeFrom(propertyIri.ontologyIri.toInternalSchema.toIri)
+      val property = Iri.unsafeFrom(propertyIri.toInternalSchema.toIri)
+      // A link property's link value property carries the same labels/comments,
+      // so its old values are replaced alongside the property's own.
+      val linkValueProp     = maybeLinkValuePropertyIri.map(iri => Iri.unsafeFrom(iri.toInternalSchema.toIri))
       val labelOrCommentIri = Iri.unsafeFrom(labelOrComment.toString) // rdfs:label or rdfs:comment
       val previousDate      = Literal.dateTime(lastModificationDate.value)
       val currentDate       = Literal.dateTime(now)
 
-      // One <subject> rdfs:label|rdfs:comment "..."@lang . triple per new value.
+      /** One `<subject> rdfs:label|rdfs:comment "..."@lang .` triple per new value. */
       def newValueTriples(subject: Iri): Fragment =
         newValues
           .map(v => sparql"$subject $labelOrCommentIri ${Literal.langString(v.value, v.language.value)} .")
           .joinLines
-
-      // A link property's link value property carries the same labels/comments,
-      // so its old values are replaced alongside the property's own.
-      val linkValueDelete = linkValueProperty.whenSome(p => sparql"$p $labelOrCommentIri ?oldLinkValueValues .")
-      val linkValueInsert = linkValueProperty.whenSome(newValueTriples)
-      val linkValueWhere  =
-        linkValueProperty.whenSome(p => sparql"OPTIONAL { $p $labelOrCommentIri ?oldLinkValueValues . }")
 
       Update(
         sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
@@ -54,21 +49,21 @@ object ChangePropertyLabelsOrCommentsQuery {
                  |  GRAPH $ontology {
                  |    $ontology knora-base:lastModificationDate $previousDate .
                  |    $property $labelOrCommentIri ?oldValues .
-                 |    $linkValueDelete
+                 |    ${linkValueProp.whenSome(p => sparql"$p $labelOrCommentIri ?oldLinkValueValues .")}
                  |  }
                  |}
                  |INSERT {
                  |  GRAPH $ontology {
                  |    $ontology knora-base:lastModificationDate $currentDate .
                  |    ${newValueTriples(property)}
-                 |    $linkValueInsert
+                 |    ${linkValueProp.whenSome(newValueTriples)}
                  |  }
                  |}
                  |WHERE {
                  |  $ontology a owl:Ontology ;
                  |    knora-base:lastModificationDate $previousDate .
                  |  OPTIONAL { $property $labelOrCommentIri ?oldValues . }
-                 |  $linkValueWhere
+                 |  ${linkValueProp.whenSome(p => sparql"OPTIONAL { $p $labelOrCommentIri ?oldLinkValueValues . }")}
                  |}""".render,
       )
     }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/CreatePropertyQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/CreatePropertyQuery.scala
@@ -41,8 +41,11 @@ object CreatePropertyQuery {
         .joinLines
     }
 
-    def linkValuePropertyTriples(definition: PropertyInfoContentV2): Fragment =
-      propertyTriples(Iri.unsafeFrom(definition.propertyIri.toInternalSchema.toIri), definition)
+    val linkValuePropertyTriples =
+      linkValuePropertyDef.whenSome(d => propertyTriples(Iri.unsafeFrom(d.propertyIri.toInternalSchema.toIri), d))
+
+    val linkValuePropertyNotExists =
+      linkValueProperty.whenSome(iri => sparql"FILTER NOT EXISTS { $iri a ?existingLinkValuePropertyType . }")
 
     Update(
       sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
@@ -60,7 +63,7 @@ object CreatePropertyQuery {
                |  GRAPH $ontology {
                |    $ontology knora-base:lastModificationDate $currentDate .
                |    ${propertyTriples(property, propertyDef)}
-               |    ${linkValuePropertyDef.whenSome(linkValuePropertyTriples)}
+               |    $linkValuePropertyTriples
                |  }
                |}
                |WHERE {
@@ -69,9 +72,7 @@ object CreatePropertyQuery {
                |      knora-base:lastModificationDate $previousDate .
                |  }
                |  FILTER NOT EXISTS { $property rdf:type ?existingPropertyType . }
-               |  ${linkValueProperty.whenSome(iri =>
-          sparql"FILTER NOT EXISTS { $iri a ?existingLinkValuePropertyType . }",
-        )}
+               |  $linkValuePropertyNotExists
                |}""".render,
     )
   }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/DeletePropertyQuery.scala
@@ -26,9 +26,6 @@ object DeletePropertyQuery {
       val previousDate      = Literal.dateTime(lmd.value)
       val currentDate       = Literal.dateTime(now)
 
-      def linkValueTriple(iri: Iri): Fragment =
-        sparql"$iri ?linkValuePropertyPred ?linkValuePropertyObj ."
-
       val update = Update(
         sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -38,7 +35,7 @@ object DeletePropertyQuery {
                  |  GRAPH $ontology {
                  |    $ontology knora-base:lastModificationDate $previousDate .
                  |    $property ?propertyPred ?propertyObj .
-                 |    ${linkValueProperty.whenSome(linkValueTriple)}
+                 |    ${linkValueProperty.whenSome(iri => sparql"$iri ?linkValuePropertyPred ?linkValuePropertyObj .")}
                  |  }
                  |}
                  |INSERT {
@@ -52,7 +49,7 @@ object DeletePropertyQuery {
                  |  $property a owl:ObjectProperty ;
                  |    ?propertyPred ?propertyObj .
                  |  FILTER NOT EXISTS { ?s ?p $property . }
-                 |  ${linkValueProperty.whenSome(linkValueTriple)}
+                 |  ${linkValueProperty.whenSome(iri => sparql"$iri ?linkValuePropertyPred ?linkValuePropertyObj .")}
                  |}""".render,
       )
       (LastModificationDate.from(now), update)

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ReplaceClassCardinalitiesQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/ontology/repo/ReplaceClassCardinalitiesQuery.scala
@@ -16,14 +16,6 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 
 object ReplaceClassCardinalitiesQuery {
 
-  private val prefixes =
-    sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-             |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-             |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-             |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-             |PREFIX owl: <http://www.w3.org/2002/07/owl#>
-             |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>"""
-
   def build(
     ontologyIri: OntologyIri,
     classIri: SmartIri,
@@ -36,62 +28,63 @@ object ReplaceClassCardinalitiesQuery {
     val previousDate = Literal.dateTime(lastModificationDate)
     val currentDate  = Literal.dateTime(currentTime)
 
-    val parts = List(
-      deleteRestrictions(ontology, clazz, previousDate),
-      insertCardinalitiesAndUpdateDate(ontology, clazz, newCardinalities, previousDate, currentDate),
-    )
+    // Statement 1: drop the class's existing blank-node cardinality restrictions.
+    val deleteRestrictions =
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+               |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+               |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+               |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>
+               |
+               |DELETE {
+               |  GRAPH $ontology {
+               |    $clazz rdfs:subClassOf ?restriction .
+               |    ?restriction ?restrictionPred ?restrictionObj .
+               |  }
+               |}
+               |WHERE {
+               |  GRAPH $ontology {
+               |    $ontology a owl:Ontology ;
+               |      knora-base:lastModificationDate $previousDate .
+               |    $clazz a owl:Class .
+               |    OPTIONAL {
+               |      $clazz rdfs:subClassOf ?restriction .
+               |      ?restriction a owl:Restriction ;
+               |        ?restrictionPred ?restrictionObj .
+               |      FILTER ( isBlank(?restriction) )
+               |    }
+               |  }
+               |}"""
 
-    Update(Fragment.join(parts, Fragment.raw(";\n")).render)
+    // Statement 2: insert the new cardinalities and move the ontology's last modification date on.
+    val insertCardinalitiesAndUpdateDate =
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+               |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+               |PREFIX owl: <http://www.w3.org/2002/07/owl#>
+               |PREFIX salsah-gui: <http://www.knora.org/ontology/salsah-gui#>
+               |
+               |DELETE {
+               |  GRAPH $ontology {
+               |    $ontology knora-base:lastModificationDate $previousDate .
+               |  }
+               |}
+               |INSERT {
+               |  GRAPH $ontology {
+               |    $ontology knora-base:lastModificationDate $currentDate .
+               |    ${cardinalityTriples(clazz, newCardinalities)}
+               |  }
+               |}
+               |WHERE {
+               |  GRAPH $ontology {
+               |    $ontology a owl:Ontology ;
+               |      knora-base:lastModificationDate $previousDate .
+               |    $clazz a owl:Class .
+               |  }
+               |}"""
+
+    Update(Fragment.join(List(deleteRestrictions, insertCardinalitiesAndUpdateDate), Fragment.raw(";\n")).render)
   }
-
-  private def deleteRestrictions(ontology: Iri, clazz: Iri, previousDate: Literal): Fragment =
-    sparql"""|$prefixes
-             |
-             |DELETE {
-             |  GRAPH $ontology {
-             |    $clazz rdfs:subClassOf ?restriction .
-             |    ?restriction ?restrictionPred ?restrictionObj .
-             |  }
-             |}
-             |WHERE {
-             |  GRAPH $ontology {
-             |    $ontology a owl:Ontology ;
-             |      knora-base:lastModificationDate $previousDate .
-             |    $clazz a owl:Class .
-             |    OPTIONAL {
-             |      $clazz rdfs:subClassOf ?restriction .
-             |      ?restriction a owl:Restriction ;
-             |        ?restrictionPred ?restrictionObj .
-             |      FILTER ( isBlank(?restriction) )
-             |    }
-             |  }
-             |}"""
-
-  private def insertCardinalitiesAndUpdateDate(
-    ontology: Iri,
-    clazz: Iri,
-    newCardinalities: Map[SmartIri, KnoraCardinalityInfo],
-    previousDate: Literal,
-    currentDate: Literal,
-  ): Fragment =
-    sparql"""|$prefixes
-             |
-             |DELETE {
-             |  GRAPH $ontology {
-             |    $ontology knora-base:lastModificationDate $previousDate .
-             |  }
-             |}
-             |INSERT {
-             |  GRAPH $ontology {
-             |    $ontology knora-base:lastModificationDate $currentDate .
-             |    ${cardinalityTriples(clazz, newCardinalities)}
-             |  }
-             |}
-             |WHERE {
-             |  GRAPH $ontology {
-             |    $ontology a owl:Ontology ;
-             |      knora-base:lastModificationDate $previousDate .
-             |    $clazz a owl:Class .
-             |  }
-             |}"""
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
@@ -142,12 +142,12 @@ object GetResourcePropertiesAndValuesQuery {
         )
       else sparql"$resource knora-base:isDeleted false ."
 
-    val versionDateFilter = maybeVersionDate.whenSome(vd =>
+    val versionDateFilter = maybeVersionDate.whenSome { vd =>
       sparql"""|{
-                                                                     |  $resource knora-base:creationDate ?creationDate .
-                                                                     |  FILTER(?creationDate <= ${Literal.dateTime(vd)})
-                                                                     |}""",
-    )
+               |  $resource knora-base:creationDate ?creationDate .
+               |  FILTER(?creationDate <= ${Literal.dateTime(vd)})
+               |}"""
+    }
 
     val values = Fragments
       .optional(
@@ -195,10 +195,12 @@ object GetResourcePropertiesAndValuesQuery {
       case None              => currentValuePatterns(maybePropertyIri, maybeValueUuid)
     }
 
-    val valueIriFilter = maybeValueIri.whenSome(vi => sparql"""|{
-                                                               |  $valueObject ?valueObjectProperty ?valueObjectValue .
-                                                               |  FILTER($valueObject = ${Iri.unsafeFrom(vi)})
-                                                               |}""")
+    val valueIriFilter = maybeValueIri.whenSome { vi =>
+      sparql"""|{
+               |  $valueObject ?valueObjectProperty ?valueObjectValue .
+               |  FILTER($valueObject = ${Iri.unsafeFrom(vi)})
+               |}"""
+    }
 
     // The value object's type and its non-standoff properties.
     val valueObjectBody =
@@ -256,14 +258,12 @@ object GetResourcePropertiesAndValuesQuery {
   ): Fragment = {
     val versionDateLiteral = Literal.dateTime(versionDate)
 
-    val propertyFilter = maybePropertyIri.whenSome(pi =>
+    val propertyFilter = maybePropertyIri.whenSome { pi =>
       sparql"""|{
-                                                                  |  $resource ?resourceValueProperty $currentValue .
-                                                                  |  FILTER(?resourceValueProperty = ${Iri.unsafeFrom(
-          pi.toIri,
-        )})
-                                                                  |}""",
-    )
+               |  $resource ?resourceValueProperty $currentValue .
+               |  FILTER(?resourceValueProperty = ${Iri.unsafeFrom(pi.toIri)})
+               |}"""
+    }
 
     val deleteFilter = Fragments
       .filterNotExists(
@@ -272,13 +272,18 @@ object GetResourcePropertiesAndValuesQuery {
       )
       .unless(withDeleted)
 
-    val uuidFilter = maybeValueUuid.whenSome(uuid =>
+    val uuidFilter = maybeValueUuid.whenSome { uuid =>
       sparql"""|{
-                                                              |  $currentValue knora-base:valueHasUUID $currentValueUUID .
-                                                              |  FILTER($currentValueUUID = ${Literal.string(
-          UuidUtil.base64Encode(uuid),
-        )})
-                                                              |}""",
+               |  $currentValue knora-base:valueHasUUID $currentValueUUID .
+               |  FILTER($currentValueUUID = ${Literal.string(UuidUtil.base64Encode(uuid))})
+               |}"""
+    }
+
+    // No version of the value was created later than the one selected but still at or before the version date.
+    val noLaterVersion = Fragments.filterNotExists(
+      sparql"""|$currentValue knora-base:previousValue* ?otherValueObject .
+               |?otherValueObject knora-base:valueCreationDate ?otherValueObjectCreationDate .
+               |FILTER(?otherValueObjectCreationDate <= $versionDateLiteral && ?otherValueObjectCreationDate > ?valueObjectCreationDate)""",
     )
 
     sparql"""|$resource ?resourceValueProperty $currentValue .
@@ -292,11 +297,7 @@ object GetResourcePropertiesAndValuesQuery {
              |  $valueObject knora-base:valueCreationDate ?valueObjectCreationDate .
              |  FILTER(?valueObjectCreationDate <= $versionDateLiteral)
              |}
-             |${Fragments.filterNotExists(
-        sparql"""|$currentValue knora-base:previousValue* ?otherValueObject .
-                       |?otherValueObject knora-base:valueCreationDate ?otherValueObjectCreationDate .
-                       |FILTER(?otherValueObjectCreationDate <= $versionDateLiteral && ?otherValueObjectCreationDate > ?valueObjectCreationDate)""",
-      )}
+             |$noLaterVersion
              |$currentValue knora-base:hasPermissions ?currentValuePermissions ."""
   }
 
@@ -305,14 +306,12 @@ object GetResourcePropertiesAndValuesQuery {
     maybePropertyIri: Option[SmartIri],
     maybeValueUuid: Option[UUID],
   ): Fragment = {
-    val propertyFilter = maybePropertyIri.whenSome(pi =>
+    val propertyFilter = maybePropertyIri.whenSome { pi =>
       sparql"""|{
-                                                                  |  $resource ?resourceValueProperty $valueObject .
-                                                                  |  FILTER(?resourceValueProperty = ${Iri.unsafeFrom(
-          pi.toIri,
-        )})
-                                                                  |}""",
-    )
+               |  $resource ?resourceValueProperty $valueObject .
+               |  FILTER(?resourceValueProperty = ${Iri.unsafeFrom(pi.toIri)})
+               |}"""
+    }
 
     val uuidPattern = maybeValueUuid.whenSome(uuid =>
       sparql"$valueObject knora-base:valueHasUUID ${Literal.string(UuidUtil.base64Encode(uuid))} .",

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourceQueries.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ResourceQueries.scala
@@ -15,9 +15,6 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Select
 /** The read queries backing [[ResourcesRepo]]. Pure rendering, so they can be tested without a triplestore. */
 private[service] object ResourceQueries {
 
-  private val knoraBasePrefix = sparql"PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>"
-  private val rdfsPrefix      = sparql"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"
-
   /**
    * Construct every value the resource points at: all triples whose object is an instance of a
    * `knora-base:Value` subclass. The subject is additionally constrained to be a resource so that
@@ -26,8 +23,8 @@ private[service] object ResourceQueries {
   def findValues(resourceIri: ResourceIri): Construct = {
     val resource = Iri.unsafeFrom(resourceIri.value)
     Construct(
-      sparql"""|$rdfsPrefix
-               |$knoraBasePrefix
+      sparql"""|PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |CONSTRUCT {
                |  $resource ?valueProperty ?value .
@@ -53,8 +50,8 @@ private[service] object ResourceQueries {
   def findLinks(resourceIri: ResourceIri): Construct = {
     val resource = Iri.unsafeFrom(resourceIri.value)
     Construct(
-      sparql"""|$rdfsPrefix
-               |$knoraBasePrefix
+      sparql"""|PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |CONSTRUCT {
                |  $resource ?valueProperty ?value .
@@ -80,8 +77,8 @@ private[service] object ResourceQueries {
   def findById(resourceIri: ResourceIri): Select = {
     val resource = Iri.unsafeFrom(resourceIri.value)
     Select(
-      sparql"""|$rdfsPrefix
-               |$knoraBasePrefix
+      sparql"""|PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |SELECT *
                |WHERE {
@@ -110,7 +107,7 @@ private[service] object ResourceQueries {
     val graph = Iri.unsafeFrom(projectDataGraph.value)
     val clazz = Iri.unsafeFrom(classIri.toInternalSchema.toIri)
     Select(
-      sparql"""|$knoraBasePrefix
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |SELECT (COUNT(?s) AS ?count)
                |WHERE {

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueQueries.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/service/ValueQueries.scala
@@ -17,16 +17,12 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 /** The SPARQL queries backing [[ValueRepo]]. Pure rendering, so they can be tested without a triplestore. */
 private[service] object ValueQueries {
 
-  private val knoraBasePrefix = sparql"PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>"
-  private val rdfPrefix       = sparql"PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>"
-  private val rdfsPrefix      = sparql"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"
-
   /** Construct the value's type, modification date, deletion flag and predecessor, if present. */
   def findById(valueIri: ValueIri): Construct = {
     val value = Iri.unsafeFrom(valueIri.value)
     Construct(
-      sparql"""|$rdfsPrefix
-               |$knoraBasePrefix
+      sparql"""|PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |CONSTRUCT {
                |  $value a ?valueClass ;
@@ -48,7 +44,7 @@ private[service] object ValueQueries {
   def findPreviousValue(valueIri: ValueIri): Select = {
     val value = Iri.unsafeFrom(valueIri.value)
     Select(
-      sparql"""|$knoraBasePrefix
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |SELECT ?previous
                |WHERE {
@@ -66,32 +62,33 @@ private[service] object ValueQueries {
     val graph = Iri.unsafeFrom(projectDataGraph.value)
     val value = Iri.unsafeFrom(valueIri.value)
 
-    val eraseStandoff =
-      sparql"""|$knoraBasePrefix
-               |
-               |WITH $graph
-               |DELETE {
-               |  ?standoffLink ?standoffProp ?standoffObj .
-               |}
-               |WHERE {
-               |  $value ?p ?o .
-               |  ?s ?oo $value .
-               |  $value knora-base:valueHasStandoff ?standoffLink .
-               |  ?standoffLink ?standoffProp ?standoffObj .
-               |}"""
-
-    val eraseTheValue =
-      sparql"""|WITH $graph
-               |DELETE {
-               |  $value ?p ?o .
-               |  ?s ?oo $value .
-               |}
-               |WHERE {
-               |  $value ?p ?o .
-               |  ?s ?oo $value .
-               |}"""
-
-    List(Update(eraseStandoff.render), Update(eraseTheValue.render))
+    List(
+      Update(
+        sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+                 |
+                 |WITH $graph
+                 |DELETE {
+                 |  ?standoffLink ?standoffProp ?standoffObj .
+                 |}
+                 |WHERE {
+                 |  $value ?p ?o .
+                 |  ?s ?oo $value .
+                 |  $value knora-base:valueHasStandoff ?standoffLink .
+                 |  ?standoffLink ?standoffProp ?standoffObj .
+                 |}""".render,
+      ),
+      Update(
+        sparql"""|WITH $graph
+                 |DELETE {
+                 |  $value ?p ?o .
+                 |  ?s ?oo $value .
+                 |}
+                 |WHERE {
+                 |  $value ?p ?o .
+                 |  ?s ?oo $value .
+                 |}""".render,
+      ),
+    )
   }
 
   /** Delete the subject/predicate/object triple that a LinkValue reifies. */
@@ -99,7 +96,7 @@ private[service] object ValueQueries {
     val graph = Iri.unsafeFrom(projectDataGraph.value)
     val value = Iri.unsafeFrom(valueIri.value)
     Update(
-      sparql"""|$rdfPrefix
+      sparql"""|PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                |
                |WITH $graph
                |DELETE {
@@ -128,7 +125,7 @@ private[service] object ValueQueries {
     val now         = Literal.dateTime(currentTime)
 
     Update(
-      sparql"""|$knoraBasePrefix
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |WITH $graph
                |DELETE {
@@ -165,7 +162,7 @@ private[service] object ValueQueries {
     }.joinLines
 
     Update(
-      sparql"""|$knoraBasePrefix
+      sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |WITH $graph
                |DELETE {

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/service/MetadataService.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/service/MetadataService.scala
@@ -49,18 +49,6 @@ private[service] object ResourcesMetadataQuery {
       case many               => Fragments.union(many.map(cls => sparql"$resourceIriVar a $cls .")*)
     }
 
-    val resourcePattern =
-      Fragments.graph(sparql"$graph")(
-        sparql"""|$resourceIriVar a $classIriVar ;
-                 |  knora-base:creationDate $creationDateVar ;
-                 |  knora-base:attachedToUser $creatorIriVar ;
-                 |  rdfs:label $labelVar .
-                 |${Fragments.optional(
-            sparql"$resourceIriVar knora-base:lastModificationDate $lastModificationDateVar .",
-          )}
-                 |${Fragments.optional(sparql"$resourceIriVar knora-base:deleteDate $deleteDateVar .")}""",
-      )
-
     Select(
       sparql"""|PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -68,7 +56,18 @@ private[service] object ResourcesMetadataQuery {
                |SELECT DISTINCT $classIriVar $creationDateVar $creatorIriVar $deleteDateVar $labelVar $lastModificationDateVar $resourceIriVar
                |WHERE {
                |  $classConstraint
-               |  $resourcePattern
+               |  GRAPH $graph {
+               |    $resourceIriVar a $classIriVar ;
+               |      knora-base:creationDate $creationDateVar ;
+               |      knora-base:attachedToUser $creatorIriVar ;
+               |      rdfs:label $labelVar .
+               |    OPTIONAL {
+               |      $resourceIriVar knora-base:lastModificationDate $lastModificationDateVar .
+               |    }
+               |    OPTIONAL {
+               |      $resourceIriVar knora-base:deleteDate $deleteDateVar .
+               |    }
+               |  }
                |}""".render,
       // A whole-project scan, so it runs on the long timeout tier, as it did before.
       SparqlTimeout.Gravsearch,

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/AbstractSparqlUpdatePlugin.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/AbstractSparqlUpdatePlugin.scala
@@ -9,10 +9,7 @@ import org.apache.jena.query.Dataset
 import org.apache.jena.update.UpdateExecutionFactory
 import org.apache.jena.update.UpdateFactory
 
-import org.knora.sparqlbuilder.*
-import org.knora.webapi.messages.OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion
 import org.knora.webapi.messages.util.rdf.*
-import org.knora.webapi.slice.admin.AdminConstants
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.upgrade.UpgradePlugin
 
@@ -30,17 +27,4 @@ abstract class AbstractSparqlUpdatePlugin extends UpgradePlugin {
     val qExec  = UpdateExecutionFactory.create(update, dataset)
     qExec.execute()
   }
-}
-
-object AbstractSparqlUpdatePlugin {
-
-  /** The `PREFIX knora-admin: <...>` declaration for the top of an update template. */
-  private[plugins] val knoraAdminPrefix: Fragment =
-    sparql"PREFIX knora-admin: ${Iri.unsafeFrom(KnoraAdminPrefixExpansion)}"
-
-  /** The named graph holding the admin data. */
-  private[plugins] val adminGraph: Iri = Iri.unsafeFrom(AdminConstants.adminDataNamedGraph.value)
-
-  /** The named graph holding the permissions data. */
-  private[plugins] val permissionsGraph: Iri = Iri.unsafeFrom(AdminConstants.permissionsDataNamedGraph.value)
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/MigrateRemoveProjectStatus.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/MigrateRemoveProjectStatus.scala
@@ -10,8 +10,6 @@ import org.knora.webapi.slice.admin.AdminConstants
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.upgrade.GraphsForMigration
 import org.knora.webapi.store.triplestore.upgrade.MigrateSpecificGraphs
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.adminGraph
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.knoraAdminPrefix
 
 /**
  * Remove the `knora-admin:status` triple from every project. The property is no longer part of the
@@ -23,10 +21,12 @@ class MigrateRemoveProjectStatus extends AbstractSparqlUpdatePlugin {
   override def graphsForMigration: GraphsForMigration =
     MigrateSpecificGraphs.from(AdminConstants.adminDataNamedGraph)
 
+  private val adminGraph: Iri = Iri.unsafeFrom(AdminConstants.adminDataNamedGraph.value)
+
   // `WITH <admin graph>` scopes both the DELETE template and the WHERE evaluation to the admin
   // data graph, so no USING or nested GRAPH clause is needed.
   private[plugins] val removeProjectStatus: Update = Update(
-    sparql"""|$knoraAdminPrefix
+    sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
              |WITH $adminGraph
              |DELETE {
              |  ?project knora-admin:status ?status .

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3110.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3110.scala
@@ -10,8 +10,6 @@ import org.knora.webapi.slice.admin.AdminConstants
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.upgrade.GraphsForMigration
 import org.knora.webapi.store.triplestore.upgrade.MigrateSpecificGraphs
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.adminGraph
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.knoraAdminPrefix
 
 /**
  * After removing `knora-admin:Institution` class and its properties from the knora-admin ontology this cleans up the DB.
@@ -22,8 +20,10 @@ class UpgradePluginPR3110 extends AbstractSparqlUpdatePlugin {
   override def graphsForMigration: GraphsForMigration =
     MigrateSpecificGraphs.from(AdminConstants.adminDataNamedGraph)
 
+  private val adminGraph: Iri = Iri.unsafeFrom(AdminConstants.adminDataNamedGraph.value)
+
   private[plugins] val removeAllInstitutions: Update = Update(
-    sparql"""|$knoraAdminPrefix
+    sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
              |DELETE {
              |  GRAPH $adminGraph { ?s ?p ?o . }
              |}
@@ -36,7 +36,7 @@ class UpgradePluginPR3110 extends AbstractSparqlUpdatePlugin {
   )
 
   private[plugins] val removeAllBelongsToInstitutionTriples: Update = Update(
-    sparql"""|$knoraAdminPrefix
+    sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
              |DELETE {
              |  GRAPH $adminGraph { ?s knora-admin:belongsToInstitution ?o . }
              |}

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3111.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3111.scala
@@ -10,8 +10,6 @@ import org.knora.webapi.slice.admin.AdminConstants
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.upgrade.GraphsForMigration
 import org.knora.webapi.store.triplestore.upgrade.MigrateSpecificGraphs
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.adminGraph
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.knoraAdminPrefix
 
 /**
  * Certain restricted views have a watermark that is not a boolean. This plugin removes the invalid watermark triples.
@@ -21,10 +19,12 @@ class UpgradePluginPR3111 extends AbstractSparqlUpdatePlugin {
   override def graphsForMigration: GraphsForMigration =
     MigrateSpecificGraphs.from(AdminConstants.adminDataNamedGraph)
 
+  private val adminGraph: Iri = Iri.unsafeFrom(AdminConstants.adminDataNamedGraph.value)
+
   private[plugins] val removeInvalidRestrictedViewWatermarkTriples: Update = {
     val invalidWatermark = Literal.string("path_to_image")
     Update(
-      sparql"""|$knoraAdminPrefix
+      sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
                |DELETE {
                |  GRAPH $adminGraph { ?s knora-admin:projectRestrictedViewWatermark $invalidWatermark . }
                |}

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3112.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3112.scala
@@ -11,8 +11,6 @@ import org.knora.webapi.slice.admin.domain.model.RestrictedView.Size
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.upgrade.GraphsForMigration
 import org.knora.webapi.store.triplestore.upgrade.MigrateSpecificGraphs
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.adminGraph
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.knoraAdminPrefix
 
 /**
  * Certain restricted views have a watermark that is not a boolean. This plugin removes the invalid watermark triples.
@@ -22,10 +20,12 @@ class UpgradePluginPR3112 extends AbstractSparqlUpdatePlugin {
   override def graphsForMigration: GraphsForMigration =
     MigrateSpecificGraphs.from(AdminConstants.adminDataNamedGraph)
 
+  private val adminGraph: Iri = Iri.unsafeFrom(AdminConstants.adminDataNamedGraph.value)
+
   private val defaultSize = Literal.string(Size.default.value)
 
   private[plugins] val removeWatermarkIfBothSet: Update = Update(
-    sparql"""|$knoraAdminPrefix
+    sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
              |DELETE {
              |  GRAPH $adminGraph { ?project knora-admin:projectRestrictedViewWatermark ?prevWatermark . }
              |}
@@ -39,7 +39,7 @@ class UpgradePluginPR3112 extends AbstractSparqlUpdatePlugin {
   )
 
   private[plugins] val addDefaultRestrictedViewSizeToProjectsWithout: Update = Update(
-    sparql"""|$knoraAdminPrefix
+    sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
              |WITH $adminGraph
              |INSERT {
              |  ?project knora-admin:projectRestrictedViewSize $defaultSize .
@@ -54,7 +54,7 @@ class UpgradePluginPR3112 extends AbstractSparqlUpdatePlugin {
   )
 
   private[plugins] val replaceWatermarkFalseWithDefaultRestrictedViewSize: Update = Update(
-    sparql"""|$knoraAdminPrefix
+    sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
              |WITH $adminGraph
              |DELETE {
              |  GRAPH $adminGraph { ?project knora-admin:projectRestrictedViewWatermark false . }

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3383.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3383.scala
@@ -10,8 +10,6 @@ import org.knora.webapi.slice.admin.AdminConstants
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.upgrade.GraphsForMigration
 import org.knora.webapi.store.triplestore.upgrade.MigrateSpecificGraphs
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.knoraAdminPrefix
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.permissionsGraph
 
 /**
  * Configuring default object access permissions on the SystemProject is not supported anymore.
@@ -22,32 +20,39 @@ class UpgradePluginPR3383 extends AbstractSparqlUpdatePlugin {
   override def graphsForMigration: GraphsForMigration =
     MigrateSpecificGraphs.from(AdminConstants.permissionsDataNamedGraph)
 
-  /** Every triple of a default object access permission restricted by the given predicate and object. */
-  private def permissionPattern(predicate: Fragment, obj: Fragment): Fragment =
-    sparql"""|?permissionIri a knora-admin:DefaultObjectAccessPermission ;
-             |               $predicate $obj ;
-             |               ?p ?o ."""
+  private val permissionsGraph: Iri = Iri.unsafeFrom(AdminConstants.permissionsDataNamedGraph.value)
 
-  /** `WITH <permissions graph>` scopes both the DELETE template and the WHERE evaluation. */
-  private def removeDefaultObjectAccessPermissions(predicate: Fragment, obj: Fragment): Update = {
-    val pattern = permissionPattern(predicate, obj)
-    Update(
-      sparql"""|$knoraAdminPrefix
-               |WITH $permissionsGraph
-               |DELETE {
-               |  $pattern
-               |}
-               |WHERE {
-               |  $pattern
-               |}""".render,
-    )
-  }
+  // `WITH <permissions graph>` scopes both the DELETE template and the WHERE evaluation.
+  private[plugins] val removeSystemProjectDefaultObjectAccessPermissions: Update = Update(
+    sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+             |WITH $permissionsGraph
+             |DELETE {
+             |  ?permissionIri a knora-admin:DefaultObjectAccessPermission ;
+             |                 knora-admin:forProject knora-admin:SystemProject ;
+             |                 ?p ?o .
+             |}
+             |WHERE {
+             |  ?permissionIri a knora-admin:DefaultObjectAccessPermission ;
+             |                 knora-admin:forProject knora-admin:SystemProject ;
+             |                 ?p ?o .
+             |}""".render,
+  )
 
-  private[plugins] val removeSystemProjectDefaultObjectAccessPermissions: Update =
-    removeDefaultObjectAccessPermissions(sparql"knora-admin:forProject", sparql"knora-admin:SystemProject")
-
-  private[plugins] val removeKnownUserDefaultObjectAccessPermissions: Update =
-    removeDefaultObjectAccessPermissions(sparql"knora-admin:forGroup", sparql"knora-admin:KnownUser")
+  // `WITH <permissions graph>` scopes both the DELETE template and the WHERE evaluation.
+  private[plugins] val removeKnownUserDefaultObjectAccessPermissions: Update = Update(
+    sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+             |WITH $permissionsGraph
+             |DELETE {
+             |  ?permissionIri a knora-admin:DefaultObjectAccessPermission ;
+             |                 knora-admin:forGroup knora-admin:KnownUser ;
+             |                 ?p ?o .
+             |}
+             |WHERE {
+             |  ?permissionIri a knora-admin:DefaultObjectAccessPermission ;
+             |                 knora-admin:forGroup knora-admin:KnownUser ;
+             |                 ?p ?o .
+             |}""".render,
+  )
 
   override def getQueries: List[Update] = List(
     removeSystemProjectDefaultObjectAccessPermissions,

--- a/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3612.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/store/triplestore/upgrade/plugins/UpgradePluginPR3612.scala
@@ -13,8 +13,6 @@ import org.knora.webapi.slice.admin.domain.model.License
 import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Update
 import org.knora.webapi.store.triplestore.upgrade.GraphsForMigration
 import org.knora.webapi.store.triplestore.upgrade.MigrateSpecificGraphs
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.adminGraph
-import org.knora.webapi.store.triplestore.upgrade.plugins.AbstractSparqlUpdatePlugin.knoraAdminPrefix
 
 /**
  * Add default values for the `hasAllowedCopyrightHolder` and `hasEnabledLicense` properties to every existing project.
@@ -23,52 +21,73 @@ class UpgradePluginPR3612 extends AbstractSparqlUpdatePlugin {
   override def graphsForMigration: GraphsForMigration =
     MigrateSpecificGraphs.from(AdminConstants.adminDataNamedGraph)
 
+  private val adminGraph: Iri = Iri.unsafeFrom(AdminConstants.adminDataNamedGraph.value)
+
   private val projectIri = Variable("projectIri")
 
-  /** `?projectIri a knora-admin:knoraProject ; <predicate> <value> ; ... .` */
-  private def projectPattern(predicate: Fragment, values: Seq[Fragment]): Fragment = {
-    val head  = sparql"$projectIri a knora-admin:knoraProject"
-    val lines = values.map(value => sparql"$predicate $value")
-    Fragment.join(head +: lines, Fragment.raw(" ;\n")) ++ sparql" ."
-  }
-
-  /** One `FILTER NOT EXISTS` per value, so that the update only fires for projects missing a default. */
-  private def missingValues(predicate: Fragment, values: Seq[Fragment]): Fragment =
-    values.map(value => Fragments.filterNotExists(sparql"$projectIri $predicate $value .")).joinLines
-
-  /** `WITH <admin graph>` scopes the DELETE and INSERT templates as well as the WHERE evaluation. */
-  private def addDefaults(predicate: Fragment, values: Seq[Fragment]): Update = {
-    val pattern = projectPattern(predicate, values)
+  /**
+   * `WITH <admin graph>` scopes the DELETE and INSERT templates as well as the WHERE evaluation.
+   * The DELETE/INSERT pair rewrites the whole pattern so that the defaults end up on the project
+   * exactly once; one `FILTER NOT EXISTS` per value makes the update fire only for projects that
+   * are still missing a default.
+   */
+  private[plugins] val addDefaultCopyrightHolder: Update = {
+    val defaults            = CopyrightHolder.default.toSeq.map(holder => Literal.string(holder.value).toFragment)
+    val projectWithDefaults =
+      Fragment.join(
+        sparql"$projectIri a knora-admin:knoraProject" +:
+          defaults.map(value => sparql"knora-admin:hasAllowedCopyrightHolder $value"),
+        Fragment.raw(" ;\n"),
+      ) ++ sparql" ."
+    val missingDefaults =
+      defaults
+        .map(value => Fragments.filterNotExists(sparql"$projectIri knora-admin:hasAllowedCopyrightHolder $value ."))
+        .joinLines
     Update(
-      sparql"""|$knoraAdminPrefix
+      sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
                |WITH $adminGraph
                |DELETE {
-               |  $pattern
+               |  $projectWithDefaults
                |}
                |INSERT {
-               |  $pattern
+               |  $projectWithDefaults
                |}
                |WHERE {
                |  $projectIri a knora-admin:knoraProject .
-               |  ${missingValues(predicate, values)}
+               |  $missingDefaults
                |}""".render,
     )
   }
 
-  private[plugins] val addDefaultCopyrightHolder: Update =
-    addDefaults(
-      sparql"knora-admin:hasAllowedCopyrightHolder",
-      CopyrightHolder.default.toSeq.map(holder => Literal.string(holder.value).toFragment),
+  /** Same shape as `addDefaultCopyrightHolder`, for the enabled licenses. */
+  private[plugins] val addDefaultEnabledLicenses: Update = {
+    val defaults =
+      License.BUILT_IN.filter(_.isRecommended == Yes).map(license => Iri.unsafeFrom(license.id.value).toFragment).toSeq
+    val projectWithDefaults =
+      Fragment.join(
+        sparql"$projectIri a knora-admin:knoraProject" +:
+          defaults.map(value => sparql"knora-admin:hasEnabledLicense $value"),
+        Fragment.raw(" ;\n"),
+      ) ++ sparql" ."
+    val missingDefaults =
+      defaults
+        .map(value => Fragments.filterNotExists(sparql"$projectIri knora-admin:hasEnabledLicense $value ."))
+        .joinLines
+    Update(
+      sparql"""|PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+               |WITH $adminGraph
+               |DELETE {
+               |  $projectWithDefaults
+               |}
+               |INSERT {
+               |  $projectWithDefaults
+               |}
+               |WHERE {
+               |  $projectIri a knora-admin:knoraProject .
+               |  $missingDefaults
+               |}""".render,
     )
-
-  private[plugins] val addDefaultEnabledLicenses: Update =
-    addDefaults(
-      sparql"knora-admin:hasEnabledLicense",
-      License.BUILT_IN
-        .filter(_.isRecommended == Yes)
-        .map(license => Iri.unsafeFrom(license.id.value).toFragment)
-        .toSeq,
-    )
+  }
 
   override def getQueries: List[Update] = List(addDefaultCopyrightHolder, addDefaultEnabledLicenses)
 }


### PR DESCRIPTION
Part of DEV-7150 (bucket). Resolves DEV-7231. Follow-up to #4301 / #4317. Stacked on #4320.

## Why

Review feedback on the stack: even after #4317 the queries read as fragmented. The preference is for each query to be as explicit and inline as possible. Concretely: `PREFIX` declarations written literally in every template, no shared `prefixes` fragment, no local vals holding static sub-segments. Repetition between queries is preferred over indirection. Only genuinely dynamic structure (optional blocks, 0..n repeated triples, runtime alternatives) stays a hole, and when an optional part changes the shape too much for a one-line hole, two complete templates are written out.

## What

- **The #4301 queries.** `ChangePropertyGuiElementQuery` is three complete statement templates with their own prefixes; the DELETE is two full templates (with / without link-value property) selected by a `match`. `ChangePropertyLabelsOrCommentsQuery` is one template with single-line `whenSome` holes. The only remaining named fragments are the 0..n gui-attribute and language-literal triples.
- **Sweep of the rest of the stack.** Inlined pulled-out prefix vals, `skeleton`/pattern vals and static helper fragments in: the six upgrade plugins (the shared companion constants on `AbstractSparqlUpdatePlugin` are gone), `ValueQueries`, `ResourceQueries`, `ViewRestrictionsByPropertyRepo` (each of the four queries is now two whole templates, with and without the item-type constraint), `ReplaceClassCardinalitiesQuery`, `LegalInfoQueries`, `AdminDataQuery` (two complete templates instead of a UNION assembled from branch vals), `MetadataService`, `DeletePropertyQuery`, `CreatePropertyQuery`; `GetResourcePropertiesAndValuesQuery` only had scalafmt-mangled multi-line lambdas reflowed. Files whose only fragments are dynamic were left as they are.
- **Docs.** New section "Keep the query readable: one explicit template per query" in `docs/development/dsp-api-sparql-queries.md` with a bad/good example, a pointer in the sparql-builder README's composition section, and a bullet in `CONVENTIONS.md`.

## Verification

Rendered SPARQL is unchanged: every rendering spec in the stack passes with its legacy fixtures untouched (`ViewRestrictionsByPropertyQuerySpec` diffs all 4 queries × 4 item types against the legacy fixtures under both Jena canonical form and algebra). `//modules/webapi:test`, `//modules/sparql-builder:test`, `just check` and markdownlint pass.

## Left as composition, on purpose

`GetResourcePropertiesAndValuesQuery` is a combinatorial builder (four booleans plus four options, with a load-bearing 4-way UNION nesting). Expanding it to whole templates would mean well over a dozen variants, so its named dynamic fragments stay. It is the one file in the stack that cannot be read as a single template. Worth a look at whether you want that expanded anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
