### PR TITLE
fix(ci): health-gate API startup and dump logs on healthcheck failure

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -384,3 +384,11 @@ jobs:
           nix develop --command just docker-build-fuseki-image ${{ steps.rbe.outputs.flags }}
       - name: Spin up the API container and wait for all healthchecks (incl. db and sipi) to pass
         run: docker compose up --wait api
+      - name: Dump container status and logs on failure
+        if: failure()
+        # `up --wait` only reports that the API container exited; it prints nothing about
+        # why. Surface the status table and the logs so a startup crash is diagnosable
+        # from the run alone instead of needing a local repro.
+        run: |
+          docker compose ps
+          docker compose logs --no-color --timestamps api db sipi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,10 +132,17 @@ services:
 
   api:
     image: daschswiss/knora-api:latest
+    # Health-gate the dependencies: the API does a single triplestore availability
+    # check at startup (core/Db.scala) with no retry and dies if it isn't ready, so
+    # it must not start before Fuseki (db) is healthy. Short-form depends_on only
+    # orders container *start*, which races Fuseki's cold start and exits the API 1.
     depends_on:
-      - alloy
-      - db
-      - sipi
+      db:
+        condition: service_healthy
+      sipi:
+        condition: service_healthy
+      alloy:
+        condition: service_started
     ports:
       - "3333:3333"
       - "5555:5555"


### PR DESCRIPTION
## Problem

The **Run the healthcheck from the container** job (`docker compose up --wait api`) fails intermittently across many PRs with the same signature — db, sipi and alloy go healthy, then:

```
container dsp-api-api-1 exited (1)
```

…and **no logs about why**. Recent examples: PR #4306, and the `admin-domain-services` / `upgrade-plugins` branches.

## Root cause

A cold-start race, plus zero diagnostics:

1. **Start-ordering, not health-gating.** `api.depends_on` used the short-form list, which only waits for dependencies to *start*. The API container starts ~20s before Fuseki reports healthy.
2. **Single no-retry triplestore check.** At startup `core/Db.scala` runs `checkTriplestore().filterOrDieWith(_ == Available)` once, inside an `.orDie`. If Fuseki isn't `Available` at that instant, the ZIO app dies → container exits 1. There's no restart policy, so the crash is terminal and `up --wait` fails.
3. **No logs on failure.** `up --wait` reports only the exit, never the cause.

## Changes

- **`docker-compose.yml`** — health-gate the API's dependencies with long-form `condition: service_healthy` (db, sipi) and `service_started` (alloy). Compose now won't start the API until Fuseki is healthy, closing the race. The healthchecks are Compose-level and already proven working (db/sipi already report `Healthy`), so this is independent of the OCI image internals.
- **`.github/workflows/build-and-test.yml`** — add an `if: failure()` step that dumps `docker compose ps` and `docker compose logs` for api/db/sipi, so any future startup crash is diagnosable from the run alone.

## Notes / follow-up

Not included here, but worth considering separately: giving the app a **bounded startup retry** around `checkTriplestore` (`Db.scala`). That's the deployment-grade fix (also helps k8s rollouts where Fuseki lags), but the Compose health-gate is sufficient for CI and keeps this change small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APiTgocmUZxiu1VrHi4AHV