### PR TITLE
feat: bump Sipi to v9.0.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -310,23 +310,23 @@ use_repo(image_versions, "dsp_image_versions")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
-# Upstream Sipi image (daschswiss/sipi:v8.0.0), pinned per-arch by manifest
+# Upstream Sipi image (daschswiss/sipi:v9.0.1), pinned per-arch by manifest
 # digest. Pulling each platform's single image manifest directly avoids
-# index/variant matching — the arm64 entry of the v8.0.0 index carries a `v8`
+# index/variant matching — the arm64 entry of the v9.0.1 index carries a `v8`
 # variant, which a bare `linux/arm64` platform request does not match. These two
 # digests are the SOLE source of the sipi version: the /version endpoint reads
 # the tag from the image's own `org.opencontainers.image.version` OCI label
 # (//tools/buildinfo:oci_config_label), so there is no duplicated tag string to
 # keep in sync. To bump, see "Bumping the SIPI version" in CLAUDE.md.
-# Index digest: sha256:8cb1098a3fdf2383c5bb3f382f46a1fe58dad4cfed0a56c7aa8c5e06f5ac5e85
+# Index digest: sha256:a115b272f59f93797ff34578a46b6d30af84e4d01c23b1f7ad3861c7670ca601
 oci.pull(
     name = "sipi_base_amd64",
-    digest = "sha256:6fb699b38b21e992719c03d3308e97a1fd4a755758fcb17e966a9c3293539ffd",
+    digest = "sha256:239a0e9ba69b6b1794590fcf2caa712855685f2ad711d8fd3d54cc1c1c04187d",
     image = "index.docker.io/daschswiss/sipi",
 )
 oci.pull(
     name = "sipi_base_arm64",
-    digest = "sha256:069a1955331576d27df0b9efd11711b807228a52449c9532e46a0c9c2df0d5b5",
+    digest = "sha256:bfbcbb383fcc490f7533d8df9e95690cbb2ed01ff538486eb7b3e18091a2828e",
     image = "index.docker.io/daschswiss/sipi",
 )
 use_repo(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - STORAGE_TEMP_DIR=/opt/temp
       - JWT_AUDIENCE=http://localhost:3340
       - JWT_ISSUER=0.0.0.0:3333
-      - JWT_SECRET=UP 4888, nice 4-8-4 steam engine
+      - JWT_SECRET=dev-only-insecure-jwt-secret-change-me
       - SIPI_USE_LOCAL_DEV=false
       - ALLOW_ERASE_PROJECTS=true
       - DB_JDBC_URL=jdbc:sqlite:/opt/db/ingest.sqlite

--- a/modules/ingest/src/main/resources/application.conf
+++ b/modules/ingest/src/main/resources/application.conf
@@ -21,7 +21,7 @@ jwt {
   audience = ${?JWT_AUDIENCE}
   issuer = "0.0.0.0:3333"
   issuer = ${?JWT_ISSUER}
-  secret = "UP 4888, nice 4-8-4 steam engine"
+  secret = "dev-only-insecure-jwt-secret-change-me"
   secret = ${?JWT_SECRET}
   disable-auth = false
   disable-auth = ${?JWT_DISABLE_AUTH}

--- a/modules/sipi/config/sipi.docker-config.lua
+++ b/modules/sipi/config/sipi.docker-config.lua
@@ -145,10 +145,10 @@ sipi = {
     knora_port = '3333',
 
     --
-    -- The secret for generating JWT's (JSON Web Tokens) (42 characters)
-    --
-    jwt_secret = 'UP 4888, nice 4-8-4 steam engine',
-    --            12345678901234567890123456789012
+    -- The secret for generating JWTs (JSON Web Tokens). Dev only: must be >= 32
+    -- bytes and must not be Sipi's shipped default, or Sipi v9 refuses to start.
+    -- Prod supplies it via SIPI_JWTKEY.
+    jwt_secret = 'dev-only-insecure-jwt-secret-change-me',
 
     --
     -- Name of the logfile (a ".txt" is added...)

--- a/modules/sipi/config/sipi.docker-no-auth-config.lua
+++ b/modules/sipi/config/sipi.docker-no-auth-config.lua
@@ -132,10 +132,10 @@ sipi = {
 
 
     --
-    -- The secret for generating JWT's (JSON Web Tokens) (42 characters)
-    --
-    jwt_secret = 'UP 4888, nice 4-8-4 steam engine',
-    --            12345678901234567890123456789012
+    -- The secret for generating JWTs (JSON Web Tokens). Dev only: must be >= 32
+    -- bytes and must not be Sipi's shipped default, or Sipi v9 refuses to start.
+    -- Prod supplies it via SIPI_JWTKEY.
+    jwt_secret = 'dev-only-insecure-jwt-secret-change-me',
 
     --
     -- Name of the logfile (a ".txt" is added...)

--- a/modules/sipi/config/sipi.docker-test-config.lua
+++ b/modules/sipi/config/sipi.docker-test-config.lua
@@ -144,10 +144,10 @@ sipi = {
     knora_port = '3333',
 
     --
-    -- The secret for generating JWT's (JSON Web Tokens) (42 characters)
-    --
-    jwt_secret = 'UP 4888, nice 4-8-4 steam engine',
-    --            12345678901234567890123456789012
+    -- The secret for generating JWTs (JSON Web Tokens). Dev only: must be >= 32
+    -- bytes and must not be Sipi's shipped default, or Sipi v9 refuses to start.
+    -- Prod supplies it via SIPI_JWTKEY.
+    jwt_secret = 'dev-only-insecure-jwt-secret-change-me',
 
     --
     -- Name of the logfile (a ".txt" is added...)

--- a/modules/sipi/config/sipi.local-config.lua
+++ b/modules/sipi/config/sipi.local-config.lua
@@ -123,10 +123,10 @@ sipi = {
     loglevel = "DEBUG",
 
     --
-    -- The secret for generating JWT's (JSON Web Tokens) (42 characters)
-    --
-    jwt_secret = 'UP 4888, nice 4-8-4 steam engine',
-    --            12345678901234567890123456789012
+    -- The secret for generating JWTs (JSON Web Tokens). Dev only: must be >= 32
+    -- bytes and must not be Sipi's shipped default, or Sipi v9 refuses to start.
+    -- Prod supplies it via SIPI_JWTKEY.
+    jwt_secret = 'dev-only-insecure-jwt-secret-change-me',
 }
 
 

--- a/modules/test-e2e/src/test/resources/sipi.docker-config.lua
+++ b/modules/test-e2e/src/test/resources/sipi.docker-config.lua
@@ -145,10 +145,10 @@ sipi = {
     knora_port = '3333',
 
     --
-    -- The secret for generating JWT's (JSON Web Tokens) (42 characters)
-    --
-    jwt_secret = 'UP 4888, nice 4-8-4 steam engine',
-    --            12345678901234567890123456789012
+    -- The secret for generating JWTs (JSON Web Tokens). Dev only: must be >= 32
+    -- bytes and must not be Sipi's shipped default, or Sipi v9 refuses to start.
+    -- Prod supplies it via SIPI_JWTKEY.
+    jwt_secret = 'dev-only-insecure-jwt-secret-change-me',
 
     --
     -- Name of the logfile (a ".txt" is added...)

--- a/modules/test-ingest-integration/src/test/scala/swiss/dasch/integration/testcontainers/DspIngestTestContainer.scala
+++ b/modules/test-ingest-integration/src/test/scala/swiss/dasch/integration/testcontainers/DspIngestTestContainer.scala
@@ -34,7 +34,7 @@ object DspIngestTestContainer {
       .withEnv("JWT_ISSUER", "0.0.0.0:3333")
       .withEnv("STORAGE_ASSET_DIR", assetDir)
       .withEnv("STORAGE_TEMP_DIR", tempDir)
-      .withEnv("JWT_SECRET", "UP 4888, nice 4-8-4 steam engine")
+      .withEnv("JWT_SECRET", "dev-only-insecure-jwt-secret-change-me")
       .withEnv("SIPI_USE_LOCAL_DEV", "false")
       .withEnv("JWT_DISABLE_AUTH", "true")
       .withEnv("DB_JDBC_URL", "jdbc:sqlite:/tmp/ingest.sqlite")

--- a/modules/test-it/src/test/resources/sipi.docker-config.lua
+++ b/modules/test-it/src/test/resources/sipi.docker-config.lua
@@ -145,10 +145,10 @@ sipi = {
     knora_port = '3333',
 
     --
-    -- The secret for generating JWT's (JSON Web Tokens) (42 characters)
-    --
-    jwt_secret = 'UP 4888, nice 4-8-4 steam engine',
-    --            12345678901234567890123456789012
+    -- The secret for generating JWTs (JSON Web Tokens). Dev only: must be >= 32
+    -- bytes and must not be Sipi's shipped default, or Sipi v9 refuses to start.
+    -- Prod supplies it via SIPI_JWTKEY.
+    jwt_secret = 'dev-only-insecure-jwt-secret-change-me',
 
     --
     -- Name of the logfile (a ".txt" is added...)

--- a/modules/test-it/src/test/scala/org/knora/sipi/SipiIT.scala
+++ b/modules/test-it/src/test/scala/org/knora/sipi/SipiIT.scala
@@ -75,7 +75,7 @@ class SipiIT extends ZIOSpecDefault {
   } yield JwtCodec.encode(
     """{"typ":"JWT","alg":"HS256"}""",
     claim.toJson,
-    "UP 4888, nice 4-8-4 steam engine".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+    "dev-only-insecure-jwt-secret-change-me".getBytes(java.nio.charset.StandardCharsets.UTF_8),
   )
 
   private val authSuite =

--- a/modules/testkit/src/main/scala/org/knora/webapi/testcontainers/DspIngestTestContainer.scala
+++ b/modules/testkit/src/main/scala/org/knora/webapi/testcontainers/DspIngestTestContainer.scala
@@ -30,7 +30,7 @@ object DspIngestTestContainer {
       .withEnv("JWT_ISSUER", "0.0.0.0:3333")
       .withEnv("STORAGE_ASSET_DIR", assetDir)
       .withEnv("STORAGE_TEMP_DIR", tempDir)
-      .withEnv("JWT_SECRET", "UP 4888, nice 4-8-4 steam engine")
+      .withEnv("JWT_SECRET", "dev-only-insecure-jwt-secret-change-me")
       .withEnv("SIPI_USE_LOCAL_DEV", "false")
       .withEnv("JWT_DISABLE_AUTH", "true")
       .withEnv("DB_JDBC_URL", "jdbc:sqlite:/tmp/ingest.sqlite")

--- a/modules/webapi/src/main/resources/application.conf
+++ b/modules/webapi/src/main/resources/application.conf
@@ -27,7 +27,7 @@ app {
 
     // configuration for the JWT authentication
     jwt {
-        secret = "UP 4888, nice 4-8-4 steam engine"
+        secret = "dev-only-insecure-jwt-secret-change-me"
         secret = ${?KNORA_WEBAPI_JWT_SECRET_KEY}
         expiration = 30 days
         expiration = ${?KNORA_WEBAPI_JWT_LONGEVITY}


### PR DESCRIPTION
## What

Bump the pinned `daschswiss/sipi` base image from **v8.0.0 → v9.0.1** (latest on Docker Hub).

- `MODULE.bazel`: both per-arch single-manifest digests (`sipi_base_amd64`, `sipi_base_arm64`) plus the tag and index-digest comment anchors updated to v9.0.1. The version is read from the image's own OCI label, so these digests are the sole source.

## Why the extra changes (v9 breaking change)

Sipi v9 **refuses to start** if `jwt_secret` is empty, shorter than 32 bytes, or equal to the old shipped default `"UP 4888, nice 4-8-4 steam engine"` (now denylisted). Our configs used exactly that literal, which would break the local stack and every container-based test.

This PR moves each runtime site that shared the literal to a distinct ≥32-byte dev secret (`dev-only-insecure-jwt-secret-change-me`) so JWT auth still verifies across dsp-api ↔ dsp-ingest ↔ Sipi:

- 4 Sipi configs under `modules/sipi/config/` + the test-resource copies in `test-it` / `test-e2e`
- `webapi` and `ingest` `application.conf`
- `docker-compose.yml` (`JWT_SECRET`)
- both `DspIngestTestContainer` helpers and `SipiIT`

The pure `JwtCodecSpec` unit test keeps the old literal as an arbitrary codec key — it never talks to a Sipi container.

Production supplies the secret via `SIPI_JWTKEY` (handled in ops-deploy, coordinated with the matching v9 rollout).

## Other v9 changes reviewed, no action needed here

- `--adminuser` / `--adminpasswd` / `SIPI_ADMIN*` removed → not used in dsp-api.
- `token.lua` postMessage route removed → not used.
- `docroot` overlap startup refusal → our `docroot` does not overlap imgroot/scriptdir/tmpdir.
- `admission_mode` now defaults to `advanced` → test uploads are small; can force `SIPI_ADMISSION_MODE=basic` if needed.
- `SIPI_PUBLIC_HOSTS` forwarded-host allowlist → dev reflect-any default is fine; prod handled in ops-deploy.

## Testing

- Rebuilt the derived `knora-sipi` image from the v9 base; its OCI version label reports `v9.0.1`.
- `SipiIT` (12 tests) passes against the v9.0.1 image — container starts (clears the v9 jwt_secret guard) and auth verifies (authorized → Ok, no-permission → Unauthorized, unknown → Not Found).
- Full local suite green: **10/10 Bazel test targets pass** — `webapi`, `ingest`, `bagit`, `jwt`, `shacl-validator`, `sparql-builder` (unit) plus `test-it`, `test-it:test_gravsearch_span`, `test-e2e`, `test-ingest-integration` (container-based). The v9 restricted-image / info.json gating changes did not shift the e2e assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fn4MNN6j99c1aNxGKejcFd
