### PR TITLE
refactor: split the resource properties-and-values CONSTRUCT by caller and drop its dead parameters (DEV-7232)

### DIFF
--- a/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -57,8 +57,8 @@ import org.knora.webapi.slice.common.service.IriConverter
 import org.knora.webapi.slice.infrastructure.SanitizedSpan
 import org.knora.webapi.slice.ontology.domain.service.OntologyCacheHelpers
 import org.knora.webapi.slice.ontology.domain.service.OntologyRepo
-import org.knora.webapi.slice.resources.repo.GetResourcePropertiesAndValuesQuery
 import org.knora.webapi.slice.resources.repo.GetResourcesByClassInProjectPrequery
+import org.knora.webapi.slice.resources.repo.SearchResultResourcesQuery
 import org.knora.webapi.slice.search.FulltextBreadthGuard
 import org.knora.webapi.slice.search.FulltextSearchTerms
 import org.knora.webapi.slice.search.SearchTimeoutException
@@ -1146,15 +1146,7 @@ final class SearchResponderV2Live(
           // Yes. Do a CONSTRUCT query to get the contents of those resources. If we're querying standoff, get
           // at most one page of standoff per text value.
           val resourceRequestSparql =
-            GetResourcePropertiesAndValuesQuery.build(
-              resourceIris = mainResourceIris,
-              preview = false,
-              withDeleted = false,
-              queryAllNonStandoff = true,
-              queryStandoff = queryStandoff,
-              maybePropertyIri = None,
-              maybeVersionDate = None,
-            )
+            SearchResultResourcesQuery.build(mainResourceIris, queryStandoff)
 
           for {
             resourceRequestResponse <- triplestore.query(resourceRequestSparql).flatMap(_.asExtended)

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuery.scala
@@ -16,39 +16,73 @@ import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Constru
 
 /**
  * Builds a CONSTRUCT query that gets the values of all properties of one or more resources.
+ *
+ * There are two shapes: one that loads the current version of each value, and one that walks the
+ * version history back to the version that was current at a given point in time. Each is a
+ * complete template of its own.
  */
 object GetResourcePropertiesAndValuesQuery {
 
-  private val resource         = Variable("resource")
-  private val valueObject      = Variable("valueObject")
-  private val currentValue     = Variable("currentValue")
-  private val currentValueUUID = Variable("currentValueUUID")
-  private val standoffNode     = Variable("standoffNode")
-
   /**
-   * @param resourceIris        the resources to load; must not be empty.
-   * @param preview             when true, only the resource metadata is loaded, no values.
-   * @param withDeleted         when true, deleted resources and values are included.
-   * @param queryAllNonStandoff when true, link values and their targets are loaded.
-   * @param queryStandoff       when true, the standoff markup of text values is loaded.
-   * @param maybePropertyIri    restricts the values to one property.
-   * @param maybeValueUuid      restricts the values to the one with this UUID.
-   * @param maybeVersionDate    loads the value versions that were current at this point in time.
-   * @param maybeValueIri       restricts the values to the one with this IRI.
-   * @param standoffTagFilter   restricts the standoff markup to one standoff tag class.
+   * @param resourceIris      the resources to load; must not be empty.
+   * @param preview           when true, only the resource metadata is loaded, no values.
+   * @param withDeleted       when true, deleted resources and values are included.
+   * @param queryStandoff     when true, the standoff markup of text values is loaded.
+   * @param maybePropertyIri  restricts the values to one property.
+   * @param maybeValueUuid    restricts the values to the one with this UUID.
+   * @param maybeVersionDate  loads the value versions that were current at this point in time.
+   * @param standoffTagFilter restricts the standoff markup to one standoff tag class.
    */
   def build(
     resourceIris: Seq[IRI],
     preview: Boolean,
     withDeleted: Boolean,
-    queryAllNonStandoff: Boolean,
     queryStandoff: Boolean,
     maybePropertyIri: Option[SmartIri] = None,
     maybeValueUuid: Option[UUID] = None,
     maybeVersionDate: Option[Instant] = None,
-    maybeValueIri: Option[IRI] = None,
     standoffTagFilter: Option[SmartIri] = None,
   ): Construct =
+    maybeVersionDate match {
+      case None =>
+        currentValuesQuery(
+          resourceIris,
+          preview,
+          withDeleted,
+          queryStandoff,
+          maybePropertyIri,
+          maybeValueUuid,
+          standoffTagFilter,
+        )
+      case Some(versionDate) =>
+        versionedValuesQuery(
+          resourceIris,
+          preview,
+          withDeleted,
+          queryStandoff,
+          maybePropertyIri,
+          maybeValueUuid,
+          versionDate,
+          standoffTagFilter,
+        )
+    }
+
+  /** Loads the current version of each value. */
+  private def currentValuesQuery(
+    resourceIris: Seq[IRI],
+    preview: Boolean,
+    withDeleted: Boolean,
+    queryStandoff: Boolean,
+    maybePropertyIri: Option[SmartIri],
+    maybeValueUuid: Option[UUID],
+    standoffTagFilter: Option[SmartIri],
+  ): Construct = {
+    val isDeletedConstruct = isDeletedConstructTriples(withDeleted)
+    val standoffConstruct  = standoffConstructTriples(queryStandoff, standoffTagFilter)
+    val isDeletedWhere     = isDeletedWherePatterns(withDeleted)
+    val valuesOptional     =
+      currentValuesOptional(queryStandoff, standoffTagFilter, maybePropertyIri, maybeValueUuid).unless(preview)
+
     Construct(
       sparql"""|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -56,271 +90,278 @@ object GetResourcePropertiesAndValuesQuery {
                |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
                |
                |CONSTRUCT {
-               |  ${constructTemplate(withDeleted, queryStandoff, queryAllNonStandoff, standoffTagFilter)}
+               |  ?resource a knora-base:Resource ;
+               |    knora-base:isMainResource true ;
+               |    knora-base:attachedToProject ?resourceProject ;
+               |    rdfs:label ?label ;
+               |    rdf:type ?resourceType ;
+               |    knora-base:attachedToUser ?resourceCreator ;
+               |    knora-base:hasPermissions ?resourcePermissions ;
+               |    knora-base:creationDate ?creationDate ;
+               |    knora-base:lastModificationDate ?lastModificationDate ;
+               |    knora-base:hasResourceAuthorship ?resourceAuthorship .
+               |  $isDeletedConstruct
+               |  ?resource knora-base:hasValue ?valueObject ;
+               |    ?resourceValueProperty ?valueObject .
+               |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
+               |    knora-base:valueHasUUID ?currentValueUUID ;
+               |    knora-base:hasPermissions ?currentValuePermissions .
+               |  $standoffConstruct
+               |  ?resource knora-base:hasLinkTo ?referredResource ;
+               |    ?resourceLinkProperty ?referredResource .
+               |  ?referredResource a knora-base:Resource ;
+               |    ?referredResourcePred ?referredResourceObj .
                |} WHERE {
-               |  ${Fragments.values(resource, resourceIris.map(Iri.unsafeFrom))}
-               |  ${wherePatterns(
-          preview,
-          withDeleted,
-          queryAllNonStandoff,
-          queryStandoff,
-          maybePropertyIri,
-          maybeValueUuid,
-          maybeVersionDate,
-          maybeValueIri,
-          standoffTagFilter,
-        )}
+               |  ${Fragments.values(Variable("resource"), resourceIris.map(Iri.unsafeFrom))}
+               |  {
+               |    ?resource rdf:type ?resourceType .
+               |    ?resourceType rdfs:subClassOf* knora-base:Resource .
+               |  }
+               |  ?resource knora-base:attachedToProject ?resourceProject ;
+               |    knora-base:attachedToUser ?resourceCreator ;
+               |    knora-base:hasPermissions ?resourcePermissions ;
+               |    knora-base:creationDate ?creationDate ;
+               |    rdfs:label ?label .
+               |  $isDeletedWhere
+               |  OPTIONAL { ?resource knora-base:lastModificationDate ?lastModificationDate . }
+               |  OPTIONAL { ?resource knora-base:hasResourceAuthorship ?resourceAuthorship . }
+               |  $valuesOptional
                |}""".render,
     )
-
-  private def constructTemplate(
-    withDeleted: Boolean,
-    queryStandoff: Boolean,
-    queryAllNonStandoff: Boolean,
-    standoffTagFilter: Option[SmartIri],
-  ): Fragment = {
-    val deleted =
-      if (withDeleted)
-        sparql"""|$resource knora-base:isDeleted ?isDeleted ;
-                 |  knora-base:deleteDate ?deletionDate ;
-                 |  knora-base:deleteComment ?deleteComment ."""
-      else sparql"$resource knora-base:isDeleted false ."
-
-    val standoff = {
-      val node = standoffTagFilter.fold(
-        sparql"""|$standoffNode ?standoffProperty ?standoffValue ;
-                 |  knora-base:targetHasOriginalXMLID ?targetOriginalXMLID .""",
-      )(tagIri => sparql"""|$standoffNode a ${Iri.unsafeFrom(tagIri.toIri)} ;
-                           |  ?standoffProperty ?standoffValue .""")
-      sparql"""|$valueObject knora-base:valueHasStandoff $standoffNode .
-               |$node""".when(queryStandoff)
-    }
-
-    val links =
-      sparql"""|$resource knora-base:hasLinkTo ?referredResource ;
-               |  ?resourceLinkProperty ?referredResource .
-               |?referredResource a knora-base:Resource ;
-               |  ?referredResourcePred ?referredResourceObj .""".when(queryAllNonStandoff)
-
-    sparql"""|$resource a knora-base:Resource ;
-             |  knora-base:isMainResource true ;
-             |  knora-base:attachedToProject ?resourceProject ;
-             |  rdfs:label ?label ;
-             |  rdf:type ?resourceType ;
-             |  knora-base:attachedToUser ?resourceCreator ;
-             |  knora-base:hasPermissions ?resourcePermissions ;
-             |  knora-base:creationDate ?creationDate ;
-             |  knora-base:lastModificationDate ?lastModificationDate ;
-             |  knora-base:hasResourceAuthorship ?resourceAuthorship .
-             |$deleted
-             |$resource knora-base:hasValue $valueObject ;
-             |  ?resourceValueProperty $valueObject .
-             |$valueObject ?valueObjectProperty ?valueObjectValue ;
-             |  knora-base:valueHasUUID $currentValueUUID ;
-             |  knora-base:hasPermissions ?currentValuePermissions .
-             |$standoff
-             |$links"""
   }
 
-  private def wherePatterns(
+  /** Loads the value versions that were current at `versionDate`. */
+  private def versionedValuesQuery(
+    resourceIris: Seq[IRI],
     preview: Boolean,
     withDeleted: Boolean,
-    queryAllNonStandoff: Boolean,
     queryStandoff: Boolean,
     maybePropertyIri: Option[SmartIri],
     maybeValueUuid: Option[UUID],
-    maybeVersionDate: Option[Instant],
-    maybeValueIri: Option[IRI],
+    versionDate: Instant,
     standoffTagFilter: Option[SmartIri],
-  ): Fragment = {
-    val deleted =
-      if (withDeleted)
-        Fragments.optional(
-          sparql"""|$resource knora-base:isDeleted ?isDeleted ;
-                   |  knora-base:deleteDate ?deletionDate .
-                   |OPTIONAL { $resource knora-base:deleteComment ?deleteComment . }""",
-        )
-      else sparql"$resource knora-base:isDeleted false ."
+  ): Construct = {
+    val isDeletedConstruct = isDeletedConstructTriples(withDeleted)
+    val standoffConstruct  = standoffConstructTriples(queryStandoff, standoffTagFilter)
+    val isDeletedWhere     = isDeletedWherePatterns(withDeleted)
+    val versionDateLiteral = Literal.dateTime(versionDate)
+    val valuesOptional     = versionedValuesOptional(
+      withDeleted,
+      queryStandoff,
+      standoffTagFilter,
+      maybePropertyIri,
+      maybeValueUuid,
+      versionDate,
+    ).unless(preview)
 
-    val versionDateFilter = maybeVersionDate.whenSome { vd =>
-      sparql"""|{
-               |  $resource knora-base:creationDate ?creationDate .
-               |  FILTER(?creationDate <= ${Literal.dateTime(vd)})
-               |}"""
-    }
-
-    val values = Fragments
-      .optional(
-        valuesBlock(
-          withDeleted,
-          queryAllNonStandoff,
-          queryStandoff,
-          maybePropertyIri,
-          maybeValueUuid,
-          maybeVersionDate,
-          maybeValueIri,
-          standoffTagFilter,
-        ),
-      )
-      .unless(preview)
-
-    sparql"""|{
-             |  $resource rdf:type ?resourceType .
-             |  ?resourceType rdfs:subClassOf* knora-base:Resource .
-             |}
-             |$resource knora-base:attachedToProject ?resourceProject ;
-             |  knora-base:attachedToUser ?resourceCreator ;
-             |  knora-base:hasPermissions ?resourcePermissions ;
-             |  knora-base:creationDate ?creationDate ;
-             |  rdfs:label ?label .
-             |$deleted
-             |$versionDateFilter
-             |OPTIONAL { $resource knora-base:lastModificationDate ?lastModificationDate . }
-             |OPTIONAL { $resource knora-base:hasResourceAuthorship ?resourceAuthorship . }
-             |$values"""
+    Construct(
+      sparql"""|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+               |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |CONSTRUCT {
+               |  ?resource a knora-base:Resource ;
+               |    knora-base:isMainResource true ;
+               |    knora-base:attachedToProject ?resourceProject ;
+               |    rdfs:label ?label ;
+               |    rdf:type ?resourceType ;
+               |    knora-base:attachedToUser ?resourceCreator ;
+               |    knora-base:hasPermissions ?resourcePermissions ;
+               |    knora-base:creationDate ?creationDate ;
+               |    knora-base:lastModificationDate ?lastModificationDate ;
+               |    knora-base:hasResourceAuthorship ?resourceAuthorship .
+               |  $isDeletedConstruct
+               |  ?resource knora-base:hasValue ?valueObject ;
+               |    ?resourceValueProperty ?valueObject .
+               |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
+               |    knora-base:valueHasUUID ?currentValueUUID ;
+               |    knora-base:hasPermissions ?currentValuePermissions .
+               |  $standoffConstruct
+               |  ?resource knora-base:hasLinkTo ?referredResource ;
+               |    ?resourceLinkProperty ?referredResource .
+               |  ?referredResource a knora-base:Resource ;
+               |    ?referredResourcePred ?referredResourceObj .
+               |} WHERE {
+               |  ${Fragments.values(Variable("resource"), resourceIris.map(Iri.unsafeFrom))}
+               |  {
+               |    ?resource rdf:type ?resourceType .
+               |    ?resourceType rdfs:subClassOf* knora-base:Resource .
+               |  }
+               |  ?resource knora-base:attachedToProject ?resourceProject ;
+               |    knora-base:attachedToUser ?resourceCreator ;
+               |    knora-base:hasPermissions ?resourcePermissions ;
+               |    knora-base:creationDate ?creationDate ;
+               |    rdfs:label ?label .
+               |  $isDeletedWhere
+               |  {
+               |    ?resource knora-base:creationDate ?creationDate .
+               |    FILTER(?creationDate <= $versionDateLiteral)
+               |  }
+               |  OPTIONAL { ?resource knora-base:lastModificationDate ?lastModificationDate . }
+               |  OPTIONAL { ?resource knora-base:hasResourceAuthorship ?resourceAuthorship . }
+               |  $valuesOptional
+               |}""".render,
+    )
   }
 
-  private def valuesBlock(
-    withDeleted: Boolean,
-    queryAllNonStandoff: Boolean,
+  private def isDeletedConstructTriples(withDeleted: Boolean): Fragment =
+    if (withDeleted)
+      sparql"""|?resource knora-base:isDeleted ?isDeleted ;
+               |  knora-base:deleteDate ?deletionDate ;
+               |  knora-base:deleteComment ?deleteComment ."""
+    else sparql"?resource knora-base:isDeleted false ."
+
+  private def isDeletedWherePatterns(withDeleted: Boolean): Fragment =
+    if (withDeleted)
+      sparql"""|OPTIONAL {
+               |  ?resource knora-base:isDeleted ?isDeleted ;
+               |    knora-base:deleteDate ?deletionDate .
+               |  OPTIONAL { ?resource knora-base:deleteComment ?deleteComment . }
+               |}"""
+    else sparql"?resource knora-base:isDeleted false ."
+
+  private def standoffConstructTriples(queryStandoff: Boolean, standoffTagFilter: Option[SmartIri]): Fragment =
+    (queryStandoff, standoffTagFilter) match {
+      case (false, _)   => Fragment.empty
+      case (true, None) =>
+        sparql"""|?valueObject knora-base:valueHasStandoff ?standoffNode .
+                 |?standoffNode ?standoffProperty ?standoffValue ;
+                 |  knora-base:targetHasOriginalXMLID ?targetOriginalXMLID ."""
+      case (true, Some(tagIri)) =>
+        sparql"""|?valueObject knora-base:valueHasStandoff ?standoffNode .
+                 |?standoffNode a ${Iri.unsafeFrom(tagIri.toIri)} ;
+                 |  ?standoffProperty ?standoffValue ."""
+    }
+
+  private def currentValuesOptional(
     queryStandoff: Boolean,
+    standoffTagFilter: Option[SmartIri],
     maybePropertyIri: Option[SmartIri],
     maybeValueUuid: Option[UUID],
-    maybeVersionDate: Option[Instant],
-    maybeValueIri: Option[IRI],
-    standoffTagFilter: Option[SmartIri],
   ): Fragment = {
-    val valueRetrieval = maybeVersionDate match {
-      case Some(versionDate) => versionedValuePatterns(withDeleted, maybePropertyIri, maybeValueUuid, versionDate)
-      case None              => currentValuePatterns(maybePropertyIri, maybeValueUuid)
+    val valueBody          = valueBodyAlternatives(queryStandoff, standoffTagFilter)
+    val propertyIriPattern = maybePropertyIri.map(pi => Iri.unsafeFrom(pi.toIri)).whenSome { propertyIri =>
+      sparql"{ ?resource ?resourceValueProperty ?valueObject . FILTER(?resourceValueProperty = $propertyIri) }"
+    }
+    val valueUuidPattern = maybeValueUuid.map(uuid => Literal.string(UuidUtil.base64Encode(uuid))).whenSome {
+      valueUuid => sparql"?valueObject knora-base:valueHasUUID $valueUuid ."
     }
 
-    val valueIriFilter = maybeValueIri.whenSome { vi =>
-      sparql"""|{
-               |  $valueObject ?valueObjectProperty ?valueObjectValue .
-               |  FILTER($valueObject = ${Iri.unsafeFrom(vi)})
-               |}"""
-    }
-
-    // The value object's type and its non-standoff properties.
-    val valueObjectBody =
-      sparql"""|$valueObject a ?valueObjectType ;
-               |  ?valueObjectProperty ?valueObjectValue .
-               |FILTER(?valueObjectProperty != knora-base:valueHasStandoff && ?valueObjectProperty != knora-base:hasPermissions)
-               |${sparql"FILTER(?valueObjectProperty != knora-base:valueHasString)".unless(queryAllNonStandoff)}"""
-
-    val standoffBody = {
-      val internalReferences = Fragments
-        .optional(
-          sparql"""|?standoffTag knora-base:standoffTagHasInternalReference ?targetStandoffTag .
-                   |?targetStandoffTag knora-base:standoffTagHasOriginalXMLID ?targetOriginalXMLID .""",
-        )
-        .when(standoffTagFilter.isEmpty)
-      val tagConstraint =
-        standoffTagFilter.whenSome(tagIri => sparql"$standoffNode a ${Iri.unsafeFrom(tagIri.toIri)} .")
-      sparql"""|$valueObject knora-base:valueHasStandoff $standoffNode .
-               |$tagConstraint
-               |$standoffNode ?standoffProperty ?standoffValue ;
-               |  knora-base:standoffTagHasStartIndex ?startIndex .
-               |$internalReferences
-               |FILTER(?startIndex >= 0)"""
-    }
-
-    val linkBody =
-      sparql"""|$valueObject a knora-base:LinkValue ;
-               |  rdf:predicate ?resourceLinkProperty ;
-               |  rdf:object ?referredResource .
-               |?referredResource ?referredResourcePred ?referredResourceObj ;
-               |  knora-base:isDeleted false ."""
-
-    // The nesting is load-bearing: with both flags the standoff UNION is itself a branch of the
-    // link UNION, as the previous builder emitted it.
-    val alternatives = (queryStandoff, queryAllNonStandoff) match {
-      case (true, true)   => Fragments.union(Fragments.union(valueObjectBody, standoffBody), linkBody)
-      case (true, false)  => Fragments.union(valueObjectBody, standoffBody)
-      case (false, true)  => Fragments.union(valueObjectBody, linkBody)
-      case (false, false) => sparql"""|{
-                                      |  $valueObjectBody
-                                      |}"""
-    }
-
-    sparql"""|$valueRetrieval
-             |$valueIriFilter
-             |$alternatives"""
+    sparql"""|OPTIONAL {
+             |  ?resource ?resourceValueProperty ?valueObject .
+             |  ?resourceValueProperty rdfs:subPropertyOf* knora-base:hasValue .
+             |  $propertyIriPattern
+             |  $valueUuidPattern
+             |  ?valueObject knora-base:hasPermissions ?currentValuePermissions .
+             |  $valueBody
+             |}"""
   }
 
-  /** Walks the value's version history back to the version that was current at `versionDate`. */
-  private def versionedValuePatterns(
+  private def versionedValuesOptional(
     withDeleted: Boolean,
+    queryStandoff: Boolean,
+    standoffTagFilter: Option[SmartIri],
     maybePropertyIri: Option[SmartIri],
     maybeValueUuid: Option[UUID],
     versionDate: Instant,
   ): Fragment = {
-    val versionDateLiteral = Literal.dateTime(versionDate)
-
-    val propertyFilter = maybePropertyIri.whenSome { pi =>
-      sparql"""|{
-               |  $resource ?resourceValueProperty $currentValue .
-               |  FILTER(?resourceValueProperty = ${Iri.unsafeFrom(pi.toIri)})
-               |}"""
+    val valueBody               = valueBodyAlternatives(queryStandoff, standoffTagFilter)
+    val vd                      = Literal.dateTime(versionDate)
+    val notDeletedAtVersionDate = sparql"""|FILTER NOT EXISTS {
+                                           |  ?currentValue knora-base:deleteDate ?currentValueDeleteDate .
+                                           |  FILTER(?currentValueDeleteDate <= $vd)
+                                           |}""".unless(withDeleted)
+    val propertyIriPattern = maybePropertyIri.map(pi => Iri.unsafeFrom(pi.toIri)).whenSome { propertyIri =>
+      sparql"{ ?resource ?resourceValueProperty ?currentValue . FILTER(?resourceValueProperty = $propertyIri) }"
     }
+    val valueUuidPattern =
+      maybeValueUuid.map(uuid => Literal.string(UuidUtil.base64Encode(uuid))).whenSome { valueUuid =>
+        sparql"{ ?currentValue knora-base:valueHasUUID ?currentValueUUID . FILTER(?currentValueUUID = $valueUuid) }"
+      }
 
-    val deleteFilter = Fragments
-      .filterNotExists(
-        sparql"""|$currentValue knora-base:deleteDate ?currentValueDeleteDate .
-                 |FILTER(?currentValueDeleteDate <= $versionDateLiteral)""",
-      )
-      .unless(withDeleted)
-
-    val uuidFilter = maybeValueUuid.whenSome { uuid =>
-      sparql"""|{
-               |  $currentValue knora-base:valueHasUUID $currentValueUUID .
-               |  FILTER($currentValueUUID = ${Literal.string(UuidUtil.base64Encode(uuid))})
-               |}"""
-    }
-
-    // No version of the value was created later than the one selected but still at or before the version date.
-    val noLaterVersion = Fragments.filterNotExists(
-      sparql"""|$currentValue knora-base:previousValue* ?otherValueObject .
-               |?otherValueObject knora-base:valueCreationDate ?otherValueObjectCreationDate .
-               |FILTER(?otherValueObjectCreationDate <= $versionDateLiteral && ?otherValueObjectCreationDate > ?valueObjectCreationDate)""",
-    )
-
-    sparql"""|$resource ?resourceValueProperty $currentValue .
-             |?resourceValueProperty rdfs:subPropertyOf* knora-base:hasValue .
-             |$propertyFilter
-             |$deleteFilter
-             |$currentValue knora-base:valueHasUUID $currentValueUUID .
-             |$uuidFilter
-             |{
-             |  $currentValue knora-base:previousValue* $valueObject .
-             |  $valueObject knora-base:valueCreationDate ?valueObjectCreationDate .
-             |  FILTER(?valueObjectCreationDate <= $versionDateLiteral)
-             |}
-             |$noLaterVersion
-             |$currentValue knora-base:hasPermissions ?currentValuePermissions ."""
+    // The second FILTER NOT EXISTS asserts that no version of the value was created later than the
+    // one selected but still at or before the version date.
+    sparql"""|OPTIONAL {
+             |  ?resource ?resourceValueProperty ?currentValue .
+             |  ?resourceValueProperty rdfs:subPropertyOf* knora-base:hasValue .
+             |  $propertyIriPattern
+             |  $notDeletedAtVersionDate
+             |  ?currentValue knora-base:valueHasUUID ?currentValueUUID .
+             |  $valueUuidPattern
+             |  {
+             |    ?currentValue knora-base:previousValue* ?valueObject .
+             |    ?valueObject knora-base:valueCreationDate ?valueObjectCreationDate .
+             |    FILTER(?valueObjectCreationDate <= $vd)
+             |  }
+             |  FILTER NOT EXISTS {
+             |    ?currentValue knora-base:previousValue* ?otherValueObject .
+             |    ?otherValueObject knora-base:valueCreationDate ?otherValueObjectCreationDate .
+             |    FILTER(?otherValueObjectCreationDate <= $vd && ?otherValueObjectCreationDate > ?valueObjectCreationDate)
+             |  }
+             |  ?currentValue knora-base:hasPermissions ?currentValuePermissions .
+             |  $valueBody
+             |}"""
   }
 
-  /** Loads the current version of each value. */
-  private def currentValuePatterns(
-    maybePropertyIri: Option[SmartIri],
-    maybeValueUuid: Option[UUID],
-  ): Fragment = {
-    val propertyFilter = maybePropertyIri.whenSome { pi =>
-      sparql"""|{
-               |  $resource ?resourceValueProperty $valueObject .
-               |  FILTER(?resourceValueProperty = ${Iri.unsafeFrom(pi.toIri)})
-               |}"""
+  // The UNION nesting is load-bearing: with standoff, the value/standoff UNION is itself one branch
+  // of the link UNION, as the previous builder emitted it. Link values are always queried.
+  private def valueBodyAlternatives(queryStandoff: Boolean, standoffTagFilter: Option[SmartIri]): Fragment =
+    (queryStandoff, standoffTagFilter) match {
+      case (false, _) =>
+        sparql"""|{
+                 |  ?valueObject a ?valueObjectType ;
+                 |    ?valueObjectProperty ?valueObjectValue .
+                 |  FILTER(?valueObjectProperty != knora-base:valueHasStandoff && ?valueObjectProperty != knora-base:hasPermissions)
+                 |} UNION {
+                 |  ?valueObject a knora-base:LinkValue ;
+                 |    rdf:predicate ?resourceLinkProperty ;
+                 |    rdf:object ?referredResource .
+                 |  ?referredResource ?referredResourcePred ?referredResourceObj ;
+                 |    knora-base:isDeleted false .
+                 |}"""
+      case (true, None) =>
+        sparql"""|{
+                 |  {
+                 |    ?valueObject a ?valueObjectType ;
+                 |      ?valueObjectProperty ?valueObjectValue .
+                 |    FILTER(?valueObjectProperty != knora-base:valueHasStandoff && ?valueObjectProperty != knora-base:hasPermissions)
+                 |  } UNION {
+                 |    ?valueObject knora-base:valueHasStandoff ?standoffNode .
+                 |    ?standoffNode ?standoffProperty ?standoffValue ;
+                 |      knora-base:standoffTagHasStartIndex ?startIndex .
+                 |    OPTIONAL {
+                 |      ?standoffTag knora-base:standoffTagHasInternalReference ?targetStandoffTag .
+                 |      ?targetStandoffTag knora-base:standoffTagHasOriginalXMLID ?targetOriginalXMLID .
+                 |    }
+                 |    FILTER(?startIndex >= 0)
+                 |  }
+                 |} UNION {
+                 |  ?valueObject a knora-base:LinkValue ;
+                 |    rdf:predicate ?resourceLinkProperty ;
+                 |    rdf:object ?referredResource .
+                 |  ?referredResource ?referredResourcePred ?referredResourceObj ;
+                 |    knora-base:isDeleted false .
+                 |}"""
+      case (true, Some(tagIri)) =>
+        sparql"""|{
+                 |  {
+                 |    ?valueObject a ?valueObjectType ;
+                 |      ?valueObjectProperty ?valueObjectValue .
+                 |    FILTER(?valueObjectProperty != knora-base:valueHasStandoff && ?valueObjectProperty != knora-base:hasPermissions)
+                 |  } UNION {
+                 |    ?valueObject knora-base:valueHasStandoff ?standoffNode .
+                 |    ?standoffNode a ${Iri.unsafeFrom(tagIri.toIri)} .
+                 |    ?standoffNode ?standoffProperty ?standoffValue ;
+                 |      knora-base:standoffTagHasStartIndex ?startIndex .
+                 |    FILTER(?startIndex >= 0)
+                 |  }
+                 |} UNION {
+                 |  ?valueObject a knora-base:LinkValue ;
+                 |    rdf:predicate ?resourceLinkProperty ;
+                 |    rdf:object ?referredResource .
+                 |  ?referredResource ?referredResourcePred ?referredResourceObj ;
+                 |    knora-base:isDeleted false .
+                 |}"""
     }
-
-    val uuidPattern = maybeValueUuid.whenSome(uuid =>
-      sparql"$valueObject knora-base:valueHasUUID ${Literal.string(UuidUtil.base64Encode(uuid))} .",
-    )
-
-    sparql"""|$resource ?resourceValueProperty $valueObject .
-             |?resourceValueProperty rdfs:subPropertyOf* knora-base:hasValue .
-             |$propertyFilter
-             |$uuidPattern
-             |$valueObject knora-base:hasPermissions ?currentValuePermissions ."""
-  }
 }

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/SearchResultResourcesQuery.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/repo/SearchResultResourcesQuery.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.resources.repo
+
+import org.knora.sparqlbuilder.*
+import org.knora.webapi.IRI
+import org.knora.webapi.store.triplestore.api.TriplestoreService.Queries.Construct
+
+/**
+ * Builds the CONSTRUCT query that loads the main resources of a search result with all of their
+ * values, their link targets and — optionally — the standoff markup of their text values.
+ *
+ * Deleted resources and values are never returned, and there is no property, UUID or version
+ * filtering: a search result is always the current, undeleted state of the matched resources.
+ */
+object SearchResultResourcesQuery {
+
+  /**
+   * @param resourceIris  the resources to load; must not be empty.
+   * @param queryStandoff when true, the standoff markup of text values is loaded as well.
+   */
+  def build(resourceIris: Seq[IRI], queryStandoff: Boolean): Construct =
+    if (queryStandoff) withStandoff(resourceIris) else withoutStandoff(resourceIris)
+
+  private def withoutStandoff(resourceIris: Seq[IRI]): Construct =
+    Construct(
+      sparql"""|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+               |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |CONSTRUCT {
+               |  ?resource a knora-base:Resource ;
+               |    knora-base:isMainResource true ;
+               |    knora-base:attachedToProject ?resourceProject ;
+               |    rdfs:label ?label ;
+               |    rdf:type ?resourceType ;
+               |    knora-base:attachedToUser ?resourceCreator ;
+               |    knora-base:hasPermissions ?resourcePermissions ;
+               |    knora-base:creationDate ?creationDate ;
+               |    knora-base:lastModificationDate ?lastModificationDate ;
+               |    knora-base:hasResourceAuthorship ?resourceAuthorship .
+               |  ?resource knora-base:isDeleted false .
+               |  ?resource knora-base:hasValue ?valueObject ;
+               |    ?resourceValueProperty ?valueObject .
+               |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
+               |    knora-base:valueHasUUID ?currentValueUUID ;
+               |    knora-base:hasPermissions ?currentValuePermissions .
+               |  ?resource knora-base:hasLinkTo ?referredResource ;
+               |    ?resourceLinkProperty ?referredResource .
+               |  ?referredResource a knora-base:Resource ;
+               |    ?referredResourcePred ?referredResourceObj .
+               |} WHERE {
+               |  ${Fragments.values(Variable("resource"), resourceIris.map(Iri.unsafeFrom))}
+               |  {
+               |    ?resource rdf:type ?resourceType .
+               |    ?resourceType rdfs:subClassOf* knora-base:Resource .
+               |  }
+               |  ?resource knora-base:attachedToProject ?resourceProject ;
+               |    knora-base:attachedToUser ?resourceCreator ;
+               |    knora-base:hasPermissions ?resourcePermissions ;
+               |    knora-base:creationDate ?creationDate ;
+               |    rdfs:label ?label .
+               |  ?resource knora-base:isDeleted false .
+               |  OPTIONAL { ?resource knora-base:lastModificationDate ?lastModificationDate . }
+               |  OPTIONAL { ?resource knora-base:hasResourceAuthorship ?resourceAuthorship . }
+               |  OPTIONAL {
+               |    ?resource ?resourceValueProperty ?valueObject .
+               |    ?resourceValueProperty rdfs:subPropertyOf* knora-base:hasValue .
+               |    ?valueObject knora-base:hasPermissions ?currentValuePermissions .
+               |    {
+               |      ?valueObject a ?valueObjectType ;
+               |        ?valueObjectProperty ?valueObjectValue .
+               |      FILTER(?valueObjectProperty != knora-base:valueHasStandoff && ?valueObjectProperty != knora-base:hasPermissions)
+               |    } UNION {
+               |      ?valueObject a knora-base:LinkValue ;
+               |        rdf:predicate ?resourceLinkProperty ;
+               |        rdf:object ?referredResource .
+               |      ?referredResource ?referredResourcePred ?referredResourceObj ;
+               |        knora-base:isDeleted false .
+               |    }
+               |  }
+               |}""".render,
+    )
+
+  // The UNION nesting is load-bearing: the standoff branch is a branch of the value UNION, and that
+  // whole UNION is in turn one branch of the link UNION, as the previous builder emitted it.
+  private def withStandoff(resourceIris: Seq[IRI]): Construct =
+    Construct(
+      sparql"""|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+               |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+               |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+               |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+               |
+               |CONSTRUCT {
+               |  ?resource a knora-base:Resource ;
+               |    knora-base:isMainResource true ;
+               |    knora-base:attachedToProject ?resourceProject ;
+               |    rdfs:label ?label ;
+               |    rdf:type ?resourceType ;
+               |    knora-base:attachedToUser ?resourceCreator ;
+               |    knora-base:hasPermissions ?resourcePermissions ;
+               |    knora-base:creationDate ?creationDate ;
+               |    knora-base:lastModificationDate ?lastModificationDate ;
+               |    knora-base:hasResourceAuthorship ?resourceAuthorship .
+               |  ?resource knora-base:isDeleted false .
+               |  ?resource knora-base:hasValue ?valueObject ;
+               |    ?resourceValueProperty ?valueObject .
+               |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
+               |    knora-base:valueHasUUID ?currentValueUUID ;
+               |    knora-base:hasPermissions ?currentValuePermissions .
+               |  ?valueObject knora-base:valueHasStandoff ?standoffNode .
+               |  ?standoffNode ?standoffProperty ?standoffValue ;
+               |    knora-base:targetHasOriginalXMLID ?targetOriginalXMLID .
+               |  ?resource knora-base:hasLinkTo ?referredResource ;
+               |    ?resourceLinkProperty ?referredResource .
+               |  ?referredResource a knora-base:Resource ;
+               |    ?referredResourcePred ?referredResourceObj .
+               |} WHERE {
+               |  ${Fragments.values(Variable("resource"), resourceIris.map(Iri.unsafeFrom))}
+               |  {
+               |    ?resource rdf:type ?resourceType .
+               |    ?resourceType rdfs:subClassOf* knora-base:Resource .
+               |  }
+               |  ?resource knora-base:attachedToProject ?resourceProject ;
+               |    knora-base:attachedToUser ?resourceCreator ;
+               |    knora-base:hasPermissions ?resourcePermissions ;
+               |    knora-base:creationDate ?creationDate ;
+               |    rdfs:label ?label .
+               |  ?resource knora-base:isDeleted false .
+               |  OPTIONAL { ?resource knora-base:lastModificationDate ?lastModificationDate . }
+               |  OPTIONAL { ?resource knora-base:hasResourceAuthorship ?resourceAuthorship . }
+               |  OPTIONAL {
+               |    ?resource ?resourceValueProperty ?valueObject .
+               |    ?resourceValueProperty rdfs:subPropertyOf* knora-base:hasValue .
+               |    ?valueObject knora-base:hasPermissions ?currentValuePermissions .
+               |    {
+               |      {
+               |        ?valueObject a ?valueObjectType ;
+               |          ?valueObjectProperty ?valueObjectValue .
+               |        FILTER(?valueObjectProperty != knora-base:valueHasStandoff && ?valueObjectProperty != knora-base:hasPermissions)
+               |      } UNION {
+               |        ?valueObject knora-base:valueHasStandoff ?standoffNode .
+               |        ?standoffNode ?standoffProperty ?standoffValue ;
+               |          knora-base:standoffTagHasStartIndex ?startIndex .
+               |        OPTIONAL {
+               |          ?standoffTag knora-base:standoffTagHasInternalReference ?targetStandoffTag .
+               |          ?targetStandoffTag knora-base:standoffTagHasOriginalXMLID ?targetOriginalXMLID .
+               |        }
+               |        FILTER(?startIndex >= 0)
+               |      }
+               |    } UNION {
+               |      ?valueObject a knora-base:LinkValue ;
+               |        rdf:predicate ?resourceLinkProperty ;
+               |        rdf:object ?referredResource .
+               |      ?referredResource ?referredResourcePred ?referredResourceObj ;
+               |        knora-base:isDeleted false .
+               |    }
+               |  }
+               |}""".render,
+    )
+}

--- a/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceLive.scala
+++ b/modules/webapi/src/main/scala/org/knora/webapi/slice/resources/service/ReadResourcesServiceLive.scala
@@ -153,7 +153,6 @@ final case class ReadResourcesServiceLive(
                   maybePropertyIri = propertyIri,
                   maybeValueUuid = valueUuid,
                   maybeVersionDate = versionDate.map(_.value),
-                  queryAllNonStandoff = true,
                   queryStandoff = queryStandoff,
                   standoffTagFilter = standoffTagFilter,
                 )

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/GetResourcePropertiesAndValuesQuerySpec.scala
@@ -31,30 +31,25 @@ class GetResourcePropertiesAndValuesQuerySpec extends ZIOSpecDefault {
   private val propertyIri  = sf.toSmartIri("http://www.knora.org/ontology/0001/anything#hasText")
   private val valueUuid    = UUID.fromString("12345678-1234-1234-1234-123456789012")
   private val versionDate  = Instant.parse("2019-08-30T10:36:54.024Z")
-  private val valueIri     = "http://rdfh.ch/0001/resource1/values/value1"
 
   private def render(
     resourceIris: Seq[String] = Seq(resourceIri1),
     preview: Boolean = false,
     withDeleted: Boolean = false,
-    queryAllNonStandoff: Boolean = true,
     queryStandoff: Boolean = false,
     maybePropertyIri: Option[org.knora.webapi.messages.SmartIri] = None,
     maybeValueUuid: Option[UUID] = None,
     maybeVersionDate: Option[Instant] = None,
-    maybeValueIri: Option[String] = None,
   ): String =
     GetResourcePropertiesAndValuesQuery
       .build(
         resourceIris = resourceIris,
         preview = preview,
         withDeleted = withDeleted,
-        queryAllNonStandoff = queryAllNonStandoff,
         queryStandoff = queryStandoff,
         maybePropertyIri = maybePropertyIri,
         maybeValueUuid = maybeValueUuid,
         maybeVersionDate = maybeVersionDate,
-        maybeValueIri = maybeValueIri,
       )
       .sparql
 
@@ -432,59 +427,6 @@ class GetResourcePropertiesAndValuesQuerySpec extends ZIOSpecDefault {
        |    <http://www.knora.org/ontology/knora-base#isDeleted> false . } }
        |}""".stripMargin
 
-  private val expectedValueIri =
-    """|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-       |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-       |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-       |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-       |
-       |CONSTRUCT {
-       |  ?resource a <http://www.knora.org/ontology/knora-base#Resource> ;
-       |    <http://www.knora.org/ontology/knora-base#isMainResource> true ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
-       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label ;
-       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
-       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
-       |    <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate ;
-       |    <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship .
-       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
-       |  ?resource <http://www.knora.org/ontology/knora-base#hasValue> ?valueObject ;
-       |    ?resourceValueProperty ?valueObject .
-       |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
-       |    <http://www.knora.org/ontology/knora-base#valueHasUUID> ?currentValueUUID ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
-       |  ?resource <http://www.knora.org/ontology/knora-base#hasLinkTo> ?referredResource ;
-       |    ?resourceLinkProperty ?referredResource .
-       |  ?referredResource a <http://www.knora.org/ontology/knora-base#Resource> ;
-       |    ?referredResourcePred ?referredResourceObj .
-       |} WHERE {
-       |  VALUES ?resource { <http://rdfh.ch/0001/resource1> }
-       |  { ?resource <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType .
-       |?resourceType <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> . }
-       |  ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
-       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
-       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label .
-       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
-       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate . }
-       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship . }
-       |  OPTIONAL { ?resource ?resourceValueProperty ?valueObject .
-       |?resourceValueProperty <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
-       |?valueObject <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
-       |{ ?valueObject ?valueObjectProperty ?valueObjectValue .
-       |FILTER ( ?valueObject = <http://rdfh.ch/0001/resource1/values/value1> ) }
-       |{ ?valueObject a ?valueObjectType ;
-       |    ?valueObjectProperty ?valueObjectValue .
-       |FILTER ( ( ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#valueHasStandoff> && ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#hasPermissions> ) ) } UNION { ?valueObject a <http://www.knora.org/ontology/knora-base#LinkValue> ;
-       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> ?resourceLinkProperty ;
-       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#object> ?referredResource .
-       |?referredResource ?referredResourcePred ?referredResourceObj ;
-       |    <http://www.knora.org/ontology/knora-base#isDeleted> false . } }
-       |}""".stripMargin
-
   private val expectedMultipleResources =
     """|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
        |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -534,50 +476,6 @@ class GetResourcePropertiesAndValuesQuerySpec extends ZIOSpecDefault {
        |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#object> ?referredResource .
        |?referredResource ?referredResourcePred ?referredResourceObj ;
        |    <http://www.knora.org/ontology/knora-base#isDeleted> false . } }
-       |}""".stripMargin
-
-  private val expectedNoNonStandoff =
-    """|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-       |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-       |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-       |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-       |
-       |CONSTRUCT {
-       |  ?resource a <http://www.knora.org/ontology/knora-base#Resource> ;
-       |    <http://www.knora.org/ontology/knora-base#isMainResource> true ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
-       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label ;
-       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
-       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
-       |    <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate ;
-       |    <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship .
-       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
-       |  ?resource <http://www.knora.org/ontology/knora-base#hasValue> ?valueObject ;
-       |    ?resourceValueProperty ?valueObject .
-       |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
-       |    <http://www.knora.org/ontology/knora-base#valueHasUUID> ?currentValueUUID ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
-       |} WHERE {
-       |  VALUES ?resource { <http://rdfh.ch/0001/resource1> }
-       |  { ?resource <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType .
-       |?resourceType <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> . }
-       |  ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
-       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
-       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label .
-       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
-       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate . }
-       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship . }
-       |  OPTIONAL { ?resource ?resourceValueProperty ?valueObject .
-       |?resourceValueProperty <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
-       |?valueObject <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
-       |{ ?valueObject a ?valueObjectType ;
-       |    ?valueObjectProperty ?valueObjectValue .
-       |FILTER ( ( ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#valueHasStandoff> && ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#hasPermissions> ) )
-       |FILTER ( ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#valueHasString> ) } }
        |}""".stripMargin
 
   private val expectedVersionDateWithDeleted =
@@ -766,56 +664,6 @@ class GetResourcePropertiesAndValuesQuerySpec extends ZIOSpecDefault {
        |    <http://www.knora.org/ontology/knora-base#isDeleted> false . } }
        |}""".stripMargin
 
-  private val expectedStandoffTagFilterNoLinks =
-    """|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-       |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-       |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-       |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-       |
-       |CONSTRUCT {
-       |  ?resource a <http://www.knora.org/ontology/knora-base#Resource> ;
-       |    <http://www.knora.org/ontology/knora-base#isMainResource> true ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
-       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label ;
-       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
-       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
-       |    <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate ;
-       |    <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship .
-       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
-       |  ?resource <http://www.knora.org/ontology/knora-base#hasValue> ?valueObject ;
-       |    ?resourceValueProperty ?valueObject .
-       |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
-       |    <http://www.knora.org/ontology/knora-base#valueHasUUID> ?currentValueUUID ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
-       |  ?valueObject <http://www.knora.org/ontology/knora-base#valueHasStandoff> ?standoffNode .
-       |  ?standoffNode a <http://www.knora.org/ontology/standoff#StandoffFootnoteTag> ;
-       |    ?standoffProperty ?standoffValue .
-       |} WHERE {
-       |  VALUES ?resource { <http://rdfh.ch/0001/resource1> }
-       |  { ?resource <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType .
-       |?resourceType <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> . }
-       |  ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
-       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
-       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
-       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
-       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label .
-       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
-       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate . }
-       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship . }
-       |  OPTIONAL { ?resource ?resourceValueProperty ?valueObject .
-       |?resourceValueProperty <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
-       |?valueObject <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
-       |{ ?valueObject a ?valueObjectType ;
-       |    ?valueObjectProperty ?valueObjectValue .
-       |FILTER ( ( ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#valueHasStandoff> && ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#hasPermissions> ) )
-       |FILTER ( ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#valueHasString> ) } UNION { ?valueObject <http://www.knora.org/ontology/knora-base#valueHasStandoff> ?standoffNode .
-       |?standoffNode a <http://www.knora.org/ontology/standoff#StandoffFootnoteTag> .
-       |?standoffNode ?standoffProperty ?standoffValue ;
-       |    <http://www.knora.org/ontology/knora-base#standoffTagHasStartIndex> ?startIndex .
-       |FILTER ( ?startIndex >= 0 ) } }
-       |}""".stripMargin
   // @formatter:on
 
   override val spec: Spec[Any, Nothing] = suite("GetResourcePropertiesAndValuesQuery")(
@@ -847,17 +695,9 @@ class GetResourcePropertiesAndValuesQuerySpec extends ZIOSpecDefault {
       val actual = render(maybeValueUuid = Some(valueUuid))
       assertTrue(canonical(actual) == canonical(expectedValueUuid))
     },
-    test("valueIri - maybeValueIri=Some(valueIri)") {
-      val actual = render(maybeValueIri = Some(valueIri))
-      assertTrue(canonical(actual) == canonical(expectedValueIri))
-    },
     test("multipleResources - resourceIris=Seq(resourceIri1, resourceIri2)") {
       val actual = render(resourceIris = Seq(resourceIri1, resourceIri2))
       assertTrue(canonical(actual) == canonical(expectedMultipleResources))
-    },
-    test("noNonStandoff - queryAllNonStandoff=false") {
-      val actual = render(queryAllNonStandoff = false)
-      assertTrue(canonical(actual) == canonical(expectedNoNonStandoff))
     },
     test("versionDateWithDeleted - withDeleted=true, maybeVersionDate=Some(versionDate)") {
       val actual = render(withDeleted = true, maybeVersionDate = Some(versionDate))
@@ -867,33 +707,18 @@ class GetResourcePropertiesAndValuesQuerySpec extends ZIOSpecDefault {
       val actual = render(maybeVersionDate = Some(versionDate), maybeValueUuid = Some(valueUuid))
       assertTrue(canonical(actual) == canonical(expectedVersionDateWithUuid))
     },
-    test("standoffTagFilter - matches the legacy rendering (queryAllNonStandoff=true)") {
+    test("standoffTagFilter - matches the legacy rendering") {
       val footnoteTagIri = sf.toSmartIri("http://www.knora.org/ontology/standoff#StandoffFootnoteTag")
       val actual         = GetResourcePropertiesAndValuesQuery
         .build(
           resourceIris = Seq(resourceIri1),
           preview = false,
           withDeleted = false,
-          queryAllNonStandoff = true,
           queryStandoff = true,
           standoffTagFilter = Some(footnoteTagIri),
         )
         .sparql
       assertTrue(canonical(actual) == canonical(expectedStandoffTagFilter))
-    },
-    test("standoffTagFilter - matches the legacy rendering (queryAllNonStandoff=false)") {
-      val footnoteTagIri = sf.toSmartIri("http://www.knora.org/ontology/standoff#StandoffFootnoteTag")
-      val actual         = GetResourcePropertiesAndValuesQuery
-        .build(
-          resourceIris = Seq(resourceIri1),
-          preview = false,
-          withDeleted = false,
-          queryAllNonStandoff = false,
-          queryStandoff = true,
-          standoffTagFilter = Some(footnoteTagIri),
-        )
-        .sparql
-      assertTrue(canonical(actual) == canonical(expectedStandoffTagFilterNoLinks))
     },
     test("standoffTagFilter - type constraint in SPARQL, no targetHasOriginalXMLID (U-2)") {
       val footnoteTagIri = sf.toSmartIri("http://www.knora.org/ontology/standoff#StandoffFootnoteTag")
@@ -902,7 +727,6 @@ class GetResourcePropertiesAndValuesQuerySpec extends ZIOSpecDefault {
           resourceIris = Seq(resourceIri1),
           preview = false,
           withDeleted = false,
-          queryAllNonStandoff = true,
           queryStandoff = true,
           standoffTagFilter = Some(footnoteTagIri),
         )

--- a/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/SearchResultResourcesQuerySpec.scala
+++ b/modules/webapi/src/test/scala/org/knora/webapi/slice/resources/repo/SearchResultResourcesQuerySpec.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2021 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.knora.webapi.slice.resources.repo
+
+import org.apache.jena.query.QueryFactory
+import org.junit.runner.RunWith
+import zio.test.*
+
+import org.knora.testrunner.DspZTestJUnitRunner
+
+@RunWith(classOf[DspZTestJUnitRunner])
+class SearchResultResourcesQuerySpec extends ZIOSpecDefault {
+
+  private def canonical(query: String): String = {
+    val parsed = QueryFactory.create(query)
+    parsed.getPrefixMapping.clearNsPrefixMap()
+    parsed.toString
+  }
+
+  private val resourceIri1 = "http://rdfh.ch/0001/resource1"
+  private val resourceIri2 = "http://rdfh.ch/0001/resource2"
+
+  // @formatter:off
+  private val expectedWithoutStandoff =
+    """|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+       |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+       |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+       |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+       |
+       |CONSTRUCT {
+       |  ?resource a <http://www.knora.org/ontology/knora-base#Resource> ;
+       |    <http://www.knora.org/ontology/knora-base#isMainResource> true ;
+       |    <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
+       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label ;
+       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType ;
+       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
+       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
+       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
+       |    <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate ;
+       |    <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship .
+       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
+       |  ?resource <http://www.knora.org/ontology/knora-base#hasValue> ?valueObject ;
+       |    ?resourceValueProperty ?valueObject .
+       |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
+       |    <http://www.knora.org/ontology/knora-base#valueHasUUID> ?currentValueUUID ;
+       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
+       |  ?resource <http://www.knora.org/ontology/knora-base#hasLinkTo> ?referredResource ;
+       |    ?resourceLinkProperty ?referredResource .
+       |  ?referredResource a <http://www.knora.org/ontology/knora-base#Resource> ;
+       |    ?referredResourcePred ?referredResourceObj .
+       |} WHERE {
+       |  VALUES ?resource { <http://rdfh.ch/0001/resource1> }
+       |  { ?resource <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType .
+       |?resourceType <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> . }
+       |  ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
+       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
+       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
+       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
+       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
+       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate . }
+       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship . }
+       |  OPTIONAL { ?resource ?resourceValueProperty ?valueObject .
+       |?resourceValueProperty <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
+       |?valueObject <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
+       |{ ?valueObject a ?valueObjectType ;
+       |    ?valueObjectProperty ?valueObjectValue .
+       |FILTER ( ( ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#valueHasStandoff> && ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#hasPermissions> ) ) } UNION { ?valueObject a <http://www.knora.org/ontology/knora-base#LinkValue> ;
+       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> ?resourceLinkProperty ;
+       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#object> ?referredResource .
+       |?referredResource ?referredResourcePred ?referredResourceObj ;
+       |    <http://www.knora.org/ontology/knora-base#isDeleted> false . } }
+       |}""".stripMargin
+
+  private val expectedWithStandoff =
+    """|PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+       |PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+       |PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+       |PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+       |
+       |CONSTRUCT {
+       |  ?resource a <http://www.knora.org/ontology/knora-base#Resource> ;
+       |    <http://www.knora.org/ontology/knora-base#isMainResource> true ;
+       |    <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
+       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label ;
+       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType ;
+       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
+       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
+       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
+       |    <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate ;
+       |    <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship .
+       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
+       |  ?resource <http://www.knora.org/ontology/knora-base#hasValue> ?valueObject ;
+       |    ?resourceValueProperty ?valueObject .
+       |  ?valueObject ?valueObjectProperty ?valueObjectValue ;
+       |    <http://www.knora.org/ontology/knora-base#valueHasUUID> ?currentValueUUID ;
+       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
+       |  ?valueObject <http://www.knora.org/ontology/knora-base#valueHasStandoff> ?standoffNode .
+       |  ?standoffNode ?standoffProperty ?standoffValue ;
+       |    <http://www.knora.org/ontology/knora-base#targetHasOriginalXMLID> ?targetOriginalXMLID .
+       |  ?resource <http://www.knora.org/ontology/knora-base#hasLinkTo> ?referredResource ;
+       |    ?resourceLinkProperty ?referredResource .
+       |  ?referredResource a <http://www.knora.org/ontology/knora-base#Resource> ;
+       |    ?referredResourcePred ?referredResourceObj .
+       |} WHERE {
+       |  VALUES ?resource { <http://rdfh.ch/0001/resource1> }
+       |  { ?resource <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?resourceType .
+       |?resourceType <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.knora.org/ontology/knora-base#Resource> . }
+       |  ?resource <http://www.knora.org/ontology/knora-base#attachedToProject> ?resourceProject ;
+       |    <http://www.knora.org/ontology/knora-base#attachedToUser> ?resourceCreator ;
+       |    <http://www.knora.org/ontology/knora-base#hasPermissions> ?resourcePermissions ;
+       |    <http://www.knora.org/ontology/knora-base#creationDate> ?creationDate ;
+       |    <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+       |  ?resource <http://www.knora.org/ontology/knora-base#isDeleted> false .
+       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#lastModificationDate> ?lastModificationDate . }
+       |  OPTIONAL { ?resource <http://www.knora.org/ontology/knora-base#hasResourceAuthorship> ?resourceAuthorship . }
+       |  OPTIONAL { ?resource ?resourceValueProperty ?valueObject .
+       |?resourceValueProperty <http://www.w3.org/2000/01/rdf-schema#subPropertyOf>* <http://www.knora.org/ontology/knora-base#hasValue> .
+       |?valueObject <http://www.knora.org/ontology/knora-base#hasPermissions> ?currentValuePermissions .
+       |{ { ?valueObject a ?valueObjectType ;
+       |    ?valueObjectProperty ?valueObjectValue .
+       |FILTER ( ( ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#valueHasStandoff> && ?valueObjectProperty != <http://www.knora.org/ontology/knora-base#hasPermissions> ) ) } UNION { ?valueObject <http://www.knora.org/ontology/knora-base#valueHasStandoff> ?standoffNode .
+       |?standoffNode ?standoffProperty ?standoffValue ;
+       |    <http://www.knora.org/ontology/knora-base#standoffTagHasStartIndex> ?startIndex .
+       |OPTIONAL { ?standoffTag <http://www.knora.org/ontology/knora-base#standoffTagHasInternalReference> ?targetStandoffTag .
+       |?targetStandoffTag <http://www.knora.org/ontology/knora-base#standoffTagHasOriginalXMLID> ?targetOriginalXMLID . }
+       |FILTER ( ?startIndex >= 0 ) } } UNION { ?valueObject a <http://www.knora.org/ontology/knora-base#LinkValue> ;
+       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> ?resourceLinkProperty ;
+       |    <http://www.w3.org/1999/02/22-rdf-syntax-ns#object> ?referredResource .
+       |?referredResource ?referredResourcePred ?referredResourceObj ;
+       |    <http://www.knora.org/ontology/knora-base#isDeleted> false . } }
+       |}""".stripMargin
+  // @formatter:on
+
+  override val spec: Spec[Any, Nothing] = suite("SearchResultResourcesQuery")(
+    test("without standoff - matches the legacy rendering") {
+      val actual = SearchResultResourcesQuery.build(Seq(resourceIri1), queryStandoff = false).sparql
+      assertTrue(canonical(actual) == canonical(expectedWithoutStandoff))
+    },
+    test("with standoff - matches the legacy rendering") {
+      val actual = SearchResultResourcesQuery.build(Seq(resourceIri1), queryStandoff = true).sparql
+      assertTrue(canonical(actual) == canonical(expectedWithStandoff))
+    },
+    test("multiple resources - all IRIs end up in the VALUES clause") {
+      val actual = SearchResultResourcesQuery.build(Seq(resourceIri1, resourceIri2), queryStandoff = false).sparql
+      assertTrue(actual.contains(s"VALUES ?resource { <$resourceIri1> <$resourceIri2> }"))
+    },
+  )
+}


### PR DESCRIPTION
Part of DEV-7150 (bucket). Resolves DEV-7232. Follow-up to #4321. Stacked on #4321.

## Why

`GetResourcePropertiesAndValuesQuery` was the one migrated query that could not be read as an explicit template: five structural switches and four optional filters. Two agreed changes bring it to the convention documented in #4321.

## What

- **Dead parameters removed.** Every production caller passed `queryAllNonStandoff = true`, and no caller set `maybeValueIri`. Both are gone, together with the value-IRI `FILTER` and the `valueHasString` exclusion that only they enabled. The three spec cases that exercised them are deleted; every surviving fixture string is unchanged.
- **Search results get their own query.** `SearchResponderV2` always loads results with `preview = false`, `withDeleted = false` and no filters, only toggling standoff. The new `SearchResultResourcesQuery` is two complete inline templates selected by that flag, with the `VALUES` list as the only hole. `SearchResultResourcesQuerySpec` pins them against what the previous builder rendered for that call.
- **The read path is two complete templates.** `GetResourcePropertiesAndValuesQuery` (used by `ReadResourcesServiceLive`) is now a current-values template and a version-date template, each written top to bottom with literal prefixes and the resource metadata inline. The remaining holes are the genuinely dynamic parts: the `withDeleted` alternatives, the whole values `OPTIONAL` dropped for previews, property and UUID filters, and the standoff toggle with its optional tag filter. The value / standoff / link UNION is written as literal blocks per shape; its pinned nesting is preserved. The `Variable` vals for fixed variable names are gone.

## Verification

All 13 surviving cases in `GetResourcePropertiesAndValuesQuerySpec` pass with unchanged fixtures; the 3 new search-results cases match the previous `basic` / `standoff` renderings. An independent verifier confirmed the two parameters were dead at every call site and re-ran `//modules/webapi:test`, `//modules/sparql-builder:test` and `just check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
